### PR TITLE
feat: cross-repo cloud preview dispatch on PRs

### DIFF
--- a/.github/workflows/cloud-preview.yml
+++ b/.github/workflows/cloud-preview.yml
@@ -1,0 +1,53 @@
+name: Cloud Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  dispatch-deploy:
+    name: Trigger Cloud Preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch preview deploy
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'AgentWorkforce',
+              repo: 'cloud',
+              workflow_id: 'preview-relayfile.yml',
+              ref: 'main',
+              inputs: {
+                pr_number: String(context.payload.pull_request.number),
+                head_sha: context.payload.pull_request.head.sha,
+                sdk_ref: context.payload.pull_request.head.ref,
+                source_repo: context.payload.repository.full_name,
+                action: 'deploy',
+              },
+            });
+
+  dispatch-cleanup:
+    name: Cleanup Cloud Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch preview cleanup
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'AgentWorkforce',
+              repo: 'cloud',
+              workflow_id: 'preview-relayfile.yml',
+              ref: 'main',
+              inputs: {
+                pr_number: String(context.payload.pull_request.number),
+                head_sha: context.payload.pull_request.head.sha,
+                source_repo: context.payload.repository.full_name,
+                action: 'cleanup',
+              },
+            });

--- a/.github/workflows/cloud-preview.yml
+++ b/.github/workflows/cloud-preview.yml
@@ -10,10 +10,17 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_PUSHER_ID }}
+          private_key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
+
       - name: Dispatch preview deploy
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'AgentWorkforce',
@@ -34,10 +41,17 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_PUSHER_ID }}
+          private_key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
+
       - name: Dispatch preview cleanup
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CLOUD_DISPATCH_TOKEN }}
+          github-token: ${{ steps.generate_token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'AgentWorkforce',


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cloud-preview.yml` that triggers ephemeral CF Worker preview deploys in the `cloud` repo when PRs are opened/updated
- Each PR gets its own isolated D1 database with fresh migrations
- Preview resources (D1, KV, worker) are cleaned up automatically on PR close

## How it works
```
PR opened/synced → dispatches cloud/preview-relayfile.yml (action=deploy)
  → creates relayfile-pr-{N} D1 + KV
  → runs all migrations from zero
  → deploys relayfile-api-pr-{N} worker
  → smoke test + E2E
  → reports ✅/❌ commit status on this PR

PR closed → dispatches cleanup (action=cleanup)
  → deletes D1, KV, worker
```

## Prerequisites
- `CLOUD_DISPATCH_TOKEN` secret (GitHub App installation token with `actions:write` on `AgentWorkforce/cloud`)

## Test plan
- [ ] Open a test PR and verify the cloud repo workflow is triggered
- [ ] Verify commit status appears on the PR
- [ ] Verify cleanup runs on PR close

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
