### PR TITLE
fix(sdk): bind fetch to globalThis for Cloudflare Workers

### DIFF
--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -281,7 +281,7 @@ export class RelayFileClient {
   constructor(options: RelayFileClientOptions) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_RELAYFILE_BASE_URL).replace(/\/+$/, "");
     this.tokenProvider = options.token;
-    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.fetchImpl = options.fetchImpl ?? fetch.bind(globalThis);
     this.userAgent = options.userAgent;
     this.retryOptions = normalizeRetryOptions(options.retry);
   }


### PR DESCRIPTION
## Summary
- Fixes "Illegal invocation" error when `RelayFileClient` is used in Cloudflare Workers
- The default `fetch` was stored as `this.fetchImpl` without preserving its `this` binding, causing Cloudflare Workers to throw when calling it as a method
- Fix: `fetch.bind(globalThis)` at construction time

## Context
Sage's `SageRelayFileReader.listGitHubRepos()` was failing with:
```
Illegal invocation: function called with incorrect `this` reference
```
This prevented Sage from reading the relayfile VFS entirely.

## Test plan
- [ ] Verify Sage no longer throws "Illegal invocation" when reading from relayfile
- [ ] Verify SDK still works in Node.js environments (fetch.bind is a no-op there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
