### PR TITLE
feat(cli): support default workspace selection

### DIFF
--- a/.trajectories/completed/2026-04/traj_mq8gu25evmdu.json
+++ b/.trajectories/completed/2026-04/traj_mq8gu25evmdu.json
@@ -1,0 +1,77 @@
+{
+  "id": "traj_mq8gu25evmdu",
+  "version": 1,
+  "task": {
+    "title": "Add relayfile CLI default workspace support"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T12:14:00.283Z",
+  "completedAt": "2026-04-17T12:24:48.149Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T12:16:24.231Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_5bzvleheiq6n",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T12:16:24.231Z",
+      "endedAt": "2026-04-17T12:24:48.149Z",
+      "events": [
+        {
+          "ts": 1776428184231,
+          "type": "decision",
+          "content": "Support active workspace resolution in CLI commands and workspace list fallback: Support active workspace resolution in CLI commands and workspace list fallback",
+          "raw": {
+            "question": "Support active workspace resolution in CLI commands and workspace list fallback",
+            "chosen": "Support active workspace resolution in CLI commands and workspace list fallback",
+            "alternatives": [],
+            "reasoning": "Remote workspace listing requires admin scopes; for scoped agent tokens, the CLI should still show and use the active workspace from RELAYFILE_WORKSPACE or token claims."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1776428367744,
+          "type": "reflection",
+          "content": "CLI default workspace implementation is in progress; key behavior is explicit workspace first, then RELAYFILE_WORKSPACE, token workspace claim, and stored default.",
+          "raw": {
+            "confidence": 0.75
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.75"
+          ]
+        },
+        {
+          "ts": 1776428674926,
+          "type": "decision",
+          "content": "Workspace list fallback prints active workspace before local catalog entries: Workspace list fallback prints active workspace before local catalog entries",
+          "raw": {
+            "question": "Workspace list fallback prints active workspace before local catalog entries",
+            "chosen": "Workspace list fallback prints active workspace before local catalog entries",
+            "alternatives": [],
+            "reasoning": "Scoped remote tokens may not authorize admin workspace listing, so the CLI should surface the active env/token workspace ahead of stale local catalog entries."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added relayfile CLI default workspace selection with workspace use, env/token/catalog resolution, active workspace list fallback, docs, and tests.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "7a0b06735555fb78f3698b8bdd049f0ce002ee1a",
+    "endRef": "7a0b06735555fb78f3698b8bdd049f0ce002ee1a"
+  }
+}

--- a/.trajectories/completed/2026-04/traj_mq8gu25evmdu.md
+++ b/.trajectories/completed/2026-04/traj_mq8gu25evmdu.md
@@ -1,0 +1,37 @@
+# Trajectory: Add relayfile CLI default workspace support
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** April 17, 2026 at 02:14 PM
+> **Completed:** April 17, 2026 at 02:24 PM
+
+---
+
+## Summary
+
+Added relayfile CLI default workspace selection with workspace use, env/token/catalog resolution, active workspace list fallback, docs, and tests.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Support active workspace resolution in CLI commands and workspace list fallback
+- **Chose:** Support active workspace resolution in CLI commands and workspace list fallback
+- **Reasoning:** Remote workspace listing requires admin scopes; for scoped agent tokens, the CLI should still show and use the active workspace from RELAYFILE_WORKSPACE or token claims.
+
+### Workspace list fallback prints active workspace before local catalog entries
+- **Chose:** Workspace list fallback prints active workspace before local catalog entries
+- **Reasoning:** Scoped remote tokens may not authorize admin workspace listing, so the CLI should surface the active env/token workspace ahead of stale local catalog entries.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Support active workspace resolution in CLI commands and workspace list fallback: Support active workspace resolution in CLI commands and workspace list fallback
+- CLI default workspace implementation is in progress; key behavior is explicit workspace first, then RELAYFILE_WORKSPACE, token workspace claim, and stored default.
+- Workspace list fallback prints active workspace before local catalog entries: Workspace list fallback prints active workspace before local catalog entries

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T11:56:26.590Z",
+  "lastUpdated": "2026-04-17T12:24:48.233Z",
   "trajectories": {
     "traj_lcvvpzmuroqb": {
       "title": "file-observer-dashboard-workflow",
@@ -36,6 +36,13 @@
       "startedAt": "2026-04-17T11:55:03.821Z",
       "completedAt": "2026-04-17T11:56:26.480Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_8gockt810ha6.json"
+    },
+    "traj_mq8gu25evmdu": {
+      "title": "Add relayfile CLI default workspace support",
+      "status": "completed",
+      "startedAt": "2026-04-17T12:14:00.283Z",
+      "completedAt": "2026-04-17T12:24:48.149Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_mq8gu25evmdu.json"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -178,11 +178,14 @@ Inspect the remote VFS directly without mounting:
 
 ```bash
 relayfile login --server https://api.relayfile.dev --token "$RELAYFILE_TOKEN"
-relayfile tree ws_123 /github --depth 5
-relayfile read ws_123 /github/repos/acme/api/pulls/42/metadata.json
-relayfile tree ws_123 /github --depth 5 --json
-relayfile read ws_123 /external/blob.bin --output blob.bin
+relayfile workspace use ws_123
+relayfile tree /github --depth 5
+relayfile read /github/repos/acme/api/pulls/42/metadata.json
+relayfile tree /github --depth 5 --json
+relayfile read /external/blob.bin --output blob.bin
 ```
+
+You can also set `RELAYFILE_WORKSPACE=ws_123` instead of storing a default.
 
 ## License
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -205,18 +205,19 @@ func printUsage(w io.Writer) {
 Usage:
   relayfile login --server URL [--token TOKEN]
   relayfile workspace create NAME
+  relayfile workspace use NAME
   relayfile workspace list
   relayfile workspace delete NAME [--yes]
-  relayfile mount WORKSPACE [LOCAL_DIR]
-  relayfile tree WORKSPACE [PATH] [--depth N]
-  relayfile read WORKSPACE PATH
-  relayfile seed WORKSPACE [DIR]
-  relayfile export WORKSPACE --format FORMAT [--output FILE]
-  relayfile status WORKSPACE
+  relayfile mount [WORKSPACE] [LOCAL_DIR]
+  relayfile tree [WORKSPACE] [PATH] [--depth N]
+  relayfile read [WORKSPACE] PATH
+  relayfile seed [WORKSPACE] [DIR]
+  relayfile export [WORKSPACE] --format FORMAT [--output FILE]
+  relayfile status [WORKSPACE]
 
 Subcommands:
   login       Store credentials in ~/.relayfile/credentials.json
-  workspace   Create, list, or delete locally tracked workspaces
+  workspace   Create, select, list, or delete locally tracked workspaces
   mount       Mirror a remote workspace to a local directory
   tree        List a remote workspace path
   read        Print a remote file's content
@@ -279,11 +280,13 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 
 func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("workspace subcommand is required: create, list, or delete")
+		return errors.New("workspace subcommand is required: create, use, list, or delete")
 	}
 	switch args[0] {
 	case "create":
 		return runWorkspaceCreate(args[1:], stdout)
+	case "use":
+		return runWorkspaceUse(args[1:], stdout)
 	case "list":
 		return runWorkspaceList(args[1:], stdout)
 	case "delete":
@@ -322,6 +325,28 @@ func runWorkspaceCreate(args []string, stdout io.Writer) error {
 	return nil
 }
 
+func runWorkspaceUse(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("workspace use", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile workspace use NAME")
+	}
+
+	record, err := setDefaultWorkspace(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+	workspaceID := record.ID
+	if workspaceID == "" {
+		workspaceID = record.Name
+	}
+	fmt.Fprintf(stdout, "Default workspace set to %s (id: %s)\n", record.Name, workspaceID)
+	return nil
+}
+
 func runWorkspaceList(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("workspace list", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -335,7 +360,8 @@ func runWorkspaceList(args []string, stdout io.Writer) error {
 	}
 
 	creds, _ := loadCredentials()
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err == nil {
 		var remote adminWorkspaceList
 		err = client.getJSON(context.Background(), "/v1/admin/workspaces", &remote)
@@ -357,8 +383,8 @@ func runWorkspaceList(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	for _, workspace := range catalog.Workspaces {
-		fmt.Fprintln(stdout, workspace.Name)
+	for _, name := range workspaceCatalogNames(catalog, tokenValue) {
+		fmt.Fprintln(stdout, name)
 	}
 	return nil
 }
@@ -413,6 +439,7 @@ func runMount(args []string) error {
 	remotePath := fs.String("remote-path", envOrDefault("RELAYFILE_REMOTE_PATH", "/"), "remote root path")
 	eventProvider := fs.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	stateFile := fs.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
+	localDirFlag := fs.String("local-dir", "", "local mirror directory")
 	interval := fs.Duration("interval", durationEnv("RELAYFILE_MOUNT_INTERVAL", 2*time.Second), "sync interval")
 	intervalJitter := fs.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := fs.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
@@ -429,30 +456,46 @@ func runMount(args []string) error {
 		"timeout":         true,
 		"websocket":       false,
 		"once":            false,
+		"local-dir":       true,
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() < 1 || fs.NArg() > 2 {
-		return errors.New("usage: relayfile mount WORKSPACE [LOCAL_DIR]")
+	if fs.NArg() > 2 {
+		return errors.New("usage: relayfile mount [WORKSPACE] [LOCAL_DIR]")
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
-	if workspaceID == "" {
-		return errors.New("workspace is required")
-	}
+	workspaceID := ""
 	localDir := "."
-	if fs.NArg() == 2 {
+	tokenValue := strings.TrimSpace(*token)
+	if tokenValue == "" {
+		return errors.New("token is required; run relayfile login or pass --token")
+	}
+	var err error
+	switch fs.NArg() {
+	case 0:
+		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+		localDir = strings.TrimSpace(*localDirFlag)
+	case 1:
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		localDir = strings.TrimSpace(*localDirFlag)
+	case 2:
+		if strings.TrimSpace(*localDirFlag) != "" {
+			return errors.New("local directory specified twice")
+		}
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
 		localDir = fs.Arg(1)
+	}
+	if err != nil {
+		return err
+	}
+	if localDir == "" {
+		localDir = "."
 	}
 	absLocalDir, err := filepath.Abs(localDir)
 	if err != nil {
 		return err
 	}
 
-	tokenValue := strings.TrimSpace(*token)
-	if tokenValue == "" {
-		return errors.New("token is required; run relayfile login or pass --token")
-	}
 	if *interval <= 0 {
 		*interval = 2 * time.Second
 	}
@@ -502,26 +545,39 @@ func runTree(args []string, stdout io.Writer) error {
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() < 1 || fs.NArg() > 2 {
-		return errors.New("usage: relayfile tree WORKSPACE [PATH] [--depth N]")
+	if fs.NArg() > 2 {
+		return errors.New("usage: relayfile tree [WORKSPACE] [PATH] [--depth N]")
 	}
 
 	creds, err := loadCredentials()
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err != nil {
 		return err
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
-	if workspaceID == "" {
-		return errors.New("workspace is required")
-	}
 	remotePath := strings.TrimSpace(*pathFlag)
-	if fs.NArg() == 2 {
+	var workspaceID string
+	switch fs.NArg() {
+	case 0:
+		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+	case 1:
+		arg := strings.TrimSpace(fs.Arg(0))
+		if strings.HasPrefix(arg, "/") {
+			workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+			remotePath = arg
+		} else {
+			workspaceID, err = resolveWorkspaceIDWithToken(arg, tokenValue)
+		}
+	case 2:
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
 		remotePath = strings.TrimSpace(fs.Arg(1))
+	}
+	if err != nil {
+		return err
 	}
 	if remotePath == "" {
 		remotePath = "/"
@@ -594,23 +650,31 @@ func runRead(args []string, stdout io.Writer) error {
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() != 2 {
-		return errors.New("usage: relayfile read WORKSPACE PATH")
+	if fs.NArg() < 1 || fs.NArg() > 2 {
+		return errors.New("usage: relayfile read [WORKSPACE] PATH")
 	}
 
 	creds, err := loadCredentials()
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err != nil {
 		return err
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
-	remotePath := strings.TrimSpace(fs.Arg(1))
-	if workspaceID == "" {
-		return errors.New("workspace is required")
+	var workspaceID string
+	var remotePath string
+	if fs.NArg() == 1 {
+		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+		remotePath = strings.TrimSpace(fs.Arg(0))
+	} else {
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		remotePath = strings.TrimSpace(fs.Arg(1))
+	}
+	if err != nil {
+		return err
 	}
 	if remotePath == "" {
 		return errors.New("path is required")
@@ -663,23 +727,33 @@ func runSeed(args []string, stdout io.Writer) error {
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() < 1 || fs.NArg() > 2 {
-		return errors.New("usage: relayfile seed WORKSPACE [DIR]")
+	if fs.NArg() > 2 {
+		return errors.New("usage: relayfile seed [WORKSPACE] [DIR]")
 	}
 
 	creds, err := loadCredentials()
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err != nil {
 		return err
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
+	workspaceID := ""
 	dir := "."
-	if fs.NArg() == 2 {
+	switch fs.NArg() {
+	case 0:
+		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+	case 1:
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+	case 2:
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
 		dir = fs.Arg(1)
+	}
+	if err != nil {
+		return err
 	}
 	root, err := filepath.Abs(dir)
 	if err != nil {
@@ -728,20 +802,27 @@ func runExport(args []string, stdout io.Writer) error {
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() != 1 {
-		return errors.New("usage: relayfile export WORKSPACE --format FORMAT [--output FILE]")
+	if fs.NArg() > 1 {
+		return errors.New("usage: relayfile export [WORKSPACE] --format FORMAT [--output FILE]")
 	}
 
 	creds, err := loadCredentials()
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err != nil {
 		return err
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
+	workspaceID, err := resolveWorkspaceIDWithToken("", tokenValue)
+	if fs.NArg() == 1 {
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+	}
+	if err != nil {
+		return err
+	}
 	path := fmt.Sprintf("/v1/workspaces/%s/fs/export?format=%s", url.PathEscape(workspaceID), url.QueryEscape(strings.ToLower(strings.TrimSpace(*format))))
 	body, _, err := client.getBytes(context.Background(), path)
 	if err != nil {
@@ -771,20 +852,27 @@ func runStatus(args []string, stdout io.Writer) error {
 	})); err != nil {
 		return err
 	}
-	if fs.NArg() != 1 {
-		return errors.New("usage: relayfile status WORKSPACE")
+	if fs.NArg() > 1 {
+		return errors.New("usage: relayfile status [WORKSPACE]")
 	}
 
 	creds, err := loadCredentials()
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(resolveServer(*server, creds), resolveToken(*token, creds))
+	tokenValue := resolveToken(*token, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err != nil {
 		return err
 	}
 
-	workspaceID := strings.TrimSpace(fs.Arg(0))
+	workspaceID, err := resolveWorkspaceIDWithToken("", tokenValue)
+	if fs.NArg() == 1 {
+		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+	}
+	if err != nil {
+		return err
+	}
 	var status syncStatusResponse
 	if err := client.getJSON(context.Background(), fmt.Sprintf("/v1/workspaces/%s/sync/status", url.PathEscape(workspaceID)), &status); err != nil {
 		return err
@@ -1096,6 +1184,39 @@ func saveWorkspaceCatalog(catalog workspaceCatalog) error {
 	return os.WriteFile(workspacesPath(), payload, 0o644)
 }
 
+func setDefaultWorkspace(name string) (workspaceRecord, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return workspaceRecord{}, errors.New("workspace name is required")
+	}
+
+	record, err := upsertWorkspace(name)
+	if err != nil {
+		return workspaceRecord{}, err
+	}
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return workspaceRecord{}, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := range catalog.Workspaces {
+		if catalog.Workspaces[i].Name == record.Name {
+			if catalog.Workspaces[i].ID == "" {
+				catalog.Workspaces[i].ID = record.Name
+			}
+			catalog.Workspaces[i].LastUsedAt = now
+			record = catalog.Workspaces[i]
+			break
+		}
+	}
+	catalog.Default = record.Name
+	if err := saveWorkspaceCatalog(catalog); err != nil {
+		return workspaceRecord{}, err
+	}
+	return record, nil
+}
+
 func upsertWorkspace(name string) (workspaceRecord, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
@@ -1167,6 +1288,124 @@ func removeWorkspace(name string) (bool, error) {
 		}
 	}
 	return true, saveWorkspaceCatalog(catalog)
+}
+
+func resolveWorkspaceIDWithToken(value, token string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value != "" {
+		if id, ok := catalogWorkspaceID(value); ok {
+			return id, nil
+		}
+		return value, nil
+	}
+
+	if workspaceID := strings.TrimSpace(os.Getenv("RELAYFILE_WORKSPACE")); workspaceID != "" {
+		if id, ok := catalogWorkspaceID(workspaceID); ok {
+			return id, nil
+		}
+		return workspaceID, nil
+	}
+
+	if workspaceID := workspaceIDFromToken(token); workspaceID != "" {
+		if id, ok := catalogWorkspaceID(workspaceID); ok {
+			return id, nil
+		}
+		return workspaceID, nil
+	}
+
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return "", err
+	}
+	defaultName := strings.TrimSpace(catalog.Default)
+	if defaultName != "" {
+		if id, ok := catalogWorkspaceIDFromCatalog(catalog, defaultName); ok {
+			return id, nil
+		}
+		return defaultName, nil
+	}
+	return "", errors.New("workspace is required; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run relayfile workspace use NAME")
+}
+
+func catalogWorkspaceID(name string) (string, bool) {
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return "", false
+	}
+	return catalogWorkspaceIDFromCatalog(catalog, name)
+}
+
+func catalogWorkspaceIDFromCatalog(catalog workspaceCatalog, name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	for _, workspace := range catalog.Workspaces {
+		if workspace.Name == name || workspace.ID == name {
+			if strings.TrimSpace(workspace.ID) != "" {
+				return strings.TrimSpace(workspace.ID), true
+			}
+			return strings.TrimSpace(workspace.Name), true
+		}
+	}
+	return "", false
+}
+
+func workspaceCatalogNames(catalog workspaceCatalog, token string) []string {
+	set := map[string]struct{}{}
+	names := make([]string, 0, len(catalog.Workspaces)+3)
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			if _, ok := set[value]; ok {
+				return
+			}
+			set[value] = struct{}{}
+			names = append(names, value)
+		}
+	}
+	add(os.Getenv("RELAYFILE_WORKSPACE"))
+	add(workspaceIDFromToken(token))
+	add(catalog.Default)
+
+	localNames := make([]string, 0, len(catalog.Workspaces))
+	for _, workspace := range catalog.Workspaces {
+		name := strings.TrimSpace(workspace.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := set[name]; ok {
+			continue
+		}
+		localNames = append(localNames, name)
+	}
+	sort.Strings(localNames)
+	names = append(names, localNames...)
+	return names
+}
+
+func workspaceIDFromToken(token string) string {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return ""
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	for _, key := range []string{"workspace_id", "wks"} {
+		if value, ok := claims[key].(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func remoteWorkspaceNames(response adminWorkspaceList) []string {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -41,6 +41,27 @@ func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
 	}
 }
 
+func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "use", "ws_cloud"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace use failed: %v", err)
+	}
+
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		t.Fatalf("loadWorkspaceCatalog failed: %v", err)
+	}
+	if catalog.Default != "ws_cloud" {
+		t.Fatalf("expected default workspace ws_cloud, got %q", catalog.Default)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Default workspace set to ws_cloud") {
+		t.Fatalf("unexpected workspace use output: %q", got)
+	}
+}
+
 func TestWorkspaceDeleteRemovesCatalogEntry(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -59,6 +80,65 @@ func TestWorkspaceDeleteRemovesCatalogEntry(t *testing.T) {
 	}
 	if len(catalog.Workspaces) != 0 {
 		t.Fatalf("expected workspace catalog to be empty, got %d entries", len(catalog.Workspaces))
+	}
+}
+
+func TestWorkspaceListIncludesEnvWorkspaceWhenRemoteListUnavailable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_WORKSPACE", "ws_env")
+	if _, err := upsertWorkspace(".relay/vfs"); err != nil {
+		t.Fatalf("upsertWorkspace .relay/vfs failed: %v", err)
+	}
+	if _, err := upsertWorkspace("relay-test"); err != nil {
+		t.Fatalf("upsertWorkspace relay-test failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "list"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace list failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "ws_env\n.relay/vfs\nrelay-test" {
+		t.Fatalf("unexpected workspace list output: %q", got)
+	}
+}
+
+func TestWorkspaceListIncludesTokenWorkspaceWhenRemoteListUnavailable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  testJWTWithWorkspace("ws_token"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "list"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace list failed: %v", err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "ws_token" {
+		t.Fatalf("unexpected workspace list output: %q", got)
 	}
 }
 
@@ -93,6 +173,40 @@ func TestWorkspaceListFallsBackToAdminSync(t *testing.T) {
 
 	if got := strings.TrimSpace(stdout.String()); got != "ws_alpha\nws_bravo" {
 		t.Fatalf("unexpected workspace list output: %q", got)
+	}
+}
+
+func TestTreeUsesEnvWorkspaceWhenWorkspaceArgOmitted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_WORKSPACE", "ws_env")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws_env/fs/tree" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("path"); got != "/github" {
+			t.Fatalf("expected path /github, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/github","entries":[],"nextCursor":null}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"tree", "/github"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run tree failed: %v", err)
+	}
+
+	if got := stdout.String(); !strings.Contains(got, "Tree /github") {
+		t.Fatalf("expected tree header, got %q", got)
 	}
 }
 
@@ -202,6 +316,40 @@ func TestReadPrintsRemoteFileContent(t *testing.T) {
 	}
 }
 
+func TestReadUsesTokenWorkspaceWhenWorkspaceArgOmitted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	token := testJWTWithWorkspace("ws_token")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws_token/fs/file" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("path"); got != "/docs/readme.md" {
+			t.Fatalf("expected file path, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/docs/readme.md","revision":"rev_1","contentType":"text/markdown","content":"ok\n"}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  token,
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"read", "/docs/readme.md"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run read failed: %v", err)
+	}
+
+	if got := stdout.String(); got != "ok\n" {
+		t.Fatalf("unexpected file content: %q", got)
+	}
+}
+
 func TestReadDecodesBase64Content(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -257,4 +405,11 @@ func clearRelayfileEnv(t *testing.T) {
 	t.Setenv("RELAYFILE_SERVER", "")
 	t.Setenv("RELAYFILE_BASE_URL", "")
 	t.Setenv("RELAYFILE_TOKEN", "")
+	t.Setenv("RELAYFILE_WORKSPACE", "")
+}
+
+func testJWTWithWorkspace(workspaceID string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"test","aud":"relayfile"}`))
+	return header + "." + payload + ".sig"
 }

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -13,7 +13,7 @@ Relayfile does not use `dotenv` or `godotenv` in application code. Runtime binar
 | --- | --- |
 | `cmd/relayfile` | Direct `os.Getenv(...)` reads plus typed helpers for ints, int64s, durations, and booleans |
 | `cmd/relayfile-mount` | Direct `os.Getenv(...)` reads plus typed helpers for durations, floats, and booleans |
-| `cmd/relayfile-cli` | Direct `os.Getenv(...)` reads for login and mount defaults; falls back to saved credentials for server and token |
+| `cmd/relayfile-cli` | Direct `os.Getenv(...)` reads for login, workspace, and mount defaults; falls back to saved credentials for server/token and saved workspace catalog defaults |
 | `scripts/*.sh` | Standard shell parameter expansion such as `${VAR:-default}` |
 | `scripts/e2e.ts`, `workflows/*.ts` | `process.env.VAR` lookups |
 | `compose.env.example` / `docker-compose.yml` | Docker Compose interpolation and container env injection |
@@ -141,13 +141,17 @@ Queue backend precedence is:
 
 ## CLI Package: `cmd/relayfile-cli`
 
-The CLI only reads a small env surface directly. Workspace ID and local directory for `relayfile mount` come from positional arguments, not env vars.
+The CLI reads a small env surface directly. Workspace resolution for commands
+that accept a workspace is: explicit positional workspace, `RELAYFILE_WORKSPACE`,
+the `workspace_id`/`wks` claim in the active token, then the default stored by
+`relayfile workspace use`.
 
 | Variable | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `RELAYFILE_SERVER` | string | unset | Preferred server override for `relayfile login` and server resolution |
 | `RELAYFILE_BASE_URL` | string | `https://relayfile-api.agentworkforce.workers.dev` for login fallback | Used when `RELAYFILE_SERVER` is unset |
 | `RELAYFILE_TOKEN` | string | unset | Used for `login` and as a token fallback before saved credentials |
+| `RELAYFILE_WORKSPACE` | string | unset | Workspace override for CLI commands when no workspace argument is supplied |
 | `RELAYFILE_REMOTE_PATH` | string | `/` | Mount command default |
 | `RELAYFILE_MOUNT_PROVIDER` | string | unset | Mount command provider filter |
 | `RELAYFILE_MOUNT_STATE_FILE` | string | unset | Mount command state-file default |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -51,6 +51,7 @@ Create a workspace for the project you want to sync:
 
 ```bash
 relayfile workspace create my-project
+relayfile workspace use my-project
 ```
 
 List available workspaces:
@@ -59,7 +60,13 @@ List available workspaces:
 relayfile workspace list
 ```
 
-If your environment already assigns you a workspace ID, you can use that directly instead of creating one.
+If your environment already assigns you a workspace ID, you can use that directly instead of creating one:
+
+```bash
+relayfile workspace use ws_123
+```
+
+`RELAYFILE_WORKSPACE=ws_123` also overrides the stored default for scripts and agent sessions.
 
 If you are using a hosted deployment, the same login flow works with your hosted base URL:
 
@@ -123,16 +130,16 @@ With the default polling interval, changes usually arrive in about 1-2 seconds.
 If you want to watch the workspace status while testing:
 
 ```bash
-relayfile status my-project
+relayfile status
 ```
 
 For direct VFS inspection without mounting:
 
 ```bash
-relayfile tree my-project / --depth 2
-relayfile tree my-project /github --depth 5 --json
-relayfile read my-project /github/repos/acme/api/pulls/42/metadata.json
-relayfile read my-project /external/blob.bin --output blob.bin
+relayfile tree / --depth 2
+relayfile tree /github --depth 5 --json
+relayfile read /github/repos/acme/api/pulls/42/metadata.json
+relayfile read /external/blob.bin --output blob.bin
 ```
 
 For low-level API testing, you can also inspect the event feed directly:


### PR DESCRIPTION
## Summary
- add `relayfile workspace use NAME` to store a default workspace
- resolve omitted workspace args from explicit env/token/catalog order: positional, `RELAYFILE_WORKSPACE`, token `workspace_id`/`wks`, stored default
- make `workspace list` surface the active env/token workspace first when remote admin listing is unavailable
- update README/getting-started/env docs and add CLI tests

## Tests
- `go test ./...`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
