### PR TITLE
chore: automated agent rules drift update

### DIFF
--- a/.claude/rules/go-httpapi-tests.md
+++ b/.claude/rules/go-httpapi-tests.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - "internal/httpapi/**/*_test.go"
+---
+# HTTP API Test Style
+
+Write HTTP API tests as table-driven tests.
+
+Call `t.Parallel()` on the parent test and on independent subtests, and keep expectations close to the table rows they validate.

--- a/.claude/rules/typescript-esm.md
+++ b/.claude/rules/typescript-esm.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "packages/core/src/**/*.ts"
+  - "packages/sdk/typescript/src/**/*.ts"
+---
+# TypeScript ESM Imports
+
+Use explicit `.js` extensions in relative imports and exports from TypeScript source files.
+
+Keep public package surfaces centralized in `src/index.ts` when you add, rename, or remove exported modules or types.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,9 @@
+# Core Package
+
+Keep `packages/core` pure.
+
+- Do not add filesystem, network, process, or other runtime I/O in this package.
+- Inject state and persistence through `StorageAdapter` and related interfaces instead of importing concrete backends.
+- Keep the public surface exported from `src/index.ts` when you add, remove, or rename modules.
+- Preserve ESM-style relative imports with explicit `.js` extensions.
+- Verify changes with `npm run build --workspace=packages/core`, and run `npm run test --workspace=packages/core` when tests are added or changed.

--- a/packages/sdk/python/AGENTS.md
+++ b/packages/sdk/python/AGENTS.md
@@ -1,0 +1,9 @@
+# Python SDK
+
+Keep the Python SDK idiomatic and in parity with the TypeScript surface.
+
+- Prefer snake_case names for Python-specific APIs; only keep camelCase when mirroring HTTP JSON keys from the wire format.
+- Re-export public SDK symbols from `src/relayfile/__init__.py` whenever you add or remove client types, errors, or provider helpers.
+- Maintain both sync and async client behavior when adding endpoints or retry/error handling.
+- Test HTTP behavior with `pytest`, `pytest-asyncio`, `respx`, and `httpx.Response` mocks under `tests/`.
+- Verify with `pytest packages/sdk/python/tests`.

--- a/packages/sdk/typescript/AGENTS.md
+++ b/packages/sdk/typescript/AGENTS.md
@@ -1,0 +1,9 @@
+# TypeScript SDK
+
+Keep this package as an ESM SDK.
+
+- Use explicit `.js` extensions in relative TypeScript imports and exports.
+- Route public API additions and removals through `src/index.ts`; do not leave exported types or helpers stranded in leaf files.
+- Match the existing Vitest style in `src/*.test.ts` for client and sync coverage.
+- Preserve package-level build, typecheck, and publish settings in `package.json` when changing release behavior.
+- Verify with `npm run build --workspace=packages/sdk/typescript`, `npm run typecheck --workspace=packages/sdk/typescript`, and `npm run test --workspace=packages/sdk/typescript`.

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,9 @@
+# Site
+
+Keep the landing page content-driven and Astro-native.
+
+- Treat `site/CONTENT.md` as the source for page copy; update the parser in `src/pages/index.astro` when section structure changes.
+- Keep page assembly in `src/pages/index.astro` and keep `src/components/*.astro` presentational with typed `Astro.props`.
+- Use the existing Astro + Tailwind toolchain from `site/package.json`, `astro.config.mjs`, and `tailwind.config.cjs`; do not introduce React-only patterns here.
+- Preserve the current bold visual language unless the task explicitly changes the design direction.
+- Verify with `npm run build` from `site/`.

--- a/workflows/AGENTS.md
+++ b/workflows/AGENTS.md
@@ -1,0 +1,9 @@
+# Workflows
+
+Write workflow definitions in the established `@agent-relay/sdk/workflows` style.
+
+- Start each file with a header comment that states purpose and the `agent-relay run workflows/<file>.ts` entrypoint.
+- Build workflows with `workflow(...)`, then set `.description()`, `.pattern()`, `.channel()`, concurrency, and timeout before agents and steps.
+- Use deterministic steps with `captureOutput: true` when later steps interpolate that output.
+- Keep agent definitions explicit about CLI, preset, role, and working directory.
+- End files with `main().catch(...)` so failures set a non-zero exit code.


