### PR TITLE
fix: correct JWT claims, writeFile path param, auto correlation ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ External Services          relayfile             Your Agents
 RELAYFILE_JWT_SECRET=my-secret go run ./cmd/relayfile
 
 # 2. Generate a token
+export RELAYFILE_AGENT_NAME=compose-agent
 SIGNING_KEY=my-secret ./scripts/generate-dev-token.sh
 
 # 3. Mount a workspace
 relayfile mount my-workspace ./files --token $TOKEN
 ```
+
+Development tokens should include `workspace_id`, `agent_name`, and `aud: ["relayfile"]`.
 
 ## Authentication & Permissions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,13 +9,16 @@ Set these once for the examples below:
 ```bash
 export RELAYFILE_BASE_URL=http://127.0.0.1:8080
 export RELAYFILE_WORKSPACE=ws_live
+export RELAYFILE_AGENT_NAME=compose-agent
 export RELAYFILE_TOKEN="$(./scripts/generate-dev-token.sh ${RELAYFILE_WORKSPACE})"
 export RELAYFILE_CORRELATION_ID="corr_$(date +%s)"
 ```
 
+`./scripts/generate-dev-token.sh` emits a JWT with `workspace_id`, `agent_name`, and `aud: ["relayfile"]`.
+
 ## Authentication Headers
 
-Authenticated requests usually include:
+Authenticated requests require:
 
 ```bash
 -H "Authorization: Bearer ${RELAYFILE_TOKEN}" \
@@ -418,4 +421,4 @@ curl -sS -X POST \
 - Most workspace and admin endpoints use Bearer token auth.
 - The OpenAPI contract defines scope-aware auth such as `fs:read` and `fs:write`.
 - Internal ingress may use service-to-service signing in production.
-- `X-Correlation-Id` is recommended for traceability and auditability across requests.
+- `X-Correlation-Id` is required on authenticated HTTP requests and is used for traceability and auditability across requests.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -193,6 +193,8 @@ The npm wrapper package does not read environment variables in its published ins
 | `RELAYFILE_AGENT_NAME` | `compose-agent` | `agent_name` claim in the generated JWT |
 | `RELAYFILE_TOKEN_EXP` | `4102444800` | Expiration epoch written into the generated JWT |
 
+The generated JWT includes `workspace_id`, `agent_name`, and `aud: ["relayfile"]`.
+
 ### `scripts/live-e2e.sh`
 
 This script sources an env file directly. By default it reads `.env` in the repo root and will create it from `compose.env.example` if missing.

--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -75,6 +75,25 @@ def _generate_correlation_id() -> str:
     return f"rf_{int(time.time() * 1000)}_{random.getrandbits(32):08x}"
 
 
+def _merge_headers(
+    headers: dict[str, str] | None,
+    *,
+    correlation_id: str | None,
+    user_agent: str | None,
+    has_json_body: bool,
+) -> dict[str, str]:
+    base_headers: dict[str, str] = {}
+    if has_json_body:
+        base_headers["Content-Type"] = "application/json"
+    if user_agent:
+        base_headers["User-Agent"] = user_agent
+    if headers:
+        base_headers.update(headers)
+    if "X-Correlation-Id" not in base_headers:
+        base_headers["X-Correlation-Id"] = correlation_id or _generate_correlation_id()
+    return base_headers
+
+
 def _enc(segment: str) -> str:
     return quote(segment, safe="")
 
@@ -264,14 +283,12 @@ class RelayFileClient:
         json_body: Any = None,
         correlation_id: str | None = None,
     ) -> httpx.Response:
-        cid = correlation_id or _generate_correlation_id()
-        base_headers: dict[str, str] = {"X-Correlation-Id": cid}
-        if json_body is not None:
-            base_headers["Content-Type"] = "application/json"
-        if self._user_agent:
-            base_headers["User-Agent"] = self._user_agent
-        if headers:
-            base_headers.update(headers)
+        base_headers = _merge_headers(
+            headers,
+            correlation_id=correlation_id,
+            user_agent=self._user_agent,
+            has_json_body=json_body is not None,
+        )
 
         url = f"{self._base_url}{path}"
         retries = 0
@@ -383,6 +400,7 @@ class RelayFileClient:
                 "permissions": input.semantics.permissions,
                 "comments": input.semantics.comments,
             }
+        # Single-file PUT expects the target path in the query string, not the JSON body.
         return self._request(
             "PUT",
             f"/v1/workspaces/{_enc(input.workspace_id)}/fs/file{query}",
@@ -827,14 +845,12 @@ class AsyncRelayFileClient:
         correlation_id: str | None = None,
     ) -> httpx.Response:
         import asyncio
