### PR TITLE
feat: add 5 end-to-end SDK examples

### DIFF
--- a/examples/01-agent-reads-files/README.md
+++ b/examples/01-agent-reads-files/README.md
@@ -1,0 +1,44 @@
+# 01 — Agent reads files
+
+The simplest relayfile example: connect to a workspace and read its contents.
+
+## What it shows
+
+| Method | Purpose |
+|--------|---------|
+| `listTree` | Browse the virtual filesystem tree |
+| `readFile` | Fetch a single file's content and metadata |
+| `queryFiles` | Search files by provider or semantic properties |
+
+## Run
+
+```bash
+export RELAYFILE_TOKEN="ey…"   # JWT with fs:read scope
+export WORKSPACE_ID="ws_demo"
+
+npx tsx index.ts
+```
+
+## Expected output
+
+```
+── listTree (depth 2) ──
+  📁 /github
+  📄 /github/pulls/42.json  rev=r_abc123
+  …
+
+── readFile /github/pulls/42.json ──
+  contentType : application/json
+  revision    : r_abc123
+  provider    : github
+  content     : {"title":"Add auth middleware",…}…
+
+── queryFiles (provider=github) ──
+  /github/pulls/42.json  props={"status":"open"}
+
+── queryFiles (property status=open) ──
+  matched 1 file(s)
+  /github/pulls/42.json
+
+Done.
+```

--- a/examples/01-agent-reads-files/index.ts
+++ b/examples/01-agent-reads-files/index.ts
@@ -1,0 +1,78 @@
+/**
+ * Example 01 — Agent reads files from a workspace
+ *
+ * Demonstrates the simplest relayfile flow: connect to a workspace and
+ * browse its virtual filesystem using listTree, readFile, and queryFiles.
+ *
+ * Run:  npx tsx index.ts
+ * Env:  RELAYFILE_TOKEN  — JWT with fs:read scope
+ *       WORKSPACE_ID     — target workspace ID
+ */
+
+import { RelayFileClient } from "@relayfile/sdk";
+
+const token = process.env.RELAYFILE_TOKEN;
+const workspaceId = process.env.WORKSPACE_ID ?? "ws_demo";
+
+if (!token) {
+  console.error("Set RELAYFILE_TOKEN before running this example.");
+  process.exit(1);
+}
+
+const client = new RelayFileClient({ token });
+
+// ── 1. List the workspace tree ──────────────────────────────────────────────
+
+console.log("── listTree (depth 2) ──");
+const tree = await client.listTree(workspaceId, { depth: 2 });
+
+for (const entry of tree.entries) {
+  const icon = entry.type === "dir" ? "📁" : "📄";
+  console.log(`  ${icon} ${entry.path}  rev=${entry.revision}`);
+}
+
+if (tree.nextCursor) {
+  console.log(`  … more entries (cursor: ${tree.nextCursor})`);
+}
+
+// ── 2. Read a single file ───────────────────────────────────────────────────
+
+const targetPath = tree.entries.find((e) => e.type === "file")?.path;
+
+if (targetPath) {
+  console.log(`\n── readFile ${targetPath} ──`);
+  const file = await client.readFile(workspaceId, targetPath);
+  console.log(`  contentType : ${file.contentType}`);
+  console.log(`  revision    : ${file.revision}`);
+  console.log(`  provider    : ${file.provider ?? "(agent-written)"}`);
+  console.log(`  content     : ${file.content.slice(0, 200)}…`);
+} else {
+  console.log("\nNo files found in tree — skipping readFile.");
+}
+
+// ── 3. Query files by provider ──────────────────────────────────────────────
+
+console.log("\n── queryFiles (provider=github) ──");
+const query = await client.queryFiles(workspaceId, { provider: "github" });
+
+if (query.items.length === 0) {
+  console.log("  (no github files — try ingesting a webhook first)");
+} else {
+  for (const item of query.items.slice(0, 5)) {
+    console.log(`  ${item.path}  props=${JSON.stringify(item.properties)}`);
+  }
+}
+
+// ── 4. Query files by semantic property ─────────────────────────────────────
+
+console.log("\n── queryFiles (property status=open) ──");
+const byProp = await client.queryFiles(workspaceId, {
+  properties: { status: "open" },
+});
+
+console.log(`  matched ${byProp.items.length} file(s)`);
+for (const item of byProp.items.slice(0, 3)) {
+  console.log(`  ${item.path}`);
+}
+
+console.log("\nDone.");

