### PR TITLE
fix(mountsync): preserve local files when the server denies the write

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -355,7 +355,15 @@ type trackedFile struct {
 	ContentType string `json:"contentType"`
 	Hash        string `json:"hash"`
 	Dirty       bool   `json:"dirty,omitempty"`
-	Denied      bool   `json:"denied,omitempty"`
+	// Denied — the server denied reading this path. The local copy (if any)
+	// has been removed and future syncs ignore it.
+	Denied bool `json:"denied,omitempty"`
+	// WriteDenied — the server denied creating this path from local. Unlike
+	// Denied, the local copy is preserved. Future sync cycles skip the push
+	// attempt as long as the file's hash still matches DeniedHash; if the
+	// user modifies the file we retry the write on the next cycle.
+	WriteDenied bool   `json:"writeDenied,omitempty"`
+	DeniedHash  string `json:"deniedHash,omitempty"`
 	ReadOnly    bool   `json:"readonly,omitempty"`
 }
 
@@ -573,7 +581,10 @@ func (s *Syncer) pushSingleFile(
 	}
 
 	baseRevision := "0"
-	if exists {
+	if exists && tracked.Revision != "" {
+		// Previously-pushed file — use its revision for optimistic concurrency.
+		// A WriteDenied entry has no Revision (the push never landed), so fall
+		// back to the create-if-absent sentinel "0".
 		baseRevision = tracked.Revision
 	}
 	result, err := s.client.WriteFile(ctx, s.workspace, remotePath, baseRevision, snapshot.ContentType, snapshot.Content)
@@ -613,11 +624,22 @@ func (s *Syncer) pushSingleFile(
 		var httpErr *HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
 			if !exists {
-				s.logDenial("WRITE_DENIED", remotePath, "agent does not have write permission")
-				if removeErr := os.Remove(localPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-					return removeErr
+				// The server rejected the create. Do NOT delete the local file —
+				// destroying user data on permission failure is worse than the
+				// workspace drifting out of sync. Record the denial + hash so the
+				// next cycle skips re-pushing (no log spam) unless the file
+				// changes, in which case we retry.
+				s.logDenial(
+					"WRITE_DENIED",
+					remotePath,
+					"agent does not have write permission; local copy preserved",
+				)
+				s.state.Files[remotePath] = trackedFile{
+					ContentType: snapshot.ContentType,
+					Hash:        snapshot.Hash,
+					WriteDenied: true,
+					DeniedHash:  snapshot.Hash,
 				}
-				delete(s.state.Files, remotePath)
 				return nil
 			}
 			return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, snapshot.ContentType)
@@ -1289,6 +1311,11 @@ func (s *Syncer) applyRemoteDelete(remotePath string, conflicted map[string]stru
 	if tracked.Denied {
 		return nil
 	}
+	// Write-denied files were never on the remote — absence from the remote
+	// snapshot is expected and must not trigger a local delete.
+	if tracked.WriteDenied {
+		return nil
+	}
 	localPath, err := remoteToLocalPath(s.localRoot, s.remoteRoot, remotePath)
 	if err != nil {
 		delete(s.state.Files, remotePath)
@@ -1363,6 +1390,13 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 		if exists && tracked.Hash == snapshot.Hash && !tracked.Dirty {
 			continue
 		}
+		// Skip re-pushing a previously write-denied file whose content hasn't
+		// changed — no point spamming the denial log. If the user edits it,
+		// Hash differs from DeniedHash and we fall through to pushSingleFile
+		// which will retry (and may succeed or log a fresh denial).
+		if exists && tracked.WriteDenied && tracked.DeniedHash == snapshot.Hash {
+			continue
+		}
 		if err := s.pushSingleFile(ctx, remotePath, localPath, snapshot, tracked, exists, conflicted); err != nil {
 			return nil, err
 		}
@@ -1377,7 +1411,9 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 	for _, remotePath := range statePaths {
 		tracked := s.state.Files[remotePath]
 		tracked.ReadOnly = !s.canWritePath(remotePath)
-		if tracked.Denied || tracked.ReadOnly {
+		// Write-denied files never made it to the remote — there's nothing to
+		// delete remotely and we must not delete the local copy.
+		if tracked.Denied || tracked.ReadOnly || tracked.WriteDenied {
 			s.state.Files[remotePath] = tracked
 			continue
 		}

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -988,6 +988,125 @@ func TestReadonlyRevertOnModify(t *testing.T) {
 	}
 }
 
+// TestLocalCreatePreservedWhenServerDeniesWrite guards the regression where
+// relayfile-mount was destroying local files if the server rejected the
+// push with 403. The correct behavior: keep the local file, log the
+// denial, skip future push attempts until the content changes, and never
+// re-enter the delete path on subsequent reconciles.
+func TestLocalCreatePreservedWhenServerDeniesWrite(t *testing.T) {
+	disableWebSocket := true
+	token := mustMountsyncTestJWT(
+		t,
+		"dev-secret",
+		"ws_local_create_denied",
+		"MountSync",
+		[]string{"relayfile:fs:write"},
+		time.Now().Add(time.Hour),
+	)
+	localDir := t.TempDir()
+	// Server: empty workspace, but configured to reject ANY write to /notion/*.
+	server := newMockMountsyncServer(
+		t,
+		map[string]RemoteFile{},
+		nil,
+		map[string]struct{}{"/notion/intro-agent.md": {}},
+	)
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, token, server.Client())
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_create_denied",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWebSocket,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	// Initial pull — workspace is empty, nothing to download.
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial pull failed: %v", err)
+	}
+
+	// Agent writes a new local file.
+	localPath := filepath.Join(localDir, "intro-agent.md")
+	const expected = "# Hello from the agent"
+	if err := os.WriteFile(localPath, []byte(expected), 0o644); err != nil {
+		t.Fatalf("write local file failed: %v", err)
+	}
+
+	// Watcher fires → mount pushes → server returns 403.
+	if err := syncer.HandleLocalChange(
+		context.Background(),
+		"intro-agent.md",
+		fsnotify.Create,
+	); err != nil {
+		t.Fatalf("handle local create failed: %v", err)
+	}
+
+	// Invariant #1: local file must be preserved.
+	assertLocalFileContent(t, localPath, expected)
+
+	// Invariant #2: denial must be logged.
+	denialLogPath := filepath.Join(localDir, ".relay", "permissions-denied.log")
+	logData, err := os.ReadFile(denialLogPath)
+	if err != nil {
+		t.Fatalf("read denial log failed: %v", err)
+	}
+	if !strings.Contains(string(logData), "WRITE_DENIED /notion/intro-agent.md") {
+		t.Fatalf("expected WRITE_DENIED entry for /intro-agent.md, got: %q", string(logData))
+	}
+
+	// Invariant #3: a subsequent reconcile (full pull + push) must NOT
+	// delete the local file or re-push / re-log the denial for the same
+	// content. We simulate this by running two more reconcile cycles.
+	startingLogLen := len(logData)
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("second reconcile failed: %v", err)
+	}
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("third reconcile failed: %v", err)
+	}
+	assertLocalFileContent(t, localPath, expected)
+	logData2, err := os.ReadFile(denialLogPath)
+	if err != nil {
+		t.Fatalf("read denial log (2nd) failed: %v", err)
+	}
+	if len(logData2) != startingLogLen {
+		t.Fatalf(
+			"expected denial log unchanged across reconciles (len=%d → %d), diff: %q",
+			startingLogLen,
+			len(logData2),
+			string(logData2[startingLogLen:]),
+		)
+	}
+
+	// Invariant #4: when the user edits the file, we retry the push.
+	// With the mock still denying writes the retry fails again, but the
+	// fresh denial line must appear (proving we didn't silently skip
+	// legitimate content changes).
+	if err := os.WriteFile(localPath, []byte("# Updated"), 0o644); err != nil {
+		t.Fatalf("update local file failed: %v", err)
+	}
+	if err := syncer.HandleLocalChange(
+		context.Background(),
+		"intro-agent.md",
+		fsnotify.Write,
+	); err != nil {
+		t.Fatalf("handle local update failed: %v", err)
+	}
+	assertLocalFileContent(t, localPath, "# Updated")
+	logData3, err := os.ReadFile(denialLogPath)
+	if err != nil {
+		t.Fatalf("read denial log (3rd) failed: %v", err)
+	}
+	denialLines := strings.Count(string(logData3), "WRITE_DENIED /notion/intro-agent.md")
+	if denialLines < 2 {
+		t.Fatalf("expected a second WRITE_DENIED entry after file edit, got: %q", string(logData3))
+	}
+}
+
 func TestReadonlyRevertOnDelete(t *testing.T) {
 	disableWebSocket := false
 	token := mustMountsyncTestJWT(t, "dev-secret", "ws_readonly_delete", "MountSync", []string{"relayfile:fs:read:/readonly/notes.md"}, time.Now().Add(time.Hour))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "relayfile",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.13",
+      "version": "0.2.0",
       "workspaces": [
         "packages/core",
         "packages/sdk/typescript",
@@ -78,6 +78,16 @@
         "crewai": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@agent-relay/sdk/node_modules/@relayfile/sdk": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.1.13.tgz",
+      "integrity": "sha512-vsy4pPNknSxA1RS/FB8KjMJCjqhDKctiBYC/4bTne49ZzzGixjL1GGPt41WWQjDdR3EO1ASyELtmiGspwLWarw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@agentworkforce/workload-router": {
@@ -2424,7 +2434,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.1.13",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2436,7 +2446,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.1.13",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.3",
@@ -2448,7 +2458,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -2477,7 +2487,7 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.1.13",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.7.3",


### PR DESCRIPTION
## Problem

`relayfile-mount` silently destroys local files in its `--local-dir` whenever the workspace server rejects the push with HTTP 403. Downstream impact observed in a live cloud orchestrator sandbox:

- Workflow agents write deliverables (e.g. `intro-<cli>.md`, `opencode.json`) to `/project`.
- Mount's next sync cycle (~1s default) attempts to push them → server returns 403 because the synced agent lacks write permission on the workspace ACL.
- `pushSingleFile` at `internal/mountsync/syncer.go:622-630` deletes the local file on 403 and removes it from sync state.
- From the agent's perspective the file is gone. Workflow verifications like `file_exists: intro-*.md` fail even though the agent successfully wrote the file moments earlier.

### Evidence from a reproducing run

\`\`\`
# /project/.relay/permissions-denied.log
[2026-04-20T09:16:30Z] WRITE_DENIED /opencode.json: agent does not have write permission
[2026-04-20T09:16:30Z] WRITE_DENIED /probe-project-1776676590.md: agent does not have write permission
...
\`\`\`

Within 5 seconds of a deterministic shell step writing `/project/probe-project-*.md`, `/project/.probe-stamp`, and `/project/opencode.json`, all three were gone from disk. Files written to \`$HOME\` (outside the mount) survived. The mount is actively, aggressively destroying user data.

## Fix

On 403 during a *create* (exists=false), keep the local file, record a \`WriteDenied\` + \`DeniedHash\` entry in the sync state, and short-circuit future push attempts for the same content.

\`\`\`diff
 var httpErr *HTTPError
 if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
     if !exists {
-        s.logDenial(\"WRITE_DENIED\", remotePath, \"agent does not have write permission\")
-        if removeErr := os.Remove(localPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-            return removeErr
-        }
-        delete(s.state.Files, remotePath)
-        return nil
+        s.logDenial(\"WRITE_DENIED\", remotePath, \"agent does not have write permission; local copy preserved\")
+        s.state.Files[remotePath] = trackedFile{
+            ContentType: snapshot.ContentType,
+            Hash:        snapshot.Hash,
+            WriteDenied: true,
+            DeniedHash:  snapshot.Hash,
+        }
+        return nil
     }
\`\`\`

### Supporting changes

- **`trackedFile`** gains \`WriteDenied bool\` and \`DeniedHash string\`. Distinct from the existing \`Denied\` (read-denied, local file removed) so future readers don't conflate semantics.
- **`pushLocal`** (first loop) skips re-pushing a write-denied entry when \`tracked.DeniedHash == snapshot.Hash\`. Prevents log spam and redundant 403 round-trips.
- **`pushLocal`** (second loop) excludes \`WriteDenied\` entries from the \"state has it, remote doesn't → delete\" reconcile path. Write-denied files were never on the remote; their absence is expected.
- **`applyRemoteDelete`** returns early for \`WriteDenied\` entries for the same reason.
- **`pushSingleFile`** revision selection: when re-trying a previously write-denied entry whose \`Revision\` is empty, fall back to the create-if-absent sentinel \"0\" instead of sending an empty revision.

### Behavior after the fix

| Scenario | Before | After |
|---|---|---|
| Agent writes new file, server 403s | File deleted within 1s | File preserved; state flags it WriteDenied |
| Same cycle, repeated | Same as above | Re-push skipped, no new denial log entry |
| User edits file | N/A (gone) | Hash differs from DeniedHash → retry; success or fresh denial log entry |
| Full reconcile / Reconcile() | Would also delete file | Excluded from delete path |

## Tests

- New: \`TestLocalCreatePreservedWhenServerDeniesWrite\` — exercises all four invariants above against a mock server that 403s every write to a specific path.
- Full mountsync suite passes (\`go test ./internal/mountsync/...\`).
- Full repo: \`go test ./...\` green.

## Follow-up (not in this PR)

The 403 itself is a server-side ACL decision. This PR makes the mount non-destructive when it happens — it does not change the ACL policy. If the orchestrator agent is expected to write back, the workspace ACL for that agent needs \`fs:write\` on the paths it pushes. That's a relayauth/relayfile ACL concern, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
