### PR TITLE
chore: allow .trajectories in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ bin/
 # Agent tool configs
 .factory/
 .gemini/
-.trajectories/
 .mcp.json
 opencode.json
 site/node_modules/


### PR DESCRIPTION
Remove .trajectories/ from .gitignore
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