--- a/examples/02-agent-writes-files/README.md
+++ b/examples/02-agent-writes-files/README.md
@@ -1,0 +1,31 @@
+# 02 — Agent writes files
+
+Write files into the relayfile virtual filesystem, then read them back.
+
+## What it shows
+
+| Method | Purpose |
+|--------|---------|
+| `writeFile` | Create or update a single file with metadata |
+| `writeFile` + `baseRevision` | Optimistic concurrency via If-Match |
+| `RevisionConflictError` | Handle 409 conflicts when a revision is stale |
+| `bulkWrite` | Atomically write multiple files in one request |
+| `readFile` | Verify written content |
+
+## Run
+
+```bash
+export RELAYFILE_TOKEN="ey…"   # JWT with fs:read + fs:write scopes
+export WORKSPACE_ID="ws_demo"
+
+npx tsx index.ts
+```
+
+## Key concepts
+
+**Optimistic locking** — pass the file's current `revision` as `baseRevision`
+to ensure your write only succeeds if the file hasn't changed since you read it.
+Use `"*"` to create-or-overwrite without checking.
+
+**Bulk writes** — `bulkWrite` writes multiple files in a single request.
+The response tells you how many succeeded and includes per-file errors.

--- a/examples/02-agent-writes-files/index.ts
+++ b/examples/02-agent-writes-files/index.ts
@@ -1,0 +1,140 @@
+/**
+ * Example 02 — Agent writes files and reads them back
+ *
+ * Demonstrates writing files into the relayfile virtual filesystem:
+ * single writes with writeFile, atomic multi-file writes with bulkWrite,
+ * and reading files back to verify.
+ *
+ * Run:  npx tsx index.ts
+ * Env:  RELAYFILE_TOKEN  — JWT with fs:read + fs:write scopes
+ *       WORKSPACE_ID     — target workspace ID
+ */
+
+import { RelayFileClient, RevisionConflictError } from "@relayfile/sdk";
+
+const token = process.env.RELAYFILE_TOKEN;
+const workspaceId = process.env.WORKSPACE_ID ?? "ws_demo";
+
+if (!token) {
+  console.error("Set RELAYFILE_TOKEN before running this example.");
+  process.exit(1);
+}
+
+const client = new RelayFileClient({ token });
+
+// ── 1. Write a single file ──────────────────────────────────────────────────
+
+console.log("── writeFile /agents/summariser/config.json ──");
+
+const writeResult = await client.writeFile({
+  workspaceId,
+  path: "/agents/summariser/config.json",
+  baseRevision: "*", // create-or-overwrite
+  content: JSON.stringify(
+    {
+      name: "summariser",
+      model: "claude-sonnet-4-6",
+      maxTokens: 4096,
+      schedule: "on-webhook",
+    },
+    null,
+    2
+  ),
+  contentType: "application/json",
+  semantics: {
+    properties: { owner: "platform-team", env: "staging" },
+    relations: ["agent:summariser"],
+  },
+});
+
+console.log(`  opId     : ${writeResult.opId}`);
+console.log(`  revision : ${writeResult.targetRevision}`);
+
+// ── 2. Read it back ─────────────────────────────────────────────────────────
+
+console.log("\n── readFile /agents/summariser/config.json ──");
+const file = await client.readFile(
+  workspaceId,
+  "/agents/summariser/config.json"
+);
+console.log(`  revision : ${file.revision}`);
+console.log(`  content  : ${file.content}`);
+
+// ── 3. Optimistic update (If-Match) ────────────────────────────────────────
+
+console.log("\n── writeFile with If-Match (optimistic update) ──");
+
+const updated = JSON.parse(file.content);
+updated.maxTokens = 8192;
+
+const updateResult = await client.writeFile({
+  workspaceId,
+  path: "/agents/summariser/config.json",
+  baseRevision: file.revision, // only succeeds if nobody else changed it
+  content: JSON.stringify(updated, null, 2),
+  contentType: "application/json",
+});
+
+console.log(`  new revision : ${updateResult.targetRevision}`);
+
+// ── 4. Demonstrate conflict detection ───────────────────────────────────────
+
+console.log("\n── writeFile with stale revision (expect 409) ──");
+
+try {
+  await client.writeFile({
+    workspaceId,
+    path: "/agents/summariser/config.json",
+    baseRevision: file.revision, // stale — already updated above
+    content: '{"stale": true}',
+    contentType: "application/json",
+  });
+} catch (err) {
+  if (err instanceof RevisionConflictError) {
+    console.log(`  Caught RevisionConflictError`);
+    console.log(`    expected : ${err.expectedRevision}`);
+    console.log(`    current  : ${err.currentRevision}`);
+  } else {
+    throw err;
+  }
+}
+
+// ── 5. Bulk write multiple files atomically ─────────────────────────────────
+
+console.log("\n── bulkWrite 3 analysis files ──");
+
+const bulkResult = await client.bulkWrite({
+  workspaceId,
+  files: [
+    {
+      path: "/analysis/2026-03-29/sentiment.json",
+      content: JSON.stringify({ score: 0.82, label: "positive" }),
+      contentType: "application/json",
+    },
+    {
+      path: "/analysis/2026-03-29/topics.json",
+      content: JSON.stringify({ topics: ["auth", "performance", "ux"] }),
+      contentType: "application/json",
+    },
+    {
+      path: "/analysis/2026-03-29/summary.md",
+      content:
+        "# Daily Summary\n\nSentiment is positive. Key topics: auth, performance, UX.",
+      contentType: "text/markdown",
+    },
+  ],
+});
+
+console.log(`  written    : ${bulkResult.written}`);
+console.log(`  errorCount : ${bulkResult.errorCount}`);
+
+// ── 6. Read back a bulk-written file ────────────────────────────────────────
+
+console.log("\n── readFile /analysis/2026-03-29/summary.md ──");
+const summary = await client.readFile(
+  workspaceId,
+  "/analysis/2026-03-29/summary.md"
+);
+console.log(`  content:\n${summary.content}`);
+
+console.log("\nDone.");

