### PR TITLE
feat(sdk): expose ContentIdentity on write types

### DIFF
--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK for relayfile — real-time filesystem for humans and agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "TypeScript SDK for relayfile — real-time filesystem for humans and agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/typescript/src/client.test.ts
+++ b/packages/sdk/typescript/src/client.test.ts
@@ -134,6 +134,43 @@ describe("RelayFileClient — existing methods", () => {
       expect(init.method).toBe("PUT");
       expect((init.headers as Record<string, string>)["If-Match"]).toBe("rev_3");
     });
+
+    it("forwards contentIdentity in the body when provided", async () => {
+      const payload: WriteQueuedResponse = {
+        opId: "op_1",
+        status: "queued",
+        targetRevision: "rev_4",
+      };
+      const f = mockFetch(payload);
+      const client = makeClient(f);
+      await client.writeFile({
+        workspaceId: "ws_acme",
+        path: "/github/push/abc123.json",
+        baseRevision: "rev_3",
+        content: "{}",
+        contentIdentity: { kind: "github.push", key: "abc123" },
+      });
+      const body = JSON.parse((f.mock.calls[0]![1] as RequestInit).body as string);
+      expect(body.contentIdentity).toEqual({ kind: "github.push", key: "abc123" });
+    });
+
+    it("omits contentIdentity from the body when not provided", async () => {
+      const payload: WriteQueuedResponse = {
+        opId: "op_1",
+        status: "queued",
+        targetRevision: "rev_4",
+      };
+      const f = mockFetch(payload);
+      const client = makeClient(f);
+      await client.writeFile({
+        workspaceId: "ws_acme",
+        path: "/x.json",
+        baseRevision: "rev_3",
+        content: "{}",
+      });
+      const body = JSON.parse((f.mock.calls[0]![1] as RequestInit).body as string);
+      expect(body.contentIdentity).toBeUndefined();
+    });
   });
 
   // ---- deleteFile ----

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -337,7 +337,7 @@ export class RelayFileClient {
   }
 
   async writeFile(input: WriteFileInput): Promise<WriteQueuedResponse> {
-    const { workspaceId, path, correlationId, baseRevision, content, contentType, encoding, semantics, signal } = input;
+    const { workspaceId, path, correlationId, baseRevision, content, contentType, encoding, contentIdentity, signal } = input;
     const query = buildQuery({ path });
     return this.request<WriteQueuedResponse>({
       method: "PUT",
@@ -351,7 +351,8 @@ export class RelayFileClient {
         contentType: contentType ?? "text/markdown",
         content,
         encoding,
-        semantics: input.semantics
+        semantics: input.semantics,
+        ...(contentIdentity ? { contentIdentity } : {})
       },
       signal
     });

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -59,6 +59,7 @@ export type {
   BulkWriteInput,
   BulkWriteResponse,
   ConflictErrorResponse,
+  ContentIdentity,
   DeleteFileInput,
   DeadLetterFeedResponse,
   DeadLetterItem,

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -49,6 +49,18 @@ export interface FileSemantics {
   comments?: string[];
 }
 
+/**
+ * Stable identity for an idempotent write, used by the server to coalesce
+ * duplicate deliveries (webhook retries, cross-product fan-in). Two writes
+ * with equal `(kind, key)` in the same workspace within the dedup window
+ * resolve to the same op. Callers typically derive `key` from the upstream
+ * event id, e.g. `github:push:<sha>`.
+ */
+export interface ContentIdentity {
+  kind: string;
+  key: string;
+}
+
 export interface FileReadResponse {
   path: string;
   revision: string;
@@ -66,6 +78,7 @@ export interface FileWriteRequest {
   content: string;
   encoding?: "utf-8" | "base64";
   semantics?: FileSemantics;
+  contentIdentity?: ContentIdentity;
 }
 
 export interface BulkWriteFile {
@@ -73,6 +86,7 @@ export interface BulkWriteFile {
   contentType?: string;
   content: string;
   encoding?: "utf-8" | "base64";
+  contentIdentity?: ContentIdentity;
 }
 
 export interface BulkWriteInput {
@@ -507,6 +521,7 @@ export interface WriteFileInput {
   contentType?: string;
   encoding?: "utf-8" | "base64";
   semantics?: FileSemantics;
+  contentIdentity?: ContentIdentity;
   correlationId?: string;
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Summary

PR #54 landed `contentIdentity` in `@relayfile/core` and bumped to v0.3.0, but the TS client SDK never exposed it on `FileWriteRequest` / `BulkWriteFile` / `WriteFileInput`. Consumers (sage, nightcto, msd) have been working around this with local `.d.ts` shims — see e.g. sage #89's `src/relayfile-sdk.d.ts`.

This PR:
- Adds `ContentIdentity { kind: string; key: string }` to the SDK's types
- Adds optional `contentIdentity` to `FileWriteRequest`, `BulkWriteFile`, `WriteFileInput`
- Forwards it on the PUT body in `client.writeFile()`
- Exports `ContentIdentity` from the public surface
- Bumps `@relayfile/sdk` to 0.3.1

Fully additive, no breakage for callers that omit the field.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (46/46, incl. two new tests for forward + omit cases)
- [ ] Publish 0.3.1 via the usual Publish Packages workflow_dispatch
- [ ] Downstream sage/nightcto/msd PRs drop their local `.d.ts` shims on a follow-up

Related: #54, platform-v1 runbook ([sage#84](https://github.com/AgentWorkforce/sage/issues/84))
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
