### PR TITLE
chore: AGENTS.md drift edits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,13 @@ npx trail start "Task description"
 
 ## When Starting Work
 
-Start a trajectory when beginning a task:
+Check the current trajectory before starting a new one:
+
+```bash
+trail status
+```
+
+If no trajectory is active, start one when beginning a task:
 
 ```bash
 trail start "Implement user authentication"
@@ -26,6 +32,19 @@ trail start "Implement user authentication"
 With external task reference:
 ```bash
 trail start "Fix login bug" --task "ENG-123"
+```
+
+If `trail status` shows an active trajectory, keep recording work in that trajectory instead of starting another one. Automated runs such as `agent-relay run` may already have an inherited trajectory open.
+
+For an automated run that inherits an active trajectory:
+```bash
+trail decision "Continuing work in inherited workflow trajectory"
+
+trail reflect "Applied the assigned rule updates inside the active trajectory" \
+  --confidence 0.8
+
+trail complete --summary "Finished the assigned rule-file update in the inherited trajectory" \
+  --confidence 0.85
 ```
 
 ## Recording Decisions


### PR DESCRIPTION
Automated AGENTS.md drift edits from a re-run of the maintain-agent-rules workflow.

Companion to #36 — that PR added 5 subdirectory AGENTS.md files and 2 `.claude/rules/*.md` files. This PR covers the root AGENTS.md edits the writer produced on the subsequent re-run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