### PR DESCRIPTION
# Rules Drift Report

## Summary
- files_audited: 2
- files_with_drift: 0
- new_rules_to_add: 7

## Drift per file
### AGENTS.md
- **Status:** clean
- **Issues:**
  - None. The `Usage`, `Recording Decisions`, `Recording Reflections`, `Completing Work`, and `Compacting Trajectories` sections still map to current `trail` subcommands.
  - None. The file stays focused on one repo-wide concern and is not the kind of monolithic mixed-topic rule file the skill recommends splitting into `.claude/rules/*.md`.
- **Proposed edits:**
  - None.

### CLAUDE.md
- **Status:** clean
- **Issues:**
  - None. The file contains the same current `trail` guidance as `AGENTS.md` and does not reference removed files, stale commands, or broken links.
  - None. The content is narrowly scoped to trajectory logging, so the skill does not indicate it should be decomposed into modular `.claude/rules/*.md` files.
- **Proposed edits:**
  - None.

## New rules to add
### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/packages/core/AGENTS.md
- **Kind:** AGENTS.md
- **Rule:** Keep `packages/core` pure and interface-driven; never add runtime I/O or concrete storage backends in this package.
- **Body:**
```md
# Core Package

Keep `packages/core` pure.

- Do not add filesystem, network, process, or other runtime I/O in this package.
- Inject state and persistence through `StorageAdapter` and related interfaces instead of importing concrete backends.
- Keep the public surface exported from `src/index.ts` when you add, remove, or rename modules.
- Preserve ESM-style relative imports with explicit `.js` extensions.
- Verify changes with `npm run build --workspace=packages/core`, and run `npm run test --workspace=packages/core` when tests are added or changed.
```
- **Evidence:** `packages/core/src/index.ts` says `"Pure functions. No I/O. No runtime dependencies. Storage is injected via the StorageAdapter interface."`; `packages/core/package.json` uses `"build": "tsc"` and `"test": "vitest run"`.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/packages/sdk/typescript/AGENTS.md
- **Kind:** AGENTS.md
- **Rule:** Keep the TypeScript SDK as an ESM package with a centralized export surface and Vitest-backed behavior tests.
- **Body:**
```md
# TypeScript SDK

Keep this package as an ESM SDK.

- Use explicit `.js` extensions in relative TypeScript imports and exports.
- Route public API additions and removals through `src/index.ts`; do not leave exported types or helpers stranded in leaf files.
- Match the existing Vitest style in `src/*.test.ts` for client and sync coverage.
- Preserve package-level build, typecheck, and publish settings in `package.json` when changing release behavior.
- Verify with `npm run build --workspace=packages/sdk/typescript`, `npm run typecheck --workspace=packages/sdk/typescript`, and `npm run test --workspace=packages/sdk/typescript`.
```
- **Evidence:** `packages/sdk/typescript/package.json` sets `"type": "module"` with `build`, `typecheck`, and `test` scripts; `packages/sdk/typescript/src/index.ts` centralizes exports; `packages/sdk/typescript/src/client.test.ts` uses `vitest`.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/packages/sdk/python/AGENTS.md
- **Kind:** AGENTS.md
- **Rule:** Keep the Python SDK idiomatic, re-exported from `src/relayfile/__init__.py`, and in sync between sync and async client surfaces.
- **Body:**
```md
# Python SDK

Keep the Python SDK idiomatic and in parity with the TypeScript surface.

- Prefer snake_case names for Python-specific APIs; only keep camelCase when mirroring HTTP JSON keys from the wire format.
- Re-export public SDK symbols from `src/relayfile/__init__.py` whenever you add or remove client types, errors, or provider helpers.
- Maintain both sync and async client behavior when adding endpoints or retry/error handling.
- Test HTTP behavior with `pytest`, `pytest-asyncio`, `respx`, and `httpx.Response` mocks under `tests/`.
- Verify with `pytest packages/sdk/python/tests`.
```
- **Evidence:** `packages/sdk/python/src/relayfile/__init__.py` re-exports the package surface; `packages/sdk/python/src/relayfile/client.py` defines sync and async token providers plus retry helpers; `packages/sdk/python/tests/test_client.py` uses `pytest`, `pytest-asyncio`, and `respx`; `packages/sdk/python/pyproject.toml` declares those dev dependencies.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/site/AGENTS.md
- **Kind:** AGENTS.md
- **Rule:** Keep the site Astro-native and content-driven; treat `site/CONTENT.md` as the source for copy and keep components presentational.
- **Body:**
```md
# Site

Keep the landing page content-driven and Astro-native.

- Treat `site/CONTENT.md` as the source for page copy; update the parser in `src/pages/index.astro` when section structure changes.
- Keep page assembly in `src/pages/index.astro` and keep `src/components/*.astro` presentational with typed `Astro.props`.
- Use the existing Astro + Tailwind toolchain from `site/package.json`, `astro.config.mjs`, and `tailwind.config.cjs`; do not introduce React-only patterns here.
- Preserve the current bold visual language unless the task explicitly changes the design direction.
- Verify with `npm run build` from `site/`.
```
- **Evidence:** `site/src/pages/index.astro` reads `../../CONTENT.md` with `fs.readFileSync(...)`; `site/src/components/Hero.astro` defines typed `Props` and renders from `Astro.props`; `site/package.json` uses `astro` and `tailwindcss`.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/workflows/AGENTS.md
- **Kind:** AGENTS.md
- **Rule:** Write workflow files in the established `@agent-relay/sdk/workflows` style with explicit metadata, deterministic steps, and non-zero exit handling.
- **Body:**
```md
# Workflows

Write workflow definitions in the established `@agent-relay/sdk/workflows` style.

- Start each file with a header comment that states purpose and the `agent-relay run workflows/<file>.ts` entrypoint.
- Build workflows with `workflow(...)`, then set `.description()`, `.pattern()`, `.channel()`, concurrency, and timeout before agents and steps.
- Use deterministic steps with `captureOutput: true` when later steps interpolate that output.
- Keep agent definitions explicit about CLI, preset, role, and working directory.
- End files with `main().catch(...)` so failures set a non-zero exit code.
```
- **Evidence:** `workflows/relayfile-ci-and-publish.ts` starts with a run header, uses `workflow(...)`, `.pattern('dag')`, `.channel(...)`, agents, and deterministic `captureOutput` steps; `workflows/sdk-reorg.ts` follows the same builder pattern and ends with `main().catch(...)`.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/.claude/rules/typescript-esm.md
- **Kind:** .claude/rules/<topic>.md
- **Rule:** Use explicit `.js` extensions in TypeScript relative imports and keep package export barrels updated whenever public modules change.
- **Body:**
```md
---
paths:
  - "packages/core/src/**/*.ts"
  - "packages/sdk/typescript/src/**/*.ts"
