### PR TITLE
fix(cli): default host and speed up mount bootstrap

### DIFF
--- a/.trajectories/completed/2026-04/traj_nv8vh0eav3v0.json
+++ b/.trajectories/completed/2026-04/traj_nv8vh0eav3v0.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_nv8vh0eav3v0",
+  "version": 1,
+  "task": {
+    "title": "Make relayfile mount bootstrap fast for sandbox agents"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T13:06:18.420Z",
+  "completedAt": "2026-04-17T13:12:14.864Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T13:11:23.270Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_4t9eii29ufpr",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T13:11:23.270Z",
+      "endedAt": "2026-04-17T13:12:14.864Z",
+      "events": [
+        {
+          "ts": 1776431483271,
+          "type": "decision",
+          "content": "Bootstrap mirror mounts from the export snapshot API: Bootstrap mirror mounts from the export snapshot API",
+          "raw": {
+            "question": "Bootstrap mirror mounts from the export snapshot API",
+            "chosen": "Bootstrap mirror mounts from the export snapshot API",
+            "alternatives": [],
+            "reasoning": "Mount startup was doing one tree request plus one file read per visible file and then walking events. The implemented export endpoint already provides a full JSON snapshot with revisions, so using it makes sandbox mounts one request while preserving a tree/read fallback for older servers."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Changed mirror mount bootstrap to use the Relayfile export JSON snapshot with server-side path filtering, preserved tree/read fallback for older servers, and documented the export path parameter.",
+    "approach": "Standard approach",
+    "confidence": 0.93
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "8e6099d4f44bccb7046a1106986513ac2bb54670",
+    "endRef": "8e6099d4f44bccb7046a1106986513ac2bb54670"
+  }
+}

--- a/.trajectories/completed/2026-04/traj_nv8vh0eav3v0.md
+++ b/.trajectories/completed/2026-04/traj_nv8vh0eav3v0.md
@@ -1,0 +1,31 @@
+# Trajectory: Make relayfile mount bootstrap fast for sandbox agents
+
+> **Status:** ✅ Completed
+> **Confidence:** 93%
+> **Started:** April 17, 2026 at 03:06 PM
+> **Completed:** April 17, 2026 at 03:12 PM
+
+---
+
+## Summary
+
+Changed mirror mount bootstrap to use the Relayfile export JSON snapshot with server-side path filtering, preserved tree/read fallback for older servers, and documented the export path parameter.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Bootstrap mirror mounts from the export snapshot API
+- **Chose:** Bootstrap mirror mounts from the export snapshot API
+- **Reasoning:** Mount startup was doing one tree request plus one file read per visible file and then walking events. The implemented export endpoint already provides a full JSON snapshot with revisions, so using it makes sandbox mounts one request while preserving a tree/read fallback for older servers.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Bootstrap mirror mounts from the export snapshot API: Bootstrap mirror mounts from the export snapshot API

--- a/.trajectories/completed/2026-04/traj_o8aamzw5k45f.json
+++ b/.trajectories/completed/2026-04/traj_o8aamzw5k45f.json
@@ -1,0 +1,53 @@
+{
+  "id": "traj_o8aamzw5k45f",
+  "version": 1,
+  "task": {
+    "title": "Fix CLI default relayfile server and token status behavior"
+  },
+  "status": "completed",
+  "startedAt": "2026-04-17T12:55:20.190Z",
+  "completedAt": "2026-04-17T12:57:08.107Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-04-17T12:56:21.095Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_m59dokzynzup",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-04-17T12:56:21.095Z",
+      "endedAt": "2026-04-17T12:57:08.107Z",
+      "events": [
+        {
+          "ts": 1776430581095,
+          "type": "decision",
+          "content": "Use api.relayfile.dev as the CLI built-in default server: Use api.relayfile.dev as the CLI built-in default server",
+          "raw": {
+            "question": "Use api.relayfile.dev as the CLI built-in default server",
+            "chosen": "Use api.relayfile.dev as the CLI built-in default server",
+            "alternatives": [],
+            "reasoning": "The hosted observer and SDK already use api.relayfile.dev, and the user expects bare relayfile commands to target that host when no server override or saved server is present."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Updated the CLI built-in default server to https://api.relayfile.dev, refreshed stale docs/workflow references, and added a regression test for default server resolution.",
+    "approach": "Standard approach",
+    "confidence": 0.95
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "3bc5ae9509934d603839c2f9a4ff7a6eb79ecd44",
+    "endRef": "3bc5ae9509934d603839c2f9a4ff7a6eb79ecd44"
+  }
+}

--- a/.trajectories/completed/2026-04/traj_o8aamzw5k45f.md
+++ b/.trajectories/completed/2026-04/traj_o8aamzw5k45f.md
@@ -1,0 +1,31 @@
+# Trajectory: Fix CLI default relayfile server and token status behavior
+
+> **Status:** ✅ Completed
+> **Confidence:** 95%
+> **Started:** April 17, 2026 at 02:55 PM
+> **Completed:** April 17, 2026 at 02:57 PM
+
+---
+
+## Summary
+
+Updated the CLI built-in default server to https://api.relayfile.dev, refreshed stale docs/workflow references, and added a regression test for default server resolution.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use api.relayfile.dev as the CLI built-in default server
+- **Chose:** Use api.relayfile.dev as the CLI built-in default server
+- **Reasoning:** The hosted observer and SDK already use api.relayfile.dev, and the user expects bare relayfile commands to target that host when no server override or saved server is present.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use api.relayfile.dev as the CLI built-in default server: Use api.relayfile.dev as the CLI built-in default server

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T12:24:48.233Z",
+  "lastUpdated": "2026-04-17T12:57:08.241Z",
   "trajectories": {
     "traj_lcvvpzmuroqb": {
       "title": "file-observer-dashboard-workflow",
@@ -43,6 +43,13 @@
       "startedAt": "2026-04-17T12:14:00.283Z",
       "completedAt": "2026-04-17T12:24:48.149Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_mq8gu25evmdu.json"
+    },
+    "traj_o8aamzw5k45f": {
+      "title": "Fix CLI default relayfile server and token status behavior",
+      "status": "completed",
+      "startedAt": "2026-04-17T12:55:20.190Z",
+      "completedAt": "2026-04-17T12:57:08.107Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_o8aamzw5k45f.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-04-17T12:57:08.241Z",
+  "lastUpdated": "2026-04-17T13:12:15.026Z",
   "trajectories": {
     "traj_lcvvpzmuroqb": {
       "title": "file-observer-dashboard-workflow",
@@ -50,6 +50,13 @@
       "startedAt": "2026-04-17T12:55:20.190Z",
       "completedAt": "2026-04-17T12:57:08.107Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_o8aamzw5k45f.json"
+    },
+    "traj_nv8vh0eav3v0": {
+      "title": "Make relayfile mount bootstrap fast for sandbox agents",
+      "status": "completed",
+      "startedAt": "2026-04-17T13:06:18.420Z",
+      "completedAt": "2026-04-17T13:12:14.864Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-04/traj_nv8vh0eav3v0.json"
     }
   }
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultServerURL        = "https://relayfile-api.agentworkforce.workers.dev"
+	defaultServerURL        = "https://api.relayfile.dev"
 	configDirName           = ".relayfile"
 	websocketReconcileEvery = 10
 )

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -41,6 +41,14 @@ func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
 	}
 }
 
+func TestResolveServerDefaultsToHostedRelayfile(t *testing.T) {
+	clearRelayfileEnv(t)
+
+	if got := resolveServer("", credentials{}); got != "https://api.relayfile.dev" {
+		t.Fatalf("expected hosted Relayfile default server, got %q", got)
+	}
+}
+
 func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -141,7 +141,8 @@ curl -sS -X POST \
 
 ### `GET /v1/workspaces/{workspaceId}/fs/export`
 
-Export visible files from a workspace.
+Export visible files from a workspace. Add `path=/github` to restrict the
+snapshot to a subtree.
 
 JSON export:
 
@@ -149,7 +150,7 @@ JSON export:
 curl -sS \
   -H "Authorization: Bearer ${RELAYFILE_TOKEN}" \
   -H "X-Correlation-Id: ${RELAYFILE_CORRELATION_ID}" \
-  "${RELAYFILE_BASE_URL}/v1/workspaces/${RELAYFILE_WORKSPACE}/fs/export?format=json" | jq .
+  "${RELAYFILE_BASE_URL}/v1/workspaces/${RELAYFILE_WORKSPACE}/fs/export?format=json&path=/" | jq .
 ```
 
 Tar export:

--- a/docs/bulk-export-design.md
+++ b/docs/bulk-export-design.md
@@ -157,7 +157,7 @@ Implementation:
 ### Endpoint
 
 ```
-GET /v1/workspaces/{workspaceId}/fs/export?format={json|tar|patch}
+GET /v1/workspaces/{workspaceId}/fs/export?format={json|tar|patch}&path={path}
 ```
 
 **Auth:** Bearer JWT with `fs:read` scope.
@@ -171,6 +171,7 @@ Download all visible workspace files as a single artifact. Used for backups, mig
 | Param | Type | Default | Description |
 |-------|------|---------|-------------|
 | `format` | string | `json` | One of: `json`, `tar`, `patch` |
+| `path` | string | `/` | Restrict the export to files under this VFS path |
 
 ### Permission Filtering
 

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -31,7 +31,7 @@ The `relayfile` CLI is the primary interface for humans and CI systems to intera
 ### Auth flow: API key (v1)
 
 ```
-relayfile login --server https://relayfile-api.agentworkforce.workers.dev
+relayfile login --server https://api.relayfile.dev
 ```
 
 1. Prompts the user for an API key (paste from dashboard or generate via API).
@@ -46,14 +46,14 @@ Same as `gh auth login` — opens a browser, completes device-code flow, stores 
 
 ```json
 {
-  "server": "https://relayfile-api.agentworkforce.workers.dev",
+  "server": "https://api.relayfile.dev",
   "token": "eyJ...",
   "refreshToken": null,
   "expiresAt": null
 }
 ```
 
-- `server` — base URL for all API calls. Default: `https://relayfile-api.agentworkforce.workers.dev`.
+- `server` — base URL for all API calls. Default: `https://api.relayfile.dev`.
 - `token` — Bearer JWT or API key.
 - `refreshToken` / `expiresAt` — reserved for OAuth flow (v2). Null for API-key auth.
 - File permissions: `0600` (user-only read/write).
@@ -72,7 +72,7 @@ relayfile login [--server URL]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--server` | `https://relayfile-api.agentworkforce.workers.dev` | Server base URL |
+| `--server` | `https://api.relayfile.dev` | Server base URL |
 
 **Behavior:**
 
@@ -113,7 +113,7 @@ relayfile workspace create <name>
   "workspaces": {
     "my-project": {
       "id": "ws_abc123",
-      "server": "https://relayfile-api.agentworkforce.workers.dev",
+      "server": "https://api.relayfile.dev",
       "createdAt": "2026-03-24T12:00:00Z"
     }
   },
@@ -329,7 +329,7 @@ relayfile status [workspace]
 3. Print:
    ```
    Workspace:  my-project (ws_abc123)
-   Server:     https://relayfile-api.agentworkforce.workers.dev
+   Server:     https://api.relayfile.dev
    Files:      142
    Last event: 2026-03-24T11:42:00Z (3 minutes ago)
    Agents:     compose-agent, reviewer-bot
@@ -382,7 +382,7 @@ Error: not authenticated. Run 'relayfile login' or set RELAYFILE_TOKEN.
 1. `--server` flag
 2. `RELAYFILE_SERVER` environment variable
 3. `~/.relayfile/credentials.json` → `server` field
-4. Default: `https://relayfile-api.agentworkforce.workers.dev`
+4. Default: `https://api.relayfile.dev`
 
 ---
 
@@ -449,7 +449,7 @@ The CLI imports `internal/mountsync` directly for the `mount` subcommand rather 
 # First-time setup
 relayfile login
 # Enter API key: ********
-# Logged in to https://relayfile-api.agentworkforce.workers.dev as my-agent
+# Logged in to https://api.relayfile.dev as my-agent
 
 # Seed a project
 relayfile seed my-workspace ./src

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -149,7 +149,7 @@ the `workspace_id`/`wks` claim in the active token, then the default stored by
 | Variable | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `RELAYFILE_SERVER` | string | unset | Preferred server override for `relayfile login` and server resolution |
-| `RELAYFILE_BASE_URL` | string | `https://relayfile-api.agentworkforce.workers.dev` for login fallback | Used when `RELAYFILE_SERVER` is unset |
+| `RELAYFILE_BASE_URL` | string | `https://api.relayfile.dev` for login fallback | Used when `RELAYFILE_SERVER` is unset |
 | `RELAYFILE_TOKEN` | string | unset | Used for `login` and as a token fallback before saved credentials |
 | `RELAYFILE_WORKSPACE` | string | unset | Workspace override for CLI commands when no workspace argument is supplied |
 | `RELAYFILE_REMOTE_PATH` | string | `/` | Mount command default |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -71,7 +71,7 @@ relayfile workspace use ws_123
 If you are using a hosted deployment, the same login flow works with your hosted base URL:
 
 ```bash
-relayfile login --server https://relayfile-api.agentworkforce.workers.dev --token YOUR_TOKEN
+relayfile login --server https://api.relayfile.dev --token YOUR_TOKEN
 ```
 
 ## Seed Files From A Project

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1406,6 +1406,10 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request, workspaceI
 	if format == "" {
 		format = "json"
 	}
+	exportRoot := normalizeRoutePath(r.URL.Query().Get("path"))
+	if exportRoot == "" {
+		exportRoot = "/"
+	}
 
 	files, err := s.store.ExportWorkspace(workspaceID)
 	if err != nil {
@@ -1419,6 +1423,9 @@ func (s *Server) handleExport(w http.ResponseWriter, r *http.Request, workspaceI
 
 	visible := make([]relayfile.File, 0, len(files))
 	for _, file := range files {
+		if !withinBasePath(exportRoot, file.Path) {
+			continue
+		}
 		effectivePermissions := s.store.ResolveFilePermissions(workspaceID, file.Path, true)
 		if !filePermissionAllows(effectivePermissions, workspaceID, &claims) {
 			continue

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -561,6 +561,44 @@ func TestExportJSON(t *testing.T) {
 	}
 }
 
+func TestExportJSONPathFilter(t *testing.T) {
+	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
+	t.Cleanup(store.Close)
+
+	if written, errs := store.BulkWrite("ws_export_json_path", []relayfile.BulkWriteFile{
+		{Path: "/github/repos/demo/README.md", ContentType: "text/markdown", Content: "# Demo"},
+		{Path: "/notion/pages/A.md", ContentType: "text/markdown", Content: "# A"},
+	}); written != 2 || len(errs) != 0 {
+		t.Fatalf("seed bulk write failed: written=%d errs=%+v", written, errs)
+	}
+
+	server := NewServer(store)
+	token := mustTestJWT(t, "dev-secret", "ws_export_json_path", "Worker1", []string{"fs:read"}, time.Now().Add(time.Hour))
+
+	resp := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_export_json_path/fs/export?format=json&path=/github",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_export_json_path_case",
+		},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200 on json export, got %d (%s)", resp.Code, resp.Body.String())
+	}
+
+	var files []relayfile.File
+	if err := json.NewDecoder(resp.Body).Decode(&files); err != nil {
+		t.Fatalf("decode export json response: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 exported file, got %d", len(files))
+	}
+	if files[0].Path != "/github/repos/demo/README.md" || files[0].Content != "# Demo" {
+		t.Fatalf("unexpected exported file: %+v", files[0])
+	}
+}
+
 func TestExportTar(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
 	t.Cleanup(store.Close)

--- a/internal/mountsync/http_client_test.go
+++ b/internal/mountsync/http_client_test.go
@@ -75,3 +75,33 @@ func TestHTTPClientListEvents(t *testing.T) {
 		t.Fatalf("expected nextCursor evt_2, got %+v", feed.NextCursor)
 	}
 }
+
+func TestHTTPClientExportFilesUsesPathFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws_export/fs/export" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Query().Get("format") != "json" {
+			t.Fatalf("expected json export format, got %q", r.URL.Query().Get("format"))
+		}
+		if r.URL.Query().Get("path") != "/github" {
+			t.Fatalf("expected path filter /github, got %q", r.URL.Query().Get("path"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"path":"/github/repos/demo/README.md","revision":"rev_1","contentType":"text/markdown","content":"# Demo"}]`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "token", server.Client())
+	files, err := client.ExportFiles(context.Background(), "ws_export", "/github")
+	if err != nil {
+		t.Fatalf("export files failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected one exported file, got %d", len(files))
+	}
+	if files[0].Path != "/github/repos/demo/README.md" || files[0].Revision != "rev_1" || files[0].Content != "# Demo" {
+		t.Fatalf("unexpected exported file: %+v", files[0])
+	}
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -101,6 +101,10 @@ type RemoteClient interface {
 	DeleteFile(ctx context.Context, workspaceID, path, baseRevision string) error
 }
 
+type exportSnapshotClient interface {
+	ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error)
+}
+
 type HTTPClient struct {
 	baseURL    string
 	token      string
@@ -191,6 +195,36 @@ func (c *HTTPClient) DeleteFile(ctx context.Context, workspaceID, path, baseRevi
 		"If-Match": baseRevision,
 	}
 	return c.doJSON(ctx, http.MethodDelete, fmt.Sprintf("/v1/workspaces/%s/fs/file?%s", url.PathEscape(workspaceID), q.Encode()), headers, nil, nil)
+}
+
+func (c *HTTPClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {
+	q := url.Values{}
+	q.Set("format", "json")
+	q.Set("path", normalizeRemotePath(path))
+	var out []struct {
+		Path        string `json:"path"`
+		Revision    string `json:"revision"`
+		ContentType string `json:"contentType"`
+		Content     string `json:"content"`
+	}
+	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/v1/workspaces/%s/fs/export?%s", url.PathEscape(workspaceID), q.Encode()), nil, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]RemoteFile, 0, len(out))
+	for _, file := range out {
+		remotePath := normalizeRemotePath(file.Path)
+		if remotePath == "/" {
+			continue
+		}
+		files = append(files, RemoteFile{
+			Path:        remotePath,
+			Revision:    file.Revision,
+			ContentType: file.ContentType,
+			Content:     file.Content,
+		})
+	}
+	return files, nil
 }
 
 func (c *HTTPClient) doJSON(
@@ -860,6 +894,9 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 	if err := s.pullRemoteFull(ctx, conflicted); err != nil {
 		return err
 	}
+	if s.wsConn != nil {
+		return nil
+	}
 	cursor, err := s.resolveLatestEventCursor(ctx)
 	if err != nil {
 		var httpErr *HTTPError
@@ -873,6 +910,50 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 }
 
 func (s *Syncer) pullRemoteFull(ctx context.Context, conflicted map[string]struct{}) error {
+	if client, ok := s.client.(exportSnapshotClient); ok {
+		used, err := s.pullRemoteFullExport(ctx, client, conflicted)
+		if used {
+			return err
+		}
+	}
+	return s.pullRemoteFullTree(ctx, conflicted)
+}
+
+func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshotClient, conflicted map[string]struct{}) (bool, error) {
+	files, err := client.ExportFiles(ctx, s.workspace, s.remoteRoot)
+	if err != nil {
+		if exportSnapshotUnsupported(err) {
+			return false, nil
+		}
+		return true, err
+	}
+	remoteFiles := map[string]RemoteFile{}
+	for _, file := range files {
+		remotePath := normalizeRemotePath(file.Path)
+		if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
+			continue
+		}
+		if tracked, ok := s.state.Files[remotePath]; ok && tracked.Denied {
+			continue
+		}
+		file.Path = remotePath
+		remoteFiles[remotePath] = file
+	}
+	return true, s.applyRemoteSnapshot(remoteFiles, conflicted)
+}
+
+func exportSnapshotUnsupported(err error) bool {
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	if httpErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return httpErr.StatusCode == http.StatusBadRequest && strings.EqualFold(httpErr.Code, "bad_request")
+}
+
+func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]struct{}) error {
 	remoteFiles := map[string]RemoteFile{}
 	cursor := ""
 	for {
@@ -911,6 +992,10 @@ func (s *Syncer) pullRemoteFull(ctx context.Context, conflicted map[string]struc
 		cursor = *page.NextCursor
 	}
 
+	return s.applyRemoteSnapshot(remoteFiles, conflicted)
+}
+
+func (s *Syncer) applyRemoteSnapshot(remoteFiles map[string]RemoteFile, conflicted map[string]struct{}) error {
 	remotePaths := make([]string, 0, len(remoteFiles))
 	for remotePath := range remoteFiles {
 		remotePaths = append(remotePaths, remotePath)

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -73,6 +74,53 @@ func TestSyncOncePullsRemoteAndPushesLocalEdits(t *testing.T) {
 	}
 	if remote.Revision == "rev_1" {
 		t.Fatalf("expected remote revision to advance")
+	}
+}
+
+func TestReconcileUsesExportSnapshotForInitialPull(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/github/repos/demo/README.md": {
+				Path:        "/github/repos/demo/README.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# Demo",
+			},
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_2",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{fakeClient: base}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_export",
+		RemoteRoot:  "/github",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot call, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 0 {
+		t.Fatalf("expected export bootstrap to avoid list tree, got %d calls", base.listTreeCalls)
+	}
+	if client.readFileCalls != 0 {
+		t.Fatalf("expected export bootstrap to avoid per-file reads, got %d calls", client.readFileCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "repos", "demo", "README.md"), "# Demo")
+	if _, err := os.Stat(filepath.Join(localDir, "notion", "Docs", "A.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected remote root filter to exclude notion file, stat err=%v", err)
 	}
 }
 
@@ -727,7 +775,7 @@ func TestCanWritePathWithRelayauthScopes(t *testing.T) {
 func TestCanReadPathWithPerFileScopes(t *testing.T) {
 	scopes := map[string]struct{}{
 		"relayfile:fs:read:/src/app.ts": {},
-		"relayfile:fs:read:/README.md": {},
+		"relayfile:fs:read:/README.md":  {},
 	}
 
 	if !canReadPath(scopes, "/src/app.ts") {
@@ -1150,6 +1198,33 @@ type fakeClient struct {
 	eventCounter      int
 	listTreeCalls     int
 	eventsUnsupported bool
+}
+
+type fakeExportClient struct {
+	*fakeClient
+	exportCalls   int
+	readFileCalls int
+}
+
+func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {
+	_ = ctx
+	_ = workspaceID
+	base := normalizeRemotePath(path)
+	files := make([]RemoteFile, 0, len(c.files))
+	for remotePath, file := range c.files {
+		if !isUnderRemoteRoot(base, remotePath) {
+			continue
+		}
+		files = append(files, file)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	c.exportCalls++
+	return files, nil
+}
+
+func (c *fakeExportClient) ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error) {
+	c.readFileCalls++
+	return c.fakeClient.ReadFile(ctx, workspaceID, path)
 }
 
 func (c *fakeClient) ListTree(ctx context.Context, workspaceID, path string, depth int, cursor string) (TreeResponse, error) {

--- a/workflows/relayfile-developer-experience.ts
+++ b/workflows/relayfile-developer-experience.ts
@@ -115,7 +115,7 @@ Write a design doc at ${RELAYFILE}/docs/cli-design.md:
    - Opens browser to OAuth flow (or accepts API key)
    - Stores credentials at ~/.relayfile/credentials.json
    - Validates by calling GET /health on the server
-   - Default server: https://relayfile-api.agentworkforce.workers.dev
+   - Default server: https://api.relayfile.dev
 
 2. relayfile workspace create <name>
    - Creates a new workspace
@@ -147,7 +147,7 @@ Write a design doc at ${RELAYFILE}/docs/cli-design.md:
 
 **Config file: ~/.relayfile/credentials.json**
 {
-  server": "https://relayfile-api.agentworkforce.workers.dev",
+  "server": "https://api.relayfile.dev",
   "token": "eyJ...",
   "refreshToken": "...",
   "expiresAt": "..."


### PR DESCRIPTION
## Summary
- change the CLI built-in default server to https://api.relayfile.dev
- update docs/workflow references from the old Workers hostname
- bootstrap mirror mounts from the Relayfile export JSON snapshot instead of per-file reads
- add server-side export path filtering so mounts can snapshot only their remote root
- keep tree/read bootstrap fallback for older servers

## Tests
- go test ./...