### PR TITLE
refactor(local-mount): rename createSymlinkMount to createMount

### DIFF
--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -12,12 +12,12 @@ npm install @relayfile/local-mount
 
 ## What it exports
 
-### `createSymlinkMount(projectDir, mountDir, options)`
+### `createMount(projectDir, mountDir, options)`
 
 Builds a mounted copy of `projectDir` at `mountDir` and returns a handle:
 
 ```ts
-interface SymlinkMountHandle {
+interface MountHandle {
   mountDir: string;
   syncBack(opts?: { signal?: AbortSignal }): Promise<number>;
   startAutoSync(opts?: AutoSyncOptions): AutoSyncHandle;
@@ -212,6 +212,18 @@ The implementation is intentionally conservative about `mountDir`:
 - if `mountDir` already exists, it must contain the `.relayfile-local-mount` marker file from a previous mount created by this package
 
 These checks help prevent accidental deletion of unrelated directories during mount recreation and cleanup.
+
+## Why copy instead of symlink?
+
+The mount is built by copying files rather than symlinking them. Symlinks would break several of the package's guarantees:
+
+1. **`.agentreadonly` can't be enforced.** Read-only is implemented by `chmod 0o444` on the mount copy. `chmod` follows symlinks, so applying it to a symlink would mark the *source* file read-only, flipping the project's permissions instead of restricting the agent's view.
+2. **The auto-sync conflict model assumes two distinct files.** Rules like "both sides changed → mount wins", "one side deleted → propagate", and "readonly paths never flow mount→project but project-side edits still flow into the mount" only make sense if mount and source are separate bytes. Through a symlink they're the same inode — there's no mount-side copy to re-chmod `0o444` after a project-side edit.
+3. **Editor save-via-rename breaks symlinks anyway.** Most editors save by writing a temp file and renaming it over the target, which replaces the symlink with a regular file and severs the link. A "live view" via symlinks isn't reliable in practice.
+4. **Containment.** A copy gives you a checkpoint: if the agent destroys files or writes garbage, the source is untouched until `syncBack()` filters and copies back. With symlinks, every keystroke is live on the project.
+5. **`.agentignore` hiding works fine with symlinks** (just don't link), but the readonly and conflict semantics still need copies — so a hybrid would be more complex than just copying everything.
+
+Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; the resolved bytes are copied. Symlinks the agent creates inside the mount are skipped on sync-back.
 
 ## Notes
 

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { createSymlinkMount } from './symlink-mount.js';
+import { createMount } from './mount.js';
 
 function tmpDir(): string {
   return mkdtempSync(path.join(os.tmpdir(), 'local-mount-autosync-'));
@@ -53,7 +53,7 @@ describe('startAutoSync', () => {
   it('propagates mount→project edits without waiting for final syncBack', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -75,7 +75,7 @@ describe('startAutoSync', () => {
   it('propagates project→mount external edits', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -97,7 +97,7 @@ describe('startAutoSync', () => {
   it('propagates mount→project deletes', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -117,7 +117,7 @@ describe('startAutoSync', () => {
   it('propagates project→mount deletes', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -137,7 +137,7 @@ describe('startAutoSync', () => {
   it('respects readonly patterns: mount-side edits do not sync back', async () => {
     write(path.join(projectDir, 'locked.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['locked.txt'],
       excludeDirs: [],
@@ -165,7 +165,7 @@ describe('startAutoSync', () => {
   it('readonly: project-side edits flow into the mount', async () => {
     write(path.join(projectDir, 'locked.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['locked.txt'],
       excludeDirs: [],
@@ -187,7 +187,7 @@ describe('startAutoSync', () => {
   it('mount-wins: concurrent edits on both sides resolve to mount content', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -218,7 +218,7 @@ describe('startAutoSync', () => {
   it('ignored paths are never synced in either direction', async () => {
     write(path.join(projectDir, 'keep.txt'), 'keep');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: ['secrets/'],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -248,7 +248,7 @@ describe('startAutoSync', () => {
     // path happens to include a segment of the same name must still sync.
     write(path.join(projectDir, 'docs/cache'), 'this is a file, not a dir');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: ['cache/'],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -270,7 +270,7 @@ describe('startAutoSync', () => {
   it('periodic full scan catches changes even if watcher events are missed', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -294,7 +294,7 @@ describe('startAutoSync', () => {
   it('stop({ signal }) skips the draining reconcile when already aborted, but still closes watchers', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -321,7 +321,7 @@ describe('startAutoSync', () => {
   });
 
   it('does not sync the _MOUNT_README.md or marker files', async () => {
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],

--- a/packages/local-mount/src/index.ts
+++ b/packages/local-mount/src/index.ts
@@ -1,8 +1,8 @@
 export {
-  createSymlinkMount,
-  type SymlinkMountOptions,
-  type SymlinkMountHandle,
-} from './symlink-mount.js';
+  createMount,
+  type MountOptions,
+  type MountHandle,
+} from './mount.js';
 
 export {
   type AutoSyncOptions,

--- a/packages/local-mount/src/launch.test.ts
+++ b/packages/local-mount/src/launch.test.ts
@@ -10,7 +10,7 @@ import {
 import os from 'node:os';
 import path from 'node:path';
 import { launchOnMount } from './launch.js';
-import * as symlinkMount from './symlink-mount.js';
+import * as mountModule from './mount.js';
 
 describe('launchOnMount', () => {
   let projectDir: string;
@@ -88,7 +88,7 @@ describe('launchOnMount', () => {
     let cleanedUp = false;
     let stopCalled = false;
 
-    const createSpy = vi.spyOn(symlinkMount, 'createSymlinkMount').mockReturnValue({
+    const createSpy = vi.spyOn(mountModule, 'createMount').mockReturnValue({
       mountDir,
       startAutoSync: () => ({
         stop: async () => {

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { createSymlinkMount, type SymlinkMountHandle } from './symlink-mount.js';
+import { createMount, type MountHandle } from './mount.js';
 import type { AutoSyncHandle, AutoSyncOptions } from './auto-sync.js';
 
 export interface LaunchOnMountOptions {
@@ -61,7 +61,7 @@ export interface LaunchOnMountResult {
  * exit code.
  */
 export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchOnMountResult> {
-  const handle: SymlinkMountHandle = createSymlinkMount(opts.projectDir, opts.mountDir, {
+  const handle: MountHandle = createMount(opts.projectDir, opts.mountDir, {
     ignoredPatterns: opts.ignoredPatterns ?? [],
     readonlyPatterns: opts.readonlyPatterns ?? [],
     excludeDirs: opts.excludeDirs ?? [],

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { createSymlinkMount } from './symlink-mount.js';
+import { createMount } from './mount.js';
 
 function tmpDir(): string {
   return mkdtempSync(path.join(os.tmpdir(), 'local-mount-test-'));
@@ -22,7 +22,7 @@ function write(file: string, body: string): void {
   writeFileSync(file, body, 'utf8');
 }
 
-describe('createSymlinkMount', () => {
+describe('createMount', () => {
   let projectDir: string;
   let mountDir: string;
 
@@ -43,7 +43,7 @@ describe('createSymlinkMount', () => {
     write(path.join(projectDir, 'docs/guide.md'), 'guide');
     write(path.join(projectDir, 'config.ro'), 'frozen');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: ['secrets/'],
       readonlyPatterns: ['*.ro', 'docs/**'],
       excludeDirs: [],
@@ -70,7 +70,7 @@ describe('createSymlinkMount', () => {
 
   it('refuses mountDir === projectDir', () => {
     expect(() =>
-      createSymlinkMount(projectDir, projectDir, {
+      createMount(projectDir, projectDir, {
         ignoredPatterns: [],
         readonlyPatterns: [],
         excludeDirs: [],
@@ -84,7 +84,7 @@ describe('createSymlinkMount', () => {
     write(path.join(projectDir, '.relay/state.json'), '{}');
     write(path.join(projectDir, 'keep.txt'), 'yes');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -103,7 +103,7 @@ describe('createSymlinkMount', () => {
     write(path.join(projectDir, 'writable.txt'), 'original');
     write(path.join(projectDir, 'readonly.txt'), 'original-ro');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['readonly.txt'],
       excludeDirs: [],
@@ -138,7 +138,7 @@ describe('createSymlinkMount', () => {
   it('syncBack: returns immediately when already aborted', async () => {
     write(path.join(projectDir, 'writable.txt'), 'original');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -162,7 +162,7 @@ describe('createSymlinkMount', () => {
     write(path.join(projectDir, 'b.txt'), 'b0');
     write(path.join(projectDir, 'c.txt'), 'c0');
 
-    const handle = createSymlinkMount(projectDir, mountDir, {
+    const handle = createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -21,7 +21,7 @@ import {
   type AutoSyncOptions,
 } from './auto-sync.js';
 
-export interface SymlinkMountOptions {
+export interface MountOptions {
   ignoredPatterns: string[];
   readonlyPatterns: string[];
   excludeDirs: string[];
@@ -32,7 +32,7 @@ export interface SymlinkMountOptions {
   agentName?: string;
 }
 
-export interface SymlinkMountHandle {
+export interface MountHandle {
   mountDir: string;
   syncBack(opts?: { signal?: AbortSignal }): Promise<number>;
   /**
@@ -50,11 +50,11 @@ const MOUNT_MARKER_FILENAME = '.relayfile-local-mount';
 const MOUNT_MARKER_CONTENT =
   'This directory is managed by @relayfile/local-mount. Do not place unrelated files here; the directory will be deleted when the mount is torn down.\n';
 
-export function createSymlinkMount(
+export function createMount(
   projectDir: string,
   mountDir: string,
-  options: SymlinkMountOptions
-): SymlinkMountHandle {
+  options: MountOptions
+): MountHandle {
   const resolvedProjectDir = realpathSync(projectDir);
   const resolvedMountDir = path.resolve(mountDir);
   const readonlyPatterns = [...options.readonlyPatterns];
@@ -191,7 +191,7 @@ function assertMountDirSafeToRemove(mountDir: string, projectDir: string): void 
   if (!existsSync(markerPath)) {
     throw new Error(
       `Refusing to remove ${resolved}: missing ${MOUNT_MARKER_FILENAME} marker. ` +
-        `Only directories previously created by createSymlinkMount can be reused as mountDir.`
+        `Only directories previously created by createMount can be reused as mountDir.`
     );
   }
 }


### PR DESCRIPTION
## Summary
- Rename `createSymlinkMount` / `SymlinkMountOptions` / `SymlinkMountHandle` to `createMount` / `MountOptions` / `MountHandle` so the API name matches the behavior — the package copies files into the mount, it doesn't symlink them.
- Move `src/symlink-mount.{ts,test.ts}` to `src/mount.{ts,test.ts}` (git rename — diff shows 93–98% similarity).
- Add a "Why copy instead of symlink?" section to the README explaining the rationale (chmod 0o444 readonly enforcement, the auto-sync conflict model, editor save-via-rename, containment).

This is a breaking change to the public API surface of `@relayfile/local-mount`. There are no other consumers in this repo. The historical name in `CHANGELOG.md` is left as-is since it records what shipped at v0.4.0.

## Test plan
- [x] `npm run typecheck` passes in `packages/local-mount`
- [x] `npm test` passes in `packages/local-mount` (26/26)
- [ ] Reviewer: confirm the renamed exports are intentional and worth the breaking-change bump on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/agentworkforce/relayfile/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