-        cid = correlation_id or _generate_correlation_id()
-        base_headers: dict[str, str] = {"X-Correlation-Id": cid}
-        if json_body is not None:
-            base_headers["Content-Type"] = "application/json"
-        if self._user_agent:
-            base_headers["User-Agent"] = self._user_agent
-        if headers:
-            base_headers.update(headers)
+        base_headers = _merge_headers(
+            headers,
+            correlation_id=correlation_id,
+            user_agent=self._user_agent,
+            has_json_body=json_body is not None,
+        )
 
         url = f"{self._base_url}{path}"
         retries = 0
@@ -951,6 +967,7 @@ class AsyncRelayFileClient:
                 "permissions": input.semantics.permissions,
                 "comments": input.semantics.comments,
             }
+        # Single-file PUT expects the target path in the query string, not the JSON body.
         return await self._request(
             "PUT",
             f"/v1/workspaces/{_enc(input.workspace_id)}/fs/file{query}",

--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -4,16 +4,25 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, TypedDict
 
 
-class RelayFileJwtClaims(TypedDict, total=False):
-    """JWT claims expected by the Relayfile API for SDK bearer tokens.
-
-    Example minting payload:
-    `{"workspace_id": "ws_123", "agent_name": "review-bot", "aud": ["relayfile"]}`
-    """
+class _RelayFileJwtClaimsRequired(TypedDict):
+    """Required JWT claims — server returns 401 if missing."""
 
     workspace_id: str
     agent_name: str
-    aud: Literal["relayfile"] | list[str]
+    aud: list[str]  # must include "relayfile"
+
+
+class RelayFileJwtClaims(_RelayFileJwtClaimsRequired, total=False):
+    """JWT claims expected by the Relayfile API for SDK bearer tokens.
+
+    Required: ``workspace_id``, ``agent_name``, ``aud``.
+    Optional: ``exp``, ``iat``, ``nbf``, ``iss``, ``sub``.
+
+    Example minting payload::
+
+        {"workspace_id": "ws_123", "agent_name": "review-bot", "aud": ["relayfile"]}
+    """
+
     exp: int
     iat: int
     nbf: int

--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -1,7 +1,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
+
+
+class RelayFileJwtClaims(TypedDict, total=False):
+    """JWT claims expected by the Relayfile API for SDK bearer tokens.
+
+    Example minting payload:
+    `{"workspace_id": "ws_123", "agent_name": "review-bot", "aud": ["relayfile"]}`
+    """
+
+    workspace_id: str
+    agent_name: str
+    aud: Literal["relayfile"] | list[str]
+    exp: int
+    iat: int
+    nbf: int
+    iss: str
+    sub: str
 
 
 ContentEncoding = Literal["utf-8", "base64"]

--- a/packages/sdk/typescript/README.md
+++ b/packages/sdk/typescript/README.md
@@ -40,6 +40,8 @@ await client.writeFile({
 });
 ```
 
+Use a relayfile JWT whose claims include `workspace_id`, `agent_name`, and `aud: ["relayfile"]`. The SDK adds `X-Correlation-Id` automatically for API calls.
+
 ## Full Docs
 
 Full documentation is available in the [relayfile docs](https://github.com/AgentWorkforce/relayfile/tree/main/docs).

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -351,7 +351,7 @@ export class RelayFileClient {
         contentType: contentType ?? "text/markdown",
         content,
         encoding,
-        semantics
+        semantics: input.semantics
       },
       signal
     });

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -45,6 +45,12 @@ import {
   RevisionConflictError
 } from "./errors.js";
 
+/**
+ * Bearer token or token factory used for Relayfile API requests.
+ *
+ * When you mint JWTs for Relayfile, the server expects claims like:
+ * `{ workspace_id: "ws_123", agent_name: "review-bot", aud: ["relayfile"] }`
+ */
 export type AccessTokenProvider = string | (() => string | Promise<string>);
 
 export interface RelayFileRetryOptions {
@@ -60,6 +66,12 @@ export const DEFAULT_RELAYFILE_BASE_URL = "https://api.relayfile.dev";
 export interface RelayFileClientOptions {
   /** API base URL. Defaults to https://api.relayfile.dev */
   baseUrl?: string;
+  /**
+   * Bearer token or token factory for SDK requests.
+   *
+   * Relayfile-authenticated JWTs should include `workspace_id`, `agent_name`,
+   * and `aud` containing `relayfile`.
+   */
   token: AccessTokenProvider;
   fetchImpl?: typeof fetch;
   userAgent?: string;
@@ -127,7 +139,20 @@ function buildQuery(params: Record<string, string | number | boolean | undefined
 }
 
 function generateCorrelationId(): string {
-  return `rf_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
+  return `rf_${crypto.randomUUID()}`;
+}
+
+function getHeaderValue(headers: Record<string, string> | undefined, name: string): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === target) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 async function resolveToken(tokenProvider: AccessTokenProvider): Promise<string> {
@@ -698,11 +723,14 @@ export class RelayFileClient {
     signal?: AbortSignal;
     accept?: string;
   }): Promise<Response> {
-    const correlationId = params.correlationId ?? generateCorrelationId();
+    const existingCorrelationId = getHeaderValue(params.headers, "X-Correlation-Id");
+    const correlationId = existingCorrelationId ?? params.correlationId ?? generateCorrelationId();
     const baseHeaders: Record<string, string> = {
-      "X-Correlation-Id": correlationId,
-      ...params.headers
+      ...(params.headers ?? {})
     };
+    if (!existingCorrelationId) {
+      baseHeaders["X-Correlation-Id"] = correlationId;
+    }
     if (params.body !== undefined) {
       baseHeaders["Content-Type"] = "application/json";
     }

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -337,21 +337,23 @@ export class RelayFileClient {
   }
 
   async writeFile(input: WriteFileInput): Promise<WriteQueuedResponse> {
-    const query = buildQuery({ path: input.path });
+    const { workspaceId, path, correlationId, baseRevision, content, contentType, encoding, semantics, signal } = input;
+    const query = buildQuery({ path });
     return this.request<WriteQueuedResponse>({
       method: "PUT",
-      path: `/v1/workspaces/${encodeURIComponent(input.workspaceId)}/fs/file${query}`,
-      correlationId: input.correlationId,
+      path: `/v1/workspaces/${encodeURIComponent(workspaceId)}/fs/file${query}`,
+      correlationId,
       headers: {
-        "If-Match": input.baseRevision
+        "If-Match": baseRevision
       },
+      // Single-file PUT expects the target path in the query string, not the JSON body.
       body: {
-        contentType: input.contentType ?? "text/markdown",
-        content: input.content,
-        encoding: input.encoding,
-        semantics: input.semantics
+        contentType: contentType ?? "text/markdown",
+        content,
+        encoding,
+        semantics
       },
-      signal: input.signal
+      signal
     });
   }
 

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -1,7 +1,9 @@
 export {
   RelayFileClient,
   DEFAULT_RELAYFILE_BASE_URL,
+  type AccessTokenProvider,
   type ConnectWebSocketOptions,
+  type RelayFileClientOptions,
   type RelayFileRetryOptions,
   type WebSocketConnection
 } from "./client.js";
@@ -87,6 +89,7 @@ export type {
   OperationStatusResponse,
   QueuedResponse,
   QueryFilesOptions,
+  RelayFileJwtClaims,
   SyncIngressStatusResponse,
   SyncProviderStatus,
   SyncProviderStatusState,

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -1,5 +1,27 @@
 export type FileNodeType = "file" | "dir";
 
+/**
+ * JWT claims expected by the Relayfile Go API when your token provider mints
+ * bearer tokens for SDK requests.
+ *
+ * Example minting payload:
+ * `const claims: RelayFileJwtClaims = { workspace_id: "ws_123", agent_name: "review-bot", aud: ["relayfile"] };`
+ */
+export interface RelayFileJwtClaims {
+  /** Workspace id the token is scoped to, for example `ws_123`. */
+  workspace_id: string;
+  /** Stable agent name presented to the Relayfile server, for example `review-bot`. */
+  agent_name: string;
+  /** Audience must contain `relayfile`. */
+  aud: "relayfile" | string[];
+  exp?: number;
+  iat?: number;
+  nbf?: number;
+  iss?: string;
+  sub?: string;
+  [claim: string]: unknown;
+}
+
 export interface TreeEntry {
   path: string;
   type: FileNodeType;

--- a/scripts/generate-dev-token.sh
+++ b/scripts/generate-dev-token.sh
@@ -12,7 +12,7 @@ b64url() {
 
 header='{"alg":"HS256","typ":"JWT"}'
 payload=$(cat <<JSON
-{"workspace_id":"${workspace_id}","agent_name":"${agent_name}","scopes":["fs:read","fs:write","sync:read","sync:trigger","ops:read","ops:replay","admin:read","admin:replay"],"exp":${exp_epoch},"aud":"relayfile"}
+{"workspace_id":"${workspace_id}","agent_name":"${agent_name}","scopes":["fs:read","fs:write","sync:read","sync:trigger","ops:read","ops:replay","admin:read","admin:replay"],"exp":${exp_epoch},"aud":["relayfile"]}
 JSON
 )
 


### PR DESCRIPTION
Fixes #26, #27, #28

**Bug 1 — JWT claim names:** Server requires `workspace_id`, `agent_name`, and `aud: ["relayfile"]`. SDK docs and examples now use correct names.

**Bug 2 — writeFile path:** Single file PUT sends path as query param (`?path=/foo`), matching server expectation. bulkWrite unchanged.

**Bug 3 — X-Correlation-Id:** SDK auto-generates `X-Correlation-Id` header (crypto.randomUUID) if not provided. Documented as required.

Also fixes Python SDK for parity.

Found during live e2e testing against the Go server.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