---
# TypeScript ESM Imports

Use explicit `.js` extensions in relative imports and exports from TypeScript source files.

Keep public package surfaces centralized in `src/index.ts` when you add, rename, or remove exported modules or types.
```
- **Evidence:** `packages/core/src/index.ts` exports `./files.js`, `./acl.js`, and other `.js` paths; `packages/sdk/typescript/src/client.ts` imports `./types.js` and `./errors.js`; `packages/sdk/typescript/src/index.ts` centralizes the SDK export surface.

### /Users/khaliqgant/Projects/AgentWorkforce/relayfile/.claude/rules/go-httpapi-tests.md
- **Kind:** .claude/rules/<topic>.md
- **Rule:** Write `internal/httpapi` tests as table-driven tests with `t.Parallel()` on the parent test and independent subtests.
- **Body:**
```md
---
paths:
  - "internal/httpapi/**/*_test.go"
---
# HTTP API Test Style

Write HTTP API tests as table-driven tests.

Call `t.Parallel()` on the parent test and on independent subtests, and keep expectations close to the table rows they validate.
```
- **Evidence:** `internal/httpapi/auth_test.go` uses table rows plus `t.Parallel()` in the parent test and subtests; `internal/httpapi/acl_test.go` follows the same pattern with `tests := []struct { ... }` and parallel subtests.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
