### PR TITLE
feat: Knowledge Extraction — spec + implementation workflow

### DIFF
--- a/docs/knowledge-extraction-spec.md
+++ b/docs/knowledge-extraction-spec.md
@@ -1,0 +1,460 @@
+# Relayfile Knowledge Extraction Spec
+
+## 1. Document Status
+
+- Status: Draft
+- Date: 2026-03-27
+- Scope: Convention extraction, path-scoped knowledge retrieval, and broker-time context injection
+- Audience: relayfile server, SDK, relay broker, and workflow authors
+- Depends on: `relayfile-v1-spec.md`, `knowledge-graph-spec.md`
+- Complements: [Agent Trajectories](https://github.com/AgentWorkforce/trajectories)
+
+## 2. Problem Statement
+
+When multiple agents work on the same codebase, each starts cold. Agent 3 discovers that the project uses Vitest, prices are stored in cents, and `pnpm install` needs `shamefully-hoist`. Agent 7, starting 20 minutes later on a related task, has none of this context. It writes a Jest test, uses dollars, and the build fails.
+
+Today the workarounds are:
+- **Massive task prompts** — inline everything ever learned. Causes E2BIG, wastes tokens on irrelevant context.
+- **AGENTS.md / .claude/rules** — static files, not updated in real-time, not scoped to paths.
+- **Step output injection** — `{{steps.X.output}}` passes one step's output to the next. Dies at workflow boundaries.
+
+The knowledge-graph spec (v2) tracks **derivation relationships** — which files were produced from which sources, staleness detection, cascade invalidation. That's structural metadata about the file graph.
+
+This spec addresses a different problem: **what have agents learned about working with this code, and how do we get that knowledge to the right agent at the right time?**
+
+## 3. Goals
+
+1. Agents can attach **knowledge annotations** to file paths at write time.
+2. Knowledge is queryable by **path scope** — "what do we know about `packages/billing/**`?"
+3. Knowledge is automatically extractable from **diffs and trajectories** without agent cooperation.
+4. The relay broker can **inject relevant knowledge** into agent task preambles at dispatch time.
+5. Knowledge accumulates over time, forming project-level "institutional memory."
+
+## 4. Non-Goals
+
+1. Semantic search over knowledge (no embeddings in v1 — path-based lookup is sufficient).
+2. Replacing trajectories. Trajectories are the full historical record; knowledge annotations are the distilled, queryable derivative.
+3. Cross-workspace knowledge sharing. Each workspace's knowledge is self-contained.
+4. Agent memory / conversation history. This is project knowledge, not agent state.
+
+## 5. Design Principles
+
+1. **Knowledge lives on files, not in a separate store.** Annotations are file-level metadata using the existing `FileSemantics.properties` model. No second database.
+2. **Write-time capture beats post-hoc extraction.** Agents that explicitly annotate produce better knowledge than automated extraction. But automated extraction is the fallback.
+3. **Injection is scoped and bounded.** Never inject more than N tokens of knowledge into a task. Relevance is determined by path overlap, not semantic similarity.
+4. **Knowledge has a TTL.** Conventions change. Annotations older than N days without reconfirmation are deprioritized.
+5. **Humans can curate.** Knowledge annotations are visible and editable. A human can mark an annotation as wrong, authoritative, or expired.
+
+## 6. Data Model
+
+### 6.1 Knowledge Annotation
+
+A knowledge annotation is a structured lesson attached to a file path (or path glob).
+
+```typescript
+interface KnowledgeAnnotation {
+  id: string;                          // unique ID
+  path: string;                        // file path or glob: "packages/billing/**"
+  category: KnowledgeCategory;
+  content: string;                     // the lesson, max 200 chars
+  confidence: "high" | "medium" | "low";
+  source: KnowledgeSource;
+  createdAt: string;                   // ISO timestamp
+  createdBy: string;                   // agent name or "human"
+  confirmedAt?: string;                // last time an agent reconfirmed this
+  confirmedBy?: string;
+  expiresAt?: string;                  // optional TTL
+  supersededBy?: string;               // ID of annotation that replaces this
+  trajectoryId?: string;               // link to trajectory that produced this
+  workflowId?: string;                 // link to workflow run
+}
+
+type KnowledgeCategory =
+  | "convention"      // "uses Vitest, not Jest"
+  | "dependency"      // "imports PlanTier from @nightcto/domain"
+  | "gotcha"          // "pnpm install fails without shamefully-hoist"
+  | "pattern"         // "all routes use zod validation middleware"
+  | "decision"        // "chose Stripe over Paddle — no test mode API"
+  | "constraint"      // "max 100 lines per step output"
+  | "environment"     // "needs STRIPE_TEST_KEY in .env"
+
+type KnowledgeSource =
+  | "agent-explicit"  // agent called writeKnowledge()
+  | "diff-extraction" // server extracted from file diff
+  | "trajectory"      // extracted from trajectory retrospective
+  | "human"           // human wrote or edited directly
+```
+
+### 6.2 Storage
+
+Annotations are stored in the existing Relayfile state model as a knowledge index per workspace. Implementation options:
+
+- **D1 table** (Cloudflare Workers): `knowledge_annotations` table with path prefix indexing
+- **KV namespace**: Key = `ws:{workspaceId}:knowledge:{path_hash}:{id}`, value = JSON annotation
+
+Path queries use prefix matching: `packages/billing/**` matches annotations on `packages/billing/src/checkout.ts`, `packages/billing/test/checkout.test.ts`, and `packages/billing/**` itself.
+
+### 6.3 Integration with FileSemantics
+
+The existing `FileSemantics.properties` field can carry a `knowledge` key pointing to annotation IDs:
+
+```typescript
+// On writeFile, the semantics.properties can reference knowledge
+await relayfile.writeFile({
+  workspaceId,
+  path: 'packages/billing/src/checkout.ts',
+  content: fileContent,
+  semantics: {
+    properties: {
+      'knowledge:convention:pricing': 'prices stored in cents, not dollars',
+      'knowledge:dependency:domain': '@nightcto/domain:PlanTier',
+    }
+  }
+});
+```
+
+But the primary API for knowledge is separate endpoints (Section 7), not embedded in every writeFile call.
+
+## 7. API Design
+
+### 7.1 Write Knowledge
+
+```
+POST /v1/workspaces/{workspaceId}/knowledge
+```
+
+Request body:
+```json
+{
+  "path": "packages/billing/**",
+  "category": "convention",
+  "content": "prices stored in cents, not dollars",
+  "confidence": "high",
+  "source": "agent-explicit",
+  "createdBy": "billing-builder-agent",
+  "trajectoryId": "traj_abc123"
+}
+```
+
+Response: `201 Created` with the annotation ID.
+
+Agents call this after completing work. The annotation is immediately queryable.
+
+### 7.2 Query Knowledge
+
+```
+GET /v1/workspaces/{workspaceId}/knowledge?paths=packages/billing/**,packages/domain/**&limit=50&categories=convention,gotcha,dependency
+```
+
+Response:
+```json
+{
+  "annotations": [
+    {
+      "id": "ka_001",
+      "path": "packages/billing/**",
+      "category": "convention",
+      "content": "prices stored in cents, not dollars",
+      "confidence": "high",
+      "createdBy": "billing-builder-agent",
+      "createdAt": "2026-03-27T01:30:00Z"
+    },
+    {
+      "id": "ka_002",
+      "path": "packages/domain/**",
+      "category": "dependency",
+      "content": "PlanTier enum exported from src/types.ts",
+      "confidence": "high",
+      "createdBy": "domain-builder-agent",
+      "createdAt": "2026-03-27T00:45:00Z"
+    }
+  ],
+  "total": 2
+}
+```
+
+Path matching rules:
+- `packages/billing/src/checkout.ts` matches annotations on `packages/billing/**`, `packages/billing/src/**`, and `packages/billing/src/checkout.ts`
+- Glob patterns use standard gitignore-style matching
+- Results sorted by: confidence (high first), then recency
+
+### 7.3 Confirm / Supersede / Delete Knowledge
+
+```
+PATCH /v1/workspaces/{workspaceId}/knowledge/{annotationId}
+```
+
+```json
+{
+  "confirmedAt": "2026-03-27T06:00:00Z",
+  "confirmedBy": "review-agent"
+}
+```
+
+Or to supersede:
+```json
+{
+  "supersededBy": "ka_005",
+  "content": "prices stored in cents — EXCEPT subscriptions which use whole dollars"
+}
+```
+
+### 7.4 Bulk Write (for trajectory extraction)
+
+```
+POST /v1/workspaces/{workspaceId}/knowledge/bulk
+```
+
+```json
+{
+  "annotations": [
+    { "path": "packages/billing/**", "category": "convention", "content": "...", ... },
+    { "path": "packages/billing/**", "category": "gotcha", "content": "...", ... }
+  ],
+  "source": "trajectory",
+  "trajectoryId": "traj_abc123"
+}
+```
+
+## 8. Automatic Extraction
+
+### 8.1 Diff-Based Extraction (Server-Side)
+
+After a write operation completes, the server can optionally extract knowledge from the diff. This runs as a background task, not in the write path.
+
+**What to extract:**
+- New `import` statements → `dependency` annotation
+- New config values / env vars → `environment` annotation  
+- Test framework usage (vitest/jest/mocha) → `convention` annotation
+- Error handling patterns → `pattern` annotation
+- Package.json dependency changes → `dependency` annotation
+
+**Implementation:** Pattern matching on diff hunks. No LLM needed for v1. A set of extractors:
+
+```typescript
+interface DiffExtractor {
+  name: string;
+  category: KnowledgeCategory;
+  match(diff: DiffHunk): KnowledgeAnnotation | null;
+}
+
+const extractors: DiffExtractor[] = [
+  {
+    name: 'import-detector',
+    category: 'dependency',
+    match(diff) {
+      // Match added lines with import/require statements
+      // Extract package name and what's imported
+    }
+  },
+  {
+    name: 'test-framework-detector',
+    category: 'convention',
+    match(diff) {
+      // Match import from vitest/jest/mocha
+      // "uses {framework} for testing"
+    }
+  },
+  {
+    name: 'env-var-detector',
+    category: 'environment',
+    match(diff) {
+      // Match process.env.X or Deno.env.get("X")
+      // "requires {VAR} environment variable"
+    }
+  },
+];
+```
+
+### 8.2 Trajectory-Based Extraction (Post-Workflow)
+
+After a workflow completes and a trajectory is written, extract knowledge from the trajectory's retrospective chapter.
+
+The trajectory retrospective already contains agent reflections like:
+- "Had to switch from Paddle to Stripe because Paddle lacks a test mode API"
+- "The project uses strict TypeScript with composite references"
+- "pnpm workspace protocol requires explicit version ranges"
+
+These are high-value knowledge entries. Extraction can use a lightweight LLM call:
+
+**Prompt:**
+```
+Extract reusable project lessons from this trajectory retrospective.
+For each lesson, output: path scope, category, and a one-line description (max 200 chars).
+Categories: convention, dependency, gotcha, pattern, decision, constraint, environment.
+
+Retrospective:
+{retrospective_text}
+
+Output JSON array of annotations.
+```
+
+This runs once per workflow, not per step — cost is minimal.
+
+### 8.3 Deduplication
+
+Before inserting, check for existing annotations with the same path + category + similar content. If a match exists:
+- Same content → update `confirmedAt` (reconfirmation)
+- Updated content → create new annotation, mark old as `supersededBy`
+- Contradicting content → flag for human review
+
+## 9. Broker Integration
+
+The highest-leverage feature: the relay broker auto-injects knowledge when dispatching tasks to agents.
+
+### 9.1 Flow
+
+1. Workflow step defines `task` text and `fileTargets` (or broker infers from task text)
+2. Before spawning the agent, broker calls `GET /v1/workspaces/{wsId}/knowledge?paths={fileTargets}&limit=30`
+3. Broker prepends a knowledge preamble to the task:
+
+```
+## Project Knowledge (auto-injected)
+The following conventions and lessons have been established by previous agents working on this codebase:
+
+**Conventions:**
+- packages/billing: prices stored in cents, not dollars
+- packages/domain: PlanTier enum exported from src/types.ts
+
+**Gotchas:**
+- root: pnpm install fails without shamefully-hoist in .npmrc
+
+**Dependencies:**
+- packages/billing → @nightcto/domain:PlanTier
+- packages/billing → stripe
+
+---
+
+{original_task_text}
+```
+
+4. Agent receives enriched task. Knowledge is in context without the agent needing to discover it.
+
+### 9.2 Budget
+
+Knowledge preamble is capped at a configurable token limit (default: 2000 tokens, ~50 annotations). If more knowledge exists than fits:
+- Prioritize by confidence (high > medium > low)
+- Prioritize by recency
+- Prioritize `gotcha` and `convention` over `dependency` (dependencies are in the code)
+- Prioritize annotations with path specificity matching the task's file targets
+
+### 9.3 Opt-In
+
+Knowledge injection is opt-in per workflow:
+
+```typescript
+workflow('my-workflow')
+  .knowledgeInjection({ enabled: true, maxTokens: 2000 })
+```
+
+Or per step:
+```typescript
+.step('implement-billing', {
+  agent: 'builder',
+  knowledge: { paths: ['packages/billing/**'], categories: ['convention', 'gotcha'] },
+  task: `...`,
+})
+```
+
+## 10. SDK Changes
+
+### 10.1 RelayFileClient Additions
+
+```typescript
+class RelayFileClient {
+  // Existing methods...
+
+  async writeKnowledge(
+    workspaceId: string,
+    annotation: Omit<KnowledgeAnnotation, 'id' | 'createdAt'>
+  ): Promise<{ id: string }>;
+
+  async writeKnowledgeBulk(
+    workspaceId: string,
+    annotations: Omit<KnowledgeAnnotation, 'id' | 'createdAt'>[],
+    source?: { trajectoryId?: string; workflowId?: string }
+  ): Promise<{ ids: string[] }>;
+
+  async queryKnowledge(
+    workspaceId: string,
+    options: {
+      paths?: string[];
+      categories?: KnowledgeCategory[];
+      limit?: number;
+      minConfidence?: 'low' | 'medium' | 'high';
+      createdAfter?: string;
+    }
+  ): Promise<{ annotations: KnowledgeAnnotation[]; total: number }>;
+
+  async confirmKnowledge(
+    workspaceId: string,
+    annotationId: string,
+    confirmedBy: string
+  ): Promise<void>;
+
+  async supersedeKnowledge(
+    workspaceId: string,
+    annotationId: string,
+    replacement: Omit<KnowledgeAnnotation, 'id' | 'createdAt'>
+  ): Promise<{ id: string }>;
+}
+```
+
+### 10.2 Relay SDK Broker Changes
+
+The relay broker (`@agent-relay/sdk`) needs a hook in the step dispatch path:
+
+```typescript
+// In runner.ts, before spawning agent for a step
+if (step.knowledge?.enabled || workflow.knowledgeInjection?.enabled) {
+  const knowledge = await relayfileClient.queryKnowledge(workspaceId, {
+    paths: step.knowledge?.paths || step.fileTargets,
+    categories: step.knowledge?.categories,
+    limit: Math.floor((step.knowledge?.maxTokens || 2000) / 40), // ~40 chars per annotation
+  });
+  
+  if (knowledge.annotations.length > 0) {
+    step.task = formatKnowledgePreamble(knowledge.annotations) + '\n\n' + step.task;
+  }
+}
+```
+
+## 11. Relationship to Other Specs
+
+| Spec | What it tracks | When it's used |
+|---|---|---|
+| **Relayfile v1** | Files, revisions, sync state | Every read/write operation |
+| **Knowledge Graph (v2)** | Derivation DAG, staleness, validation | When files are derived from other files |
+| **Knowledge Extraction (this)** | Conventions, lessons, gotchas | When agents need context about unfamiliar code |
+| **Trajectories** | Full agent work history | After-the-fact review, source for extraction |
+
+Knowledge extraction is orthogonal to the knowledge graph. The graph tracks "file A was derived from file B." Extraction tracks "when working on file A, we learned X." They can coexist: a file can have derivation edges (graph) AND knowledge annotations (extraction).
+
+## 12. Implementation Phases
+
+### Phase 1: Explicit Write + Query (1-2 days)
+- `POST /knowledge` and `GET /knowledge` endpoints on relayfile server
+- `writeKnowledge()` and `queryKnowledge()` on SDK
+- D1 table for annotation storage
+- Path prefix matching
+
+### Phase 2: Diff-Based Auto-Extraction (2-3 days)
+- Background worker on write operations
+- Pattern-matching extractors (imports, env vars, test frameworks)
+- Deduplication logic
+
+### Phase 3: Trajectory Extraction (1-2 days)
+- Post-workflow hook that reads trajectory retrospective
+- Lightweight LLM extraction call
+- Bulk write to knowledge store
+
+### Phase 4: Broker Injection (2-3 days)
+- Hook in relay SDK step dispatch
+- Knowledge preamble formatting
+- Token budget management
+- `knowledgeInjection` workflow/step config
+
+### Phase 5: Curation UI (future)
+- Dashboard view of knowledge per workspace
+- Human can confirm, supersede, delete annotations
+- Confidence decay over time (annotations not reconfirmed lose confidence)

--- a/packages/relayfile/package.json
+++ b/packages/relayfile/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "CLI for relayfile — real-time filesystem for humans and agents",
   "bin": {
-    "relayfile": "bin/relayfile"
+    "relayfile": "scripts/run.js"
   },
   "scripts": {
     "postinstall": "node scripts/install.js || true"

--- a/packages/relayfile/scripts/install.js
+++ b/packages/relayfile/scripts/install.js
@@ -8,7 +8,6 @@ const https = require("https");
 
 const VERSION = require("../package.json").version;
 const BIN_DIR = path.join(__dirname, "..", "bin");
-const BIN_PATH = path.join(BIN_DIR, "relayfile");
 
 const PLATFORM_MAP = {
   darwin: "darwin",
@@ -20,6 +19,10 @@ const ARCH_MAP = {
   x64: "amd64",
   arm64: "arm64",
 };
+
+function getBinaryFilename() {
+  return os.platform() === "win32" ? "relayfile.exe" : "relayfile";
+}
 
 function getDownloadUrl() {
   const platform = PLATFORM_MAP[os.platform()];
@@ -61,13 +64,14 @@ function download(url, dest) {
 
 async function main() {
   const url = getDownloadUrl();
+  const binPath = path.join(BIN_DIR, getBinaryFilename());
 
   fs.mkdirSync(BIN_DIR, { recursive: true });
 
   console.log(`Downloading relayfile v${VERSION}...`);
   try {
-    await download(url, BIN_PATH);
-    fs.chmodSync(BIN_PATH, 0o755);
+    await download(url, binPath);
+    fs.chmodSync(binPath, 0o755);
     console.log("relayfile installed successfully.");
   } catch (err) {
     console.error(`Failed to download relayfile: ${err.message}`);

--- a/packages/relayfile/scripts/run.js
+++ b/packages/relayfile/scripts/run.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const binName = os.platform() === "win32" ? "relayfile.exe" : "relayfile";
+const binPath = path.join(__dirname, "..", "bin", binName);
+
+if (!fs.existsSync(binPath)) {
+  console.error(
+    `relayfile binary not found at ${binPath}. Reinstall the package or run postinstall again.`
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binPath, process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(`Failed to launch relayfile binary: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (typeof result.status === "number") {
+  process.exit(result.status);
+}
+
+process.exit(1);

--- a/workflows/relayfile-knowledge-extraction.ts
+++ b/workflows/relayfile-knowledge-extraction.ts
@@ -1,0 +1,236 @@
+/**
+ * relayfile-knowledge-extraction.ts
+ *
+ * Implements the Knowledge Extraction spec: agents can write and query
+ * project knowledge scoped to file paths. The relay broker can inject
+ * relevant knowledge into task preambles at dispatch time.
+ *
+ * After this workflow:
+ *   - POST /v1/workspaces/:id/knowledge writes annotations
+ *   - GET /v1/workspaces/:id/knowledge?paths=... queries them
+ *   - SDK has writeKnowledge() and queryKnowledge() methods
+ *   - Diff-based extractors auto-capture conventions from writes
+ *   - Trajectory retrospectives are mined for knowledge post-workflow
+ *
+ * Run: agent-relay run workflows/relayfile-knowledge-extraction.ts
+ */
+
+import { workflow } from '@agent-relay/sdk/workflows';
+
+const RELAYFILE = '/Users/khaliqgant/Projects/AgentWorkforce/relayfile';
+
+async function main() {
+const result = await workflow('relayfile-knowledge-extraction')
+  .description('Knowledge extraction and context injection for multi-agent collaboration')
+  .pattern('dag')
+  .channel('wf-relayfile-knowledge')
+  .maxConcurrency(4)
+  .timeout(3_600_000)
+
+  .agent('architect', { cli: 'claude', role: 'Designs knowledge extraction system' })
+  .agent('server-builder', { cli: 'codex', preset: 'worker', role: 'Implements server endpoints and storage' })
+  .agent('sdk-builder', { cli: 'codex', preset: 'worker', role: 'Implements SDK methods and extractors' })
+  .agent('reviewer', { cli: 'claude', preset: 'reviewer', role: 'Reviews implementation' })
+
+  // ── Phase 1: Storage + API ──────────────────────────────────────
+
+  .step('design-storage', {
+    agent: 'architect',
+    task: `Read ${RELAYFILE}/docs/knowledge-extraction-spec.md and the existing server code.
+
+Design the D1 schema and API routes for knowledge annotations. Output:
+1. D1 migration SQL (create table, indexes for path prefix queries)
+2. API route signatures (POST /knowledge, GET /knowledge, PATCH /knowledge/:id, POST /knowledge/bulk)
+3. Path matching strategy (how glob patterns query the D1 table efficiently)
+
+Keep output under 80 lines. Use the existing Hono app pattern from ${RELAYFILE}/packages/server/src/.
+End with STORAGE_DESIGN_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'STORAGE_DESIGN_COMPLETE' },
+    timeout: 180_000,
+  })
+
+  .step('implement-server', {
+    agent: 'server-builder',
+    dependsOn: ['design-storage'],
+    task: `Implement knowledge extraction server endpoints in ${RELAYFILE} based on:
+{{steps.design-storage.output}}
+
+Create/modify files:
+1. packages/server/src/routes/knowledge.ts — Hono routes:
+   - POST /v1/workspaces/:workspaceId/knowledge (single annotation)
+   - POST /v1/workspaces/:workspaceId/knowledge/bulk (batch from trajectories)
+   - GET /v1/workspaces/:workspaceId/knowledge (query by paths, categories, confidence)
+   - PATCH /v1/workspaces/:workspaceId/knowledge/:id (confirm, supersede, delete)
+
+2. packages/server/src/storage/knowledge.ts — D1 operations:
+   - insertAnnotation(), queryByPaths(), confirmAnnotation(), supersedeAnnotation()
+   - Path glob matching via SQL LIKE with prefix optimization
+
+3. packages/server/src/migrations/003-knowledge-annotations.sql — D1 migration:
+   - Table: knowledge_annotations (id, workspace_id, path, category, content, confidence, source, created_by, created_at, confirmed_at, confirmed_by, expires_at, superseded_by, trajectory_id, workflow_id)
+   - Index on (workspace_id, path) for prefix queries
+   - Index on (workspace_id, category) for category filtering
+
+4. Register routes in packages/server/src/worker.ts
+
+Types: use the KnowledgeAnnotation and KnowledgeCategory types from the spec.
+Run: cd ${RELAYFILE} && pnpm build && pnpm test
+End with SERVER_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'SERVER_COMPLETE' },
+    timeout: 600_000,
+  })
+
+  .step('implement-sdk', {
+    agent: 'sdk-builder',
+    dependsOn: ['design-storage'],
+    task: `Add knowledge methods to the Relayfile SDK in ${RELAYFILE}/packages/relayfile-sdk/src/.
+
+1. Update types.ts — add KnowledgeAnnotation, KnowledgeCategory, KnowledgeSource interfaces (from spec)
+
+2. Update client.ts — add methods to RelayFileClient:
+   - writeKnowledge(workspaceId, annotation) → { id }
+   - writeKnowledgeBulk(workspaceId, annotations, source?) → { ids }
+   - queryKnowledge(workspaceId, { paths?, categories?, limit?, minConfidence? }) → { annotations, total }
+   - confirmKnowledge(workspaceId, annotationId, confirmedBy) → void
+   - supersedeKnowledge(workspaceId, annotationId, replacement) → { id }
+
+3. Add tests: packages/relayfile-sdk/test/knowledge.test.ts
+   - Test queryKnowledge path matching
+   - Test writeKnowledge + queryKnowledge round-trip
+   - Test confirmKnowledge updates confirmedAt
+   - Test supersedeKnowledge marks old annotation
+
+Run: cd ${RELAYFILE} && pnpm build && pnpm test
+End with SDK_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'SDK_COMPLETE' },
+    timeout: 600_000,
+  })
+
+  .step('review-phase1', {
+    agent: 'reviewer',
+    dependsOn: ['implement-server', 'implement-sdk'],
+    task: `Review knowledge extraction Phase 1 in ${RELAYFILE}.
+
+Check (keep output under 40 lines):
+1. Server routes match the spec API design (Section 7)
+2. D1 schema supports efficient path prefix queries
+3. SDK methods match the spec interfaces (Section 10)
+4. Types are consistent between server and SDK
+5. Tests cover write, query, confirm, supersede flows
+6. pnpm build passes
+
+Fix anything broken. End with PHASE1_REVIEW_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'PHASE1_REVIEW_COMPLETE' },
+    timeout: 300_000,
+  })
+
+  // ── Phase 2: Auto-Extraction ────────────────────────────────────
+
+  .step('implement-extractors', {
+    agent: 'sdk-builder',
+    dependsOn: ['review-phase1'],
+    task: `Implement diff-based knowledge extractors in ${RELAYFILE}/packages/server/src/extractors/.
+
+1. extractors/index.ts — DiffExtractor interface and runner:
+   - interface DiffExtractor { name: string; category: KnowledgeCategory; match(diff: DiffHunk): KnowledgeAnnotation | null }
+   - function extractKnowledge(diffs: DiffHunk[]): KnowledgeAnnotation[]
+
+2. extractors/import-detector.ts — extracts dependency annotations from import/require statements
+3. extractors/test-framework-detector.ts — detects vitest/jest/mocha/playwright usage → convention
+4. extractors/env-var-detector.ts — detects process.env / Deno.env usage → environment
+5. extractors/package-json-detector.ts — detects new dependencies in package.json changes → dependency
+
+6. extractors/deduplication.ts — before inserting:
+   - Same path + category + similar content → update confirmedAt
+   - Contradicting content → flag for review (set confidence: "low")
+
+7. Tests: packages/server/test/extractors.test.ts
+   - Test each extractor with sample diffs
+   - Test deduplication logic
+
+Keep extractors simple — pattern matching on diff lines, no AST parsing.
+Run: cd ${RELAYFILE} && pnpm build && pnpm test
+End with EXTRACTORS_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'EXTRACTORS_COMPLETE' },
+    timeout: 600_000,
+  })
+
+  // ── Phase 3: Trajectory Integration ─────────────────────────────
+
+  .step('implement-trajectory-extraction', {
+    agent: 'server-builder',
+    dependsOn: ['review-phase1'],
+    task: `Implement trajectory-based knowledge extraction in ${RELAYFILE}/packages/server/src/extractors/trajectory.ts.
+
+1. trajectory.ts:
+   - function extractFromRetrospective(retrospective: string, trajectoryId: string): KnowledgeAnnotation[]
+   - Parse the retrospective text for lessons, conventions, gotchas
+   - For v1: use regex/heuristic extraction (look for "learned", "discovered", "had to", "switched from", "because", "convention", "requires")
+   - Each extracted lesson becomes an annotation with source: "trajectory"
+   - Path scope: infer from trajectory's changed files (or default to "**")
+
+2. Hook into the POST /knowledge/bulk endpoint — add a "source: trajectory" path that:
+   - Accepts { trajectoryId, retrospective, changedFiles }
+   - Runs extractFromRetrospective()
+   - Deduplicates against existing annotations
+   - Bulk inserts results
+
+3. Tests: test with sample retrospective text from the NightCTO trajectories
+
+Keep output under 30 lines. End with TRAJECTORY_EXTRACTION_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'TRAJECTORY_EXTRACTION_COMPLETE' },
+    timeout: 600_000,
+  })
+
+  // ── Final: Review + Commit ──────────────────────────────────────
+
+  .step('final-review', {
+    agent: 'reviewer',
+    dependsOn: ['implement-extractors', 'implement-trajectory-extraction'],
+    task: `Final review of knowledge extraction feature in ${RELAYFILE}.
+
+Check (keep output under 40 lines):
+1. Full write → extract → query flow works
+2. Diff extractors produce sensible annotations from real diffs
+3. Trajectory extraction handles typical retrospective text
+4. Deduplication prevents duplicate annotations
+5. All tests pass: pnpm test
+6. Build succeeds: pnpm build
+
+Fix anything broken. End with FINAL_REVIEW_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'FINAL_REVIEW_COMPLETE' },
+    timeout: 300_000,
+  })
+
+  .step('commit', {
+    agent: 'server-builder',
+    dependsOn: ['final-review'],
+    task: `In ${RELAYFILE}:
+1. git checkout -b feat/knowledge-extraction
+2. git add -A
+3. git commit -m "feat: knowledge extraction — write, query, auto-extract, trajectory integration
+
+Implements the Knowledge Extraction spec:
+- POST/GET /v1/workspaces/:id/knowledge endpoints
+- SDK writeKnowledge(), queryKnowledge(), confirmKnowledge() methods
+- Diff-based extractors (imports, test frameworks, env vars, packages)
+- Trajectory retrospective extraction
+- Deduplication and supersede logic
+- D1 migration for knowledge_annotations table"
+4. git push origin feat/knowledge-extraction
+
+Report commit hash. End with COMMIT_COMPLETE.`,
+    verification: { type: 'output_contains', value: 'COMMIT_COMPLETE' },
+    timeout: 120_000,
+  })
+
+  .onError('retry', { maxRetries: 1, retryDelayMs: 10_000 })
+  .run({ onEvent: (event) => console.log(`[knowledge] ${event.type}`) });
+
+console.log('Knowledge extraction complete:', result.status);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Knowledge Extraction for Relayfile

### Problem
When multiple agents work on the same codebase, each starts cold. Agent 3 discovers conventions, dependencies, and gotchas — but agent 7, starting 20 minutes later, has none of this context.

### Solution
File-path-scoped knowledge annotations that agents write (explicitly or auto-extracted from diffs/trajectories) and query before starting work. The relay broker can inject relevant knowledge into task preambles automatically.

### What's included
- **Spec**: `docs/knowledge-extraction-spec.md` — full design covering data model, API, extraction strategies, broker integration
- **Workflow**: `workflows/relayfile-knowledge-extraction.ts` — 7-step implementation workflow (2 Claude + 2 Codex agents)

### Key design decisions
- Knowledge lives on files as metadata, not in a separate store
- Path-based lookup (no embeddings needed for v1)
- Automatic diff-based extraction (regex/pattern matching, no LLM)
- Trajectory retrospectives as a knowledge source
- Token-budgeted injection at broker dispatch time
- Complements (not replaces) the existing knowledge-graph spec (derivation DAG)

### Relationship to other specs
| Spec | Tracks | Purpose |
|---|---|---|
| Relayfile v1 | Files, revisions, sync | Storage |
| Knowledge Graph v2 | Derivation DAG, staleness | Structural relationships |
| **Knowledge Extraction** | Conventions, lessons, gotchas | Agent context injection |
| Trajectories | Full work history | Source for extraction |

### Not included (future phases)
- Broker integration (needs relay SDK changes)
- Semantic search / embeddings
- Curation UI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