--- a/examples/03-webhook-to-vfs/README.md
+++ b/examples/03-webhook-to-vfs/README.md
@@ -1,0 +1,36 @@
+# 03 — Webhook to VFS
+
+Ingest external webhooks into the relayfile virtual filesystem.
+
+## What it shows
+
+| Concept | Purpose |
+|---------|---------|
+| `computeCanonicalPath` | Map provider objects to deterministic file paths |
+| `ingestWebhook` | Push external events (GitHub, Slack, etc.) into the VFS |
+| `readFile` | Read back the ingested data as a file |
+
+## Run
+
+```bash
+export RELAYFILE_TOKEN="ey…"   # JWT with sync:trigger + fs:read scopes
+export WORKSPACE_ID="ws_demo"
+
+npx tsx index.ts
+```
+
+## How it works
+
+```
+GitHub webhook ──► ingestWebhook ──► /github/pulls/42.json
+                                         │
+                   readFile ◄────────────┘
+```
+
+`computeCanonicalPath("github", "pulls", "42")` always returns
+`/github/pulls/42.json` — every agent reading or writing that PR
+agrees on the same path, making collaboration deterministic.
+
+The webhook payload is queued as an **envelope**. The server deduplicates
+by `delivery_id`, coalesces rapid updates, and writes the final content
+to the canonical path.

