### PR TITLE
feat: add shared ConnectionProvider interface to SDK

### DIFF
--- a/packages/sdk/typescript/src/connection.ts
+++ b/packages/sdk/typescript/src/connection.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared ConnectionProvider interface and related types.
+ *
+ * These types are the contract every provider package must implement.
+ */
+
+export type ProxyMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+export type ProxyHeaders = Record<string, string>;
+export type ProxyQuery = Record<string, string>;
+
+/** Request sent through a connection provider's proxy. */
+export interface ProxyRequest {
+  method: ProxyMethod;
+  /** Base API URL for the upstream service. */
+  baseUrl: string;
+  endpoint: string;
+  connectionId: string;
+  headers?: ProxyHeaders;
+  body?: unknown;
+  query?: ProxyQuery;
+}
+
+/** Response returned from a proxied request. */
+export interface ProxyResponse<T = unknown> {
+  status: number;
+  headers: ProxyHeaders;
+  data: T;
+}
+
+/** Webhook normalized into a provider-agnostic shape. */
+export interface NormalizedWebhook {
+  provider: string;
+  connectionId: string;
+  eventType: string;
+  objectType: string;
+  objectId: string;
+  payload: Record<string, unknown>;
+}
+
+/** Interface every connection provider must implement. */
+export interface ConnectionProvider {
+  readonly name: string;
+  proxy<T = unknown>(request: ProxyRequest): Promise<ProxyResponse<T>>;
+  healthCheck(connectionId: string): Promise<boolean>;
+  handleWebhook?(rawPayload: unknown): Promise<NormalizedWebhook>;
+  getConnection?(connectionId: string): Promise<Record<string, unknown>>;
+  listConnections?(): Promise<Array<Record<string, unknown>>>;
+}

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -23,6 +23,16 @@ export {
 // Integration providers
 export { IntegrationProvider, computeCanonicalPath } from "./provider.js";
 export type { WebhookInput, ListProviderFilesOptions, WatchProviderEventsOptions } from "./provider.js";
+// Connection provider contract
+export type {
+  ConnectionProvider,
+  NormalizedWebhook,
+  ProxyHeaders,
+  ProxyMethod,
+  ProxyQuery,
+  ProxyRequest,
+  ProxyResponse,
+} from "./connection.js";
 
 export type {
   AckResponse,


### PR DESCRIPTION
Extracts ConnectionProvider, ProxyRequest, ProxyResponse, NormalizedWebhook into @relayfile/sdk. Adapters depend on SDK interface, not provider packages.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
