### PR TITLE
fix: writeback/pending filtering and If-Match wildcard support

### DIFF
--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -4768,7 +4768,7 @@ func TestWritebackQueueACK(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
 	defer store.Close()
 	server := NewServer(store)
-	token := mustTestJWT(t, "dev-secret", "ws_1", "Worker1", []string{"fs:read", "fs:write", "sync:read", "sync:trigger", "ops:replay"}, time.Now().Add(time.Hour))
+	token := mustTestJWT(t, "dev-secret", "ws_1", "Worker1", []string{"fs:read", "fs:write", "sync:read", "sync:trigger", "ops:read", "ops:replay"}, time.Now().Add(time.Hour))
 
 	// Create a file write that will queue a writeback
 	writeResp := doRequest(t, server, request{
@@ -4837,6 +4837,47 @@ func TestWritebackQueueACK(t *testing.T) {
 
 	if ackResp.Code != http.StatusOK {
 		t.Fatalf("expected 200 OK on ack, got %d (%s)", ackResp.Code, ackResp.Body.String())
+	}
+
+	opResp := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_1/ops/" + itemID,
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_ack_2",
+		},
+	})
+	if opResp.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK fetching op after ack, got %d (%s)", opResp.Code, opResp.Body.String())
+	}
+	var op relayfile.OperationStatus
+	if err := json.NewDecoder(opResp.Body).Decode(&op); err != nil {
+		t.Fatalf("failed to decode op response: %v", err)
+	}
+	if op.Status != "succeeded" {
+		t.Fatalf("expected acked op to be succeeded, got %q", op.Status)
+	}
+
+	pendingAfterResp := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_1/writeback/pending",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_query_2",
+		},
+	})
+	if pendingAfterResp.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK querying pending after ack, got %d (%s)", pendingAfterResp.Code, pendingAfterResp.Body.String())
+	}
+
+	var itemsAfter []map[string]any
+	if err := json.NewDecoder(pendingAfterResp.Body).Decode(&itemsAfter); err != nil {
+		t.Fatalf("failed to decode pending response after ack: %v", err)
+	}
+	for _, pending := range itemsAfter {
+		if pendingID, _ := pending["id"].(string); pendingID == itemID {
+			t.Fatalf("expected acked item %q to be filtered from pending writebacks, got %+v", itemID, itemsAfter)
+		}
 	}
 }
 

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -1190,7 +1190,7 @@ func (s *Store) WriteFile(req WriteRequest) (WriteResult, error) {
 
 	existing, exists := ws.Files[path]
 	if !exists {
-		if req.IfMatch != "0" {
+		if req.IfMatch != "0" && req.IfMatch != "*" {
 			s.mu.Unlock()
 			return WriteResult{}, ErrNotFound
 		}
@@ -1213,7 +1213,7 @@ func (s *Store) WriteFile(req WriteRequest) (WriteResult, error) {
 		return result, nil
 	}
 
-	if req.IfMatch != existing.Revision {
+	if req.IfMatch != "*" && req.IfMatch != existing.Revision {
 		s.mu.Unlock()
 		return WriteResult{}, &ConflictError{
 			ExpectedRevision:      req.IfMatch,
@@ -1363,7 +1363,7 @@ func (s *Store) DeleteFile(req DeleteRequest) (WriteResult, error) {
 		s.mu.Unlock()
 		return WriteResult{}, ErrNotFound
 	}
-	if req.IfMatch != existing.Revision {
+	if req.IfMatch != "*" && req.IfMatch != existing.Revision {
 		s.mu.Unlock()
 		return WriteResult{}, &ConflictError{
 			ExpectedRevision:      req.IfMatch,
@@ -2381,18 +2381,35 @@ func (s *Store) GetPendingWritebacks(workspaceID string) []map[string]any {
 		return []map[string]any{}
 	}
 
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ws, ok := s.workspaces[workspaceID]
+	if !ok {
+		return []map[string]any{}
+	}
+
 	items := snapshotter.SnapshotWritebacks()
 	result := make([]map[string]any, 0)
 	for _, item := range items {
-		if item.WorkspaceID == workspaceID {
-			result = append(result, map[string]any{
-				"id":            item.OpID,
-				"workspaceId":   item.WorkspaceID,
-				"path":          item.Path,
-				"revision":      item.Revision,
-				"correlationId": item.CorrelationID,
-			})
+		if item.WorkspaceID != workspaceID {
+			continue
 		}
+		op, ok := ws.Ops[item.OpID]
+		if !ok {
+			continue
+		}
+		// External consumers should only see work that still needs processing.
+		if op.Status != "pending" && op.Status != "running" {
+			continue
+		}
+		result = append(result, map[string]any{
+			"id":            item.OpID,
+			"workspaceId":   item.WorkspaceID,
+			"path":          item.Path,
+			"revision":      item.Revision,
+			"correlationId": item.CorrelationID,
+		})
 	}
 	return result
 }


### PR DESCRIPTION
## Summary
- **Bug #1**: `GET /writeback/pending` now cross-checks queue snapshot against op state, filtering out acknowledged/succeeded items. Previously acked items leaked back through the pending endpoint, causing duplicate processing for external consumers.
- **Bug #2**: `WriteFile` and `DeleteFile` now accept `If-Match: *` (wildcard) for unconditional writes/deletes, following standard HTTP ETag semantics. `If-Match: 0` for creation still works (backward compatible).

Both bugs were found during live multi-agent testing with two agents (agent-alpha/agent-beta) running against the real server binary.

## Test plan
- [x] All 209+ existing tests pass
- [x] New regression test `TestWritebackQueueACK` verifies acked items are excluded from pending
- [x] Live server verified: `If-Match: *` creates, updates, and deletes correctly
- [x] Live server verified: `If-Match: 0` still rejects writes to existing files (conflict detection preserved)
- [x] Concurrent multi-agent writes still safe under parallel load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