--- a/examples/03-webhook-to-vfs/index.ts
+++ b/examples/03-webhook-to-vfs/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Example 03 — Webhook ingestion into the virtual filesystem
+ *
+ * Demonstrates how external events (e.g. a GitHub pull request) flow into
+ * relayfile via ingestWebhook, and how computeCanonicalPath maps provider
+ * objects to deterministic file paths.
+ *
+ * Run:  npx tsx index.ts
+ * Env:  RELAYFILE_TOKEN  — JWT with sync:trigger + fs:read scopes
+ *       WORKSPACE_ID     — target workspace ID
+ */
+
+import {
+  RelayFileClient,
+  computeCanonicalPath,
+} from "@relayfile/sdk";
+
+const token = process.env.RELAYFILE_TOKEN;
+const workspaceId = process.env.WORKSPACE_ID ?? "ws_demo";
+
+if (!token) {
+  console.error("Set RELAYFILE_TOKEN before running this example.");
+  process.exit(1);
+}
+
+const client = new RelayFileClient({ token });
+
+// ── 1. Show canonical path mapping ──────────────────────────────────────────
+
+console.log("── computeCanonicalPath examples ──");
+
+const paths = [
+  computeCanonicalPath("github", "pulls", "42"),
+  computeCanonicalPath("github", "issues", "108"),
+  computeCanonicalPath("slack", "messages", "C04QZ1234-1711700000.000100"),
+  computeCanonicalPath("zendesk", "tickets", "98765"),
+  computeCanonicalPath("stripe", "invoices", "inv_abc123"),
+];
+
+for (const p of paths) {
+  console.log(`  ${p}`);
+}
+
+// ── 2. Ingest a GitHub PR webhook ───────────────────────────────────────────
+
+console.log("\n── ingestWebhook (GitHub PR opened) ──");
+
+const prPayload = {
+  provider: "github",
+  event_type: "pull_request.opened",
+  path: computeCanonicalPath("github", "pulls", "42"),
+  delivery_id: `ghd_${Date.now()}`,
+  timestamp: new Date().toISOString(),
+  data: {
+    number: 42,
+    title: "Add JWT auth middleware",
+    state: "open",
+    user: { login: "khaliqgant" },
+    head: { ref: "feat/jwt-auth", sha: "a1b2c3d" },
+    base: { ref: "main", sha: "e4f5g6h" },
+    body: "Implements JWT-based auth with refresh tokens.\n\nCloses #37",
+    created_at: "2026-03-29T10:00:00Z",
+    updated_at: "2026-03-29T10:00:00Z",
+    labels: [{ name: "auth" }, { name: "security" }],
+    requested_reviewers: [{ login: "reviewer-1" }],
+  },
+};
+
+const ingestResult = await client.ingestWebhook({
+  workspaceId,
+  ...prPayload,
+});
+
+console.log(`  status        : ${ingestResult.status}`);
+console.log(`  envelopeId    : ${ingestResult.id}`);
+console.log(`  correlationId : ${ingestResult.correlationId}`);
+
+// ── 3. Ingest a second event (PR review submitted) ──────────────────────────
+
+console.log("\n── ingestWebhook (GitHub PR review submitted) ──");
+
+const reviewResult = await client.ingestWebhook({
+  workspaceId,
+  provider: "github",
+  event_type: "pull_request_review.submitted",
+  path: computeCanonicalPath("github", "pull_reviews", "42-1"),
+  delivery_id: `ghd_${Date.now()}_review`,
+  data: {
+    pull_number: 42,
+    review_id: 1,
+    state: "approved",
+    user: { login: "reviewer-1" },
+    body: "LGTM — auth flow looks solid.",
+    submitted_at: "2026-03-29T11:30:00Z",
+  },
+});
+
+console.log(`  envelopeId : ${reviewResult.id}`);
+
+// ── 4. Read the ingested file back ──────────────────────────────────────────
+
+console.log("\n── readFile (the ingested PR) ──");
+
+// Give the server a moment to process the envelope
+await new Promise((r) => setTimeout(r, 1000));
+
+try {
+  const pr = await client.readFile(
+    workspaceId,
+    computeCanonicalPath("github", "pulls", "42")
+  );
+  console.log(`  revision    : ${pr.revision}`);
+  console.log(`  provider    : ${pr.provider}`);
+  console.log(`  contentType : ${pr.contentType}`);
+
+  const data = JSON.parse(pr.content);
+  console.log(`  PR title    : ${data.title}`);
+  console.log(`  PR state    : ${data.state}`);
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  console.log(`  (file not yet available — ${msg})`);
+  console.log("  This is normal if the server is still processing the envelope.");
+}
+
+console.log("\nDone.");

--- a/examples/04-realtime-events/README.md
+++ b/examples/04-realtime-events/README.md
@@ -1,0 +1,49 @@
+# 04 — Realtime events
+
+Watch for file changes in a workspace using event polling.
+
+## What it shows
+
+| Concept | Purpose |
+|---------|---------|
+| `getEvents` | Fetch filesystem events with cursor-based pagination |
+| Cursor tracking | Resume from where you left off — never miss an event |
+| Provider filtering | Watch only events from a specific provider |
+
+## Run
+
+```bash
+export RELAYFILE_TOKEN="ey…"   # JWT with fs:read scope
+export WORKSPACE_ID="ws_demo"
+
+npx tsx index.ts
+```
+
+## Event types
+
+| Type | Trigger |
+|------|---------|
+| `file.created` | New file written or ingested |
+| `file.updated` | Existing file content changed |
+| `file.deleted` | File removed |
+| `dir.created` | New directory created |
+| `dir.deleted` | Directory removed |
+| `sync.error` | Provider sync failure |
+
+## Polling pattern
+
+```typescript
+let cursor: string | undefined;
+
+while (true) {
+  const feed = await client.getEvents(workspaceId, { cursor, limit: 50 });
+  for (const evt of feed.events) {
+    // handle event
+  }
+  cursor = feed.nextCursor;
+  await sleep(2000);
+}
+```
+
+Save `cursor` to disk if your agent restarts — you'll pick up exactly
+where you left off with no duplicates.

