### PR TITLE
feat: default baseUrl to api.relayfile.dev

### DIFF
--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -200,13 +200,16 @@ def _throw_for_error(status: int, payload: Any, headers: httpx.Headers) -> None:
 # ======================================================================
 
 
+DEFAULT_RELAYFILE_BASE_URL = "https://api.relayfile.dev"
+
+
 class RelayFileClient:
     """Synchronous RelayFile SDK client with retry support."""
 
     def __init__(
         self,
-        base_url: str,
-        token: AccessTokenProvider,
+        base_url: str = DEFAULT_RELAYFILE_BASE_URL,
+        token: AccessTokenProvider = "",
         *,
         timeout: float = 30.0,
         user_agent: str | None = None,
@@ -766,8 +769,8 @@ class AsyncRelayFileClient:
 
     def __init__(
         self,
-        base_url: str,
-        token: AsyncAccessTokenProvider,
+        base_url: str = DEFAULT_RELAYFILE_BASE_URL,
+        token: AsyncAccessTokenProvider = "",
         *,
         timeout: float = 30.0,
         user_agent: str | None = None,

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -54,8 +54,12 @@ export interface RelayFileRetryOptions {
   jitterRatio?: number;
 }
 
+/** Default base URL for the hosted Relayfile API */
+export const DEFAULT_RELAYFILE_BASE_URL = "https://api.relayfile.dev";
+
 export interface RelayFileClientOptions {
-  baseUrl: string;
+  /** API base URL. Defaults to https://api.relayfile.dev */
+  baseUrl?: string;
   token: AccessTokenProvider;
   fetchImpl?: typeof fetch;
   userAgent?: string;
@@ -250,7 +254,7 @@ export class RelayFileClient {
   private readonly retryOptions: NormalizedRetryOptions;
 
   constructor(options: RelayFileClientOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.baseUrl = (options.baseUrl ?? DEFAULT_RELAYFILE_BASE_URL).replace(/\/+$/, "");
     this.tokenProvider = options.token;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.userAgent = options.userAgent;

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -1,5 +1,6 @@
 export {
   RelayFileClient,
+  DEFAULT_RELAYFILE_BASE_URL,
   type ConnectWebSocketOptions,
   type RelayFileRetryOptions,
   type WebSocketConnection


### PR DESCRIPTION
Makes `baseUrl` optional in both TS and Python SDKs. Defaults to `https://api.relayfile.dev`.

3 files changed:
- `packages/sdk/typescript/src/client.ts` — optional baseUrl + default
- `packages/sdk/typescript/src/index.ts` — export constant
- `packages/sdk/python/src/relayfile/client.py` — optional base_url + default

```ts
// Before
const client = new RelayFileClient({ baseUrl: 'https://api.relayfile.dev', token: '...' });

// After  
const client = new RelayFileClient({ token: '...' });
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
