### PR TITLE
fix: listTree default depth 2→10, max 10→100

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1242,7 +1242,7 @@ func (s *Server) handleTree(w http.ResponseWriter, r *http.Request, workspaceID,
 	if path == "" {
 		path = "/"
 	}
-	depth := parseBoundedInt(r.URL.Query().Get("depth"), 2, 1, 10)
+	depth := parseBoundedInt(r.URL.Query().Get("depth"), 10, 1, 100)
 	resp, err := s.store.ListTree(workspaceID, path, depth, r.URL.Query().Get("cursor"))
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not_found", err.Error(), correlationID)


### PR DESCRIPTION
Closes #28

Default depth of 2 only showed directories for typical VFS paths (7+ levels deep). Files were invisible without explicit `?depth=10`.

Found during live e2e testing. One-line Go change, all tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