--- a/examples/04-realtime-events/index.ts
+++ b/examples/04-realtime-events/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Example 04 — Watch for file changes via event polling
+ *
+ * Demonstrates how an agent can watch for filesystem changes using the
+ * getEvents polling API. Events are delivered in order with cursor-based
+ * pagination, so you never miss a change.
+ *
+ * Run:  npx tsx index.ts
+ * Env:  RELAYFILE_TOKEN  — JWT with fs:read scope
+ *       WORKSPACE_ID     — target workspace ID
+ */
+
+import { RelayFileClient, type FilesystemEvent } from "@relayfile/sdk";
+
+const token = process.env.RELAYFILE_TOKEN;
+const workspaceId = process.env.WORKSPACE_ID ?? "ws_demo";
+
+if (!token) {
+  console.error("Set RELAYFILE_TOKEN before running this example.");
+  process.exit(1);
+}
+
+const client = new RelayFileClient({ token });
+
+// ── 1. Fetch recent events ──────────────────────────────────────────────────
+
+console.log("── getEvents (last 10) ──");
+
+const initial = await client.getEvents(workspaceId, { limit: 10 });
+
+if (initial.events.length === 0) {
+  console.log("  (no events yet — write some files first)");
+} else {
+  for (const evt of initial.events) {
+    printEvent(evt);
+  }
+}
+
+// ── 2. Poll for new events ──────────────────────────────────────────────────
+
+console.log("\n── polling for new events (3 rounds, 2s apart) ──");
+
+let cursor = initial.nextCursor;
+const POLL_ROUNDS = 3;
+const POLL_INTERVAL_MS = 2000;
+
+for (let round = 1; round <= POLL_ROUNDS; round++) {
+  await sleep(POLL_INTERVAL_MS);
+  console.log(`\n  [poll ${round}/${POLL_ROUNDS}]`);
+
+  const feed = await client.getEvents(workspaceId, { cursor, limit: 20 });
+
+  if (feed.events.length === 0) {
+    console.log("    (no new events)");
+  } else {
+    for (const evt of feed.events) {
+      printEvent(evt);
+    }
+  }
+
+  cursor = feed.nextCursor;
+}
+
+// ── 3. Filter events by provider ────────────────────────────────────────────
+
+console.log("\n── getEvents (provider=github) ──");
+
+const githubEvents = await client.getEvents(workspaceId, {
+  provider: "github",
+  limit: 5,
+});
+
+if (githubEvents.events.length === 0) {
+  console.log("  (no github events)");
+} else {
+  for (const evt of githubEvents.events) {
+    printEvent(evt);
+  }
+}
+
+console.log("\nDone.");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function printEvent(evt: FilesystemEvent) {
+  const ts = new Date(evt.timestamp).toLocaleTimeString();
+  console.log(
+    `    ${ts}  ${padRight(evt.type, 14)}  ${evt.path}  (${evt.origin})`
+  );
+}
+
+function padRight(s: string, len: number): string {
+  return s.length >= len ? s : s + " ".repeat(len - s.length);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/examples/05-relayauth-scoped-agent/README.md
+++ b/examples/05-relayauth-scoped-agent/README.md
@@ -1,0 +1,61 @@
+# 05 — Scoped agent permissions
+
+Demonstrate how relayfile tokens restrict agent access with path-based scopes.
+
+## What it shows
+
+| Concept | Purpose |
+|---------|---------|
+| Path-scoped tokens | `fs:read:/github/*` limits reads to one subtree |
+| Write rejection | A read-only scope blocks writes with 403 |
+| Cross-path rejection | Reading outside the allowed path returns 403 |
+| `RelayFileApiError` | Catch and inspect permission errors |
+
+## Run
+
+```bash
+# Generate scoped tokens with relayauth
+export RELAYFILE_TOKEN_SCOPED=$(relayauth sign \
+  --workspace ws_demo --agent reader \
+  --scope "fs:read:/github/*")
+
+export RELAYFILE_TOKEN_ADMIN=$(relayauth sign \
+  --workspace ws_demo --agent admin \
+  --scope "fs:read" --scope "fs:write")
+
+export WORKSPACE_ID="ws_demo"
+
+npx tsx index.ts
+```
+
+## Scope format
+
+```
+plane:resource:action:path
+```
+
+| Scope | Grants |
+|-------|--------|
+| `fs:read` | Read all files |
+| `fs:write` | Write all files |
+| `fs:read:/github/*` | Read only `/github/` subtree |
+| `fs:write:/reports/*` | Write only `/reports/` subtree |
+| `sync:trigger` | Ingest webhooks, trigger syncs |
+| `ops:read` | View operation status |
+
+## Token claims
+
+A relayfile JWT contains:
+
+```json
+{
+  "workspace_id": "ws_demo",
+  "agent_name": "reader",
+  "scopes": ["fs:read:/github/*"],
+  "aud": "relayfile",
+  "exp": 1743300000
+}
+```
+
+The server checks scopes on every request — agents can only access
+what their token explicitly allows.

--- a/examples/05-relayauth-scoped-agent/index.ts
+++ b/examples/05-relayauth-scoped-agent/index.ts
@@ -1,0 +1,145 @@
+/**
+ * Example 05 — Agent with scoped permissions
+ *
+ * Demonstrates how relayfile tokens restrict agent access using scopes.
+ * A token scoped to `fs:read:/github/*` can read GitHub files but cannot
+ * write to any path, and cannot read files outside /github/.
+ *
+ * This example uses two clients:
+ *   1. A scoped "reader" agent — can only read /github/*
+ *   2. A full-access "admin" agent — can read and write everything
+ *
+ * Run:  npx tsx index.ts
+ * Env:  RELAYFILE_TOKEN_SCOPED  — JWT with scope fs:read:/github/*
+ *       RELAYFILE_TOKEN_ADMIN   — JWT with scopes fs:read + fs:write
+ *       WORKSPACE_ID            — target workspace ID
+ */
+
+import { RelayFileClient, RelayFileApiError } from "@relayfile/sdk";
+
+const scopedToken = process.env.RELAYFILE_TOKEN_SCOPED;
+const adminToken = process.env.RELAYFILE_TOKEN_ADMIN;
+const workspaceId = process.env.WORKSPACE_ID ?? "ws_demo";
+
+if (!scopedToken || !adminToken) {
+  console.error(
+    "Set both RELAYFILE_TOKEN_SCOPED and RELAYFILE_TOKEN_ADMIN before running."
+  );
+  console.error("");
+  console.error("Generate tokens with relayauth:");
+  console.error(
+    '  Scoped:  relayauth sign --workspace ws_demo --agent reader --scope "fs:read:/github/*"'
+  );
+  console.error(
+    '  Admin:   relayauth sign --workspace ws_demo --agent admin --scope "fs:read" --scope "fs:write"'
+  );
+  process.exit(1);
+}
+
+const scopedClient = new RelayFileClient({ token: scopedToken });
+const adminClient = new RelayFileClient({ token: adminToken });
+
+// ── 1. Admin writes a file the scoped agent can read ────────────────────────
+
+console.log("── admin: writeFile /github/pulls/99.json ──");
+
+await adminClient.writeFile({
+  workspaceId,
+  path: "/github/pulls/99.json",
+  baseRevision: "*",
+  content: JSON.stringify(
+    {
+      number: 99,
+      title: "Upgrade to Node 22",
+      state: "open",
+      user: { login: "khaliqgant" },
+    },
+    null,
+    2
+  ),
+  contentType: "application/json",
+  semantics: {
+    properties: { status: "open", priority: "high" },
+    relations: ["repo:relayfile"],
+  },
+});
+
+console.log("  written.");
+
+// ── 2. Scoped agent reads /github/* — should succeed ────────────────────────
+
+console.log("\n── scoped agent: readFile /github/pulls/99.json ──");
+
+const pr = await scopedClient.readFile(
+  workspaceId,
+  "/github/pulls/99.json"
+);
+console.log(`  title    : ${JSON.parse(pr.content).title}`);
+console.log(`  revision : ${pr.revision}`);
+
+// ── 3. Scoped agent lists /github tree — should succeed ─────────────────────
+
+console.log("\n── scoped agent: listTree /github ──");
+
+const tree = await scopedClient.listTree(workspaceId, { path: "/github" });
+
+for (const entry of tree.entries) {
+  console.log(`  ${entry.type === "dir" ? "📁" : "📄"} ${entry.path}`);
+}
+
+// ── 4. Scoped agent tries to write — expect 403 ────────────────────────────
+
+console.log("\n── scoped agent: writeFile (expect 403 Forbidden) ──");
+
+try {
+  await scopedClient.writeFile({
+    workspaceId,
+    path: "/github/pulls/99.json",
+    baseRevision: "*",
+    content: '{"hijacked": true}',
+    contentType: "application/json",
+  });
+  console.log("  ERROR: write should have been rejected!");
+} catch (err) {
+  if (err instanceof RelayFileApiError && err.status === 403) {
+    console.log(`  Blocked: ${err.message}`);
+    console.log("  (scope fs:read:/github/* does not grant write access)");
+  } else {
+    throw err;
+  }
+}
+
+// ── 5. Scoped agent tries to read outside /github — expect 403 ─────────────
+
+console.log("\n── scoped agent: readFile /agents/config.json (expect 403) ──");
+
+// First, make sure the file exists
+await adminClient.writeFile({
+  workspaceId,
+  path: "/agents/config.json",
+  baseRevision: "*",
+  content: '{"secret": "do-not-leak"}',
+  contentType: "application/json",
+});
+
+try {
+  await scopedClient.readFile(workspaceId, "/agents/config.json");
+  console.log("  ERROR: read should have been rejected!");
+} catch (err) {
+  if (err instanceof RelayFileApiError && err.status === 403) {
+    console.log(`  Blocked: ${err.message}`);
+    console.log("  (scope fs:read:/github/* does not cover /agents/)");
+  } else {
+    throw err;
+  }
+}
+
+// ── Summary ─────────────────────────────────────────────────────────────────
+
+console.log("\n── Summary ──");
+console.log("  Scoped token (fs:read:/github/*):");
+console.log("    ✓ Read  /github/pulls/99.json");
+console.log("    ✓ List  /github/");
+console.log("    ✗ Write /github/pulls/99.json  → 403");
+console.log("    ✗ Read  /agents/config.json    → 403");
+console.log("\nDone.");

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,43 @@
+# relayfile SDK examples
+
+End-to-end examples showing how agents interact with the relayfile virtual filesystem.
+
+## Prerequisites
+
+```bash
+npm install @relayfile/sdk
+npm install -D tsx
+```
+
+Each example reads configuration from environment variables:
+
+```bash
+export RELAYFILE_TOKEN="ey…"   # JWT for your agent
+export WORKSPACE_ID="ws_demo"  # target workspace
+```
+
+Generate tokens with [relayauth](https://github.com/AgentWorkforce/relayauth):
+
+```bash
+relayauth sign --workspace ws_demo --agent my-agent --scope "fs:read" --scope "fs:write"
+```
+
+## Examples
+
+| # | Directory | What it shows |
+|---|-----------|---------------|
+| 01 | [agent-reads-files](./01-agent-reads-files/) | `listTree`, `readFile`, `queryFiles` — browse a workspace |
+| 02 | [agent-writes-files](./02-agent-writes-files/) | `writeFile`, `bulkWrite`, optimistic locking, conflict detection |
+| 03 | [webhook-to-vfs](./03-webhook-to-vfs/) | `ingestWebhook`, `computeCanonicalPath` — external events to files |
+| 04 | [realtime-events](./04-realtime-events/) | `getEvents` polling — watch for file changes with cursors |
+| 05 | [relayauth-scoped-agent](./05-relayauth-scoped-agent/) | Path-scoped tokens, 403 rejection, least-privilege agents |
+
+## Running
+
+```bash
+cd examples/01-agent-reads-files
+npx tsx index.ts
+```
+
+Each example is self-contained — run them in any order.
+Examples 01 and 04 are read-only; the others write data.


### PR DESCRIPTION
## Examples

1. **Agent reads files** — listTree, readFile, queryFiles
2. **Agent writes files** — writeFile, bulkWrite, optimistic locking
3. **Webhook to VFS** — ingestWebhook, computeCanonicalPath
4. **Realtime events** — getEvents polling with cursors
5. **Relayauth scoped agent** — scoped tokens, 403 on unauthorized access

Each example is runnable with `npx tsx` and has its own README.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
