### PR TITLE
Productize Relayfile cloud mount flow

### DIFF
--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-01T15:27:12.684Z",
+  "lastUpdated": "2026-05-04T10:01:57.858Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -110,6 +110,27 @@
       "startedAt": "2026-05-01T15:22:05.684Z",
       "completedAt": "2026-05-01T15:27:12.578Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_hyqnsfininh5.json"
+    },
+    "traj_ailh4waboewf": {
+      "title": "Design relayfile low-friction cloud login and integration mount flow",
+      "status": "completed",
+      "startedAt": "2026-05-01T23:39:39.687Z",
+      "completedAt": "2026-05-01T23:45:39.611Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_ailh4waboewf.json"
+    },
+    "traj_ozxb98dy7hk5": {
+      "title": "Research relayfile positioning vs MCP and CLI",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:00:09.507Z",
+      "completedAt": "2026-05-04T10:01:10.778Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_ozxb98dy7hk5.json"
+    },
+    "traj_rnldje4mr6nw": {
+      "title": "Research relayfile positioning vs MCP and CLI",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:01:57.596Z",
+      "completedAt": "2026-05-04T10:01:57.776Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_rnldje4mr6nw.json"
     }
   }
 }

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-04T10:01:57.858Z",
+  "lastUpdated": "2026-05-04T10:40:25.933Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -131,6 +131,34 @@
       "startedAt": "2026-05-04T10:01:57.596Z",
       "completedAt": "2026-05-04T10:01:57.776Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_rnldje4mr6nw.json"
+    },
+    "traj_78fn1fyq1m4d": {
+      "title": "Explain relayfile relayauth governance model",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:16:51.523Z",
+      "completedAt": "2026-05-04T10:17:37.753Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_78fn1fyq1m4d.json"
+    },
+    "traj_aomtlnb3g5sa": {
+      "title": "Identify relayfile relayauth changes for per-user governance",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:22:29.278Z",
+      "completedAt": "2026-05-04T10:22:29.396Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_aomtlnb3g5sa.json"
+    },
+    "traj_5uxheavo6d3q": {
+      "title": "Write per-user relayfile governance spec",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:25:24.905Z",
+      "completedAt": "2026-05-04T10:27:40.891Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_5uxheavo6d3q.json"
+    },
+    "traj_2nl6e3gqkvki": {
+      "title": "Document programmatic Notion connect interface",
+      "status": "completed",
+      "startedAt": "2026-05-04T10:38:33.363Z",
+      "completedAt": "2026-05-04T10:40:25.800Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_2nl6e3gqkvki.json"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -48,16 +48,47 @@ This starts relayfile on `:9090` and relayauth on `:9091`, seeds a `ws_demo` wor
 
 ## Getting Started
 
-**Relayfile Cloud** — everything managed. Run the CLI, sign in with the hosted browser flow, choose an integration, and Relayfile mounts it as ordinary files for your agent:
+**Relayfile Cloud** — everything managed. Run the CLI, sign in with the hosted browser flow, choose an integration, and Relayfile mirrors it as ordinary files on disk for your agent:
 
 ```bash
 relayfile
 ```
 
-For non-interactive setup, provide the choices up front:
+This runs a guided wizard: Cloud login, workspace name, integration provider, local directory, and OAuth consent. Files appear under `./relayfile-mount/<provider>/` within 30 seconds of OAuth completing.
+
+For non-interactive / CI setup:
 
 ```bash
-relayfile setup --provider github --workspace my-project --local-dir ./relayfile-mount
+relayfile setup \
+  --cloud-token "$RELAYFILE_CLOUD_TOKEN" \
+  --provider github \
+  --workspace my-project \
+  --local-dir ./relayfile-mount \
+  --no-open \
+  --once
+```
+
+> **Note:** The default attachment is a **synced mirror**, not a kernel FUSE mount. Files are ordinary files on disk; a daemon polls the Cloud every 30 s and handles writeback. FUSE is available via `--mode=fuse` but is not required. See [docs/guides/vfs-cloud-setup.md](docs/guides/vfs-cloud-setup.md) for the full human guide including limitations, conflict resolution, and troubleshooting.
+
+After setup you can add more integrations without remounting:
+
+```bash
+relayfile integration connect notion
+relayfile integration connect linear
+relayfile integration list
+```
+
+Check live sync state at any time:
+
+```bash
+relayfile status
+```
+
+Run the sync loop in the background:
+
+```bash
+relayfile mount --background my-project ./relayfile-mount
+relayfile stop my-project
 ```
 
 **Self-hosted:**
@@ -175,12 +206,26 @@ docker compose up --build -d
 Mount a workspace as a local directory:
 
 ```bash
-# FUSE mount (real-time)
-relayfile mount ws_123 ./files --token $TOKEN
+# Synced mirror (default, recommended)
+relayfile mount ws_123 ./files
 
-# Polling sync (no FUSE required)
+# One-shot sync (CI/probe)
+relayfile mount ws_123 ./files --once
+
+# Background daemon
+relayfile mount --background ws_123 ./files
+relayfile stop ws_123
+
+# FUSE mount (opt-in, requires FUSE support)
+relayfile mount ws_123 ./files --mode=fuse
+
+# Self-hosted: polling sync without Cloud
 go run ./cmd/relayfile-mount --workspace ws_123 --local-dir ./files --interval 2s --token $TOKEN
 ```
+
+The default mode is a **synced mirror** (`--mode=poll`). It is not a real-time POSIX filesystem. Known differences: file handles are not stable across syncs, `mtime` reflects local write time only, directory listings can lag by up to 30 s. See [docs/guides/vfs-cloud-setup.md#known-limitations](docs/guides/vfs-cloud-setup.md#known-limitations).
+
+**For agents:** See [docs/guides/agent-vfs-usage.md](docs/guides/agent-vfs-usage.md) and the installable skill at [docs/skills/relayfile-workspace.md](docs/skills/relayfile-workspace.md).
 
 ## CLI Inspection
 
@@ -203,6 +248,34 @@ Open the hosted observer for the active workspace:
 relayfile observer
 relayfile observer ws_123 --no-open
 ```
+
+Inspect and recover dead-lettered writeback operations:
+
+```bash
+relayfile ops list
+relayfile ops replay op_abc123
+```
+
+Check which paths are writable for a provider:
+
+```bash
+relayfile permissions
+relayfile permissions github/repos/acme/api/pulls/
+```
+
+## Documentation
+
+| Guide | Audience |
+|-------|----------|
+| [docs/guides/getting-started.md](docs/guides/getting-started.md) | First steps with self-hosted Relayfile |
+| [docs/guides/vfs-cloud-setup.md](docs/guides/vfs-cloud-setup.md) | Human guide: Cloud setup, integrations, status, daemon, troubleshooting |
+| [docs/guides/agent-vfs-usage.md](docs/guides/agent-vfs-usage.md) | Agent guide: mount discovery, reads, writes, conflicts, writeback |
+| [docs/guides/cloud-integration.md](docs/guides/cloud-integration.md) | Cloud workflow model for orchestrators |
+| [docs/guides/collaboration.md](docs/guides/collaboration.md) | Multi-human and human+agent collaboration patterns |
+| [docs/skills/relayfile-workspace.md](docs/skills/relayfile-workspace.md) | Installable agent skill (copy to `.agents/skills/`) |
+| [docs/cli-design.md](docs/cli-design.md) | CLI command reference and design |
+| [docs/productized-cloud-mount-contract.md](docs/productized-cloud-mount-contract.md) | v1 product contract (normative) |
+| [docs/api-reference.md](docs/api-reference.md) | REST API reference |
 
 ## Changelogs
 

--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -1,0 +1,258 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestA14BackgroundModeWritesPidAndStopSignalsCleanly is the acceptance test
+// for productized cloud-mount contract A14: `relayfile mount --background`
+// writes `mount.pid` and `mount.log`; `relayfile stop` signals the daemon
+// cleanly within 5 s. The test spawns a long-lived child process and treats
+// it as the daemon target so we can exercise `runStop` without standing up
+// a full mount loop.
+func TestA14BackgroundModeWritesPidAndStopSignalsCleanly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep subprocess failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_, _ = cmd.Process.Wait()
+	})
+
+	pidFile := mountPIDFile(localDir)
+	logFile := mountLogFile(localDir)
+	if err := writeDaemonPIDState(pidFile, daemonPIDState{
+		PID:         cmd.Process.Pid,
+		WorkspaceID: "ws_demo",
+		LocalDir:    localDir,
+		LogFile:     logFile,
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+	// A14 also requires the daemon to allocate a mount.log; we synthesize it
+	// here because the test does not run the real mount loop.
+	if err := os.WriteFile(logFile, []byte("mount started\n"), 0o644); err != nil {
+		t.Fatalf("seed mount.log failed: %v", err)
+	}
+
+	if _, err := os.Stat(pidFile); err != nil {
+		t.Fatalf("expected mount.pid in place, got err=%v", err)
+	}
+	if _, err := os.Stat(logFile); err != nil {
+		t.Fatalf("expected mount.log in place, got err=%v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"stop", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run stop failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "Stopped background mount") {
+		t.Fatalf("unexpected stop output: %q", got)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	exited := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		exited <- err
+	}()
+	select {
+	case err := <-exited:
+		if err == nil {
+			return
+		}
+		// `sleep` killed by SIGTERM exits with a *exec.ExitError; that is
+		// the expected signal-induced termination per A14.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() && status.Signal() == syscall.SIGTERM {
+				return
+			}
+		}
+		t.Fatalf("subprocess exited with unexpected error: %v", err)
+	case <-time.After(time.Until(deadline)):
+		t.Fatalf("subprocess did not exit within 5s of SIGTERM")
+	}
+}
+
+// TestA14StopReportsErrorWhenNoDaemonRunning verifies the stop command does
+// not silently no-op when the workspace has no recorded mount.pid.
+func TestA14StopReportsErrorWhenNoDaemonRunning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{"stop", "demo"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected stop to error when no pid file present, got nil")
+	}
+	if !strings.Contains(err.Error(), "no running mount") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestA2RunCloudLoginReturnsStateMismatchSentinel exercises productized
+// cloud-mount contract A2: when the OAuth callback's `state` parameter does
+// not match the value the CLI generated, runCloudLogin must return the
+// ErrCloudLoginStateMismatch sentinel so main() can exit 10.
+func TestA2RunCloudLoginReturnsStateMismatchSentinel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	// Read stdout via a pipe so the test can wait for the listener URL line
+	// before forging the callback request.
+	pipeR, pipeW := io.Pipe()
+	scannerOut := make(chan string, 1)
+	go func() {
+		// Pull at most a few KB until we see the login URL the function
+		// prints, then forward the rest into a discard sink.
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 256)
+		re := regexp.MustCompile(`Sign in to Relayfile Cloud:\s+(\S+)`)
+		for {
+			n, err := pipeR.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+				if matches := re.FindSubmatch(buf); matches != nil {
+					scannerOut <- string(matches[1])
+					_, _ = io.Copy(io.Discard, pipeR)
+					return
+				}
+			}
+			if err != nil {
+				close(scannerOut)
+				return
+			}
+		}
+	}()
+
+	loginErr := make(chan error, 1)
+	go func() {
+		_, err := runCloudLogin("https://cloud.example.test", 10*time.Second, false, pipeW)
+		_ = pipeW.Close()
+		loginErr <- err
+	}()
+
+	var loginURL string
+	select {
+	case loginURL = <-scannerOut:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("runCloudLogin did not print login URL in time")
+	}
+
+	parsed, err := url.Parse(loginURL)
+	if err != nil {
+		t.Fatalf("parse login URL failed: %v", err)
+	}
+	redirectURI := parsed.Query().Get("redirect_uri")
+	if redirectURI == "" {
+		t.Fatalf("login URL missing redirect_uri: %s", loginURL)
+	}
+	callback, err := url.Parse(redirectURI)
+	if err != nil {
+		t.Fatalf("parse redirect_uri failed: %v", err)
+	}
+	q := callback.Query()
+	q.Set("state", "tampered-or-replayed")
+	q.Set("access_token", "bogus")
+	callback.RawQuery = q.Encode()
+
+	resp, err := http.Get(callback.String())
+	if err != nil {
+		t.Fatalf("forge callback request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case err := <-loginErr:
+		if !errors.Is(err, ErrCloudLoginStateMismatch) {
+			t.Fatalf("expected ErrCloudLoginStateMismatch, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("runCloudLogin did not return after state mismatch")
+	}
+}
+
+// TestA14LogsCommandTailsBackgroundLog ensures `relayfile logs` reads from
+// the recorded mount.log path the daemon would have written.
+func TestA14LogsCommandTailsBackgroundLog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, ".relay", "mount.log"), []byte("line1\nline2\nline3\n"), 0o644); err != nil {
+		t.Fatalf("write mount.log failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"logs", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run logs failed: %v", err)
+	}
+	got := stdout.String()
+	for _, line := range []string{"line1", "line2", "line3"} {
+		if !strings.Contains(got, line) {
+			t.Fatalf("expected %q in logs output, got %q", line, got)
+		}
+	}
+}

--- a/cmd/relayfile-cli/catalog_test.go
+++ b/cmd/relayfile-cli/catalog_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+)
+
+// TestA12CatalogRevalidatedAfterCloudConflict covers productized cloud-mount
+// contract A12 (409 force-revalidate path): when the cloud rejects a
+// connect-session because the requested provider id is no longer in the
+// catalog (HTTP 409), the CLI must drop the cached catalog so the next
+// invocation pulls a fresh provider list.
+func TestA12CatalogRevalidatedAfterCloudConflict(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := ensureConfigDir(); err != nil {
+		t.Fatalf("ensureConfigDir failed: %v", err)
+	}
+	if err := writeIntegrationCatalogCache(integrationCatalogCacheEntry{
+		APIURL:    "https://cloud.example.test",
+		FetchedAt: "2026-05-04T11:00:00Z",
+		Version:   "v_old",
+		Providers: []integrationCatalogEntry{
+			{ID: "deprecated-provider", DisplayName: "Old", VFSRoot: "/old"},
+		},
+	}); err != nil {
+		t.Fatalf("seed catalog cache failed: %v", err)
+	}
+	if _, err := os.Stat(integrationCatalogCachePath()); err != nil {
+		t.Fatalf("expected seeded cache file, got err=%v", err)
+	}
+
+	var connectCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/integrations/connect-session":
+			atomic.AddInt32(&connectCalls, 1)
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error":"unknown_provider","providers":[{"id":"notion","displayName":"Notion","vfsRoot":"/notion"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+
+	err := connectCloudIntegration(server.URL, "ws_demo", "tok", "deprecated-provider", localDir, 0, false, &stubWriter{})
+	if err == nil {
+		t.Fatalf("expected error from connect-session 409, got nil")
+	}
+	if !isAPIConflict(err) {
+		t.Fatalf("expected 409 to surface as apiError; got: %v", err)
+	}
+	if got := atomic.LoadInt32(&connectCalls); got != 1 {
+		t.Fatalf("expected exactly 1 connect-session call, got %d", got)
+	}
+	if _, err := os.Stat(integrationCatalogCachePath()); !os.IsNotExist(err) {
+		t.Fatalf("expected catalog cache invalidated after 409, got err=%v", err)
+	}
+}
+
+// TestA12CatalogRefetchedAfterTTLExpiry verifies that a stale catalog cache
+// (older than the TTL) is treated as a miss so a freshly added provider
+// appears within the contract's "1 h or after a 409" window.
+func TestA12CatalogRefetchedAfterTTLExpiry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	apiURL := "https://cloud.example.test"
+	if err := ensureConfigDir(); err != nil {
+		t.Fatalf("ensureConfigDir failed: %v", err)
+	}
+	// Backdated cache far past the TTL.
+	if err := writeIntegrationCatalogCache(integrationCatalogCacheEntry{
+		APIURL:    apiURL,
+		FetchedAt: "2024-01-01T00:00:00Z",
+		Version:   "v_stale",
+		Providers: []integrationCatalogEntry{{ID: "notion", DisplayName: "Notion", VFSRoot: "/notion"}},
+	}); err != nil {
+		t.Fatalf("seed stale catalog cache failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/integrations/catalog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[{"id":"notion","displayName":"Notion","vfsRoot":"/notion"},{"id":"github","displayName":"GitHub","vfsRoot":"/github"}],"version":"v_fresh"}`))
+	}))
+	defer server.Close()
+
+	providers, err := loadIntegrationCatalog(server.URL, "tok")
+	if err != nil {
+		t.Fatalf("loadIntegrationCatalog failed: %v", err)
+	}
+	ids := make([]string, 0, len(providers))
+	for _, p := range providers {
+		ids = append(ids, p.ID)
+	}
+	hasGitHub := false
+	for _, id := range ids {
+		if id == "github" {
+			hasGitHub = true
+		}
+	}
+	if !hasGitHub {
+		t.Fatalf("expected stale cache to be refetched and surface new github provider, got: %v", ids)
+	}
+}
+
+// stubWriter swallows output during connect-session tests where the
+// printed connect-link is not under assertion.
+type stubWriter struct{}
+
+func (stubWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+var _ = context.Background // ensure context import is referenced for future tests

--- a/cmd/relayfile-cli/daemon_unix.go
+++ b/cmd/relayfile-cli/daemon_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return nil
+}

--- a/cmd/relayfile-cli/daemon_unix.go
+++ b/cmd/relayfile-cli/daemon_unix.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -10,4 +11,10 @@ import (
 func configureDetachedProcess(cmd *exec.Cmd) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	return nil
+}
+
+// signalDaemonStop asks a background mount to terminate gracefully. Unix
+// uses SIGTERM so the daemon can flush its state file before exiting.
+func signalDaemonStop(process *os.Process) error {
+	return process.Signal(syscall.SIGTERM)
 }

--- a/cmd/relayfile-cli/daemon_windows.go
+++ b/cmd/relayfile-cli/daemon_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(cmd *exec.Cmd) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | syscall.DETACHED_PROCESS,
+	}
+	return nil
+}

--- a/cmd/relayfile-cli/daemon_windows.go
+++ b/cmd/relayfile-cli/daemon_windows.go
@@ -3,13 +3,25 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 func configureDetachedProcess(cmd *exec.Cmd) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | syscall.DETACHED_PROCESS,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
 	}
 	return nil
+}
+
+// signalDaemonStop asks a background mount to terminate. On Windows the
+// kernel only routes os.Kill through Process.Signal, so we use Kill()
+// (which calls TerminateProcess) instead of SIGTERM. The mount loop's
+// state file is flushed on every cycle, so terminating between cycles
+// is safe even though it is not as graceful as the Unix path.
+func signalDaemonStop(process *os.Process) error {
+	return process.Kill()
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -140,6 +140,7 @@ type syncProviderStatus struct {
 	FailureCodes          map[string]int `json:"failureCodes"`
 	DeadLetteredEnvelopes int            `json:"deadLetteredEnvelopes"`
 	DeadLetteredOps       int            `json:"deadLetteredOps"`
+	WebhookHealthy        *bool          `json:"webhookHealthy,omitempty"`
 }
 
 type exportedFile struct {
@@ -315,6 +316,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runWorkspace(args[1:], stdin, stdout)
 	case "integration":
 		return runIntegration(args[1:], stdin, stdout)
+	case "ops":
+		return runOps(args[1:], stdin, stdout)
 	case "mount":
 		return runMount(args[1:])
 	case "tree", "ls":
@@ -356,6 +359,8 @@ Usage:
   relayfile integration connect PROVIDER [--workspace NAME]
   relayfile integration list [--workspace NAME] [--json]
   relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
+  relayfile ops list [--workspace NAME] [--json]
+  relayfile ops replay OPID [--workspace NAME]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile tree [WORKSPACE] [PATH] [--depth N]
   relayfile read [WORKSPACE] PATH
@@ -371,6 +376,7 @@ Subcommands:
   login       Store credentials in ~/.relayfile/credentials.json
   workspace   Create, select, list, or delete locally tracked workspaces
   integration Connect, list, or disconnect workspace integrations
+  ops         List or replay dead-lettered writeback ops
   mount       Mirror a remote workspace to a local directory; add --background to detach
   tree        List a remote workspace path
   read        Print a remote file's content
@@ -1232,6 +1238,176 @@ func runIntegrationDisconnect(args []string, stdin io.Reader, stdout io.Writer) 
 	return nil
 }
 
+// deadLetterRecord matches the on-disk shape produced by the mount writeback
+// path per contract §8.4. Fields are kept lenient so we can read records
+// written by older syncer versions without failing the list output.
+type deadLetterRecord struct {
+	OpID            string `json:"opId"`
+	Path            string `json:"path,omitempty"`
+	Code            string `json:"code,omitempty"`
+	Message         string `json:"message,omitempty"`
+	CreatedAt       string `json:"createdAt,omitempty"`
+	LastAttemptedAt string `json:"lastAttemptedAt,omitempty"`
+	Attempts        int    `json:"attempts,omitempty"`
+	ReplayURL       string `json:"replayUrl,omitempty"`
+}
+
+func deadLetterDirFor(localDir string) string {
+	return filepath.Join(localDir, ".relay", "dead-letter")
+}
+
+func runOps(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("ops subcommand is required: list or replay")
+	}
+	switch args[0] {
+	case "list":
+		return runOpsList(args[1:], stdout)
+	case "replay":
+		return runOpsReplay(args[1:], stdin, stdout)
+	default:
+		return fmt.Errorf("unknown ops subcommand %q", args[0])
+	}
+}
+
+func runOpsList(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("ops list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	jsonOutput := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace": true,
+		"json":      false,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return errors.New("usage: relayfile ops list [--workspace NAME] [--json]")
+	}
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	if record.LocalDir == "" {
+		if *jsonOutput {
+			return writeJSON(stdout, []deadLetterRecord{})
+		}
+		fmt.Fprintln(stdout, "No dead-lettered ops")
+		return nil
+	}
+	records, err := readDeadLetterRecords(record.LocalDir)
+	if err != nil {
+		return err
+	}
+	if *jsonOutput {
+		return writeJSON(stdout, records)
+	}
+	if len(records) == 0 {
+		fmt.Fprintln(stdout, "No dead-lettered ops")
+		return nil
+	}
+	fmt.Fprintln(stdout, "op_id\tpath\tcode\tattempts\tlast_attempted_at")
+	for _, r := range records {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%d\t%s\n",
+			r.OpID,
+			defaultIfBlank(r.Path, "-"),
+			defaultIfBlank(r.Code, "-"),
+			r.Attempts,
+			defaultIfBlank(r.LastAttemptedAt, "-"),
+		)
+	}
+	return nil
+}
+
+func readDeadLetterRecords(localDir string) ([]deadLetterRecord, error) {
+	dir := deadLetterDirFor(localDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	records := make([]deadLetterRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		payload, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var record deadLetterRecord
+		if err := json.Unmarshal(payload, &record); err != nil {
+			return nil, fmt.Errorf("invalid dead-letter record %s: %w", entry.Name(), err)
+		}
+		if strings.TrimSpace(record.OpID) == "" {
+			// Use filename as a fallback so the user can still replay it.
+			record.OpID = strings.TrimSuffix(entry.Name(), ".json")
+		}
+		records = append(records, record)
+	}
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].OpID < records[j].OpID
+	})
+	return records, nil
+}
+
+func runOpsReplay(args []string, stdin io.Reader, stdout io.Writer) error {
+	_ = stdin
+	fs := flag.NewFlagSet("ops replay", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":     true,
+		"cloud-api-url": true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile ops replay OPID [--workspace NAME]")
+	}
+	opID := strings.TrimSpace(fs.Arg(0))
+	if opID == "" {
+		return errors.New("opId is required")
+	}
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, io.Discard)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	if err != nil {
+		return err
+	}
+	if err := client.postJSON(
+		context.Background(),
+		fmt.Sprintf("/api/v1/workspaces/%s/ops/%s/replay", url.PathEscape(record.ID), url.PathEscape(opID)),
+		struct{}{},
+		nil,
+	); err != nil {
+		return err
+	}
+	// Per contract §8.4, on successful replay the local mirror record is
+	// removed so the user's view stays in sync with the queue.
+	if record.LocalDir != "" {
+		path := filepath.Join(deadLetterDirFor(record.LocalDir), opID+".json")
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stdout, "warning: replay queued but failed to remove %s: %v\n", path, err)
+		}
+	}
+	fmt.Fprintf(stdout, "Replay queued for op %s\n", opID)
+	return nil
+}
+
 func runWorkspaceCreate(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("workspace create", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -1899,6 +2075,13 @@ func runStatus(args []string, stdout io.Writer) error {
 			line += "   last error: " + strings.TrimSpace(*provider.LastError)
 		}
 		fmt.Fprintln(stdout, line)
+		// Contract §7.4: warn when the webhook is unhealthy and the watermark
+		// has fallen behind, so users know polling is the only thing keeping
+		// the mirror current.
+		if provider.WebhookHealthy != nil && !*provider.WebhookHealthy && provider.LagSeconds > 60 {
+			fmt.Fprintf(stdout, "    %s webhook unhealthy — falling back to periodic sync (lag %s)\n",
+				provider.Provider, formatLag(provider.LagSeconds))
+		}
 	}
 	if record.LocalDir != "" {
 		fmt.Fprintf(stdout, "\nlocal mirror: %s\n", record.LocalDir)

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -618,9 +618,15 @@ func cloudAccessTokenExpiredSoon(creds cloudCredentials) bool {
 	return !time.Now().UTC().Before(expiry.Add(-60 * time.Second))
 }
 
+// ErrCloudRefreshExpired indicates the cloud refresh token cannot mint new
+// access tokens. The mount loop uses this to enter the read-only degraded
+// state described in the productized cloud-mount contract acceptance test
+// A9 ("Cloud refresh token expired").
+var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
+
 func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
 	if strings.TrimSpace(creds.RefreshToken) == "" {
-		return creds, errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
+		return creds, ErrCloudRefreshExpired
 	}
 	client, err := newAPIClient(creds.APIURL, creds.AccessToken)
 	if err != nil {
@@ -633,7 +639,10 @@ func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
 	if err != nil {
 		var httpErr *apiError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden && strings.EqualFold(strings.TrimSpace(httpErr.Code), "invalid_grant") {
-			return creds, errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
+			return creds, ErrCloudRefreshExpired
+		}
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+			return creds, ErrCloudRefreshExpired
 		}
 		return creds, fmt.Errorf("refresh cloud session: %w", err)
 	}
@@ -2360,7 +2369,8 @@ func runStatus(args []string, stdout io.Writer) error {
 		return err
 	}
 	record, _ := workspaceRecordByID(workspaceID)
-	snapshot := buildSyncStateSnapshot(status, workspaceID, defaultMountMode, defaultMountInterval, record.LocalDir, readDaemonPID(record.LocalDir), "")
+	persistedStallReason := readPersistedStallReason(record.LocalDir)
+	snapshot := buildSyncStateSnapshot(status, workspaceID, defaultMountMode, defaultMountInterval, record.LocalDir, readDaemonPID(record.LocalDir), persistedStallReason)
 	if *jsonOutput {
 		return writeJSON(stdout, snapshot)
 	}
@@ -2398,8 +2408,26 @@ func runStatus(args []string, stdout io.Writer) error {
 			fmt.Fprintln(stdout, "daemon: not running")
 		}
 	}
+	if persistedStallReason != "" {
+		fmt.Fprintf(stdout, "\nstall: %s\n", persistedStallReason)
+	}
 	fmt.Fprintf(stdout, "\npending writebacks: %d    conflicts: %d    denied: %d\n", snapshot.PendingWriteback, snapshot.PendingConflicts, snapshot.DeniedPaths)
 	return nil
+}
+
+func readPersistedStallReason(localDir string) string {
+	if localDir == "" {
+		return ""
+	}
+	payload, err := os.ReadFile(filepath.Join(localDir, ".relay", "state.json"))
+	if err != nil {
+		return ""
+	}
+	var snapshot syncStateFile
+	if err := json.Unmarshal(payload, &snapshot); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(snapshot.StallReason)
 }
 
 func runStop(args []string, stdout io.Writer) error {
@@ -3975,6 +4003,37 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	}
 	lastSuccess := time.Now()
 	stallReason := ""
+	degraded := false
+	var lastDegradedNotice time.Time
+	const degradedRecoveryInterval = time.Minute
+	const degradedStallReason = "cloud session expired — run 'relayfile login' to refresh"
+
+	enterDegraded := func() {
+		if !degraded {
+			degraded = true
+			stallReason = degradedStallReason
+			lastDegradedNotice = time.Time{}
+			log.Printf("mount entering read-only degraded state: %s", degradedStallReason)
+		}
+	}
+	exitDegraded := func() {
+		if degraded {
+			degraded = false
+			stallReason = ""
+			lastDegradedNotice = time.Time{}
+			log.Printf("mount exiting degraded state; cloud session restored")
+		}
+	}
+	maybePrintRecovery := func() {
+		if !degraded {
+			return
+		}
+		if time.Since(lastDegradedNotice) < degradedRecoveryInterval {
+			return
+		}
+		log.Printf("mount degraded: %s", degradedStallReason)
+		lastDegradedNotice = time.Now()
+	}
 
 	refreshMountAuth := func(force bool) error {
 		if httpClient == nil {
@@ -3989,6 +4048,11 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		}
 		cloudCreds, err = refreshCloudCredentialsIfNeeded(cloudCreds)
 		if err != nil {
+			// Surface the typed error so the loop can enter degraded
+			// state per A9. Other refresh errors stay non-fatal.
+			if errors.Is(err, ErrCloudRefreshExpired) {
+				return err
+			}
 			log.Printf("cloud session refresh failed: %v", err)
 			return nil
 		}
@@ -4047,6 +4111,22 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	}
 
 	runCycle := func(reconcile bool) error {
+		if degraded {
+			// Try to recover by re-running auth refresh. If creds are
+			// still missing/expired, stay degraded and emit the
+			// recovery notice on the configured cadence.
+			if err := refreshMountAuth(true); err != nil {
+				if errors.Is(err, ErrCloudRefreshExpired) {
+					maybePrintRecovery()
+					writeSnapshot()
+					return err
+				}
+				log.Printf("mount degraded: refresh attempt failed: %v", err)
+				writeSnapshot()
+				return err
+			}
+			exitDegraded()
+		}
 		err := withAuthRefresh(func(ctx context.Context) error {
 			if reconcile {
 				return syncer.Reconcile(ctx)
@@ -4054,6 +4134,12 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			return syncer.SyncOnce(ctx)
 		})
 		if err != nil {
+			if errors.Is(err, ErrCloudRefreshExpired) {
+				enterDegraded()
+				maybePrintRecovery()
+				writeSnapshot()
+				return err
+			}
 			stallReason = err.Error()
 			log.Printf("mount sync cycle failed: %v", err)
 			writeSnapshot()
@@ -4073,9 +4159,22 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	}
 
 	watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
+		if degraded {
+			// Local edit observed while we have no usable cloud session.
+			// Leave the dirty state in place so the next successful cycle
+			// after re-login picks it up; do not attempt to push now.
+			maybePrintRecovery()
+			return
+		}
 		if err := withAuthRefresh(func(ctx context.Context) error {
 			return syncer.HandleLocalChange(ctx, relativePath, op)
 		}); err != nil {
+			if errors.Is(err, ErrCloudRefreshExpired) {
+				enterDegraded()
+				maybePrintRecovery()
+				writeSnapshot()
+				return
+			}
 			log.Printf("mount local change failed: %v", err)
 		}
 		writeSnapshot()
@@ -4104,7 +4203,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			if reconcile {
 				_ = runCycle(true)
 			}
-			if time.Since(lastSuccess) >= 10*time.Minute {
+			if !degraded && time.Since(lastSuccess) >= 10*time.Minute {
 				stallReason = "no successful reconcile for 10m"
 				log.Printf("mount stalled: %s", stallReason)
 				writeSnapshot()

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -318,6 +318,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runIntegration(args[1:], stdin, stdout)
 	case "ops":
 		return runOps(args[1:], stdin, stdout)
+	case "pull":
+		return runPull(args[1:], stdout)
 	case "mount":
 		return runMount(args[1:])
 	case "tree", "ls":
@@ -361,6 +363,7 @@ Usage:
   relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
   relayfile ops list [--workspace NAME] [--json]
   relayfile ops replay OPID [--workspace NAME]
+  relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile tree [WORKSPACE] [PATH] [--depth N]
   relayfile read [WORKSPACE] PATH
@@ -377,6 +380,7 @@ Subcommands:
   workspace   Create, select, list, or delete locally tracked workspaces
   integration Connect, list, or disconnect workspace integrations
   ops         List or replay dead-lettered writeback ops
+  pull        Trigger an immediate sync refresh for one or all providers
   mount       Mirror a remote workspace to a local directory; add --background to detach
   tree        List a remote workspace path
   read        Print a remote file's content
@@ -677,7 +681,67 @@ func normalizeProviderID(value string) string {
 	}
 }
 
+// integrationCatalogTTL bounds how long a cached catalog response remains
+// authoritative without revalidation per contract §6 / verdict §A12.
+const integrationCatalogTTL = time.Hour
+
+type integrationCatalogCacheEntry struct {
+	APIURL    string                            `json:"apiUrl"`
+	FetchedAt string                            `json:"fetchedAt"`
+	Version   string                            `json:"version,omitempty"`
+	Providers []integrationCatalogEntry         `json:"providers"`
+}
+
+func integrationCatalogCachePath() string {
+	return filepath.Join(configDir(), "catalog-cache.json")
+}
+
+func readIntegrationCatalogCache() (integrationCatalogCacheEntry, bool) {
+	payload, err := os.ReadFile(integrationCatalogCachePath())
+	if err != nil {
+		return integrationCatalogCacheEntry{}, false
+	}
+	var entry integrationCatalogCacheEntry
+	if err := json.Unmarshal(payload, &entry); err != nil {
+		return integrationCatalogCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func writeIntegrationCatalogCache(entry integrationCatalogCacheEntry) error {
+	if err := ensureConfigDir(); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeFileAtomically(integrationCatalogCachePath(), payload, 0o644)
+}
+
+func invalidateIntegrationCatalogCache() {
+	_ = os.Remove(integrationCatalogCachePath())
+}
+
+func cachedCatalogIsFresh(entry integrationCatalogCacheEntry, apiURL string) bool {
+	if entry.APIURL != apiURL || len(entry.Providers) == 0 {
+		return false
+	}
+	fetched, err := time.Parse(time.RFC3339, entry.FetchedAt)
+	if err != nil {
+		return false
+	}
+	return time.Since(fetched) < integrationCatalogTTL
+}
+
 func loadIntegrationCatalog(cloudAPIURL, accessToken string) ([]integrationCatalogEntry, error) {
+	if entry, ok := readIntegrationCatalogCache(); ok && cachedCatalogIsFresh(entry, cloudAPIURL) {
+		return entry.Providers, nil
+	}
+	return fetchIntegrationCatalog(cloudAPIURL, accessToken)
+}
+
+func fetchIntegrationCatalog(cloudAPIURL, accessToken string) ([]integrationCatalogEntry, error) {
 	client, err := newAPIClient(cloudAPIURL, accessToken)
 	if err != nil {
 		return fallbackIntegrationCatalog(), err
@@ -689,7 +753,20 @@ func loadIntegrationCatalog(cloudAPIURL, accessToken string) ([]integrationCatal
 	if len(payload.Providers) == 0 {
 		return fallbackIntegrationCatalog(), nil
 	}
+	_ = writeIntegrationCatalogCache(integrationCatalogCacheEntry{
+		APIURL:    cloudAPIURL,
+		FetchedAt: time.Now().UTC().Format(time.RFC3339),
+		Version:   payload.Version,
+		Providers: payload.Providers,
+	})
 	return payload.Providers, nil
+}
+
+// isAPIConflict reports whether err is a 409 from the cloud API. A 409 forces
+// catalog revalidation per contract verdict §A12.
+func isAPIConflict(err error) bool {
+	var apiErr *apiError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict
 }
 
 func fallbackIntegrationCatalog() []integrationCatalogEntry {
@@ -914,6 +991,13 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 	if err := client.postJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations/connect-session", url.PathEscape(workspaceID)), cloudConnectSessionRequest{
 		AllowedIntegrations: []string{provider},
 	}, &session); err != nil {
+		// Per contract verdict §A12, a 409 from connect-session means the
+		// requested provider is no longer in the catalog. Drop the cached
+		// catalog so the next invocation pulls fresh provider ids before
+		// surfacing the error to the user.
+		if isAPIConflict(err) {
+			invalidateIntegrationCatalogCache()
+		}
 		return fmt.Errorf("create %s connect session: %w", provider, err)
 	}
 
@@ -1275,14 +1359,20 @@ func runOpsList(args []string, stdout io.Writer) error {
 	fs.SetOutput(io.Discard)
 	workspaceName := fs.String("workspace", "", "workspace name or id")
 	jsonOutput := fs.Bool("json", false, "emit JSON")
+	noRefresh := fs.Bool("no-refresh", false, "skip refreshing the local mirror from the server")
+	server := fs.String("server", "", "relayfile server URL override")
+	tokenOverride := fs.String("token", "", "relayfile token override")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"workspace": true,
-		"json":      false,
+		"workspace":  true,
+		"json":       false,
+		"no-refresh": false,
+		"server":     true,
+		"token":      true,
 	})); err != nil {
 		return err
 	}
 	if fs.NArg() > 0 {
-		return errors.New("usage: relayfile ops list [--workspace NAME] [--json]")
+		return errors.New("usage: relayfile ops list [--workspace NAME] [--json] [--no-refresh]")
 	}
 	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
 	if err != nil {
@@ -1295,6 +1385,16 @@ func runOpsList(args []string, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "No dead-lettered ops")
 		return nil
 	}
+
+	if !*noRefresh {
+		// Best-effort refresh: surface the warning but keep showing the
+		// local mirror so users can still see and replay known failures
+		// when offline.
+		if err := refreshDeadLetterMirror(record, strings.TrimSpace(*server), strings.TrimSpace(*tokenOverride)); err != nil {
+			fmt.Fprintf(stdout, "warning: could not refresh from server: %v\n", err)
+		}
+	}
+
 	records, err := readDeadLetterRecords(record.LocalDir)
 	if err != nil {
 		return err
@@ -1353,6 +1453,128 @@ func readDeadLetterRecords(localDir string) ([]deadLetterRecord, error) {
 	return records, nil
 }
 
+type opsListResponse struct {
+	Items []struct {
+		OpID          string  `json:"opId"`
+		Path          string  `json:"path,omitempty"`
+		Action        string  `json:"action,omitempty"`
+		Provider      string  `json:"provider,omitempty"`
+		Status        string  `json:"status"`
+		AttemptCount  int     `json:"attemptCount"`
+		LastError     *string `json:"lastError,omitempty"`
+		CreatedAt     string  `json:"createdAt,omitempty"`
+		UpdatedAt     string  `json:"updatedAt,omitempty"`
+		CorrelationID string  `json:"correlationId,omitempty"`
+	} `json:"items"`
+	NextCursor *string `json:"nextCursor,omitempty"`
+}
+
+// refreshDeadLetterMirror reconciles the local .relay/dead-letter/ directory
+// against the server's view per contract §8.4. New dead-lettered ops are
+// written; ops the server no longer reports as dead-lettered are pruned so
+// the local mirror does not show stale entries after replay or ack.
+func refreshDeadLetterMirror(record workspaceRecord, serverOverride, tokenOverride string) error {
+	if record.LocalDir == "" {
+		return nil
+	}
+	creds, err := loadCredentials()
+	if err != nil {
+		return err
+	}
+	tokenValue := resolveToken(tokenOverride, creds)
+	client, err := newAPIClient(resolveServer(serverOverride, creds), tokenValue)
+	if err != nil {
+		return err
+	}
+
+	var feed opsListResponse
+	if err := client.getJSON(
+		context.Background(),
+		fmt.Sprintf("/v1/workspaces/%s/ops?status=dead_lettered&limit=200", url.PathEscape(record.ID)),
+		&feed,
+	); err != nil {
+		return err
+	}
+
+	dir := deadLetterDirFor(record.LocalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	keep := make(map[string]struct{}, len(feed.Items))
+	baseURL := strings.TrimRight(client.baseURL, "/")
+	for _, item := range feed.Items {
+		opID := strings.TrimSpace(item.OpID)
+		if opID == "" {
+			continue
+		}
+		keep[opID] = struct{}{}
+		message := ""
+		if item.LastError != nil {
+			message = strings.TrimSpace(*item.LastError)
+		}
+		code := classifyDeadLetterCode(message)
+		dl := deadLetterRecord{
+			OpID:            opID,
+			Path:            item.Path,
+			Code:            code,
+			Message:         message,
+			CreatedAt:       item.CreatedAt,
+			LastAttemptedAt: item.UpdatedAt,
+			Attempts:        item.AttemptCount,
+			ReplayURL: fmt.Sprintf(
+				"%s/v1/workspaces/%s/ops/%s/replay",
+				baseURL,
+				url.PathEscape(record.ID),
+				url.PathEscape(opID),
+			),
+		}
+		payload, err := json.MarshalIndent(dl, "", "  ")
+		if err != nil {
+			return err
+		}
+		if err := writeFileAtomically(filepath.Join(dir, opID+".json"), payload, 0o644); err != nil {
+			return err
+		}
+	}
+
+	// Prune local records the server no longer reports as dead-lettered.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		opID := strings.TrimSuffix(entry.Name(), ".json")
+		if _, ok := keep[opID]; ok {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, entry.Name()))
+	}
+	return nil
+}
+
+func classifyDeadLetterCode(message string) string {
+	lower := strings.ToLower(message)
+	switch {
+	case strings.Contains(lower, "schema") || strings.Contains(lower, "validation"):
+		return "validation_error"
+	case strings.Contains(lower, "permission") || strings.Contains(lower, "forbidden"):
+		return "forbidden"
+	case strings.Contains(lower, "not found"):
+		return "not_found"
+	case message == "":
+		return "non_retryable"
+	default:
+		return "non_retryable"
+	}
+}
+
 func runOpsReplay(args []string, stdin io.Reader, stdout io.Writer) error {
 	_ = stdin
 	fs := flag.NewFlagSet("ops replay", flag.ContinueOnError)
@@ -1406,6 +1628,91 @@ func runOpsReplay(args []string, stdin io.Reader, stdout io.Writer) error {
 	}
 	fmt.Fprintf(stdout, "Replay queued for op %s\n", opID)
 	return nil
+}
+
+func runPull(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("pull", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	provider := fs.String("provider", "", "provider id (default: refresh all connected providers)")
+	reason := fs.String("reason", "manual", "free-form reason recorded server-side")
+	server := fs.String("server", "", "relayfile server URL override")
+	tokenOverride := fs.String("token", "", "relayfile token override")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace": true,
+		"provider":  true,
+		"reason":    true,
+		"server":    true,
+		"token":     true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return errors.New("usage: relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]")
+	}
+
+	creds, err := loadCredentials()
+	if err != nil {
+		return err
+	}
+	tokenValue := resolveToken(*tokenOverride, creds)
+	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
+	if err != nil {
+		return err
+	}
+
+	workspaceID, err := resolveWorkspaceIDWithToken(strings.TrimSpace(*workspaceName), tokenValue)
+	if err != nil {
+		return err
+	}
+
+	providers, err := resolvePullProviders(client, workspaceID, strings.TrimSpace(*provider))
+	if err != nil {
+		return err
+	}
+	if len(providers) == 0 {
+		fmt.Fprintln(stdout, "No connected providers to refresh")
+		return nil
+	}
+
+	for _, p := range providers {
+		var queued struct {
+			Status string `json:"status"`
+			ID     string `json:"id"`
+		}
+		body := struct {
+			Provider string `json:"provider"`
+			Reason   string `json:"reason,omitempty"`
+		}{Provider: p, Reason: strings.TrimSpace(*reason)}
+		if err := client.postJSON(
+			context.Background(),
+			fmt.Sprintf("/v1/workspaces/%s/sync/refresh", url.PathEscape(workspaceID)),
+			body,
+			&queued,
+		); err != nil {
+			return fmt.Errorf("refresh %s: %w", p, err)
+		}
+		fmt.Fprintf(stdout, "%s refresh queued (%s)\n", p, defaultIfBlank(queued.ID, "queued"))
+	}
+	return nil
+}
+
+func resolvePullProviders(client *apiClient, workspaceID, requested string) ([]string, error) {
+	if requested != "" {
+		return []string{normalizeProviderID(requested)}, nil
+	}
+	status, err := fetchWorkspaceSyncStatus(client, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	providers := make([]string, 0, len(status.Providers))
+	for _, entry := range status.Providers {
+		if strings.TrimSpace(entry.Provider) == "" {
+			continue
+		}
+		providers = append(providers, entry.Provider)
+	}
+	return providers, nil
 }
 
 func runWorkspaceCreate(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -294,10 +294,24 @@ func (e *apiError) Error() string {
 	return fmt.Sprintf("http %d %s: %s", e.StatusCode, e.Code, e.Message)
 }
 
+// cloudLoginStateMismatchExitCode is the exit code mandated by productized
+// cloud-mount contract A2 when the browser callback's state parameter does
+// not match the value the CLI generated. The dedicated code lets shells and
+// CI distinguish a tampered/replayed login flow from a generic CLI error.
+const cloudLoginStateMismatchExitCode = 10
+
+// ErrCloudLoginStateMismatch is returned by runCloudLogin when the OAuth
+// callback's `state` query parameter does not match the value the CLI
+// generated. main() maps this sentinel to exit code 10 per A2.
+var ErrCloudLoginStateMismatch = errors.New("Relayfile Cloud login state mismatch")
+
 func main() {
 	log.SetFlags(0)
 	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
+		if errors.Is(err, ErrCloudLoginStateMismatch) {
+			os.Exit(cloudLoginStateMismatchExitCode)
+		}
 		os.Exit(1)
 	}
 }
@@ -926,7 +940,7 @@ func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser 
 		}
 		if got := r.URL.Query().Get("state"); got != state {
 			http.Error(w, "Relayfile Cloud login state mismatch", http.StatusBadRequest)
-			errCh <- errors.New("Relayfile Cloud login state mismatch")
+			errCh <- ErrCloudLoginStateMismatch
 			return
 		}
 		if loginError := strings.TrimSpace(r.URL.Query().Get("error")); loginError != "" {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -40,7 +40,12 @@ const (
 	defaultObserverURL      = "https://agentrelay.com/observer/file"
 	configDirName           = ".relayfile"
 	websocketReconcileEvery = 10
+	defaultMountMode        = "poll"
+	defaultMountInterval    = 30 * time.Second
+	defaultMountTimeout     = 15 * time.Second
 )
+
+var defaultJoinScopes = []string{"fs:read", "fs:write"}
 
 type credentials struct {
 	Server    string `json:"server"`
@@ -63,10 +68,15 @@ type workspaceCatalog struct {
 }
 
 type workspaceRecord struct {
-	Name       string `json:"name"`
-	ID         string `json:"id,omitempty"`
-	CreatedAt  string `json:"createdAt"`
-	LastUsedAt string `json:"lastUsedAt,omitempty"`
+	Name        string   `json:"name"`
+	ID          string   `json:"id,omitempty"`
+	CreatedAt   string   `json:"createdAt"`
+	LastUsedAt  string   `json:"lastUsedAt,omitempty"`
+	LocalDir    string   `json:"localDir,omitempty"`
+	Server      string   `json:"server,omitempty"`
+	CloudAPIURL string   `json:"cloudApiUrl,omitempty"`
+	AgentName   string   `json:"agentName,omitempty"`
+	Scopes      []string `json:"scopes,omitempty"`
 }
 
 type apiClient struct {
@@ -199,6 +209,77 @@ type cloudIntegrationReadyResponse struct {
 	Ready bool `json:"ready"`
 }
 
+type cloudTokenRefreshRequest struct {
+	RefreshToken string `json:"refreshToken"`
+}
+
+type cloudIntegrationCatalogResponse struct {
+	Providers []integrationCatalogEntry `json:"providers"`
+	Version   string                    `json:"version,omitempty"`
+}
+
+type integrationCatalogEntry struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName,omitempty"`
+	ConfigKey   string `json:"configKey,omitempty"`
+	VFSRoot     string `json:"vfsRoot,omitempty"`
+	Deprecated  bool   `json:"deprecated,omitempty"`
+}
+
+type cloudIntegrationListEntry struct {
+	Provider       string `json:"provider"`
+	Status         string `json:"status,omitempty"`
+	LagSeconds     int    `json:"lagSeconds,omitempty"`
+	LastEventAt    string `json:"lastEventAt,omitempty"`
+	ConnectionID   string `json:"connectionId,omitempty"`
+	WebhookHealthy *bool  `json:"webhookHealthy,omitempty"`
+	Deprecated     bool   `json:"deprecated,omitempty"`
+}
+
+type syncStateFile struct {
+	WorkspaceID      string              `json:"workspaceId"`
+	Mode             string              `json:"mode"`
+	LastReconcileAt  string              `json:"lastReconcileAt,omitempty"`
+	LastEventAt      string              `json:"lastEventAt,omitempty"`
+	IntervalMs       int64               `json:"intervalMs"`
+	Providers        []syncStateProvider `json:"providers,omitempty"`
+	PendingWriteback int                 `json:"pendingWriteback"`
+	PendingConflicts int                 `json:"pendingConflicts"`
+	DeniedPaths      int                 `json:"deniedPaths"`
+	StallReason      string              `json:"stallReason,omitempty"`
+	Daemon           *syncStateDaemon    `json:"daemon,omitempty"`
+}
+
+type syncStateProvider struct {
+	Provider        string `json:"provider"`
+	Status          string `json:"status"`
+	LagSeconds      int    `json:"lagSeconds"`
+	DeadLetteredOps int    `json:"deadLetteredOps"`
+	LastError       string `json:"lastError,omitempty"`
+	LastEventAt     string `json:"lastEventAt,omitempty"`
+}
+
+type syncStateDaemon struct {
+	PID     int    `json:"pid,omitempty"`
+	LogFile string `json:"logFile,omitempty"`
+	PIDFile string `json:"pidFile,omitempty"`
+}
+
+type integrationConnectionState struct {
+	Provider     string `json:"provider"`
+	ConnectionID string `json:"connectionId,omitempty"`
+	ConnectedAt  string `json:"connectedAt,omitempty"`
+	UpdatedAt    string `json:"updatedAt,omitempty"`
+}
+
+type daemonPIDState struct {
+	PID         int    `json:"pid"`
+	WorkspaceID string `json:"workspaceId"`
+	LocalDir    string `json:"localDir"`
+	LogFile     string `json:"logFile"`
+	StartedAt   string `json:"startedAt"`
+}
+
 type apiError struct {
 	StatusCode int
 	Code       string
@@ -232,6 +313,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runLogin(args[1:], stdin, stdout)
 	case "workspace":
 		return runWorkspace(args[1:], stdin, stdout)
+	case "integration":
+		return runIntegration(args[1:], stdin, stdout)
 	case "mount":
 		return runMount(args[1:])
 	case "tree", "ls":
@@ -244,6 +327,10 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runExport(args[1:], stdout)
 	case "status":
 		return runStatus(args[1:], stdout)
+	case "stop":
+		return runStop(args[1:], stdout)
+	case "logs":
+		return runLogs(args[1:], stdout)
 	case "observer":
 		return runObserver(args[1:], stdout)
 	case "help", "-h", "--help":
@@ -266,24 +353,32 @@ Usage:
   relayfile workspace use NAME
   relayfile workspace list
   relayfile workspace delete NAME [--yes]
+  relayfile integration connect PROVIDER [--workspace NAME]
+  relayfile integration list [--workspace NAME] [--json]
+  relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile tree [WORKSPACE] [PATH] [--depth N]
   relayfile read [WORKSPACE] PATH
   relayfile seed [WORKSPACE] [DIR]
   relayfile export [WORKSPACE] --format FORMAT [--output FILE]
   relayfile status [WORKSPACE]
+  relayfile stop [WORKSPACE]
+  relayfile logs [WORKSPACE]
   relayfile observer [WORKSPACE] [--no-open]
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
   login       Store credentials in ~/.relayfile/credentials.json
   workspace   Create, select, list, or delete locally tracked workspaces
-  mount       Mirror a remote workspace to a local directory
+  integration Connect, list, or disconnect workspace integrations
+  mount       Mirror a remote workspace to a local directory; add --background to detach
   tree        List a remote workspace path
   read        Print a remote file's content
   seed        Upload a directory tree with bulk writes
   export      Export a workspace as json, tar, or patch
-  status      Show sync status for a workspace
+  status      Show sync status and local mirror state for a workspace
+  stop        Stop a background mount
+  logs        Print the background mount log
   observer    Open the hosted file observer for a workspace`)
 }
 
@@ -323,27 +418,11 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 		cloudAPI = defaultCloudAPIURL
 	}
 
-	fmt.Fprintln(stdout, "Relayfile setup")
-	fmt.Fprintln(stdout, "This signs you in, connects an integration, and prepares a local VFS mount.")
+	fmt.Fprintln(stdout, "Relayfile setup. This signs you in, connects an integration, and prepares a local VFS mount.")
 
-	tokenSet := cloudCredentials{
-		APIURL:      cloudAPI,
-		AccessToken: strings.TrimSpace(*cloudToken),
-		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
-	}
-	if tokenSet.AccessToken == "" {
-		var err error
-		tokenSet, err = runCloudLogin(cloudAPI, *loginTimeout, !*noOpen, stdout)
-		if err != nil {
-			return err
-		}
-		if err := saveCloudCredentials(tokenSet); err != nil {
-			return err
-		}
-	} else {
-		if err := saveCloudCredentials(tokenSet); err != nil {
-			return err
-		}
+	tokenSet, err := ensureCloudCredentials(cloudAPI, strings.TrimSpace(*cloudToken), *loginTimeout, !*noOpen, stdout)
+	if err != nil {
+		return err
 	}
 
 	name := strings.TrimSpace(*workspaceName)
@@ -361,7 +440,8 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 
 	selectedProvider := strings.TrimSpace(*provider)
 	if selectedProvider == "" {
-		prompted, err := promptLine(stdin, stdout, "Integration (github, notion, linear, slack-sage, none) [github]: ")
+		providers, _ := loadIntegrationCatalog(tokenSet.APIURL, tokenSet.AccessToken)
+		prompted, err := promptLine(stdin, stdout, fmt.Sprintf("Integration (%s) [github]: ", providerPromptText(providers)))
 		if err != nil {
 			return err
 		}
@@ -370,7 +450,7 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 			selectedProvider = "github"
 		}
 	}
-	selectedProvider = strings.ToLower(selectedProvider)
+	selectedProvider = normalizeProviderID(selectedProvider)
 
 	localDir := strings.TrimSpace(*localDirFlag)
 	if localDir == "" {
@@ -383,59 +463,47 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 			localDir = "./relayfile-mount"
 		}
 	}
-
-	cloudClient, err := newAPIClient(cloudAPI, tokenSet.AccessToken)
+	absLocalDir, err := filepath.Abs(localDir)
 	if err != nil {
 		return err
 	}
-	var created cloudWorkspaceCreateResponse
-	if err := cloudClient.postJSON(context.Background(), "/api/v1/workspaces", cloudWorkspaceCreateRequest{Name: name}, &created); err != nil {
-		return fmt.Errorf("create cloud workspace: %w", err)
-	}
-	workspaceID := strings.TrimSpace(created.WorkspaceID)
-	if workspaceID == "" {
-		return errors.New("cloud workspace response missing workspaceId")
-	}
-
-	var joined cloudWorkspaceJoinResponse
-	if err := cloudClient.postJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/join", url.PathEscape(workspaceID)), cloudWorkspaceJoinRequest{
-		AgentName: "relayfile-cli",
-		Scopes:    []string{"fs:read", "fs:write"},
-	}, &joined); err != nil {
-		return fmt.Errorf("join cloud workspace: %w", err)
-	}
-	if strings.TrimSpace(joined.WorkspaceID) == "" {
-		joined.WorkspaceID = workspaceID
-	}
-	if strings.TrimSpace(joined.Token) == "" {
-		return errors.New("cloud join response missing token")
-	}
-	if strings.TrimSpace(joined.RelayfileURL) == "" {
-		if strings.TrimSpace(created.RelayfileURL) == "" {
-			return errors.New("cloud join response missing relayfileUrl")
-		}
-		joined.RelayfileURL = created.RelayfileURL
-	}
-
-	if err := saveCredentials(credentials{
-		Server:    strings.TrimRight(joined.RelayfileURL, "/"),
-		Token:     joined.Token,
-		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		return err
-	}
-	if _, err := upsertWorkspaceRecord(name, joined.WorkspaceID); err != nil {
-		return err
-	}
-	if _, err := setDefaultWorkspace(name); err != nil {
+	if err := ensureMirrorLayout(absLocalDir); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(stdout, "Workspace %s ready (id: %s)\n", name, joined.WorkspaceID)
+	record, createdWorkspace, err := ensureWorkspaceForSetup(tokenSet, name, absLocalDir)
+	if err != nil {
+		return err
+	}
+
+	joined, err := joinWorkspaceViaCloud(tokenSet, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	if err := persistJoinedWorkspace(record, joined, tokenSet.APIURL, absLocalDir); err != nil {
+		return err
+	}
+
+	if createdWorkspace {
+		fmt.Fprintf(stdout, "Workspace %s ready (id: %s)\n", record.Name, record.ID)
+	} else {
+		fmt.Fprintf(stdout, "Workspace %s reused (id: %s)\n", record.Name, record.ID)
+	}
 
 	if selectedProvider != "" && selectedProvider != "none" && selectedProvider != "skip" {
-		if err := connectCloudIntegration(cloudAPI, joined.WorkspaceID, joined.Token, selectedProvider, *connectTimeout, !*noOpen, stdout); err != nil {
-			return err
+		if createdWorkspace {
+			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+				return err
+			}
+		} else {
+			if err := ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+				return err
+			}
+		}
+		if !*skipMount {
+			if err := waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, selectedProvider, absLocalDir, *connectTimeout, stdout); err != nil {
+				return err
+			}
 		}
 	} else {
 		fmt.Fprintln(stdout, "Integration connection skipped")
@@ -444,19 +512,302 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	mountArgs := []string{
 		"--server", strings.TrimRight(joined.RelayfileURL, "/"),
 		"--token", joined.Token,
-		joined.WorkspaceID,
+		record.ID,
 		localDir,
 	}
 	if *once {
 		mountArgs = append(mountArgs, "--once")
 	}
 	if *skipMount {
-		fmt.Fprintf(stdout, "Setup complete. Start the VFS mount with:\n  relayfile mount %s %s\n", joined.WorkspaceID, localDir)
+		fmt.Fprintf(stdout, "Setup complete. Start the VFS mount with:\n  relayfile mount %s %s\n", record.ID, localDir)
 		return nil
 	}
 
 	fmt.Fprintf(stdout, "Starting VFS mount at %s\n", localDir)
 	return runMount(mountArgs)
+}
+
+func ensureCloudCredentials(cloudAPIURL, explicitToken string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (cloudCredentials, error) {
+	explicitToken = strings.TrimSpace(explicitToken)
+	cloudAPIURL = strings.TrimRight(strings.TrimSpace(cloudAPIURL), "/")
+	if cloudAPIURL == "" {
+		cloudAPIURL = defaultCloudAPIURL
+	}
+	if explicitToken != "" {
+		creds := cloudCredentials{
+			APIURL:      cloudAPIURL,
+			AccessToken: explicitToken,
+			UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+		}
+		if err := saveCloudCredentials(creds); err != nil {
+			return cloudCredentials{}, err
+		}
+		return creds, nil
+	}
+
+	creds, err := loadCloudCredentials()
+	if err == nil {
+		if strings.TrimSpace(creds.APIURL) == "" {
+			creds.APIURL = cloudAPIURL
+		}
+		if strings.TrimRight(strings.TrimSpace(creds.APIURL), "/") != cloudAPIURL {
+			creds.APIURL = cloudAPIURL
+		}
+		refreshed, refreshErr := refreshCloudCredentialsIfNeeded(creds)
+		if refreshErr == nil {
+			return refreshed, nil
+		}
+	}
+
+	creds, err = runCloudLogin(cloudAPIURL, timeout, shouldOpenBrowser, stdout)
+	if err != nil {
+		return cloudCredentials{}, err
+	}
+	if err := saveCloudCredentials(creds); err != nil {
+		return cloudCredentials{}, err
+	}
+	return creds, nil
+}
+
+func loadCloudCredentials() (cloudCredentials, error) {
+	var creds cloudCredentials
+	payload, err := os.ReadFile(cloudCredentialsPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return creds, fmt.Errorf("cloud credentials not found at %s; run relayfile setup or relayfile login", cloudCredentialsPath())
+		}
+		return creds, err
+	}
+	if err := json.Unmarshal(payload, &creds); err != nil {
+		return creds, fmt.Errorf("parse %s: %w", cloudCredentialsPath(), err)
+	}
+	if strings.TrimSpace(creds.APIURL) == "" {
+		creds.APIURL = defaultCloudAPIURL
+	}
+	return creds, nil
+}
+
+func refreshCloudCredentialsIfNeeded(creds cloudCredentials) (cloudCredentials, error) {
+	if !cloudAccessTokenExpiredSoon(creds) {
+		if strings.TrimSpace(creds.APIURL) == "" {
+			creds.APIURL = defaultCloudAPIURL
+		}
+		return creds, nil
+	}
+	return refreshCloudCredentials(creds)
+}
+
+func cloudAccessTokenExpiredSoon(creds cloudCredentials) bool {
+	if strings.TrimSpace(creds.AccessToken) == "" {
+		return true
+	}
+	expiry, ok := parseRFC3339(strings.TrimSpace(creds.AccessTokenExpiresAt))
+	if !ok {
+		return false
+	}
+	return !time.Now().UTC().Before(expiry.Add(-60 * time.Second))
+}
+
+func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
+	if strings.TrimSpace(creds.RefreshToken) == "" {
+		return creds, errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
+	}
+	client, err := newAPIClient(creds.APIURL, creds.AccessToken)
+	if err != nil {
+		return creds, err
+	}
+	var refreshed cloudCredentials
+	err = client.postJSON(context.Background(), "/api/v1/auth/token/refresh", cloudTokenRefreshRequest{
+		RefreshToken: creds.RefreshToken,
+	}, &refreshed)
+	if err != nil {
+		var httpErr *apiError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden && strings.EqualFold(strings.TrimSpace(httpErr.Code), "invalid_grant") {
+			return creds, errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
+		}
+		return creds, fmt.Errorf("refresh cloud session: %w", err)
+	}
+	if strings.TrimSpace(refreshed.APIURL) == "" {
+		refreshed.APIURL = creds.APIURL
+	}
+	if strings.TrimSpace(refreshed.RefreshToken) == "" {
+		refreshed.RefreshToken = creds.RefreshToken
+	}
+	if strings.TrimSpace(refreshed.RefreshTokenExpiresAt) == "" {
+		refreshed.RefreshTokenExpiresAt = creds.RefreshTokenExpiresAt
+	}
+	refreshed.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := saveCloudCredentials(refreshed); err != nil {
+		return creds, err
+	}
+	return refreshed, nil
+}
+
+func providerPromptText(entries []integrationCatalogEntry) string {
+	ids := make([]string, 0, len(entries)+1)
+	for _, entry := range entries {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		ids = []string{"github", "notion", "linear", "slack-sage", "none"}
+	}
+	if !containsString(ids, "none") {
+		ids = append(ids, "none")
+	}
+	return strings.Join(ids, ", ")
+}
+
+func normalizeProviderID(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "slack", "slack-sage":
+		return "slack-sage"
+	default:
+		return value
+	}
+}
+
+func loadIntegrationCatalog(cloudAPIURL, accessToken string) ([]integrationCatalogEntry, error) {
+	client, err := newAPIClient(cloudAPIURL, accessToken)
+	if err != nil {
+		return fallbackIntegrationCatalog(), err
+	}
+	var payload cloudIntegrationCatalogResponse
+	if err := client.getJSON(context.Background(), "/api/v1/integrations/catalog", &payload); err != nil {
+		return fallbackIntegrationCatalog(), err
+	}
+	if len(payload.Providers) == 0 {
+		return fallbackIntegrationCatalog(), nil
+	}
+	return payload.Providers, nil
+}
+
+func fallbackIntegrationCatalog() []integrationCatalogEntry {
+	return []integrationCatalogEntry{
+		{ID: "github", DisplayName: "GitHub", VFSRoot: "/github"},
+		{ID: "notion", DisplayName: "Notion", VFSRoot: "/notion"},
+		{ID: "linear", DisplayName: "Linear", VFSRoot: "/linear"},
+		{ID: "slack-sage", DisplayName: "Slack", VFSRoot: "/slack"},
+		{ID: "slack-my-senior-dev", DisplayName: "Slack (MSD)", VFSRoot: "/slack-msd"},
+		{ID: "slack-nightcto", DisplayName: "Slack (NightCTO)", VFSRoot: "/slack-nightcto"},
+	}
+}
+
+func ensureMirrorLayout(localDir string) error {
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(localDir, ".relay"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(localDir, ".relay", "integrations"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(localDir, ".relay", "disconnected"), 0o755); err != nil {
+		return err
+	}
+	return os.MkdirAll(filepath.Join(localDir, ".relay", "conflicts"), 0o755)
+}
+
+func ensureWorkspaceForSetup(cloud cloudCredentials, name, localDir string) (workspaceRecord, bool, error) {
+	if record, ok := workspaceRecordByName(name); ok {
+		if record.ID == "" {
+			record.ID = record.Name
+		}
+		if record.AgentName == "" {
+			record.AgentName = "relayfile-cli"
+		}
+		if len(record.Scopes) == 0 {
+			record.Scopes = append([]string(nil), defaultJoinScopes...)
+		}
+		return record, false, nil
+	}
+	client, err := newAPIClient(cloud.APIURL, cloud.AccessToken)
+	if err != nil {
+		return workspaceRecord{}, false, err
+	}
+	var created cloudWorkspaceCreateResponse
+	if err := client.postJSON(context.Background(), "/api/v1/workspaces", cloudWorkspaceCreateRequest{Name: name}, &created); err != nil {
+		return workspaceRecord{}, false, fmt.Errorf("create cloud workspace: %w", err)
+	}
+	record := workspaceRecord{
+		Name:        name,
+		ID:          strings.TrimSpace(created.WorkspaceID),
+		CreatedAt:   strings.TrimSpace(created.CreatedAt),
+		LastUsedAt:  time.Now().UTC().Format(time.RFC3339),
+		LocalDir:    localDir,
+		CloudAPIURL: cloud.APIURL,
+		Server:      strings.TrimRight(strings.TrimSpace(created.RelayfileURL), "/"),
+		AgentName:   "relayfile-cli",
+		Scopes:      append([]string(nil), defaultJoinScopes...),
+	}
+	if record.CreatedAt == "" {
+		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if record.ID == "" {
+		return workspaceRecord{}, false, errors.New("cloud workspace response missing workspaceId")
+	}
+	return record, true, nil
+}
+
+func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinResponse, cloudAPIURL, localDir string) error {
+	serverURL := strings.TrimRight(strings.TrimSpace(joined.RelayfileURL), "/")
+	if err := saveCredentials(credentials{
+		Server:    serverURL,
+		Token:     strings.TrimSpace(joined.Token),
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		return err
+	}
+	record.Server = serverURL
+	record.LocalDir = localDir
+	record.CloudAPIURL = cloudAPIURL
+	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	if record.AgentName == "" {
+		record.AgentName = "relayfile-cli"
+	}
+	if len(record.Scopes) == 0 {
+		record.Scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	if _, err := upsertWorkspaceDetails(record); err != nil {
+		return err
+	}
+	_, err := setDefaultWorkspace(record.Name)
+	return err
+}
+
+func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string, scopes []string) (cloudWorkspaceJoinResponse, error) {
+	if agentName == "" {
+		agentName = "relayfile-cli"
+	}
+	if len(scopes) == 0 {
+		scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	client, err := newAPIClient(cloud.APIURL, cloud.AccessToken)
+	if err != nil {
+		return cloudWorkspaceJoinResponse{}, err
+	}
+	var joined cloudWorkspaceJoinResponse
+	if err := client.postJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/join", url.PathEscape(workspaceID)), cloudWorkspaceJoinRequest{
+		AgentName: agentName,
+		Scopes:    scopes,
+	}, &joined); err != nil {
+		return cloudWorkspaceJoinResponse{}, fmt.Errorf("join cloud workspace: %w", err)
+	}
+	if strings.TrimSpace(joined.WorkspaceID) == "" {
+		joined.WorkspaceID = workspaceID
+	}
+	if strings.TrimSpace(joined.Token) == "" {
+		return cloudWorkspaceJoinResponse{}, errors.New("cloud join response missing token")
+	}
+	if strings.TrimSpace(joined.RelayfileURL) == "" {
+		return cloudWorkspaceJoinResponse{}, errors.New("cloud join response missing relayfileUrl")
+	}
+	return joined, nil
 }
 
 func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (cloudCredentials, error) {
@@ -537,7 +888,18 @@ func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser 
 	}
 }
 
-func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
+func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
+	connectionID := loadSavedConnectionID(localDir, provider)
+	if connectionID != "" {
+		if ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID); err == nil && ready {
+			fmt.Fprintf(stdout, "%s already connected\n", provider)
+			return nil
+		}
+	}
+	return connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir, timeout, shouldOpenBrowser, stdout)
+}
+
+func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
 	client, err := newAPIClient(cloudAPIURL, workspaceToken)
 	if err != nil {
 		return err
@@ -553,6 +915,12 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider 
 	if connectionID == "" {
 		connectionID = workspaceID
 	}
+	_ = saveIntegrationConnection(localDir, integrationConnectionState{
+		Provider:     provider,
+		ConnectionID: connectionID,
+		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	})
 
 	if connectLink := strings.TrimSpace(session.ConnectLink); connectLink != "" {
 		fmt.Fprintf(stdout, "Connect %s: %s\n", provider, connectLink)
@@ -570,12 +938,12 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider 
 	}
 	deadline := time.Now().Add(timeout)
 	for {
-		ready, err := cloudIntegrationReady(client, workspaceID, provider, connectionID)
+		ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID)
 		if err != nil {
 			return err
 		}
 		if ready {
-			fmt.Fprintf(stdout, "%s connected\n", provider)
+			fmt.Fprintf(stdout, "%s connected. Files will appear under %s/%s within ~30s.\n", provider, localDir, providerRootDir(provider))
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -585,14 +953,53 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider 
 	}
 }
 
-func cloudIntegrationReady(client *apiClient, workspaceID, provider, connectionID string) (bool, error) {
+func cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID string) (bool, error) {
+	client, err := newAPIClient(cloudAPIURL, workspaceToken)
+	if err != nil {
+		return false, err
+	}
 	query := url.Values{}
-	query.Set("connectionId", connectionID)
+	if strings.TrimSpace(connectionID) != "" {
+		query.Set("connectionId", connectionID)
+	}
 	var status cloudIntegrationReadyResponse
 	if err := client.getJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/status?%s", url.PathEscape(workspaceID), url.PathEscape(provider), query.Encode()), &status); err != nil {
 		return false, fmt.Errorf("check %s connection: %w", provider, err)
 	}
 	return status.Ready, nil
+}
+
+func waitForInitialSync(serverURL, token, workspaceID, provider, localDir string, timeout time.Duration, stdout io.Writer) error {
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	client, err := newAPIClient(serverURL, token)
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(timeout)
+	lastPrinted := time.Time{}
+	for {
+		status, err := fetchWorkspaceSyncStatus(client, workspaceID)
+		if err != nil {
+			return err
+		}
+		providerStatus, ok := syncProviderByName(status, provider)
+		if ok && providerReadyForMirror(client, workspaceID, provider, providerStatus) {
+			return writeMirrorStateFile(localDir, buildSyncStateSnapshot(status, workspaceID, defaultMountMode, defaultMountInterval, localDir, readDaemonPID(localDir), ""))
+		}
+		if time.Since(lastPrinted) >= 5*time.Second {
+			lastPrinted = time.Now()
+			if ok {
+				fmt.Fprintf(stdout, "Syncing %s... lag %ds status=%s\n", provider, providerStatus.LagSeconds, providerStatus.Status)
+			}
+		}
+		if time.Now().After(deadline) {
+			fmt.Fprintf(stdout, "%s still syncing in the background. Files will continue to populate. See 'relayfile status'.\n", provider)
+			return nil
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
@@ -663,6 +1070,166 @@ func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 	default:
 		return fmt.Errorf("unknown workspace subcommand %q", args[0])
 	}
+}
+
+func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) == 0 {
+		return errors.New("integration subcommand is required: connect, list, or disconnect")
+	}
+	switch args[0] {
+	case "connect":
+		return runIntegrationConnect(args[1:], stdin, stdout)
+	case "list":
+		return runIntegrationList(args[1:], stdout)
+	case "disconnect":
+		return runIntegrationDisconnect(args[1:], stdin, stdout)
+	default:
+		return fmt.Errorf("unknown integration subcommand %q", args[0])
+	}
+}
+
+func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration connect", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	noOpen := fs.Bool("no-open", false, "print the hosted URL instead of opening it")
+	timeout := fs.Duration("timeout", 5*time.Minute, "integration readiness timeout")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":     true,
+		"cloud-api-url": true,
+		"no-open":       false,
+		"timeout":       true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile integration connect PROVIDER [--workspace NAME] [--no-open] [--timeout 5m]")
+	}
+	provider := normalizeProviderID(fs.Arg(0))
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, stdout)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	if err := persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir); err != nil {
+		return err
+	}
+	if err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, record.LocalDir, *timeout, !*noOpen, stdout); err != nil {
+		return err
+	}
+	return waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, provider, record.LocalDir, *timeout, stdout)
+}
+
+func runIntegrationList(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration list", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	jsonOutput := fs.Bool("json", false, "emit JSON")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":     true,
+		"json":          false,
+		"cloud-api-url": true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() > 0 {
+		return errors.New("usage: relayfile integration list [--workspace NAME] [--json]")
+	}
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, io.Discard)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	if err != nil {
+		return err
+	}
+	var entries []cloudIntegrationListEntry
+	if err := client.getJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations", url.PathEscape(record.ID)), &entries); err != nil {
+		return err
+	}
+	if *jsonOutput {
+		return writeJSON(stdout, entries)
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(stdout, "No integrations connected")
+		return nil
+	}
+	fmt.Fprintln(stdout, "provider\tstatus\tlag\tlast_event_at")
+	for _, entry := range entries {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", entry.Provider, defaultIfBlank(entry.Status, "unknown"), formatLag(entry.LagSeconds), defaultIfBlank(entry.LastEventAt, "-"))
+	}
+	return nil
+}
+
+func runIntegrationDisconnect(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration disconnect", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	yes := fs.Bool("yes", false, "skip confirmation")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":     true,
+		"cloud-api-url": true,
+		"yes":           false,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]")
+	}
+	provider := normalizeProviderID(fs.Arg(0))
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	if !*yes {
+		answer, err := promptLine(stdin, stdout, fmt.Sprintf("Disconnect %q from workspace %q? [y/N]: ", provider, record.Name))
+		if err != nil {
+			return err
+		}
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintln(stdout, "Aborted")
+			return nil
+		}
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, io.Discard)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	if err != nil {
+		return err
+	}
+	if _, _, err := client.do(context.Background(), http.MethodDelete, fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/status", url.PathEscape(record.ID), url.PathEscape(provider)), nil); err != nil {
+		return err
+	}
+	if err := markProviderDisconnected(record.LocalDir, provider); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "%s disconnected from workspace %s\n", provider, record.Name)
+	return nil
 }
 
 func runWorkspaceCreate(args []string, stdout io.Writer) error {
@@ -809,10 +1376,15 @@ func runMount(args []string) error {
 	eventProvider := fs.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	stateFile := fs.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
 	localDirFlag := fs.String("local-dir", "", "local mirror directory")
-	interval := fs.Duration("interval", durationEnv("RELAYFILE_MOUNT_INTERVAL", 2*time.Second), "sync interval")
+	mode := fs.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", defaultMountMode), "mount mode: poll (recommended) or fuse")
+	interval := fs.Duration("interval", durationEnv("RELAYFILE_MOUNT_INTERVAL", defaultMountInterval), "sync interval")
 	intervalJitter := fs.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
-	timeout := fs.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
+	timeout := fs.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", defaultMountTimeout), "per-sync timeout")
 	websocketEnabled := fs.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
+	background := fs.Bool("background", false, "detach and keep syncing in the background")
+	pidFileFlag := fs.String("pid-file", "", "pid file path for background mode")
+	logFileFlag := fs.String("log-file", "", "log file path for background mode")
+	daemonized := fs.Bool("daemonized", false, "internal flag used by relayfile mount --background")
 	once := fs.Bool("once", false, "run one sync cycle and exit")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"server":          true,
@@ -820,10 +1392,15 @@ func runMount(args []string) error {
 		"remote-path":     true,
 		"provider":        true,
 		"state-file":      true,
+		"mode":            true,
 		"interval":        true,
 		"interval-jitter": true,
 		"timeout":         true,
 		"websocket":       false,
+		"background":      false,
+		"pid-file":        true,
+		"log-file":        true,
+		"daemonized":      false,
 		"once":            false,
 		"local-dir":       true,
 	})); err != nil {
@@ -864,14 +1441,48 @@ func runMount(args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := ensureMirrorLayout(absLocalDir); err != nil {
+		return err
+	}
 
+	if strings.EqualFold(strings.TrimSpace(*mode), "fuse") || boolEnv("RELAYFILE_MOUNT_FUSE", false) {
+		return errors.New("fuse mode is not available in this build; rerun with --mode=poll")
+	}
 	if *interval <= 0 {
-		*interval = 2 * time.Second
+		*interval = defaultMountInterval
 	}
 	if *timeout <= 0 {
-		*timeout = 15 * time.Second
+		*timeout = defaultMountTimeout
 	}
 	*intervalJitter = clampJitterRatio(*intervalJitter)
+
+	pidFile := strings.TrimSpace(*pidFileFlag)
+	if pidFile == "" {
+		pidFile = mountPIDFile(absLocalDir)
+	}
+	logFile := strings.TrimSpace(*logFileFlag)
+	if logFile == "" {
+		logFile = mountLogFile(absLocalDir)
+	}
+
+	if *background && !*daemonized {
+		return spawnBackgroundMountProcess(args, absLocalDir, pidFile, logFile)
+	}
+	if *daemonized {
+		if err := rotateLogFile(logFile); err != nil {
+			return err
+		}
+		if err := writeDaemonPIDState(pidFile, daemonPIDState{
+			PID:         os.Getpid(),
+			WorkspaceID: workspaceID,
+			LocalDir:    absLocalDir,
+			LogFile:     logFile,
+			StartedAt:   time.Now().UTC().Format(time.RFC3339),
+		}); err != nil {
+			return err
+		}
+		defer os.Remove(pidFile)
+	}
 
 	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -893,8 +1504,22 @@ func runMount(args []string) error {
 	if _, err := upsertWorkspace(workspaceID); err != nil {
 		return err
 	}
+	record, _ := workspaceRecordByID(workspaceID)
+	record.ID = workspaceID
+	if record.Name == "" {
+		record.Name = workspaceID
+	}
+	record.LocalDir = absLocalDir
+	record.Server = strings.TrimRight(strings.TrimSpace(*server), "/")
+	if record.AgentName == "" {
+		record.AgentName = "relayfile-cli"
+	}
+	if len(record.Scopes) == 0 {
+		record.Scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	_, _ = upsertWorkspaceDetails(record)
 
-	return runMountLoop(rootCtx, syncer, absLocalDir, *timeout, *interval, *intervalJitter, *websocketEnabled, *once)
+	return runMountLoop(rootCtx, syncer, absLocalDir, workspaceID, strings.TrimRight(strings.TrimSpace(*server), "/"), *timeout, *interval, *intervalJitter, *websocketEnabled, *once, *daemonized, pidFile, logFile)
 }
 
 func runTree(args []string, stdout io.Writer) error {
@@ -1215,14 +1840,16 @@ func runStatus(args []string, stdout io.Writer) error {
 	fs.SetOutput(io.Discard)
 	server := fs.String("server", "", "relayfile server URL override")
 	token := fs.String("token", "", "relayfile token override")
+	jsonOutput := fs.Bool("json", false, "emit JSON")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"server": true,
 		"token":  true,
+		"json":   false,
 	})); err != nil {
 		return err
 	}
 	if fs.NArg() > 1 {
-		return errors.New("usage: relayfile status [WORKSPACE]")
+		return errors.New("usage: relayfile status [WORKSPACE] [--json]")
 	}
 
 	creds, err := loadCredentials()
@@ -1242,44 +1869,102 @@ func runStatus(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	var status syncStatusResponse
-	if err := client.getJSON(context.Background(), fmt.Sprintf("/v1/workspaces/%s/sync/status", url.PathEscape(workspaceID)), &status); err != nil {
+	status, err := fetchWorkspaceSyncStatus(client, workspaceID)
+	if err != nil {
 		return err
 	}
 	if _, err := upsertWorkspace(workspaceID); err != nil {
 		return err
 	}
-
-	fileCountText := "unknown"
-	var exported []exportedFile
-	if err := client.getJSON(context.Background(), fmt.Sprintf("/v1/workspaces/%s/fs/export?format=json", url.PathEscape(workspaceID)), &exported); err == nil {
-		fileCountText = strconv.Itoa(len(exported))
+	record, _ := workspaceRecordByID(workspaceID)
+	snapshot := buildSyncStateSnapshot(status, workspaceID, defaultMountMode, defaultMountInterval, record.LocalDir, readDaemonPID(record.LocalDir), "")
+	if *jsonOutput {
+		return writeJSON(stdout, snapshot)
 	}
-
-	fmt.Fprintf(stdout, "Workspace: %s\n", status.WorkspaceID)
-	fmt.Fprintf(stdout, "File count: %s\n", fileCountText)
-	if len(status.Providers) == 0 {
-		fmt.Fprintln(stdout, "Last activity: unknown")
-		return nil
+	workspaceLabel := workspaceID
+	if strings.TrimSpace(record.Name) != "" && record.Name != workspaceID {
+		workspaceLabel = fmt.Sprintf("%s (%s)", workspaceID, record.Name)
 	}
-
-	lastActivity := "unknown"
+	fmt.Fprintf(stdout, "workspace %s   mode: %s   lag: %s\n", workspaceLabel, snapshot.Mode, formatLag(maxLagSeconds(status.Providers)))
 	for _, provider := range status.Providers {
-		if provider.WatermarkTs != nil && strings.TrimSpace(*provider.WatermarkTs) != "" {
-			if lastActivity == "unknown" || strings.TrimSpace(*provider.WatermarkTs) > lastActivity {
-				lastActivity = strings.TrimSpace(*provider.WatermarkTs)
-			}
+		lastEvent := "-"
+		if provider.WatermarkTs != nil {
+			lastEvent = humanizeRecentTime(strings.TrimSpace(*provider.WatermarkTs))
 		}
-	}
-	fmt.Fprintf(stdout, "Last activity: %s\n", lastActivity)
-	for _, provider := range status.Providers {
-		line := fmt.Sprintf("%s: %s", provider.Provider, provider.Status)
-		if provider.LagSeconds > 0 {
-			line += fmt.Sprintf(" lag=%ds", provider.LagSeconds)
+		line := fmt.Sprintf("  %-12s %-8s lag %s", provider.Provider, provider.Status, formatLag(provider.LagSeconds))
+		if lastEvent != "-" {
+			line += "   last event " + lastEvent
 		}
 		if provider.LastError != nil && strings.TrimSpace(*provider.LastError) != "" {
-			line += fmt.Sprintf(" error=%q", *provider.LastError)
+			line += "   last error: " + strings.TrimSpace(*provider.LastError)
 		}
+		fmt.Fprintln(stdout, line)
+	}
+	if record.LocalDir != "" {
+		fmt.Fprintf(stdout, "\nlocal mirror: %s\n", record.LocalDir)
+		if pid := readDaemonPID(record.LocalDir); pid != 0 {
+			fmt.Fprintf(stdout, "daemon: running (pid %d)\n", pid)
+		} else {
+			fmt.Fprintln(stdout, "daemon: not running")
+		}
+	}
+	fmt.Fprintf(stdout, "\npending writebacks: %d    conflicts: %d    denied: %d\n", snapshot.PendingWriteback, snapshot.PendingConflicts, snapshot.DeniedPaths)
+	return nil
+}
+
+func runStop(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("stop", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{})); err != nil {
+		return err
+	}
+	if fs.NArg() > 1 {
+		return errors.New("usage: relayfile stop [WORKSPACE]")
+	}
+	record, err := resolveWorkspaceRecord(firstArg(fs))
+	if err != nil {
+		return err
+	}
+	pid := readDaemonPID(record.LocalDir)
+	if pid == 0 {
+		return fmt.Errorf("no running mount found for workspace %s", record.Name)
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
+	return nil
+}
+
+func runLogs(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	lines := fs.Int("lines", 40, "number of lines to print")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"lines": true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() > 1 {
+		return errors.New("usage: relayfile logs [WORKSPACE] [--lines N]")
+	}
+	record, err := resolveWorkspaceRecord(firstArg(fs))
+	if err != nil {
+		return err
+	}
+	payload, err := os.ReadFile(mountLogFile(record.LocalDir))
+	if err != nil {
+		return err
+	}
+	linesOut := strings.Split(strings.TrimRight(string(payload), "\n"), "\n")
+	if *lines > 0 && len(linesOut) > *lines {
+		linesOut = linesOut[len(linesOut)-*lines:]
+	}
+	for _, line := range linesOut {
 		fmt.Fprintln(stdout, line)
 	}
 	return nil
@@ -1594,7 +2279,7 @@ func saveCredentials(creds credentials) error {
 		return err
 	}
 	payload = append(payload, '\n')
-	return os.WriteFile(credentialsPath(), payload, 0o600)
+	return writeFileAtomically(credentialsPath(), payload, 0o600)
 }
 
 func saveCloudCredentials(creds cloudCredentials) error {
@@ -1612,7 +2297,7 @@ func saveCloudCredentials(creds cloudCredentials) error {
 		return err
 	}
 	payload = append(payload, '\n')
-	return os.WriteFile(cloudCredentialsPath(), payload, 0o600)
+	return writeFileAtomically(cloudCredentialsPath(), payload, 0o600)
 }
 
 func loadCredentials() (credentials, error) {
@@ -1660,7 +2345,7 @@ func saveWorkspaceCatalog(catalog workspaceCatalog) error {
 		return err
 	}
 	payload = append(payload, '\n')
-	return os.WriteFile(workspacesPath(), payload, 0o644)
+	return writeFileAtomically(workspacesPath(), payload, 0o644)
 }
 
 func setDefaultWorkspace(name string) (workspaceRecord, error) {
@@ -1816,6 +2501,135 @@ func upsertWorkspaceRecord(name, id string) (workspaceRecord, error) {
 	return record, nil
 }
 
+func upsertWorkspaceDetails(record workspaceRecord) (workspaceRecord, error) {
+	record.Name = strings.TrimSpace(record.Name)
+	record.ID = strings.TrimSpace(record.ID)
+	if record.Name == "" {
+		return workspaceRecord{}, errors.New("workspace name is required")
+	}
+	if record.ID == "" {
+		record.ID = record.Name
+	}
+	if record.CreatedAt == "" {
+		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	record.LocalDir = strings.TrimSpace(record.LocalDir)
+	record.Server = strings.TrimRight(strings.TrimSpace(record.Server), "/")
+	record.CloudAPIURL = strings.TrimRight(strings.TrimSpace(record.CloudAPIURL), "/")
+	record.AgentName = strings.TrimSpace(record.AgentName)
+	if len(record.Scopes) == 0 {
+		record.Scopes = append([]string(nil), defaultJoinScopes...)
+	}
+
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return workspaceRecord{}, err
+	}
+	for i := range catalog.Workspaces {
+		current := catalog.Workspaces[i]
+		if current.Name == record.Name || (record.ID != "" && current.ID == record.ID) {
+			if record.CreatedAt == "" {
+				record.CreatedAt = current.CreatedAt
+			}
+			catalog.Workspaces[i] = mergeWorkspaceRecords(current, record)
+			if err := saveWorkspaceCatalog(catalog); err != nil {
+				return workspaceRecord{}, err
+			}
+			return catalog.Workspaces[i], nil
+		}
+	}
+	catalog.Workspaces = append(catalog.Workspaces, record)
+	if strings.TrimSpace(catalog.Default) == "" {
+		catalog.Default = record.Name
+	}
+	if err := saveWorkspaceCatalog(catalog); err != nil {
+		return workspaceRecord{}, err
+	}
+	return record, nil
+}
+
+func mergeWorkspaceRecords(current, update workspaceRecord) workspaceRecord {
+	merged := current
+	if update.Name != "" {
+		merged.Name = update.Name
+	}
+	if update.ID != "" {
+		merged.ID = update.ID
+	}
+	if update.CreatedAt != "" {
+		merged.CreatedAt = update.CreatedAt
+	}
+	if update.LastUsedAt != "" {
+		merged.LastUsedAt = update.LastUsedAt
+	}
+	if update.LocalDir != "" {
+		merged.LocalDir = update.LocalDir
+	}
+	if update.Server != "" {
+		merged.Server = update.Server
+	}
+	if update.CloudAPIURL != "" {
+		merged.CloudAPIURL = update.CloudAPIURL
+	}
+	if update.AgentName != "" {
+		merged.AgentName = update.AgentName
+	}
+	if len(update.Scopes) > 0 {
+		merged.Scopes = append([]string(nil), update.Scopes...)
+	}
+	return merged
+}
+
+func workspaceRecordByName(name string) (workspaceRecord, bool) {
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return workspaceRecord{}, false
+	}
+	name = strings.TrimSpace(name)
+	for _, record := range catalog.Workspaces {
+		if record.Name == name {
+			return record, true
+		}
+	}
+	return workspaceRecord{}, false
+}
+
+func workspaceRecordByID(id string) (workspaceRecord, bool) {
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return workspaceRecord{}, false
+	}
+	id = strings.TrimSpace(id)
+	for _, record := range catalog.Workspaces {
+		if record.ID == id {
+			return record, true
+		}
+	}
+	return workspaceRecord{}, false
+}
+
+func resolveWorkspaceRecord(nameOrID string) (workspaceRecord, error) {
+	nameOrID = strings.TrimSpace(nameOrID)
+	if nameOrID != "" {
+		if record, ok := workspaceRecordByName(nameOrID); ok {
+			return record, nil
+		}
+		if record, ok := workspaceRecordByID(nameOrID); ok {
+			return record, nil
+		}
+		return workspaceRecord{}, fmt.Errorf("workspace %q not found in %s", nameOrID, workspacesPath())
+	}
+	workspaceID, err := resolveWorkspaceIDWithToken("", "")
+	if err != nil {
+		return workspaceRecord{}, err
+	}
+	if record, ok := workspaceRecordByID(workspaceID); ok {
+		return record, nil
+	}
+	return workspaceRecord{Name: workspaceID, ID: workspaceID}, nil
+}
+
 func resolveWorkspaceIDWithToken(value, token string) (string, error) {
 	value = strings.TrimSpace(value)
 	if value != "" {
@@ -1959,6 +2773,441 @@ func readCloudCredentialsFromQuery(values url.Values, fallbackAPIURL string) (cl
 		RefreshTokenExpiresAt: strings.TrimSpace(values.Get("refresh_token_expires_at")),
 		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
 	}, nil
+}
+
+func fetchWorkspaceSyncStatus(client *apiClient, workspaceID string) (syncStatusResponse, error) {
+	var status syncStatusResponse
+	if err := client.getJSON(context.Background(), fmt.Sprintf("/v1/workspaces/%s/sync/status", url.PathEscape(workspaceID)), &status); err != nil {
+		return syncStatusResponse{}, err
+	}
+	return status, nil
+}
+
+func syncProviderByName(status syncStatusResponse, provider string) (syncProviderStatus, bool) {
+	provider = normalizeProviderID(provider)
+	for _, entry := range status.Providers {
+		if normalizeProviderID(entry.Provider) == provider {
+			return entry, true
+		}
+	}
+	return syncProviderStatus{}, false
+}
+
+func providerReadyForMirror(client *apiClient, workspaceID, provider string, status syncProviderStatus) bool {
+	switch status.Status {
+	case "ready":
+		return true
+	case "syncing":
+		if status.LagSeconds >= 30 {
+			return false
+		}
+		body, _, err := client.getBytes(context.Background(), fmt.Sprintf("/v1/workspaces/%s/fs/tree?path=%s&depth=1", url.PathEscape(workspaceID), url.QueryEscape("/"+providerRootDir(provider))))
+		if err != nil {
+			return false
+		}
+		var tree treeResponse
+		if err := json.Unmarshal(body, &tree); err != nil {
+			return false
+		}
+		return len(tree.Entries) > 0
+	default:
+		return false
+	}
+}
+
+func buildSyncStateSnapshot(status syncStatusResponse, workspaceID, mode string, interval time.Duration, localDir string, pid int, stallReason string) syncStateFile {
+	snapshot := syncStateFile{
+		WorkspaceID:      workspaceID,
+		Mode:             defaultIfBlank(mode, defaultMountMode),
+		IntervalMs:       interval.Milliseconds(),
+		PendingWriteback: countDirtyTrackedFiles(localDir),
+		PendingConflicts: countFilesInDir(filepath.Join(localDir, ".relay", "conflicts")),
+		DeniedPaths:      countLines(filepath.Join(localDir, ".relay", "permissions-denied.log")),
+		StallReason:      stallReason,
+	}
+	if pid != 0 {
+		snapshot.Daemon = &syncStateDaemon{
+			PID:     pid,
+			LogFile: mountLogFile(localDir),
+			PIDFile: mountPIDFile(localDir),
+		}
+	}
+	providers := make([]syncStateProvider, 0, len(status.Providers))
+	var lastEvent string
+	for _, provider := range status.Providers {
+		item := syncStateProvider{
+			Provider:        provider.Provider,
+			Status:          provider.Status,
+			LagSeconds:      provider.LagSeconds,
+			DeadLetteredOps: provider.DeadLetteredOps,
+		}
+		if provider.LastError != nil {
+			item.LastError = strings.TrimSpace(*provider.LastError)
+		}
+		if provider.WatermarkTs != nil {
+			item.LastEventAt = strings.TrimSpace(*provider.WatermarkTs)
+			if item.LastEventAt > lastEvent {
+				lastEvent = item.LastEventAt
+			}
+		}
+		providers = append(providers, item)
+	}
+	snapshot.Providers = providers
+	snapshot.LastEventAt = lastEvent
+	return snapshot
+}
+
+func writeMirrorStateFile(localDir string, snapshot syncStateFile) error {
+	if localDir == "" {
+		return nil
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		return err
+	}
+	snapshot.LastReconcileAt = time.Now().UTC().Format(time.RFC3339)
+	payload, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	return writeFileAtomically(filepath.Join(localDir, ".relay", "state.json"), payload, 0o644)
+}
+
+func countDirtyTrackedFiles(localDir string) int {
+	if localDir == "" {
+		return 0
+	}
+	var state struct {
+		Files map[string]struct {
+			Dirty bool `json:"dirty"`
+		} `json:"files"`
+	}
+	payload, err := os.ReadFile(filepath.Join(localDir, ".relayfile-mount-state.json"))
+	if err != nil {
+		return 0
+	}
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return 0
+	}
+	count := 0
+	for _, tracked := range state.Files {
+		if tracked.Dirty {
+			count++
+		}
+	}
+	return count
+}
+
+func countFilesInDir(dir string) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			if entry.Name() == "resolved" {
+				continue
+			}
+			count += countFilesInDir(filepath.Join(dir, entry.Name()))
+			continue
+		}
+		if !entry.IsDir() {
+			count++
+		}
+	}
+	return count
+}
+
+func countLines(path string) int {
+	payload, err := os.ReadFile(path)
+	if err != nil || len(payload) == 0 {
+		return 0
+	}
+	return bytes.Count(payload, []byte{'\n'})
+}
+
+func mountPIDFile(localDir string) string {
+	return filepath.Join(localDir, ".relay", "mount.pid")
+}
+
+func mountLogFile(localDir string) string {
+	return filepath.Join(localDir, ".relay", "mount.log")
+}
+
+func writeDaemonPIDState(path string, state daemonPIDState) error {
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	return writeFileAtomically(path, payload, 0o644)
+}
+
+func readDaemonPID(localDir string) int {
+	if localDir == "" {
+		return 0
+	}
+	payload, err := os.ReadFile(mountPIDFile(localDir))
+	if err != nil {
+		return 0
+	}
+	var state daemonPIDState
+	if json.Unmarshal(payload, &state) == nil && state.PID > 0 {
+		return state.PID
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(payload)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}
+
+func rotateLogFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if info.Size() < 10*1024*1024 {
+		return nil
+	}
+	_ = os.Remove(path + ".3")
+	for idx := 2; idx >= 1; idx-- {
+		src := fmt.Sprintf("%s.%d", path, idx)
+		dst := fmt.Sprintf("%s.%d", path, idx+1)
+		if _, err := os.Stat(src); err == nil {
+			if err := os.Rename(src, dst); err != nil {
+				return err
+			}
+		}
+	}
+	return os.Rename(path, path+".1")
+}
+
+func integrationConnectionPath(localDir, provider string) string {
+	return filepath.Join(localDir, ".relay", "integrations", provider+".json")
+}
+
+func saveIntegrationConnection(localDir string, state integrationConnectionState) error {
+	if localDir == "" || strings.TrimSpace(state.Provider) == "" {
+		return nil
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	return writeFileAtomically(integrationConnectionPath(localDir, state.Provider), payload, 0o644)
+}
+
+func loadSavedConnectionID(localDir, provider string) string {
+	if localDir == "" || strings.TrimSpace(provider) == "" {
+		return ""
+	}
+	payload, err := os.ReadFile(integrationConnectionPath(localDir, provider))
+	if err != nil {
+		return ""
+	}
+	var state integrationConnectionState
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(state.ConnectionID)
+}
+
+func markProviderDisconnected(localDir, provider string) error {
+	if localDir == "" {
+		return nil
+	}
+	_ = os.RemoveAll(filepath.Join(localDir, providerRootDir(provider)))
+	if err := ensureMirrorLayout(localDir); err != nil {
+		return err
+	}
+	marker := map[string]string{
+		"provider":       provider,
+		"disconnectedAt": time.Now().UTC().Format(time.RFC3339),
+	}
+	payload, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	if err := writeFileAtomically(filepath.Join(localDir, ".relay", "disconnected", provider+".json"), payload, 0o644); err != nil {
+		return err
+	}
+	_ = os.Remove(integrationConnectionPath(localDir, provider))
+	return nil
+}
+
+func providerRootDir(provider string) string {
+	provider = normalizeProviderID(provider)
+	switch provider {
+	case "slack-sage":
+		return "slack"
+	default:
+		return provider
+	}
+}
+
+func writeJSON(w io.Writer, value any) error {
+	payload, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	_, err = w.Write(payload)
+	return err
+}
+
+func writeFileAtomically(path string, payload []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func parseRFC3339(value string) (time.Time, bool) {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultIfBlank(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func firstArg(fs *flag.FlagSet) string {
+	if fs.NArg() == 0 {
+		return ""
+	}
+	return fs.Arg(0)
+}
+
+func formatLag(seconds int) string {
+	if seconds <= 0 {
+		return "0s"
+	}
+	return (time.Duration(seconds) * time.Second).String()
+}
+
+func humanizeRecentTime(value string) string {
+	parsed, ok := parseRFC3339(value)
+	if !ok {
+		return value
+	}
+	ago := time.Since(parsed)
+	if ago < time.Second {
+		return "just now"
+	}
+	return fmt.Sprintf("%s ago", ago.Round(time.Second).String())
+}
+
+func maxLagSeconds(providers []syncProviderStatus) int {
+	maxLag := 0
+	for _, provider := range providers {
+		if provider.LagSeconds > maxLag {
+			maxLag = provider.LagSeconds
+		}
+	}
+	return maxLag
+}
+
+func syncerClient(syncer *mountsync.Syncer) (*mountsync.HTTPClient, bool) {
+	return syncer.HTTPClient()
+}
+
+func relayfileTokenNeedsRefresh(token string) bool {
+	claims, ok := parseJWTClaims(token)
+	if !ok {
+		return false
+	}
+	expUnix, ok := claims["exp"].(float64)
+	if !ok {
+		return false
+	}
+	exp := time.Unix(int64(expUnix), 0)
+	threshold := 5 * time.Minute
+	if iatUnix, ok := claims["iat"].(float64); ok {
+		issuedAt := time.Unix(int64(iatUnix), 0)
+		lifetime := exp.Sub(issuedAt)
+		if lifetime > 0 {
+			candidate := lifetime / 10
+			if candidate > threshold {
+				threshold = candidate
+			}
+		}
+	}
+	return !time.Now().UTC().Before(exp.Add(-threshold))
+}
+
+func parseJWTClaims(token string) (map[string]any, bool) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) < 2 {
+		return nil, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		return nil, false
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, false
+	}
+	return claims, true
+}
+
+func isMountAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var httpErr *mountsync.HTTPError
+	return errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)
 }
 
 func buildCloudURL(baseURL, path string) (*url.URL, error) {
@@ -2180,35 +3429,166 @@ func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64)
 	return delay
 }
 
-func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir string, timeout, interval time.Duration, intervalJitter float64, websocketEnabled, once bool) error {
-	runCycle := func(reconcile bool) error {
-		ctx, cancel := context.WithTimeout(rootCtx, timeout)
-		defer cancel()
-		var err error
-		if reconcile {
-			err = syncer.Reconcile(ctx)
-		} else {
-			err = syncer.SyncOnce(ctx)
+func spawnBackgroundMountProcess(originalArgs []string, localDir, pidFile, logFile string) error {
+	if err := ensureMirrorLayout(localDir); err != nil {
+		return err
+	}
+	if err := rotateLogFile(logFile); err != nil {
+		return err
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	filteredArgs := make([]string, 0, len(originalArgs)+5)
+	for i := 0; i < len(originalArgs); i++ {
+		arg := originalArgs[i]
+		if arg == "--background" || arg == "-background" {
+			continue
 		}
+		if strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
+			continue
+		}
+		filteredArgs = append(filteredArgs, arg)
+	}
+	childArgs := append([]string{"mount"}, filteredArgs...)
+	childArgs = append(childArgs, "--daemonized", "--pid-file", pidFile, "--log-file", logFile)
+	logHandle, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer logHandle.Close()
+	cmd := exec.Command(executable, childArgs...)
+	cmd.Stdout = logHandle
+	cmd.Stderr = logHandle
+	if err := configureDetachedProcess(cmd); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "Mirror started in background at %s. Logs: %s\n", localDir, logFile)
+	return nil
+}
+
+func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, workspaceID, serverURL string, timeout, interval time.Duration, intervalJitter float64, websocketEnabled, once, daemonized bool, pidFile, logFile string) error {
+	httpClient, _ := syncerClient(syncer)
+	record, _ := workspaceRecordByID(workspaceID)
+	if record.ID == "" {
+		record.ID = workspaceID
+	}
+	if record.Name == "" {
+		record.Name = workspaceID
+	}
+	lastSuccess := time.Now()
+	stallReason := ""
+
+	refreshMountAuth := func(force bool) error {
+		if httpClient == nil {
+			return nil
+		}
+		if !force && !relayfileTokenNeedsRefresh(httpClient.Token()) {
+			return nil
+		}
+		cloudCreds, err := loadCloudCredentials()
 		if err != nil {
-			log.Printf("mount sync cycle failed: %v", err)
+			return nil
+		}
+		cloudCreds, err = refreshCloudCredentialsIfNeeded(cloudCreds)
+		if err != nil {
+			log.Printf("cloud session refresh failed: %v", err)
+			return nil
+		}
+		joined, err := joinWorkspaceViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
+		if err != nil {
 			return err
 		}
-		log.Printf("mount sync cycle completed")
+		httpClient.SetToken(joined.Token)
+		syncer.ResetWebSocket()
+		if err := saveCredentials(credentials{
+			Server:    strings.TrimRight(joined.RelayfileURL, "/"),
+			Token:     joined.Token,
+			UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+		}); err != nil {
+			return err
+		}
+		record.Server = strings.TrimRight(joined.RelayfileURL, "/")
+		record.CloudAPIURL = cloudCreds.APIURL
+		if _, err := upsertWorkspaceDetails(record); err != nil {
+			return err
+		}
 		return nil
 	}
 
+	withAuthRefresh := func(operation func(context.Context) error) error {
+		if err := refreshMountAuth(false); err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(rootCtx, timeout)
+		defer cancel()
+		err := operation(ctx)
+		if isMountAuthError(err) {
+			if refreshErr := refreshMountAuth(true); refreshErr != nil {
+				return refreshErr
+			}
+			retryCtx, retryCancel := context.WithTimeout(rootCtx, timeout)
+			defer retryCancel()
+			return operation(retryCtx)
+		}
+		return err
+	}
+
+	writeSnapshot := func() {
+		if httpClient == nil {
+			return
+		}
+		client, err := newAPIClient(serverURL, httpClient.Token())
+		if err != nil {
+			return
+		}
+		status, err := fetchWorkspaceSyncStatus(client, workspaceID)
+		if err != nil {
+			return
+		}
+		_ = writeMirrorStateFile(localDir, buildSyncStateSnapshot(status, workspaceID, defaultMountMode, interval, localDir, readDaemonPID(localDir), stallReason))
+	}
+
+	runCycle := func(reconcile bool) error {
+		err := withAuthRefresh(func(ctx context.Context) error {
+			if reconcile {
+				return syncer.Reconcile(ctx)
+			}
+			return syncer.SyncOnce(ctx)
+		})
+		if err != nil {
+			stallReason = err.Error()
+			log.Printf("mount sync cycle failed: %v", err)
+			writeSnapshot()
+			return err
+		}
+		stallReason = ""
+		lastSuccess = time.Now()
+		log.Printf("mount sync cycle completed")
+		writeSnapshot()
+		return nil
+	}
+
+	log.Printf("Mirror started at %s. Sync interval %s ±%.0f%%. Type 'relayfile status' for live state.", localDir, interval.String(), intervalJitter*100)
 	initialErr := runCycle(true)
 	if once {
 		return initialErr
 	}
 
 	watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
-		ctx, cancel := context.WithTimeout(rootCtx, timeout)
-		defer cancel()
-		if err := syncer.HandleLocalChange(ctx, relativePath, op); err != nil {
+		if err := withAuthRefresh(func(ctx context.Context) error {
+			return syncer.HandleLocalChange(ctx, relativePath, op)
+		}); err != nil {
 			log.Printf("mount local change failed: %v", err)
 		}
+		writeSnapshot()
 	})
 	if err != nil {
 		return fmt.Errorf("create file watcher: %w", err)
@@ -2226,12 +3606,18 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir st
 		select {
 		case <-rootCtx.Done():
 			log.Printf("mount sync stopping: %v", rootCtx.Err())
+			writeSnapshot()
 			return nil
 		case <-timer.C:
 			cycle++
 			reconcile := !websocketEnabled || cycle%websocketReconcileEvery == 0
 			if reconcile {
 				_ = runCycle(true)
+			}
+			if time.Since(lastSuccess) >= 10*time.Minute {
+				stallReason = "no successful reconcile for 10m"
+				log.Printf("mount stalled: %s", stallReason)
+				writeSnapshot()
 			}
 			timer.Reset(jitteredIntervalWithSample(interval, intervalJitter, mathrand.Float64()))
 		}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1910,6 +1910,14 @@ func runMount(args []string) error {
 		"once":            false,
 		"local-dir":       true,
 	})); err != nil {
+		// `--help` / `-h` come back from flag.ContinueOnError as
+		// flag.ErrHelp. Per contract A13 §3.6, surface the synced-mirror
+		// limitations alongside the flag list so users know what the
+		// default mode does and does not provide.
+		if errors.Is(err, flag.ErrHelp) {
+			printMountHelp(os.Stdout)
+			return nil
+		}
 		return err
 	}
 	if fs.NArg() > 2 {
@@ -2026,6 +2034,55 @@ func runMount(args []string) error {
 	_, _ = upsertWorkspaceDetails(record)
 
 	return runMountLoop(rootCtx, syncer, absLocalDir, workspaceID, strings.TrimRight(strings.TrimSpace(*server), "/"), *timeout, *interval, *intervalJitter, *websocketEnabled, *once, *daemonized, pidFile, logFile)
+}
+
+// mountStartBanner formats the user-facing line printed when the mount loop
+// starts. Per contract A13 / §3.1, the banner identifies the default mode
+// as a "synced mirror" so users do not assume kernel-level FUSE semantics.
+func mountStartBanner(localDir string, interval time.Duration, intervalJitter float64) string {
+	return fmt.Sprintf(
+		"Synced mirror started at %s. Sync interval %s ±%.0f%%. Type 'relayfile status' for live state.",
+		localDir,
+		interval.Round(time.Second).String(),
+		intervalJitter*100,
+	)
+}
+
+// printMountHelp surfaces the contract §3.6 list of synced-mirror
+// limitations alongside `relayfile mount`'s flag summary so that
+// `relayfile mount --help` is self-describing per A13.
+func printMountHelp(w io.Writer) {
+	fmt.Fprintln(w, `Usage: relayfile mount [WORKSPACE] [LOCAL_DIR]
+
+Mirror a remote workspace to a local directory. The default mode is a
+synced mirror (--mode=poll): ordinary files on disk that a daemon polls
+the cloud for every 30 s and writes back through. FUSE is opt-in via
+--mode=fuse.
+
+Synced-mirror limitations (§3.6 of the productized cloud-mount contract):
+  - File handles are not stable across syncs; an editor that holds a
+    file open during a remote update will see content change underneath
+    it on the next reconcile.
+  - mtime reflects the local write time, not the source-of-truth event
+    time. Use .relay/state.json for ordering.
+  - Directory listings can briefly omit a newly created remote file
+    until the next reconcile (default 30 s) or a websocket event.
+  - inotify/fsevents watchers downstream of the mirror will see
+    synthetic create events on every reconcile of new content; debounce
+    >= 1 s if a downstream tool requires single-shot events.
+
+Common flags:
+  --workspace NAME     workspace name or id (defaults to the active workspace)
+  --local-dir DIR      local mirror directory (defaults to a relay-... folder)
+  --mode poll|fuse     poll (synced mirror, default) or fuse
+  --interval 30s       sync interval (default 30s)
+  --background         detach and keep syncing in the background
+  --once               run one sync cycle and exit (used by setup/CI)
+  --timeout 5m         per-sync timeout
+  --no-websocket       disable websocket event streaming
+
+See 'relayfile help' for the full command list and
+docs/guides/vfs-cloud-setup.md#known-limitations for details.`)
 }
 
 func runTree(args []string, stdout io.Writer) error {
@@ -4166,7 +4223,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		return nil
 	}
 
-	log.Printf("Mirror started at %s. Sync interval %s ±%.0f%%. Type 'relayfile status' for live state.", localDir, interval.String(), intervalJitter*100)
+	log.Print(mountStartBanner(localDir, interval, intervalJitter))
 	initialErr := runCycle(true)
 	if once {
 		return initialErr

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -2522,7 +2522,10 @@ func runStop(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := process.Signal(syscall.SIGTERM); err != nil {
+	// Platform-specific: SIGTERM on Unix, TerminateProcess on Windows.
+	// The Windows kernel only routes os.Kill through Process.Signal, so a
+	// hard-coded SIGTERM here would always fail there.
+	if err := signalDaemonStop(process); err != nil {
 		return err
 	}
 	fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
@@ -3637,11 +3640,20 @@ func markProviderDisconnected(localDir, provider string) error {
 	return nil
 }
 
+// providerRootDir maps a provider id to the directory name it occupies
+// inside the local mirror. The mapping must stay aligned with the
+// `vfsRoot` values that fallbackIntegrationCatalog and the cloud
+// catalog endpoint advertise — otherwise status probes and disconnect
+// cleanup would target the wrong path for that provider.
 func providerRootDir(provider string) string {
 	provider = normalizeProviderID(provider)
 	switch provider {
-	case "slack-sage":
+	case "slack", "slack-sage":
 		return "slack"
+	case "slack-my-senior-dev":
+		return "slack-msd"
+	case "slack-nightcto":
+		return "slack-nightcto"
 	default:
 		return provider
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1026,7 +1026,7 @@ func TestOpsListReadsLocalDeadLetterMirror(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	if err := run([]string{"ops", "list", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+	if err := run([]string{"ops", "list", "--workspace", "demo", "--no-refresh"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run ops list failed: %v", err)
 	}
 	got := stdout.String()
@@ -1053,11 +1053,236 @@ func TestOpsListReportsEmptyWhenNoDeadLetterDir(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	if err := run([]string{"ops", "list", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+	if err := run([]string{"ops", "list", "--workspace", "demo", "--no-refresh"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run ops list failed: %v", err)
 	}
 	if got := strings.TrimSpace(stdout.String()); got != "No dead-lettered ops" {
 		t.Fatalf("expected empty marker, got: %q", got)
+	}
+}
+
+func TestOpsListRefreshesMirrorFromServer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	dlDir := filepath.Join(localDir, ".relay", "dead-letter")
+	if err := os.MkdirAll(dlDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead-letter failed: %v", err)
+	}
+	// Pre-existing record that the server no longer reports — must be pruned.
+	if err := os.WriteFile(filepath.Join(dlDir, "op_old.json"), []byte(`{"opId":"op_old"}`), 0o644); err != nil {
+		t.Fatalf("write stale record failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/workspaces/ws_demo/ops" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("status"); got != "dead_lettered" {
+			t.Fatalf("unexpected status filter: %q", got)
+		}
+		_, _ = w.Write([]byte(`{"items":[{"opId":"op_new","path":"/notion/page.json","status":"dead_lettered","attemptCount":3,"lastError":"schema validation failed: body must include event","createdAt":"2026-05-02T17:00:00Z","updatedAt":"2026-05-02T18:05:00Z"}]}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"ops", "list", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run ops list failed: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "op_new") {
+		t.Fatalf("expected refreshed record op_new in output: %q", got)
+	}
+	if strings.Contains(got, "op_old") {
+		t.Fatalf("expected stale record op_old to be pruned, got: %q", got)
+	}
+	// Verify the new record landed on disk with the expected shape.
+	payload, err := os.ReadFile(filepath.Join(dlDir, "op_new.json"))
+	if err != nil {
+		t.Fatalf("read refreshed record failed: %v", err)
+	}
+	var record deadLetterRecord
+	if err := json.Unmarshal(payload, &record); err != nil {
+		t.Fatalf("unmarshal refreshed record failed: %v", err)
+	}
+	if record.Code != "validation_error" {
+		t.Fatalf("expected validation_error code, got %q", record.Code)
+	}
+	if !strings.HasSuffix(record.ReplayURL, "/v1/workspaces/ws_demo/ops/op_new/replay") {
+		t.Fatalf("unexpected replay URL: %q", record.ReplayURL)
+	}
+	if _, err := os.Stat(filepath.Join(dlDir, "op_old.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected stale record removed, got err=%v", err)
+	}
+}
+
+func TestPullTriggersSyncRefreshForConnectedProviders(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	refreshes := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"ready","lagSeconds":4},{"provider":"github","status":"ready","lagSeconds":1}]}`))
+		case "/v1/workspaces/ws_demo/sync/refresh":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", r.Method)
+			}
+			var body struct {
+				Provider string `json:"provider"`
+				Reason   string `json:"reason"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode refresh body failed: %v", err)
+			}
+			if body.Reason != "manual" {
+				t.Fatalf("unexpected refresh reason: %q", body.Reason)
+			}
+			refreshes[body.Provider] = true
+			_, _ = w.Write([]byte(`{"status":"queued","id":"sync_job_1"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"pull", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run pull failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	for _, provider := range []string{"notion", "github"} {
+		if !refreshes[provider] {
+			t.Fatalf("expected refresh for %s", provider)
+		}
+	}
+	if got := stdout.String(); !strings.Contains(got, "notion refresh queued") || !strings.Contains(got, "github refresh queued") {
+		t.Fatalf("unexpected pull output: %q", got)
+	}
+}
+
+func TestPullScopedToSingleProviderSkipsStatusCall(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/workspaces/ws_demo/sync/refresh" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"status":"queued","id":"sync_job_2"}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"pull", "--workspace", "demo", "--provider", "notion", "--reason", "investigation"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run pull failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "notion refresh queued") {
+		t.Fatalf("unexpected pull output: %q", got)
+	}
+}
+
+func TestIntegrationCatalogCacheServesWithinTTL(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/integrations/catalog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[{"id":"notion","displayName":"Notion","vfsRoot":"/notion"}],"version":"v1"}`))
+	}))
+	defer server.Close()
+
+	first, err := loadIntegrationCatalog(server.URL, "tok")
+	if err != nil {
+		t.Fatalf("loadIntegrationCatalog first call failed: %v", err)
+	}
+	second, err := loadIntegrationCatalog(server.URL, "tok")
+	if err != nil {
+		t.Fatalf("loadIntegrationCatalog second call failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 catalog fetch, got %d", calls)
+	}
+	if len(first) != 1 || first[0].ID != "notion" || len(second) != 1 || second[0].ID != "notion" {
+		t.Fatalf("unexpected catalog contents: %+v / %+v", first, second)
+	}
+}
+
+func TestIntegrationCatalogCacheRefetchesAfterInvalidate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/integrations/catalog" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"providers":[{"id":"notion","displayName":"Notion","vfsRoot":"/notion"}],"version":"v1"}`))
+	}))
+	defer server.Close()
+
+	if _, err := loadIntegrationCatalog(server.URL, "tok"); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	invalidateIntegrationCatalogCache()
+	if _, err := loadIntegrationCatalog(server.URL, "tok"); err != nil {
+		t.Fatalf("post-invalidate call failed: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 catalog fetches after invalidate, got %d", calls)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -916,6 +917,113 @@ func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"` + agentName + `","aud":"relayfile"}`))
 	return header + "." + payload + ".sig"
+}
+
+func TestRefreshCloudCredentialsReturnsSentinelOnInvalidGrant(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/token/refresh" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"code":"invalid_grant","message":"refresh token expired"}`))
+	}))
+	defer server.Close()
+
+	_, err := refreshCloudCredentials(cloudCredentials{
+		APIURL:       server.URL,
+		AccessToken:  "cld_old",
+		RefreshToken: "rt_expired",
+	})
+	if !errors.Is(err, ErrCloudRefreshExpired) {
+		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
+	}
+}
+
+func TestRefreshCloudCredentialsReturnsSentinelOnUnauthorized(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"unauthorized","message":"unauthenticated"}`))
+	}))
+	defer server.Close()
+
+	_, err := refreshCloudCredentials(cloudCredentials{
+		APIURL:       server.URL,
+		AccessToken:  "cld_old",
+		RefreshToken: "rt_expired",
+	})
+	if !errors.Is(err, ErrCloudRefreshExpired) {
+		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
+	}
+}
+
+func TestRefreshCloudCredentialsReturnsSentinelWithoutRefreshToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	_, err := refreshCloudCredentials(cloudCredentials{
+		APIURL:      "https://cloud.example.test",
+		AccessToken: "cld_old",
+	})
+	if !errors.Is(err, ErrCloudRefreshExpired) {
+		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
+	}
+}
+
+func TestStatusSurfacesDegradedStallReason(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	persisted := syncStateFile{
+		WorkspaceID: "ws_demo",
+		Mode:        defaultMountMode,
+		StallReason: "cloud session expired — run 'relayfile login' to refresh",
+	}
+	if err := writeMirrorStateFile(localDir, persisted); err != nil {
+		t.Fatalf("writeMirrorStateFile failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "stall: cloud session expired") {
+		t.Fatalf("expected degraded stall reason in status output, got: %q", got)
+	}
+	if !strings.Contains(got, "relayfile login") {
+		t.Fatalf("expected recovery hint in status output, got: %q", got)
+	}
 }
 
 func TestStatusRendersWebhookUnhealthyWarning(t *testing.T) {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
@@ -173,7 +174,8 @@ func TestWorkspaceListIncludesEnvWorkspaceWhenRemoteListUnavailable(t *testing.T
 		t.Fatalf("upsertWorkspace relay-test failed: %v", err)
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 	}))
 	defer server.Close()
@@ -199,7 +201,8 @@ func TestWorkspaceListIncludesTokenWorkspaceWhenRemoteListUnavailable(t *testing
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 	}))
 	defer server.Close()
@@ -494,7 +497,8 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 	clearRelayfileEnv(t)
 
 	seen := map[string]bool{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/v1/workspaces":
@@ -596,6 +600,304 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 	}
 }
 
+func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_123",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:               "https://stale.example.test",
+		AccessToken:          "cld_old",
+		RefreshToken:         "refresh_123",
+		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+
+	seen := map[string]bool{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/auth/token/refresh":
+			seen["refresh"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_old" {
+				t.Fatalf("unexpected refresh Authorization: %q", got)
+			}
+			var body cloudTokenRefreshRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode refresh body failed: %v", err)
+			}
+			if body.RefreshToken != "refresh_123" {
+				t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
+			}
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case "/api/v1/workspaces/ws_123/join":
+			seen["join"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected join Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case "/api/v1/workspaces/ws_123/integrations/connect-session":
+			seen["connect"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected connect Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789"}`))
+		case "/api/v1/workspaces/ws_123/integrations/notion/status":
+			seen["status"] = true
+			if got := r.URL.Query().Get("connectionId"); got != "conn_789" {
+				t.Fatalf("unexpected connectionId: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"ready":true}`))
+		case "/v1/workspaces/ws_123/sync/status":
+			seen["sync"] = true
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	creds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	creds.APIURL = server.URL
+	if err := saveCloudCredentials(creds); err != nil {
+		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{
+		"integration", "connect", "notion",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "1s",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("run integration connect failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	for _, key := range []string{"refresh", "join", "connect", "status", "sync"} {
+		if !seen[key] {
+			t.Fatalf("expected %s request", key)
+		}
+	}
+	if got := stdout.String(); !strings.Contains(got, "notion connected") {
+		t.Fatalf("unexpected integration connect output: %q", got)
+	}
+}
+
+func TestStatusIncludesLocalMirrorAndDaemonCounts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), []byte(`{"files":{"a":{"dirty":true},"b":{"dirty":false}}}`), 0o644); err != nil {
+		t.Fatalf("write mount state failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, ".relay", "permissions-denied.log"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatalf("write denied log failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, ".relay", "conflicts", "note.local"), []byte("conflict"), 0o644); err != nil {
+		t.Fatalf("write conflict file failed: %v", err)
+	}
+	if err := writeDaemonPIDState(mountPIDFile(localDir), daemonPIDState{PID: 4242, WorkspaceID: "ws_demo", LocalDir: localDir}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/workspaces/ws_demo/sync/status" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials(update) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v", err)
+	}
+	got := stdout.String()
+	for _, fragment := range []string{
+		"workspace ws_demo (demo)",
+		"daemon: running (pid 4242)",
+		"pending writebacks: 1",
+		"conflicts: 1",
+		"denied: 2",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("expected %q in status output, got %q", fragment, got)
+		}
+	}
+}
+
+func TestLogsPrintsTailForWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := os.WriteFile(mountLogFile(localDir), []byte("one\ntwo\nthree\nfour\n"), 0o644); err != nil {
+		t.Fatalf("write mount log failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"logs", "demo", "--lines", "2"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run logs failed: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "three\nfour" {
+		t.Fatalf("unexpected logs output: %q", got)
+	}
+}
+
+func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	oldToken := testJWTWithWorkspaceAndAgent("ws_refresh", "old")
+	newToken := testJWTWithWorkspaceAndAgent("ws_refresh", "new")
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      defaultCloudAPIURL,
+		AccessToken: "cld_access",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_refresh",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	eventCalls := 0
+	exportCalls := 0
+	joinCalls := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_refresh/join":
+			joinCalls++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+				t.Fatalf("unexpected join Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_refresh","token":"` + newToken + `","relayfileUrl":"` + server.URL + `"}`))
+		case "/v1/workspaces/ws_refresh/fs/events":
+			eventCalls++
+			gotAuth := r.Header.Get("Authorization")
+			if gotAuth != "Bearer "+oldToken && gotAuth != "Bearer "+newToken {
+				t.Fatalf("unexpected events Authorization: %q", gotAuth)
+			}
+			_, _ = w.Write([]byte(`{"events":[]}`))
+		case "/v1/workspaces/ws_refresh/fs/export":
+			exportCalls++
+			gotAuth := r.Header.Get("Authorization")
+			if exportCalls == 1 {
+				if gotAuth != "Bearer "+oldToken {
+					t.Fatalf("unexpected initial export Authorization: %q", gotAuth)
+				}
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"code":"unauthorized","message":"expired"}`))
+				return
+			}
+			if gotAuth != "Bearer "+newToken {
+				t.Fatalf("unexpected refreshed export Authorization: %q", gotAuth)
+			}
+			_, _ = w.Write([]byte(`[]`))
+		case "/v1/workspaces/ws_refresh/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_refresh","providers":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	cloudCreds.APIURL = server.URL
+	if err := saveCloudCredentials(cloudCreds); err != nil {
+		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
+	}
+
+	if err := run([]string{
+		"mount", "ws_refresh", localDir,
+		"--server", server.URL,
+		"--token", oldToken,
+		"--once",
+		"--websocket=false",
+	}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run mount failed: %v", err)
+	}
+	if joinCalls != 1 || exportCalls != 2 {
+		t.Fatalf("expected 1 join and 2 export calls, got join=%d events=%d export=%d", joinCalls, eventCalls, exportCalls)
+	}
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	if creds.Token != newToken {
+		t.Fatalf("expected refreshed token to be persisted, got %q", creds.Token)
+	}
+}
+
 func clearRelayfileEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("RELAYFILE_SERVER", "")
@@ -607,7 +909,11 @@ func clearRelayfileEnv(t *testing.T) {
 }
 
 func testJWTWithWorkspace(workspaceID string) string {
+	return testJWTWithWorkspaceAndAgent(workspaceID, "test")
+}
+
+func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
-	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"test","aud":"relayfile"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"` + agentName + `","aud":"relayfile"}`))
 	return header + "." + payload + ".sig"
 }

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -917,3 +917,225 @@ func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"` + agentName + `","aud":"relayfile"}`))
 	return header + "." + payload + ".sig"
 }
+
+func TestStatusRendersWebhookUnhealthyWarning(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/workspaces/ws_demo/sync/status" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"lagging","lagSeconds":80,"watermarkTs":"2026-05-02T18:00:00Z","webhookHealthy":false}]}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "notion webhook unhealthy") {
+		t.Fatalf("expected webhook-unhealthy warning row, got: %q", got)
+	}
+	if !strings.Contains(got, "lag 1m20s") {
+		t.Fatalf("expected lag in warning row, got: %q", got)
+	}
+}
+
+func TestStatusOmitsWebhookWarningWhenHealthy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z","webhookHealthy":true}]}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v", err)
+	}
+	if got := stdout.String(); strings.Contains(got, "webhook unhealthy") {
+		t.Fatalf("did not expect webhook-unhealthy warning, got: %q", got)
+	}
+}
+
+func TestOpsListReadsLocalDeadLetterMirror(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	dlDir := filepath.Join(localDir, ".relay", "dead-letter")
+	if err := os.MkdirAll(dlDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead-letter failed: %v", err)
+	}
+	record := `{"opId":"op_abc","path":"/notion/page.json","code":"validation_error","message":"body must include event","attempts":3,"lastAttemptedAt":"2026-05-02T18:05:00Z","replayUrl":"https://cloud.test/api/v1/workspaces/ws_demo/ops/op_abc/replay"}`
+	if err := os.WriteFile(filepath.Join(dlDir, "op_abc.json"), []byte(record), 0o644); err != nil {
+		t.Fatalf("write dead-letter record failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"ops", "list", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run ops list failed: %v", err)
+	}
+	got := stdout.String()
+	for _, fragment := range []string{"op_abc", "/notion/page.json", "validation_error", "2026-05-02T18:05:00Z"} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("expected %q in ops list output, got %q", fragment, got)
+		}
+	}
+}
+
+func TestOpsListReportsEmptyWhenNoDeadLetterDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"ops", "list", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run ops list failed: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "No dead-lettered ops" {
+		t.Fatalf("expected empty marker, got: %q", got)
+	}
+}
+
+func TestOpsReplayPostsToCloudAndRemovesLocalRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	dlDir := filepath.Join(localDir, ".relay", "dead-letter")
+	if err := os.MkdirAll(dlDir, 0o755); err != nil {
+		t.Fatalf("mkdir dead-letter failed: %v", err)
+	}
+	dlPath := filepath.Join(dlDir, "op_abc.json")
+	if err := os.WriteFile(dlPath, []byte(`{"opId":"op_abc","attempts":3}`), 0o644); err != nil {
+		t.Fatalf("write dead-letter record failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	seen := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/join":
+			seen["join"] = true
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_join","relayfileUrl":"https://relayfile.test"}`))
+		case "/api/v1/workspaces/ws_demo/ops/op_abc/replay":
+			seen["replay"] = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected replay method: %s", r.Method)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected replay Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"status":"queued","id":"op_abc"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:               server.URL,
+		AccessToken:          "cld_token",
+		AccessTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"ops", "replay", "op_abc",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run ops replay failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	for _, key := range []string{"join", "replay"} {
+		if !seen[key] {
+			t.Fatalf("expected %s request", key)
+		}
+	}
+	if got := stdout.String(); !strings.Contains(got, "Replay queued for op op_abc") {
+		t.Fatalf("unexpected replay output: %q", got)
+	}
+	if _, err := os.Stat(dlPath); !os.IsNotExist(err) {
+		t.Fatalf("expected dead-letter record removed, got err=%v", err)
+	}
+}

--- a/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
+++ b/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
@@ -1,0 +1,868 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/mountsync"
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestProductizedCloudMountE2EProof(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := filepath.Join(t.TempDir(), "relayfile-mount")
+	relay := newProductizedRelayfileMock(t)
+	defer relay.Close()
+	relay.SetProviderStatus("github", "ready", 1)
+	relay.UpsertFile("/github/repos/acme/api/pulls/42/metadata.json", "application/json", `{"title":"Initial PR"}`)
+
+	cloud := newProductizedCloudMock(t, relay)
+	defer cloud.Close()
+
+	var setupOut bytes.Buffer
+	if err := run([]string{
+		"setup",
+		"--cloud-api-url", cloud.URL(),
+		"--cloud-token", cloud.initialAccessToken,
+		"--workspace", "demo",
+		"--provider", "github",
+		"--local-dir", localDir,
+		"--no-open",
+		"--once",
+		"--connect-timeout", "2s",
+	}, strings.NewReader(""), &setupOut, &setupOut); err != nil {
+		t.Fatalf("setup failed: %v\noutput:\n%s", err, setupOut.String())
+	}
+	assertFileContentEventually(t, filepath.Join(localDir, "github", "repos", "acme", "api", "pulls", "42", "metadata.json"), `{"title":"Initial PR"}`)
+	if cloud.JoinCount() != 1 {
+		t.Fatalf("expected one workspace join after setup, got %d", cloud.JoinCount())
+	}
+
+	relay.SetProviderStatus("notion", "syncing", 4)
+	relay.UpsertFile("/notion/Docs/Plan.md", "text/markdown", "# Seeded notion plan\n")
+
+	var connectOut bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "notion",
+		"--workspace", "demo",
+		"--cloud-api-url", cloud.URL(),
+		"--no-open",
+		"--timeout", "2s",
+	}, strings.NewReader(""), &connectOut, &connectOut); err != nil {
+		t.Fatalf("integration connect failed: %v\noutput:\n%s", err, connectOut.String())
+	}
+	if !strings.Contains(connectOut.String(), "notion connected") {
+		t.Fatalf("expected notion connect confirmation, got %q", connectOut.String())
+	}
+	relay.SetProviderStatus("notion", "ready", 1)
+
+	var listOut bytes.Buffer
+	if err := run([]string{
+		"integration", "list",
+		"--workspace", "demo",
+		"--cloud-api-url", cloud.URL(),
+		"--json",
+	}, strings.NewReader(""), &listOut, &listOut); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, listOut.String())
+	}
+	var listed []cloudIntegrationListEntry
+	if err := json.Unmarshal(listOut.Bytes(), &listed); err != nil {
+		t.Fatalf("parse integration list failed: %v\npayload:\n%s", err, listOut.String())
+	}
+	if providers := integrationProviders(listed); strings.Join(providers, ",") != "github,notion" {
+		t.Fatalf("expected github and notion integrations, got %v", providers)
+	}
+
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	record, err := resolveWorkspaceRecord("demo")
+	if err != nil {
+		t.Fatalf("resolveWorkspaceRecord failed: %v", err)
+	}
+
+	prevLogWriter := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(prevLogWriter)
+
+	rootCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	disableWebSocket := false
+	syncer, err := mountsync.NewSyncer(
+		mountsync.NewHTTPClient(creds.Server, creds.Token, relay.HTTPClient()),
+		mountsync.SyncerOptions{
+			WorkspaceID: record.ID,
+			RemoteRoot:  "/",
+			LocalRoot:   localDir,
+			WebSocket:   &disableWebSocket,
+			RootCtx:     rootCtx,
+			Logger:      log.New(io.Discard, "", 0),
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewSyncer failed: %v", err)
+	}
+
+	pidFile := mountPIDFile(localDir)
+	logFile := mountLogFile(localDir)
+	if err := writeDaemonPIDState(pidFile, daemonPIDState{
+		PID:         4242,
+		WorkspaceID: record.ID,
+		LocalDir:    localDir,
+		LogFile:     logFile,
+		StartedAt:   time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+
+	loopErrCh := make(chan error, 1)
+	go func() {
+		loopErrCh <- runMountLoop(
+			rootCtx,
+			syncer,
+			localDir,
+			record.ID,
+			creds.Server,
+			500*time.Millisecond,
+			100*time.Millisecond,
+			0,
+			false,
+			false,
+			false,
+			pidFile,
+			logFile,
+		)
+	}()
+
+	waitForFile(t, filepath.Join(localDir, ".relay", "state.json"), "public mirror state")
+
+	relay.UpsertFile("/notion/Docs/RemoteAdded.md", "text/markdown", "# Remote added\n")
+	assertFileContentEventually(t, filepath.Join(localDir, "notion", "Docs", "RemoteAdded.md"), "# Remote added\n")
+
+	localWritebackPath := filepath.Join(localDir, "notion", "Docs", "RemoteAdded.md")
+	if err := os.WriteFile(localWritebackPath, []byte("# Local writeback\n"), 0o644); err != nil {
+		t.Fatalf("write local mirror file failed: %v", err)
+	}
+	if err := syncer.HandleLocalChange(context.Background(), "notion/Docs/RemoteAdded.md", fsnotify.Write); err != nil {
+		t.Fatalf("HandleLocalChange writeback failed: %v", err)
+	}
+	waitForCondition(t, 5*time.Second, "remote writeback", func() bool {
+		file, ok := relay.File("/notion/Docs/RemoteAdded.md")
+		return ok && file.Content == "# Local writeback\n"
+	})
+
+	relay.UpsertFile("/notion/Docs/RemoteAdded.md", "text/markdown", "# Remote conflict\n")
+	relay.ConflictOnce("/notion/Docs/RemoteAdded.md")
+	if err := os.WriteFile(localWritebackPath, []byte("# Local conflict\n"), 0o644); err != nil {
+		t.Fatalf("write local conflicting file failed: %v", err)
+	}
+	if err := syncer.HandleLocalChange(context.Background(), "notion/Docs/RemoteAdded.md", fsnotify.Write); err != nil {
+		t.Fatalf("HandleLocalChange conflict failed: %v", err)
+	}
+	assertFileContentEventually(t, localWritebackPath, "# Remote conflict\n")
+	waitForCondition(t, 5*time.Second, "conflict artifact", func() bool {
+		matches, _ := filepath.Glob(filepath.Join(localDir, ".relay", "conflicts", "notion", "Docs", "RemoteAdded.md.*.local"))
+		return len(matches) == 1
+	})
+
+	var statusOut bytes.Buffer
+	if err := run([]string{"status", "demo", "--json"}, strings.NewReader(""), &statusOut, &statusOut); err != nil {
+		t.Fatalf("status failed: %v\noutput:\n%s", err, statusOut.String())
+	}
+	var snapshot syncStateFile
+	if err := json.Unmarshal(statusOut.Bytes(), &snapshot); err != nil {
+		t.Fatalf("parse status json failed: %v\npayload:\n%s", err, statusOut.String())
+	}
+	if snapshot.PendingConflicts != 1 {
+		t.Fatalf("expected one visible conflict, got %+v", snapshot)
+	}
+	if snapshot.Daemon == nil || snapshot.Daemon.PID != 4242 {
+		t.Fatalf("expected daemon metadata in status snapshot, got %+v", snapshot.Daemon)
+	}
+	if providers := syncStateProviders(snapshot.Providers); strings.Join(providers, ",") != "github,notion" {
+		t.Fatalf("expected github and notion providers in status, got %v", providers)
+	}
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:               cloud.URL(),
+		AccessToken:          cloud.expiredAccessToken,
+		RefreshToken:         cloud.refreshToken,
+		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		UpdatedAt:            time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+
+	currentToken, err := currentRelayToken()
+	if err != nil {
+		t.Fatalf("currentRelayToken failed: %v", err)
+	}
+	relay.RejectToken(currentToken)
+	waitForCondition(t, 5*time.Second, "cloud token refresh + workspace rejoin", func() bool {
+		creds, loadErr := loadCredentials()
+		if loadErr != nil {
+			return false
+		}
+		return cloud.RefreshCount() >= 1 && cloud.JoinCount() >= 3 && creds.Token != currentToken
+	})
+
+	relay.UpsertFile("/github/repos/acme/api/pulls/42/after-refresh.md", "text/markdown", "# After refresh\n")
+	assertFileContentEventually(t, filepath.Join(localDir, "github", "repos", "acme", "api", "pulls", "42", "after-refresh.md"), "# After refresh\n")
+
+	cancel()
+	select {
+	case err := <-loopErrCh:
+		if err != nil {
+			t.Fatalf("mount loop exited with error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mount loop shutdown")
+	}
+	if err := os.Remove(pidFile); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove pid file failed: %v", err)
+	}
+
+	relay.UpsertFile("/github/repos/acme/api/pulls/42/restarted.md", "text/markdown", "# Restarted sync\n")
+	var restartOut bytes.Buffer
+	if err := run([]string{
+		"mount", "demo", localDir,
+		"--once",
+		"--websocket=false",
+	}, strings.NewReader(""), &restartOut, &restartOut); err != nil {
+		t.Fatalf("restart mount failed: %v\noutput:\n%s", err, restartOut.String())
+	}
+	assertFileContentEventually(t, filepath.Join(localDir, "github", "repos", "acme", "api", "pulls", "42", "restarted.md"), "# Restarted sync\n")
+}
+
+type productizedRelayfileMock struct {
+	t *testing.T
+
+	mu             sync.Mutex
+	server         *httptest.Server
+	revisionCount  int
+	files          map[string]productizedRemoteFile
+	providers      map[string]*productizedProviderStatus
+	validTokens    map[string]struct{}
+	rejectedTokens map[string]struct{}
+	conflictOnce   map[string]struct{}
+}
+
+type productizedRemoteFile struct {
+	Path        string
+	Revision    string
+	ContentType string
+	Content     string
+	Encoding    string
+}
+
+type productizedProviderStatus struct {
+	Provider    string
+	Status      string
+	LagSeconds  int
+	LastEventAt string
+}
+
+func newProductizedRelayfileMock(t *testing.T) *productizedRelayfileMock {
+	t.Helper()
+	mock := &productizedRelayfileMock{
+		t:             t,
+		files:         map[string]productizedRemoteFile{},
+		providers:     map[string]*productizedProviderStatus{},
+		validTokens:   map[string]struct{}{},
+		rejectedTokens: map[string]struct{}{},
+		conflictOnce:  map[string]struct{}{},
+	}
+	mock.server = httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	return mock
+}
+
+func (m *productizedRelayfileMock) Close() {
+	m.server.Close()
+}
+
+func (m *productizedRelayfileMock) URL() string {
+	return m.server.URL
+}
+
+func (m *productizedRelayfileMock) HTTPClient() *http.Client {
+	return m.server.Client()
+}
+
+func (m *productizedRelayfileMock) ActivateToken(token string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rejectedTokens, token)
+	m.validTokens[token] = struct{}{}
+}
+
+func (m *productizedRelayfileMock) RejectToken(token string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rejectedTokens[token] = struct{}{}
+}
+
+func (m *productizedRelayfileMock) SetProviderStatus(provider, status string, lagSeconds int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current := m.ensureProvider(provider)
+	current.Status = status
+	current.LagSeconds = lagSeconds
+	if current.LastEventAt == "" {
+		current.LastEventAt = time.Now().UTC().Format(time.RFC3339)
+	}
+}
+
+func (m *productizedRelayfileMock) UpsertFile(path, contentType, content string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.upsertFileLocked(path, contentType, content)
+}
+
+func (m *productizedRelayfileMock) ConflictOnce(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.conflictOnce[normalizeMockRemotePath(path)] = struct{}{}
+}
+
+func (m *productizedRelayfileMock) File(path string) (productizedRemoteFile, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	file, ok := m.files[normalizeMockRemotePath(path)]
+	return file, ok
+}
+
+func (m *productizedRelayfileMock) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	token := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if !m.authorized(token) {
+		writeMockJSON(w, http.StatusUnauthorized, map[string]any{
+			"code":    "unauthorized",
+			"message": "token rejected",
+		})
+		return
+	}
+
+	switch {
+	case strings.HasSuffix(r.URL.Path, "/sync/status") && r.Method == http.MethodGet:
+		m.serveSyncStatus(w)
+	case strings.HasSuffix(r.URL.Path, "/fs/export") && r.Method == http.MethodGet:
+		m.serveExport(w, r)
+	case strings.HasSuffix(r.URL.Path, "/fs/tree") && r.Method == http.MethodGet:
+		m.serveTree(w, r)
+	case strings.HasSuffix(r.URL.Path, "/fs/events") && r.Method == http.MethodGet:
+		writeMockJSON(w, http.StatusOK, mountsync.EventFeed{Events: []mountsync.FilesystemEvent{}})
+	case strings.HasSuffix(r.URL.Path, "/fs/file") && r.Method == http.MethodGet:
+		m.serveReadFile(w, r)
+	case strings.HasSuffix(r.URL.Path, "/fs/bulk") && r.Method == http.MethodPost:
+		m.serveBulkWrite(w, r)
+	default:
+		writeMockJSON(w, http.StatusNotFound, map[string]any{
+			"code":    "not_found",
+			"message": fmt.Sprintf("unhandled route %s %s", r.Method, r.URL.Path),
+		})
+	}
+}
+
+func (m *productizedRelayfileMock) authorized(token string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if token == "" {
+		return false
+	}
+	if _, rejected := m.rejectedTokens[token]; rejected {
+		return false
+	}
+	_, ok := m.validTokens[token]
+	return ok
+}
+
+func (m *productizedRelayfileMock) serveSyncStatus(w http.ResponseWriter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	providers := make([]syncProviderStatus, 0, len(m.providers))
+	for _, status := range m.providers {
+		lastEvent := status.LastEventAt
+		providers = append(providers, syncProviderStatus{
+			Provider:    status.Provider,
+			Status:      status.Status,
+			LagSeconds:  status.LagSeconds,
+			WatermarkTs: stringPtr(lastEvent),
+		})
+	}
+	sort.Slice(providers, func(i, j int) bool { return providers[i].Provider < providers[j].Provider })
+	writeMockJSON(w, http.StatusOK, syncStatusResponse{
+		WorkspaceID: "ws_productized",
+		Providers:   providers,
+	})
+}
+
+func (m *productizedRelayfileMock) serveExport(w http.ResponseWriter, r *http.Request) {
+	root := normalizeMockRemotePath(r.URL.Query().Get("path"))
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	files := make([]exportedFile, 0, len(m.files))
+	for _, file := range m.files {
+		if !isUnderMockRoot(root, file.Path) {
+			continue
+		}
+		files = append(files, exportedFile{
+			Path:        file.Path,
+			Revision:    file.Revision,
+			ContentType: file.ContentType,
+			Content:     file.Content,
+			Encoding:    file.Encoding,
+		})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	writeMockJSON(w, http.StatusOK, files)
+}
+
+func (m *productizedRelayfileMock) serveTree(w http.ResponseWriter, r *http.Request) {
+	root := normalizeMockRemotePath(r.URL.Query().Get("path"))
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entries := make([]treeEntry, 0)
+	seenDirs := map[string]struct{}{}
+	for _, file := range m.files {
+		if !isUnderMockRoot(root, file.Path) {
+			continue
+		}
+		relative := strings.TrimPrefix(file.Path, root)
+		relative = strings.TrimPrefix(relative, "/")
+		if relative == "" {
+			entries = append(entries, treeEntry{Path: file.Path, Type: "file", Revision: file.Revision})
+			continue
+		}
+		parts := strings.Split(relative, "/")
+		if len(parts) == 1 {
+			entries = append(entries, treeEntry{Path: file.Path, Type: "file", Revision: file.Revision})
+			continue
+		}
+		dirPath := normalizeMockRemotePath(root + "/" + parts[0])
+		if _, seen := seenDirs[dirPath]; seen {
+			continue
+		}
+		seenDirs[dirPath] = struct{}{}
+		entries = append(entries, treeEntry{Path: dirPath, Type: "dir", Revision: "dir_rev_1"})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	writeMockJSON(w, http.StatusOK, treeResponse{Path: root, Entries: entries})
+}
+
+func (m *productizedRelayfileMock) serveReadFile(w http.ResponseWriter, r *http.Request) {
+	path := normalizeMockRemotePath(r.URL.Query().Get("path"))
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	file, ok := m.files[path]
+	if !ok {
+		writeMockJSON(w, http.StatusNotFound, map[string]any{
+			"code":    "not_found",
+			"message": "file not found",
+		})
+		return
+	}
+	writeMockJSON(w, http.StatusOK, readFileResponse{
+		Path:        file.Path,
+		Revision:    file.Revision,
+		ContentType: file.ContentType,
+		Content:     file.Content,
+		Encoding:    file.Encoding,
+	})
+}
+
+func (m *productizedRelayfileMock) serveBulkWrite(w http.ResponseWriter, r *http.Request) {
+	var payload struct {
+		Files []mountsync.BulkWriteFile `json:"files"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeMockJSON(w, http.StatusBadRequest, map[string]any{
+			"code":    "bad_request",
+			"message": "invalid json",
+		})
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	response := mountsync.BulkWriteResponse{
+		Errors:  []mountsync.BulkWriteError{},
+		Results: []mountsync.BulkWriteResult{},
+	}
+	for _, file := range payload.Files {
+		path := normalizeMockRemotePath(file.Path)
+		if _, conflict := m.conflictOnce[path]; conflict {
+			delete(m.conflictOnce, path)
+			response.Errors = append(response.Errors, mountsync.BulkWriteError{
+				Path:    path,
+				Code:    "conflict",
+				Message: "revision conflict",
+			})
+			continue
+		}
+		if strings.TrimSpace(file.ContentType) == "" {
+			file.ContentType = "text/markdown"
+		}
+		updated := m.upsertFileLocked(path, file.ContentType, file.Content)
+		response.Results = append(response.Results, mountsync.BulkWriteResult{
+			Path:        updated.Path,
+			Revision:    updated.Revision,
+			ContentType: updated.ContentType,
+		})
+		response.Written++
+	}
+	response.ErrorCount = len(response.Errors)
+	response.CorrelationID = "corr_productized_mock_bulk"
+	writeMockJSON(w, http.StatusAccepted, response)
+}
+
+func (m *productizedRelayfileMock) upsertFileLocked(path, contentType, content string) productizedRemoteFile {
+	path = normalizeMockRemotePath(path)
+	m.revisionCount++
+	file := productizedRemoteFile{
+		Path:        path,
+		Revision:    fmt.Sprintf("rev_%d", m.revisionCount),
+		ContentType: strings.TrimSpace(contentType),
+		Content:     content,
+	}
+	if file.ContentType == "" {
+		file.ContentType = "text/markdown"
+	}
+	m.files[path] = file
+	provider := providerFromRemotePath(path)
+	status := m.ensureProvider(provider)
+	if status.Status == "" {
+		status.Status = "ready"
+	}
+	status.LastEventAt = time.Now().UTC().Format(time.RFC3339)
+	return file
+}
+
+func (m *productizedRelayfileMock) ensureProvider(provider string) *productizedProviderStatus {
+	current, ok := m.providers[provider]
+	if !ok {
+		current = &productizedProviderStatus{Provider: provider, Status: "ready"}
+		m.providers[provider] = current
+	}
+	return current
+}
+
+type productizedCloudMock struct {
+	t *testing.T
+
+	mu                 sync.Mutex
+	server             *httptest.Server
+	relay              *productizedRelayfileMock
+	workspaceID        string
+	initialAccessToken string
+	expiredAccessToken string
+	refreshedToken     string
+	refreshToken       string
+	joinCount          int
+	refreshCount       int
+	providers          map[string]string
+}
+
+func newProductizedCloudMock(t *testing.T, relay *productizedRelayfileMock) *productizedCloudMock {
+	t.Helper()
+	mock := &productizedCloudMock{
+		t:                  t,
+		relay:              relay,
+		workspaceID:        "ws_productized",
+		initialAccessToken: "cld_setup",
+		expiredAccessToken: "cld_expired",
+		refreshedToken:     "cld_refreshed",
+		refreshToken:       "cld_refresh",
+		providers:          map[string]string{},
+	}
+	mock.server = httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
+	return mock
+}
+
+func (m *productizedCloudMock) Close() {
+	m.server.Close()
+}
+
+func (m *productizedCloudMock) URL() string {
+	return m.server.URL
+}
+
+func (m *productizedCloudMock) JoinCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.joinCount
+}
+
+func (m *productizedCloudMock) RefreshCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.refreshCount
+}
+
+func (m *productizedCloudMock) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case r.URL.Path == "/api/v1/workspaces" && r.Method == http.MethodPost:
+		m.serveCreateWorkspace(w, r)
+	case r.URL.Path == "/api/v1/auth/token/refresh" && r.Method == http.MethodPost:
+		m.serveRefreshCloudToken(w, r)
+	case strings.HasSuffix(r.URL.Path, "/join") && r.Method == http.MethodPost:
+		m.serveJoinWorkspace(w, r)
+	case strings.HasSuffix(r.URL.Path, "/integrations/connect-session") && r.Method == http.MethodPost:
+		m.serveConnectSession(w, r)
+	case strings.Contains(r.URL.Path, "/integrations/") && strings.HasSuffix(r.URL.Path, "/status") && r.Method == http.MethodGet:
+		m.serveIntegrationStatus(w, r)
+	case strings.HasSuffix(r.URL.Path, "/integrations") && r.Method == http.MethodGet:
+		m.serveIntegrationList(w, r)
+	default:
+		writeMockJSON(w, http.StatusNotFound, map[string]any{
+			"code":    "not_found",
+			"message": fmt.Sprintf("unhandled route %s %s", r.Method, r.URL.Path),
+		})
+	}
+}
+
+func (m *productizedCloudMock) serveCreateWorkspace(w http.ResponseWriter, r *http.Request) {
+	if got := bearerToken(r); got != m.initialAccessToken {
+		m.t.Fatalf("unexpected create workspace token: %q", got)
+	}
+	writeMockJSON(w, http.StatusOK, cloudWorkspaceCreateResponse{
+		WorkspaceID:  m.workspaceID,
+		RelayfileURL: m.relay.URL(),
+		CreatedAt:    "2026-05-02T00:00:00Z",
+		Name:         "demo",
+	})
+}
+
+func (m *productizedCloudMock) serveRefreshCloudToken(w http.ResponseWriter, r *http.Request) {
+	if got := bearerToken(r); got != m.expiredAccessToken {
+		m.t.Fatalf("unexpected refresh token auth header: %q", got)
+	}
+	var body cloudTokenRefreshRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		m.t.Fatalf("decode refresh request failed: %v", err)
+	}
+	if body.RefreshToken != m.refreshToken {
+		m.t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
+	}
+	m.mu.Lock()
+	m.refreshCount++
+	m.mu.Unlock()
+	writeMockJSON(w, http.StatusOK, cloudCredentials{
+		APIURL:                m.URL(),
+		AccessToken:           m.refreshedToken,
+		RefreshToken:          m.refreshToken,
+		AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+	})
+}
+
+func (m *productizedCloudMock) serveJoinWorkspace(w http.ResponseWriter, r *http.Request) {
+	got := bearerToken(r)
+	if got != m.initialAccessToken && got != m.refreshedToken {
+		m.t.Fatalf("unexpected join token: %q", got)
+	}
+	m.mu.Lock()
+	m.joinCount++
+	token := fmt.Sprintf("rf_token_%d", m.joinCount)
+	m.mu.Unlock()
+
+	m.relay.ActivateToken(token)
+	writeMockJSON(w, http.StatusOK, cloudWorkspaceJoinResponse{
+		WorkspaceID: m.workspaceID,
+		Token:       token,
+		RelayfileURL: m.relay.URL(),
+	})
+}
+
+func (m *productizedCloudMock) serveConnectSession(w http.ResponseWriter, r *http.Request) {
+	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+		m.t.Fatalf("unexpected connect-session auth token: %q", got)
+	}
+	var body cloudConnectSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		m.t.Fatalf("decode connect-session body failed: %v", err)
+	}
+	if len(body.AllowedIntegrations) != 1 {
+		m.t.Fatalf("expected exactly one allowed integration, got %#v", body.AllowedIntegrations)
+	}
+	provider := body.AllowedIntegrations[0]
+	connectionID := "conn_" + provider
+	m.mu.Lock()
+	m.providers[provider] = connectionID
+	m.mu.Unlock()
+	writeMockJSON(w, http.StatusOK, cloudConnectSessionResponse{
+		ConnectLink:  "https://connect.mock.local/" + provider,
+		ConnectionID: connectionID,
+	})
+}
+
+func (m *productizedCloudMock) serveIntegrationStatus(w http.ResponseWriter, r *http.Request) {
+	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+		m.t.Fatalf("unexpected integration status auth token: %q", got)
+	}
+	writeMockJSON(w, http.StatusOK, cloudIntegrationReadyResponse{Ready: true})
+}
+
+func (m *productizedCloudMock) serveIntegrationList(w http.ResponseWriter, r *http.Request) {
+	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+		m.t.Fatalf("unexpected integration list auth token: %q", got)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entries := make([]cloudIntegrationListEntry, 0, len(m.providers))
+	for provider, connectionID := range m.providers {
+		fileStatus, lag, lastEventAt := m.providerSnapshot(provider)
+		entries = append(entries, cloudIntegrationListEntry{
+			Provider:     provider,
+			Status:       fileStatus,
+			LagSeconds:   lag,
+			LastEventAt:  lastEventAt,
+			ConnectionID: connectionID,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Provider < entries[j].Provider })
+	writeMockJSON(w, http.StatusOK, entries)
+}
+
+func (m *productizedCloudMock) providerSnapshot(provider string) (string, int, string) {
+	m.relay.mu.Lock()
+	defer m.relay.mu.Unlock()
+	current := m.relay.providers[provider]
+	if current == nil {
+		return "unknown", 0, ""
+	}
+	return current.Status, current.LagSeconds, current.LastEventAt
+}
+
+func integrationProviders(entries []cloudIntegrationListEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.Provider)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func syncStateProviders(entries []syncStateProvider) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry.Provider)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func currentRelayToken() (string, error) {
+	creds, err := loadCredentials()
+	if err != nil {
+		return "", err
+	}
+	return creds.Token, nil
+}
+
+func waitForCondition(t *testing.T, timeout time.Duration, description string, predicate func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if predicate() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func waitForFile(t *testing.T, path, description string) {
+	t.Helper()
+	waitForCondition(t, 5*time.Second, description, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	})
+}
+
+func assertFileContentEventually(t *testing.T, path, want string) {
+	t.Helper()
+	waitForCondition(t, 5*time.Second, path, func() bool {
+		data, err := os.ReadFile(path)
+		return err == nil && string(data) == want
+	})
+}
+
+func normalizeMockRemotePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || path == "/" {
+		return "/"
+	}
+	path = strings.ReplaceAll(path, "\\", "/")
+	path = strings.TrimPrefix(path, "/")
+	return "/" + strings.Trim(path, "/")
+}
+
+func isUnderMockRoot(root, path string) bool {
+	root = normalizeMockRemotePath(root)
+	path = normalizeMockRemotePath(path)
+	if root == "/" {
+		return true
+	}
+	return path == root || strings.HasPrefix(path, root+"/")
+}
+
+func providerFromRemotePath(path string) string {
+	path = strings.TrimPrefix(normalizeMockRemotePath(path), "/")
+	first, _, _ := strings.Cut(path, "/")
+	if first == "" {
+		return "unknown"
+	}
+	return first
+}
+
+func providerFromStatusPath(path string) string {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 7 {
+		return "unknown"
+	}
+	return parts[6]
+}
+
+func writeMockJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if payload == nil {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		panic(err)
+	}
+}
+
+func bearerToken(r *http.Request) string {
+	raw := strings.TrimSpace(r.Header.Get("Authorization"))
+	return strings.TrimSpace(strings.TrimPrefix(raw, "Bearer "))
+}
+
+func stringPtr(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -188,6 +188,43 @@ func TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady(t *testing.T) {
 	}
 }
 
+// TestProviderRootDirHandlesAllSlackVariants pins the mapping between
+// catalog provider ids and the directory each provider occupies inside
+// the local mirror. Drift here breaks status probes, integration disconnect
+// cleanup, and the connect "files will appear under <localDir>/<root>"
+// banner — so each Slack variant in fallbackIntegrationCatalog must be
+// represented.
+func TestProviderRootDirHandlesAllSlackVariants(t *testing.T) {
+	cases := []struct {
+		provider string
+		want     string
+	}{
+		{"github", "github"},
+		{"notion", "notion"},
+		{"linear", "linear"},
+		{"slack", "slack"},
+		{"slack-sage", "slack"},
+		{"slack-my-senior-dev", "slack-msd"},
+		{"slack-nightcto", "slack-nightcto"},
+	}
+	for _, tc := range cases {
+		if got := providerRootDir(tc.provider); got != tc.want {
+			t.Fatalf("providerRootDir(%q)=%q, want %q", tc.provider, got, tc.want)
+		}
+	}
+
+	// Cross-check against fallbackIntegrationCatalog so future catalog
+	// additions cannot quietly leave providerRootDir behind. Every entry
+	// in the catalog must round-trip: vfsRoot stripped of the leading
+	// slash MUST equal providerRootDir of the same id.
+	for _, entry := range fallbackIntegrationCatalog() {
+		want := strings.TrimPrefix(entry.VFSRoot, "/")
+		if got := providerRootDir(entry.ID); got != want {
+			t.Fatalf("providerRootDir(%q)=%q, but catalog vfsRoot=%q", entry.ID, got, entry.VFSRoot)
+		}
+	}
+}
+
 // TestA13MountHelpListsSyncedMirrorLimitations exercises contract A13: the
 // `relayfile mount --help` output must surface the §3.6 list of synced-
 // mirror limitations so the user does not assume kernel filesystem

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestA10InitialSyncGateExitsZeroOnReady covers productized cloud-mount
+// contract A10 (positive path): the cloud reports `cataloging` while the
+// initial sync runs, the CLI polls until the provider transitions to
+// `ready`, and `waitForInitialSync` returns nil so setup exits 0.
+func TestA10InitialSyncGateExitsZeroOnReady(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/sync/status":
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"cataloging","lagSeconds":120,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"ready","lagSeconds":2,"watermarkTs":"2026-05-02T18:00:05Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := waitForInitialSync(server.URL, "tok", "ws_demo", "notion", localDir, 10*time.Second, &stdout); err != nil {
+		t.Fatalf("waitForInitialSync failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got < 2 {
+		t.Fatalf("expected at least 2 sync status polls, got %d", got)
+	}
+}
+
+// TestA10InitialSyncGateExitsZeroOnTimeout covers productized cloud-mount
+// contract A10 (timeout path): when the configured deadline elapses with
+// the provider still in `cataloging`, `waitForInitialSync` MUST exit 0
+// with the resume hint so the workspace and mount stay usable while sync
+// catches up in the background.
+func TestA10InitialSyncGateExitsZeroOnTimeout(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"notion","status":"cataloging","lagSeconds":120,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	start := time.Now()
+	if err := waitForInitialSync(server.URL, "tok", "ws_demo", "notion", localDir, 100*time.Millisecond, &stdout); err != nil {
+		t.Fatalf("expected nil error on timeout, got: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected timeout to surface within 5s, took %s", elapsed)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "notion still syncing in the background") {
+		t.Fatalf("expected resume hint, got: %q", got)
+	}
+}

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +11,204 @@ import (
 	"testing"
 	"time"
 )
+
+// signedExpJWT crafts an unsigned JWT with the given exp (relative to now)
+// and iat=now. The CLI's relayfileTokenNeedsRefresh predicate only inspects
+// claims, so a `none`-alg token is sufficient for these tests.
+func signedExpJWT(t *testing.T, expIn time.Duration) string {
+	t.Helper()
+	now := time.Now().UTC().Unix()
+	claims := map[string]any{
+		"iat": now,
+		"exp": time.Now().UTC().Add(expIn).Unix(),
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal jwt claims failed: %v", err)
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + encoded + ".sig"
+}
+
+// TestA8RelayfileTokenNeedsRefreshDetectsNearExpiry covers the predicate
+// the mount loop uses (in withAuthRefresh) to decide when to call
+// joinWorkspaceViaCloud — the trigger half of contract acceptance test
+// A8 ("Token refresh: VFS token expires mid-mount").
+func TestA8RelayfileTokenNeedsRefreshDetectsNearExpiry(t *testing.T) {
+	cases := []struct {
+		name string
+		exp  time.Duration
+		want bool
+	}{
+		{"already expired", -10 * time.Second, true},
+		{"under 5 minute leeway", 30 * time.Second, true},
+		{"under lifetime/10 leeway (1h token)", 4 * time.Minute, true},
+		{"safely in the future", time.Hour, false},
+		{"far in the future", 24 * time.Hour, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			token := signedExpJWT(t, tc.exp)
+			if got := relayfileTokenNeedsRefresh(token); got != tc.want {
+				t.Fatalf("relayfileTokenNeedsRefresh(%s)=%v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+
+	if got := relayfileTokenNeedsRefresh(""); got != false {
+		t.Fatalf("empty token should not trigger refresh, got %v", got)
+	}
+	if got := relayfileTokenNeedsRefresh("not.a.jwt"); got != false {
+		t.Fatalf("unparseable token should not trigger refresh, got %v", got)
+	}
+}
+
+// TestA8JoinWorkspaceMintsFreshRelayfileToken covers the action half of A8:
+// when the cloud access token is valid and we call joinWorkspaceViaCloud,
+// the cloud responds with a brand-new relayfile token + URL without the
+// CLI dropping the websocket. We verify the call shape (token bearer, body)
+// and that the returned credentials are well-formed.
+func TestA8JoinWorkspaceMintsFreshRelayfileToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var joinCalls int32
+	var seenBody cloudWorkspaceJoinRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/api/v1/workspaces/ws_demo/join" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+			t.Fatalf("unexpected join Authorization: %q", got)
+		}
+		atomic.AddInt32(&joinCalls, 1)
+		if err := json.NewDecoder(r.Body).Decode(&seenBody); err != nil {
+			t.Fatalf("decode join body failed: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_new_token","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws"}`))
+	}))
+	defer server.Close()
+
+	creds := cloudCredentials{
+		APIURL:               server.URL,
+		AccessToken:          "cld_access",
+		AccessTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+	}
+	joined, err := joinWorkspaceViaCloud(creds, "ws_demo", "relayfile-cli", append([]string(nil), defaultJoinScopes...))
+	if err != nil {
+		t.Fatalf("joinWorkspaceViaCloud failed: %v", err)
+	}
+	if atomic.LoadInt32(&joinCalls) != 1 {
+		t.Fatalf("expected exactly 1 /join call, got %d", joinCalls)
+	}
+	if joined.Token != "rf_new_token" {
+		t.Fatalf("expected fresh relayfile token, got %q", joined.Token)
+	}
+	if joined.RelayfileURL == "" || joined.WSURL == "" {
+		t.Fatalf("expected join response to include relayfileUrl and wsUrl, got %+v", joined)
+	}
+	if seenBody.AgentName != "relayfile-cli" {
+		t.Fatalf("expected agent name in join body, got %+v", seenBody)
+	}
+}
+
+// TestA1SetupHappyPathBannerAfterSetup verifies productized cloud-mount
+// contract A1's mount-cycle requirement: after `relayfile setup` runs the
+// happy path with --cloud-token (no browser) and exits, the synced-mirror
+// banner is the user-visible signal the mount loop printed before exiting.
+// We assert the formatter directly so the test is independent of stdlib log
+// flag plumbing.
+func TestA1SyncedMirrorBannerNamingMatchesContract(t *testing.T) {
+	got := mountStartBanner("/tmp/relay", 30*time.Second, 0.2)
+	if !strings.HasPrefix(got, "Synced mirror started at /tmp/relay.") {
+		t.Fatalf("expected banner to lead with 'Synced mirror started at <dir>.', got: %q", got)
+	}
+	if !strings.Contains(got, "Sync interval 30s") {
+		t.Fatalf("expected banner to mention the 30s interval, got: %q", got)
+	}
+	if !strings.Contains(got, "±20%") {
+		t.Fatalf("expected banner to advertise the jitter, got: %q", got)
+	}
+}
+
+// TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady exercises the
+// re-run half of contract A3: when a previously-saved connection id is
+// already `ready`, ensureCloudIntegration MUST short-circuit instead of
+// creating a fresh connect-session.
+func TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := saveIntegrationConnection(localDir, integrationConnectionState{
+		Provider:     "notion",
+		ConnectionID: "conn_existing",
+		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveIntegrationConnection failed: %v", err)
+	}
+
+	var statusCalls, connectCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/integrations/notion/status":
+			atomic.AddInt32(&statusCalls, 1)
+			if got := r.URL.Query().Get("connectionId"); got != "conn_existing" {
+				t.Fatalf("expected status to use saved connection id, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"ready":true}`))
+		case "/api/v1/workspaces/ws_demo/integrations/connect-session":
+			atomic.AddInt32(&connectCalls, 1)
+			t.Fatalf("connect-session should be skipped on re-run with ready integration")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "notion", localDir, 5*time.Second, false, &stdout); err != nil {
+		t.Fatalf("ensureCloudIntegration failed: %v", err)
+	}
+	if atomic.LoadInt32(&statusCalls) != 1 {
+		t.Fatalf("expected exactly one status check, got %d", statusCalls)
+	}
+	if atomic.LoadInt32(&connectCalls) != 0 {
+		t.Fatalf("expected zero connect-session calls, got %d", connectCalls)
+	}
+	if !strings.Contains(stdout.String(), "notion already connected") {
+		t.Fatalf("expected 'already connected' notice on re-run, got: %q", stdout.String())
+	}
+}
+
+// TestA13MountHelpListsSyncedMirrorLimitations exercises contract A13: the
+// `relayfile mount --help` output must surface the §3.6 list of synced-
+// mirror limitations so the user does not assume kernel filesystem
+// semantics.
+func TestA13MountHelpListsSyncedMirrorLimitations(t *testing.T) {
+	var buf bytes.Buffer
+	printMountHelp(&buf)
+	got := buf.String()
+	for _, fragment := range []string{
+		"Synced-mirror limitations",
+		"File handles are not stable",
+		"mtime reflects the local write time",
+		"Directory listings can briefly omit",
+		"inotify/fsevents",
+		"--mode poll|fuse",
+	} {
+		if !strings.Contains(got, fragment) {
+			t.Fatalf("expected mount --help to contain %q, got:\n%s", fragment, got)
+		}
+	}
+}
 
 // TestA10InitialSyncGateExitsZeroOnReady covers productized cloud-mount
 // contract A10 (positive path): the cloud reports `cataloging` while the

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -65,7 +66,7 @@ func main() {
 	intervalJitter := flag.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := flag.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
 	websocketEnabled := flag.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
-	mode := flag.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", mountModePoll), "mount mode: poll or fuse")
+	mode := flag.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", mountModePoll), "mount mode: poll (synced mirror, recommended) or fuse")
 	fuse := flag.Bool("fuse", boolEnv("RELAYFILE_MOUNT_FUSE", false), "shortcut for --mode=fuse")
 	once := flag.Bool("once", false, "run one sync cycle and exit")
 	flag.Parse()
@@ -158,10 +159,13 @@ func runPollingMount(rootCtx context.Context, cfg mountConfig) error {
 		WebSocket:     boolPtr(cfg.websocketEnabled),
 		RootCtx:       rootCtx,
 		Logger:        log.Default(),
+		Mode:          cfg.mode,
+		Interval:      cfg.interval,
 	})
 	if err != nil {
 		return fmt.Errorf("initialize mount syncer: %w", err)
 	}
+	log.Printf("Mirror started at %s. Sync interval %s +/- %.0f%%. Public state: %s", cfg.localDir, cfg.interval.Round(time.Second), cfg.intervalJitter*100, filepath.Join(cfg.localDir, ".relay", "state.json"))
 
 	run := func(reconcile bool) {
 		ctx, cancel := context.WithTimeout(rootCtx, cfg.timeout)

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -1,7 +1,7 @@
 # RelayFile CLI — Design Doc
 
-**Status:** Draft
-**Date:** 2026-03-24
+**Status:** Updated for v1 Cloud productization
+**Date:** 2026-05-02 (original: 2026-03-24)
 
 ---
 
@@ -89,6 +89,12 @@ relayfile setup [--provider github] [--workspace my-project] [--local-dir ./rela
 3. Create and join a Cloud workspace, then store the Relayfile VFS URL/token in `~/.relayfile/credentials.json`.
 4. Request a hosted Nango connect session for the selected integration and wait until the Cloud status endpoint reports it ready.
 5. Start the existing `relayfile mount` sync loop so the user and agent see ordinary files.
+
+Re-running `relayfile setup` with the same workspace name reuses the locally
+tracked workspace ID, refreshes the Cloud session if needed, re-joins to mint a
+fresh Relayfile JWT, preserves the existing local mirror directory, and only
+opens a new integration connect flow when the requested provider is not already
+connected.
 
 This path is intentionally a wrapper over the lower-level commands and Cloud APIs. Existing `login`, `workspace`, `mount`, `tree`, and `read` commands remain available for CI, self-hosted servers, and scripted workflows.
 
@@ -209,25 +215,24 @@ relayfile mount <workspace> [local-dir]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--interval` | `2s` | Polling interval between sync cycles |
+| `--interval` | `30s` | Polling interval between sync cycles |
 | `--once` | `false` | Run a single sync cycle and exit |
-| `--provider` | (none) | Filter events by provider name |
+| `--mode` | `poll` | `poll` (synced mirror, recommended) or `fuse` (opt-in, POSIX) |
+| `--background` | `false` | Detach from terminal; write PID to `.relay/mount.pid`, logs to `.relay/mount.log` |
+| `--pid-file` | `.relay/mount.pid` | Override PID file path |
 | `--no-websocket` | `false` | Disable WebSocket streaming, poll only |
 
 **Behavior:**
 
-1. Resolve workspace name to ID.
-2. Create `local-dir` if it doesn't exist.
-3. Load or initialize state file at `<local-dir>/.relayfile-mount-state.json`.
-4. Start the existing `mountsync.Syncer` engine (reuses `internal/mountsync`).
-5. Run in foreground. Print sync activity to stderr:
-   ```
-   [mount] syncing ws_abc123 -> ./my-project
-   [mount] + /src/main.go (1.2 KB)
-   [mount] ~ /README.md (updated)
-   [mount] waiting for changes...
-   ```
-6. `Ctrl+C` (SIGINT/SIGTERM) triggers graceful shutdown.
+1. Print on start: `Mirror started at <local-dir>. Sync interval 30s ±20%. Type 'relayfile status' for live state.`
+2. Resolve workspace name to ID.
+3. Create `local-dir` if it doesn't exist; create `.relay/` subdirectory.
+4. Start `mountsync.Syncer` in foreground (default) or detached (`--background`).
+5. Foreground mode logs to stderr; `Ctrl+C` flushes pending writes (≤5 s), persists `.relay/state.json`, and exits.
+6. Background mode (`--background`): fork + setsid (macOS/Linux) or detached child (Windows); redirect stdio to `.relay/mount.log` (rotated at 10 MB × 3); write PID to `.relay/mount.pid`.
+7. On `--mode=fuse` in an environment without FUSE: exit 50 with `fuse mode is not available in this build; rerun with --mode=poll`.
+
+**Sync state:** After every cycle and on clean exit, the daemon writes `.relay/state.json` atomically. Token expiry triggers an automatic workspace rejoin without dropping the process. If no successful reconcile occurs for ≥10 minutes, logs `mount stalled: <reason>` but keeps running.
 
 **Relationship to `relayfile-mount`:** This command replaces the standalone `relayfile-mount` binary for end users. The `cmd/relayfile-mount` binary remains available for backwards compatibility and for deployments that need a minimal single-purpose daemon.
 
@@ -344,10 +349,10 @@ relayfile export <workspace> [--format tar|json|patch] [--output file]
 
 ### `relayfile status`
 
-Show workspace status and stats.
+Show workspace sync status including per-provider state.
 
 ```
-relayfile status [workspace]
+relayfile status [workspace] [--json]
 ```
 
 | Argument | Required | Default | Description |
@@ -357,15 +362,136 @@ relayfile status [workspace]
 **Behavior:**
 
 1. Resolve workspace (uses default if omitted).
-2. Fetch workspace metadata and tree stats.
-3. Print:
+2. Read Cloud `/sync` endpoint and local `.relay/state.json`.
+3. Print one-screen summary:
    ```
-   Workspace:  my-project (ws_abc123)
-   Server:     https://api.relayfile.dev
-   Files:      142
-   Last event: 2026-03-24T11:42:00Z (3 minutes ago)
-   Agents:     compose-agent, reviewer-bot
+   workspace ws_abc (my-project)   mode: poll   lag: 4s
+     github       ready    2,400 files   last event 2s ago
+     notion       ready      214 files   last event 4s ago
+     linear       error    last error: 401 invalid_grant (3 min ago)
+
+   pending writebacks: 0    conflicts: 0    denied: 12
+     see .relay/permissions-denied.log for denied paths
    ```
+4. If `webhookHealthy=false` and `lagSeconds > 60` for any provider, add a warning row.
+
+`--json` emits the same shape machine-readably.
+
+---
+
+### `relayfile integration`
+
+Manage provider integrations after initial setup.
+
+```
+relayfile integration connect <provider> [--workspace NAME] [--no-open] [--timeout 5m]
+relayfile integration list      [--workspace NAME] [--json]
+relayfile integration disconnect <provider> [--workspace NAME] [--yes]
+```
+
+**`connect` behavior:**
+
+1. Call `POST /api/v1/workspaces/{id}/integrations/connect-session` with the provider.
+2. Print the `connectLink`; open browser unless `--no-open`.
+3. Poll `GET /api/v1/workspaces/{id}/integrations/{provider}/status` every 2 s.
+4. On ready: `<provider> connected. Files will appear under <local-dir>/<provider> within ~30s.`
+5. On timeout (default 5 m): print progress hint and exit 0 (sync continues in background).
+6. Persist Nango connection ID to `.relay/integrations/<provider>.json`.
+7. Does **not** require remounting. The running mount loop picks up new files on the next cycle.
+
+**`list` output:**
+
+```
+provider     status    lag     last event
+github       ready     2s      just now
+notion       syncing   18s     5s ago
+linear       error     —       401 invalid_grant (3 min ago)
+```
+
+**`disconnect` behavior:**
+
+1. Prompt for confirmation unless `--yes`.
+2. `DELETE /api/v1/workspaces/{id}/integrations/{provider}/status`.
+3. Remove `<local-dir>/<provider>/` from the mirror.
+4. Write `.relay/disconnected/<provider>.json` marker.
+
+---
+
+### `relayfile pull`
+
+Force a reconcile of a path or the entire workspace, discarding stale remote-deleted files.
+
+```
+relayfile pull [PATH]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PATH` | No | workspace root | Subtree or file to refresh |
+
+**Behavior:**
+
+1. Re-fetch the given subtree from the Cloud VFS.
+2. Discard local copies of files no longer present remotely (unless locally dirty).
+3. Locally modified (dirty) files are **not** discarded; if a remote change would overwrite them, they land in `.relay/conflicts/`.
+
+---
+
+### `relayfile permissions`
+
+Show writeback rules for a path.
+
+```
+relayfile permissions [PATH]
+```
+
+Reads `/<provider>/_PERMISSIONS.md` and the catalog for the given path (or workspace root). Prints which paths are writable and the expected schema.
+
+---
+
+### `relayfile ops`
+
+Inspect and replay dead-lettered writeback operations.
+
+```
+relayfile ops list   [--workspace NAME] [--json]
+relayfile ops replay <opId>
+```
+
+**`list` output:**
+
+```
+opId        path                                 code               attempts   created
+op_abc123   github/.../review.json               validation_error   3          2026-05-02T18:00Z
+```
+
+**`replay` behavior:**
+
+1. `POST /v1/workspaces/{id}/ops/{opId}/replay`.
+2. On success: delete `.relay/dead-letter/<opId>.json` and print `op_abc123 replayed successfully`.
+3. On failure: print the error and leave the dead-letter file in place.
+
+---
+
+### `relayfile stop`
+
+Signal a background mount daemon to shut down.
+
+```
+relayfile stop [workspace]
+```
+
+Sends SIGTERM to the PID in `.relay/mount.pid`. The daemon flushes pending writes (≤5 s) and exits cleanly.
+
+### `relayfile logs`
+
+Print the detached mount log for a workspace.
+
+```
+relayfile logs [workspace] [--lines 40]
+```
+
+Reads `<local-dir>/.relay/mount.log` and prints the requested tail.
 
 ---
 
@@ -387,8 +513,23 @@ These flags apply to all commands:
 
 ```
 ~/.relayfile/
-  credentials.json    # server URL + token (0600)
-  workspaces.json     # workspace name -> ID mapping + default
+  cloud-credentials.json    # Cloud login tokens (access + refresh) (0600)
+  credentials.json          # Relayfile VFS workspace token (0600)
+  workspaces.json           # workspace name → ID mapping + default + lastUsedAt
+
+<local-dir>/
+  <provider>/               # one top-level dir per connected provider
+  .relay/
+    state.json              # sync state (updated atomically after each cycle)
+    mount.pid               # PID of background daemon
+    mount.log               # daemon log (rotated at 10 MB × 3)
+    conflicts/              # one file per unresolved conflict
+      resolved/             # cleared conflicts (audit trail)
+    dead-letter/            # one JSON per permanently failed writeback op
+    disconnected/           # markers for removed integrations
+    permissions-denied.log  # append-only denial log
+    integrations/
+      <provider>.json       # Nango connectionId per provider
 ```
 
 ---
@@ -426,13 +567,20 @@ Error: not authenticated. Run 'relayfile login' or set RELAYFILE_TOKEN.
 | 1 | General error (network, server error, invalid input) |
 | 2 | Authentication failure (no token, token rejected) |
 | 3 | Resource not found (workspace doesn't exist) |
+| 10 | Cloud login failed (OAuth state mismatch or error) |
+| 11 | Cloud login timed out |
+| 20 | Workspace create/join failed |
+| 30 | Integration connect failed |
+| 31 | Integration not ready before deadline |
+| 40 | Initial sync not ready before deadline |
+| 50 | Mount initialization failed (includes FUSE unavailable) |
 | 130 | Interrupted (Ctrl+C) |
 
 ---
 
 ## Implementation plan
 
-### Phase 1 — Core (ship first)
+### Phase 1 — Core (shipped)
 
 1. `relayfile login` — API key auth, credential storage
 2. `relayfile mount` — wraps existing `mountsync` engine
@@ -440,18 +588,30 @@ Error: not authenticated. Run 'relayfile login' or set RELAYFILE_TOKEN.
 4. `relayfile export` — wraps export API
 5. `relayfile status` — workspace info
 
-### Phase 2 — Workspace management
+### Phase 2 — Workspace management (shipped)
 
 6. `relayfile workspace create`
 7. `relayfile workspace list`
 8. `relayfile workspace delete`
 
-### Phase 3 — Polish
+### Phase 3 — Cloud productization (v1, current)
 
-9. OAuth browser flow
-10. Auto-update / version check
-11. Shell completions (bash, zsh, fish)
-12. `relayfile doctor` — diagnose connectivity and auth issues
+9. `relayfile setup` / `relayfile` — guided Cloud setup wizard
+10. `relayfile integration connect/list/disconnect` — multi-provider management
+11. `relayfile status` extended — per-provider sync state, webhook health, conflict counts
+12. `relayfile mount --background` + `relayfile stop` — daemon mode
+13. `relayfile pull` — force reconcile
+14. `relayfile permissions` — writable path inspection
+15. `relayfile ops list/replay` — dead-letter visibility and recovery
+16. Cloud token refresh + VFS token rejoin (automatic, inside mount daemon)
+17. `.relay/state.json`, `.relay/conflicts/`, `.relay/dead-letter/` directories
+
+### Phase 4 — Polish (planned)
+
+18. `relayfile doctor` — diagnose connectivity and auth issues
+19. Auto-update / version check
+20. Shell completions (bash, zsh, fish)
+21. `relayfile install-service` — launchd/systemd/Windows service (out of scope for v1)
 
 ### Build target
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -152,11 +152,15 @@ the `workspace_id`/`wks` claim in the active token, then the default stored by
 | `RELAYFILE_BASE_URL` | string | `https://api.relayfile.dev` for login fallback | Used when `RELAYFILE_SERVER` is unset |
 | `RELAYFILE_TOKEN` | string | unset | Used for `login` and as a token fallback before saved credentials |
 | `RELAYFILE_WORKSPACE` | string | unset | Workspace override for CLI commands when no workspace argument is supplied |
+| `RELAYFILE_CLOUD_API_URL` | string | `https://agentrelay.com/cloud` | Cloud control-plane URL used by `relayfile`, `relayfile setup`, and integration lifecycle commands |
+| `RELAYFILE_CLOUD_TOKEN` | string | unset | Cloud access token used for headless setup/integration flows; skips browser login when set |
 | `RELAYFILE_OBSERVER_URL` | string | `https://agentrelay.com/observer/file` | Hosted observer URL used by `relayfile observer` |
 | `RELAYFILE_REMOTE_PATH` | string | `/` | Mount command default |
 | `RELAYFILE_MOUNT_PROVIDER` | string | unset | Mount command provider filter |
 | `RELAYFILE_MOUNT_STATE_FILE` | string | unset | Mount command state-file default |
-| `RELAYFILE_MOUNT_INTERVAL` | duration | `2s` | Mount command interval default |
+| `RELAYFILE_MOUNT_MODE` | string | `poll` | Mount mode for `relayfile mount`; only `poll` is supported in this checkout |
+| `RELAYFILE_MOUNT_FUSE` | bool | `false` | Legacy opt-in checked by the CLI to reject unsupported FUSE mode with a clear error |
+| `RELAYFILE_MOUNT_INTERVAL` | duration | `30s` | Mount command interval default |
 | `RELAYFILE_MOUNT_INTERVAL_JITTER` | float | `0.2` | Mount command jitter default |
 | `RELAYFILE_MOUNT_TIMEOUT` | duration | `15s` | Mount command timeout default |
 | `RELAYFILE_MOUNT_WEBSOCKET` | bool | `true` | Mount command WebSocket default |

--- a/docs/evidence/mount-safety-status-slice.md
+++ b/docs/evidence/mount-safety-status-slice.md
@@ -1,0 +1,22 @@
+# Mount Safety/Status Slice Evidence
+
+This slice makes the synced mirror self-describing without depending on FUSE:
+
+- public local status lives at `<mount>/.relay/state.json`
+- unresolved conflicts are materialized under `<mount>/.relay/conflicts/`
+- resolved conflict artifacts move to `<mount>/.relay/conflicts/resolved/`
+- denied writes remain visible in `<mount>/.relay/permissions-denied.log`
+
+The machine-readable status file now exposes:
+
+- `status`: `ready`, `stale`, `offline`, `conflict`, or `writeback-pending`
+- `pendingWriteback`, `pendingConflicts`, and `deniedPaths`
+- per-file status entries, including `encoding: "base64"` for binary mirrors
+- `lastError` for rejected or offline writeback attempts
+
+Safety behavior covered by tests:
+
+- revision conflicts preserve the local edit as an artifact and refresh the remote copy in place
+- binary files round-trip as raw local bytes with base64-on-the-wire writeback
+- rejected large writes stay local and remain visible as pending writeback
+- remote deletes remain per-file and settle to a clean local status

--- a/docs/evidence/productized-cloud-mount-final-evidence.md
+++ b/docs/evidence/productized-cloud-mount-final-evidence.md
@@ -1,0 +1,123 @@
+# Productized Cloud Mount Final Evidence
+
+Date: 2026-05-02
+
+Status: green
+
+This evidence package proves the productized Relayfile Cloud mount flow with deterministic local mocks and targeted cross-repo test coverage. The proof was built against the contract in [docs/productized-cloud-mount-contract.md](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/docs/productized-cloud-mount-contract.md) after reviewing the changed files in both `relayfile` and `../cloud`.
+
+## What Was Added Or Fixed
+
+1. Added a stitched end-to-end CLI proof in [cmd/relayfile-cli/productized_cloud_mount_e2e_test.go](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go).
+2. Fixed `relayfile status` conflict visibility in [cmd/relayfile-cli/main.go](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/cmd/relayfile-cli/main.go) so nested conflict artifacts under `.relay/conflicts/<provider>/...` are counted recursively while skipping `.relay/conflicts/resolved/`.
+
+## Deterministic Proof Shape
+
+The new Relayfile proof test uses:
+
+- A local mock Cloud server for workspace create, workspace join, connect-session, integration status, integration list, and cloud token refresh.
+- A local mock Relayfile VFS server for `/sync/status`, `/fs/export`, `/fs/tree`, `/fs/file`, and `/fs/bulk`.
+- The real CLI code paths for `setup`, `integration connect`, `integration list`, `status`, and `mount`.
+- The real sync loop for mirror reconcile, remote pull, local writeback, conflict materialization, persisted credential reuse, and rejoin after auth failure.
+
+Supporting Cloud-side tests use local mocks for Nango/webhook/writeback behavior:
+
+- `tests/sdk-setup-client-routes.test.ts`
+- `tests/nango-sync-relayfile.test.ts`
+- `tests/nango-webhook-router-fanout.test.ts`
+- `tests/relayfile-writeback-bridge.test.ts`
+
+## Requirement Coverage
+
+| Requirement | Proof |
+| --- | --- |
+| 1. Realistic local mocks for Cloud, Relayfile VFS, and Nango/webhook/writeback | `TestProductizedCloudMountE2EProof` uses local mock Cloud + VFS servers. Cloud tests use mocked Nango SDK/proxy servers and webhook/writeback routes. |
+| 2. First-run setup with at least two integrations | `TestProductizedCloudMountE2EProof` runs `relayfile setup ... --provider github --once`, then `relayfile integration connect notion`, then `relayfile integration list --json` and asserts `github` + `notion`. |
+| 3. Daemon/synced mirror startup, remote-to-local sync, local-to-remote writeback, conflict visibility, and status reporting | The stitched proof starts the real mount loop, waits for `.relay/state.json`, proves remote file appearance in the local mirror, pushes a local edit back to remote, forces a conflict and checks `.relay/conflicts/...`, then verifies `relayfile status --json` reports the conflict and daemon metadata. |
+| 4. Token refresh or workspace rejoin for a long-lived mount | The stitched proof expires saved cloud credentials, forces the Relayfile token to return 401, waits for `/api/v1/auth/token/refresh`, then verifies a fresh workspace join and continued sync with the new token. |
+| 5. Recovery after process restart using persisted config | After stopping the long-lived mount, the stitched proof runs `relayfile mount demo <dir> --once --websocket=false` without passing `--server` or `--token` and confirms a newly added remote file is recovered locally. |
+| 6. Save final evidence under `docs/evidence/productized-cloud-mount-final-evidence.md` | This document. |
+
+## Commands Run
+
+Relayfile targeted proof and regression slice:
+
+```bash
+go test ./cmd/relayfile-cli -run 'Test(ProductizedCloudMountE2EProof|SetupCreatesWorkspaceConnectsIntegrationAndSkipsMount|IntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace|StatusIncludesLocalMirrorAndDaemonCounts|MountOnceRejoinsWorkspaceTokenAfterUnauthorized)$'
+```
+
+Result:
+
+```text
+ok  	github.com/agentworkforce/relayfile/cmd/relayfile-cli	0.352s
+```
+
+Relayfile mountsync safety slice:
+
+```bash
+go test ./internal/mountsync -run 'Test(BulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote|SyncOnceUsesWebSocketForRealtimeUpdatesAndSkipsPollingWhileConnected|LocalCreatePreservedWhenServerDeniesWrite)$'
+```
+
+Result:
+
+```text
+ok  	github.com/agentworkforce/relayfile/internal/mountsync	0.439s
+```
+
+Wider Relayfile package confirmation:
+
+```bash
+go test ./cmd/relayfile-cli ./internal/mountsync
+```
+
+Result:
+
+```text
+ok  	github.com/agentworkforce/relayfile/cmd/relayfile-cli	0.363s
+ok  	github.com/agentworkforce/relayfile/internal/mountsync	2.492s
+```
+
+Cloud route and readiness coverage:
+
+```bash
+npx vitest run tests/sdk-setup-client-routes.test.ts tests/nango-sync-relayfile.test.ts tests/nango-webhook-router-fanout.test.ts
+```
+
+Result:
+
+```text
+✓ tests/nango-webhook-router-fanout.test.ts  (5 tests)
+✓ tests/nango-sync-relayfile.test.ts         (12 tests)
+✓ tests/sdk-setup-client-routes.test.ts      (19 tests)
+Test Files  3 passed (3)
+Tests      36 passed (36)
+```
+
+Cloud writeback bridge coverage:
+
+```bash
+npx tsx --test tests/relayfile-writeback-bridge.test.ts
+```
+
+Result:
+
+```text
+✔ relayfile writeback bridge
+ℹ tests 5
+ℹ pass 5
+ℹ fail 0
+```
+
+## Key Outcomes
+
+1. The productized setup path now has a deterministic product-level proof instead of only slice tests.
+2. The proof surfaced and closed a real user-visible bug: `relayfile status` previously undercounted conflicts because artifacts live in nested provider directories.
+3. The final green set covers the control plane, the mirror lifecycle, auth refresh/rejoin, webhook/readiness routing, and writeback bridging.
+
+## Artifacts Produced
+
+- [cmd/relayfile-cli/productized_cloud_mount_e2e_test.go](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go)
+- [cmd/relayfile-cli/main.go](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/cmd/relayfile-cli/main.go)
+- [docs/evidence/productized-cloud-mount-final-evidence.md](/Users/khaliqgant/Projects/AgentWorkforce/relayfile/docs/evidence/productized-cloud-mount-final-evidence.md)
+
+PRODUCTIZED_CLOUD_MOUNT_E2E_READY

--- a/docs/guides/agent-vfs-usage.md
+++ b/docs/guides/agent-vfs-usage.md
@@ -1,0 +1,365 @@
+# Relayfile VFS — Agent Usage Guide
+
+This guide is for agents (and the skill loaders that initialize them). It covers everything needed to discover, read, write, and safely writeback through the synced mirror.
+
+**Context budget warning:** This guide is self-contained. Low-context agents should read it top-to-bottom without skipping sections. Every section is load-bearing.
+
+---
+
+## Mental Model
+
+The Relayfile VFS is a **synced mirror** of provider APIs (GitHub, Notion, Linear, Slack) materialized as ordinary files on disk. An agent reads and writes those files normally. The sync daemon handles authentication, webhooks, and writeback to the provider.
+
+Key facts:
+- Files are ordinary local files. Use file tools, not provider APIs.
+- The mirror lags the source of truth by up to 30 s (default poll interval).
+- Writes are eventually propagated. A write is not committed to the provider until the sync daemon acknowledges it.
+- `mtime` is local write time, not source-of-truth event time. Do not sort by `mtime`.
+- The `.relay/` directory is reserved. Do not write to it.
+
+---
+
+## Step 1: Discover the Mount Path
+
+Find the local mirror directory in this priority order:
+
+### 1. Environment variable (always wins)
+
+```bash
+echo $RELAYFILE_LOCAL_DIR
+```
+
+If set, use that path. Done.
+
+### 2. CLI status command
+
+```bash
+relayfile status --json | jq -r '.localDir'
+```
+
+For multi-workspace setups, the default workspace `localDir` is returned. To target a specific workspace:
+
+```bash
+relayfile status my-project --json | jq -r '.localDir'
+```
+
+### 3. Walk upward from CWD
+
+Search parent directories for the first one containing `.relay/state.json`. That directory is the mount root.
+
+### Failure case
+
+If none of the above resolves, fail with a clear message and stop:
+
+```
+relayfile mount not found. Run 'relayfile setup' or set RELAYFILE_LOCAL_DIR.
+```
+
+Do not guess paths. Do not proceed without a confirmed mount root.
+
+---
+
+## Step 2: Check Sync State Before Acting
+
+Before any non-trivial read or any write, read `.relay/state.json`:
+
+```bash
+cat <mount>/.relay/state.json
+```
+
+Example:
+
+```json
+{
+  "workspaceId": "ws_abc",
+  "mode": "poll",
+  "lastReconcileAt": "2026-05-02T18:34:11Z",
+  "lastEventAt":     "2026-05-02T18:34:08Z",
+  "intervalMs": 30000,
+  "providers": [
+    { "provider": "notion", "status": "ready", "lagSeconds": 4,
+      "deadLetteredOps": 0, "lastError": null }
+  ],
+  "pendingWriteback": 0,
+  "pendingConflicts": 0,
+  "deniedPaths": 0
+}
+```
+
+**Rules:**
+- If the provider you need has `status != "ready"`, wait or warn. Do not assume files are current.
+- If `lagSeconds > 60`, treat data as potentially stale. Note it in your response.
+- If `pendingConflicts > 0`, check `.relay/conflicts/` before writing to affected paths.
+- Do not use `mtime` for ordering. Use `lastReconcileAt` and `lagSeconds`.
+
+---
+
+## Path Conventions
+
+### Provider-backed files
+
+```
+<mount>/github/                                         # GitHub
+<mount>/github/repos/<owner>/<repo>/pulls/<n>/
+  metadata.json                                         # PR metadata (read-only)
+  files.json                                            # changed files (read-only)
+  reviews/<timestamp>.json                              # posted reviews (read-only)
+  reviews/review.json                                   # write here to post a review
+
+<mount>/notion/                                         # Notion pages
+<mount>/notion/pages/<page-id>/content.md               # page body (check _PERMISSIONS.md)
+
+<mount>/linear/                                         # Linear issues
+<mount>/linear/issues/<issue-id>/metadata.json          # issue metadata
+<mount>/linear/issues/<issue-id>/comments/new.json      # write to add a comment
+
+<mount>/slack/                                          # Slack
+<mount>/slack/channels/<channel-id>/messages/           # channel messages (read-only)
+<mount>/slack/channels/<channel-id>/messages/new.json   # write to send a message
+```
+
+### Writeback rules per provider
+
+Each provider publishes its own rules:
+
+```
+<mount>/<provider>/_PERMISSIONS.md
+```
+
+Always read `_PERMISSIONS.md` before writing to a provider subtree. It lists exactly which paths trigger writeback and the schema each writeback path expects. Writing to a read-only path will be denied by the Cloud and logged to `.relay/permissions-denied.log`.
+
+### Reserved Relayfile metadata paths (do not write)
+
+```
+<mount>/.relay/state.json             # sync state (read-only for agents)
+<mount>/.relay/conflicts/             # conflict staging area (read-only for agents)
+<mount>/.relay/dead-letter/           # dead-lettered ops (read-only for agents)
+<mount>/.relay/permissions-denied.log # denial log (read-only for agents)
+<mount>/.relay/mount.pid              # daemon PID
+<mount>/.relay/mount.log              # daemon log
+```
+
+**Do not write to any path under `.relay/`.** Do not delete or rename top-level provider directories (`github/`, `notion/`, etc.).
+
+---
+
+## Reading Files
+
+Use standard file read operations. No special API needed.
+
+```bash
+cat <mount>/github/repos/acme/api/pulls/42/metadata.json
+```
+
+**When to prefer file reads over provider APIs:**
+- Always. The VFS exists so agents never need provider credentials or API knowledge.
+- Provider APIs require OAuth tokens the agent does not have.
+- File reads are simpler, cacheable, and work offline from the last sync.
+
+**Staleness check:** If freshness matters, verify `lagSeconds` in `state.json` for the relevant provider. If lag is acceptable, proceed. If not, run `relayfile pull <path>` to force a refresh before reading.
+
+---
+
+## Writing Files (Safe Edit Pattern)
+
+Writes trigger writeback to the provider. Follow this exact sequence:
+
+### 1. Read the current file
+
+```bash
+cat <mount>/github/repos/acme/api/pulls/42/reviews/review.json
+```
+
+Capture the current content. Note the path for later.
+
+### 2. Check `_PERMISSIONS.md`
+
+Verify the target path is a writeback path, not read-only. Check the required schema.
+
+```bash
+cat <mount>/github/_PERMISSIONS.md
+```
+
+### 3. Validate your payload against the schema
+
+For JSON writeback paths, validate locally before saving. Example for a GitHub review:
+
+```json
+{
+  "body": "Looks good to me.",
+  "event": "APPROVE"
+}
+```
+
+`event` must be one of `APPROVE`, `REQUEST_CHANGES`, `COMMENT`. Writing an invalid schema causes a schema validation error: the Cloud rejects the write, moves the file to `.relay/conflicts/<path>.invalid.<ts>`, and restores the previous version. Fix and retry from that conflict file.
+
+### 4. Write atomically
+
+```bash
+# Write the file
+cat > <mount>/github/repos/acme/api/pulls/42/reviews/review.json << 'EOF'
+{"body": "Looks good to me.", "event": "APPROVE"}
+EOF
+```
+
+The mount's file watcher picks up the change within 100 ms and queues the upload.
+
+### 5. Wait for acknowledgement
+
+Poll `.relay/state.json` until `pendingWriteback == 0` or the file appears in `.relay/conflicts/` or `.relay/dead-letter/`.
+
+```bash
+# Simple poll loop (30 s timeout)
+timeout=30
+elapsed=0
+while [ $elapsed -lt $timeout ]; do
+  pending=$(jq '.pendingWriteback' <mount>/.relay/state.json)
+  conflicts=$(ls <mount>/.relay/conflicts/ 2>/dev/null | grep -c "review.json" || true)
+  [ "$pending" -eq 0 ] && [ "$conflicts" -eq 0 ] && echo "ack" && break
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+```
+
+The SDK provides `waitForWriteback(path, { timeoutMs })` for TypeScript callers.
+
+### 6. Handle conflicts on retry
+
+If a conflict appears:
+
+1. Read both versions: the current path (remote) and `.relay/conflicts/<path>.<rev>.local` (your edit).
+2. Merge the intent into the current file at the original path.
+3. Save again (step 4).
+4. Wait for ack again (step 5).
+5. Do not delete the conflict file yourself — the system moves it to `resolved/` automatically after a successful write.
+
+---
+
+## After Writing: What Success Looks Like
+
+A write is **not** confirmed until:
+- `pendingWriteback` returns to 0, AND
+- No new entry for the path appears under `.relay/conflicts/` or `.relay/dead-letter/`
+
+A write that lands in `.relay/dead-letter/` has permanently failed. Inspect the dead-letter JSON:
+
+```bash
+cat <mount>/.relay/dead-letter/<opId>.json
+```
+
+Fields include: `path`, `code`, `message`, `attempts`, `replayUrl`. Fix the underlying issue (schema, permissions, provider auth) then replay:
+
+```bash
+relayfile ops replay <opId>
+```
+
+---
+
+## Status Codes and Provider States
+
+| Provider status | Meaning for agents |
+|---|---|
+| `pending` | Provider just connected; no files yet. Wait. |
+| `cataloging` | Listing remote objects. Files will appear soon. Wait. |
+| `syncing` | Files populating. Partial data. Read with caution. |
+| `ready` | Fully synced. Safe to read and write. |
+| `error` | Last sync attempt failed. Check `lastError`. Reads may be stale. |
+| `degraded` | Sync lag > 10 min. Reads serve stale data. Note in response. |
+
+When a provider is `cataloging` or `syncing`, do not delete local files under that subtree. The mount will not delete them either — it waits for `ready` before applying remote-delete semantics.
+
+---
+
+## Multi-Agent Coordination
+
+When two agents share a mount:
+
+- **Treat `.relay/conflicts/` as a coordination signal.** If you see a conflict on a path another agent owns, back off. Do not overwrite it.
+- **Prefer disjoint paths.** Agents working on different files never conflict. Structure parallel work to use separate paths.
+- **Use agent-relay channels for handoffs** when two agents need to coordinate on a shared file. One agent can post "done editing `github/.../review.json`" before the next one picks it up.
+- **Do not use file locking.** The VFS does not support locks across processes. Coordinate through channels or by convention.
+
+---
+
+## Low-Context Agent Checklist
+
+Paste this into a low-context agent's initial context if the full guide is too large:
+
+```
+RELAYFILE VFS QUICK REFERENCE
+
+Mount discovery (in order):
+  1. $RELAYFILE_LOCAL_DIR
+  2. relayfile status --json | jq -r '.localDir'
+  3. Walk upward from CWD for .relay/state.json
+
+Before reading or writing:
+  - Read .relay/state.json
+  - provider.status must be "ready"
+  - provider.lagSeconds should be < 60
+
+Path rules:
+  - Files are at <mount>/<provider>/...
+  - Read _PERMISSIONS.md before writing to any path
+  - Never write to .relay/
+  - Never delete top-level provider dirs
+
+Safe write sequence:
+  1. Read current file
+  2. Check _PERMISSIONS.md for schema
+  3. Validate JSON payload locally
+  4. Write file
+  5. Poll state.json until pendingWriteback == 0
+  6. If .relay/conflicts/ contains your path: merge and retry
+  7. If .relay/dead-letter/ contains your path: inspect and replay
+
+Do NOT:
+  - Trust mtime for ordering (use lastReconcileAt)
+  - Call provider APIs directly (use files)
+  - Write to .relay/
+  - Ignore lagSeconds > 60
+```
+
+---
+
+## SDK Helpers (TypeScript)
+
+The `@relayfile/sdk` `WorkspaceHandle` exposes these helpers:
+
+```typescript
+import { WorkspaceHandle } from "@relayfile/sdk";
+
+const handle = await WorkspaceHandle.connect({ workspaceId: "ws_abc" });
+
+// Read sync state
+const state = await handle.readState();
+// { lastReconcileAt, providers: [{ provider, status, lagSeconds }], ... }
+
+// Wait for a provider to be ready
+await handle.enforceProviderReady("notion", { timeoutMs: 60_000 });
+
+// Write a file and wait for writeback ack
+await handle.writeFile("github/repos/acme/api/pulls/42/reviews/review.json",
+  JSON.stringify({ body: "LGTM!", event: "APPROVE" })
+);
+await handle.waitForWriteback("github/repos/acme/api/pulls/42/reviews/review.json",
+  { timeoutMs: 30_000 }
+);
+
+// Refresh the workspace token (called automatically after 55 min)
+await handle.refreshToken();
+```
+
+---
+
+## Common Errors and Recovery
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| File missing from `<mount>/<provider>/` | Provider still syncing | Check `state.json` status; wait for `ready` |
+| Write moves to `.relay/conflicts/*.invalid.*` | Schema validation failed | Read `_PERMISSIONS.md`, fix payload, retry |
+| Write moves to `.relay/conflicts/*.local` | Concurrent edit conflict | Merge remote + local, re-save |
+| Write moves to `.relay/dead-letter/` | Permanent API error | Inspect JSON, fix root cause, `relayfile ops replay <id>` |
+| `lagSeconds > 60` | Webhook unhealthy or network lag | Note staleness in response; run `relayfile pull` if needed |
+| `status == "error"` | Provider auth or API failure | Run `relayfile integration list` and `relayfile integration connect <provider>` |
+| Permission denial in log | Path is read-only | Read `_PERMISSIONS.md` for writable paths |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -139,6 +139,21 @@ If you want to watch the workspace status while testing:
 relayfile status
 ```
 
+The synced mirror also writes a machine-readable local status file at
+`<mount>/.relay/state.json`. That file is the authoritative local surface for:
+
+- sync freshness (`status`, `lastSuccessfulReconcileAt`, `staleAfter`)
+- pending local writeback (`pendingWriteback`, per-file `status`)
+- unresolved conflicts under `<mount>/.relay/conflicts/`
+- denied paths and the append-only `<mount>/.relay/permissions-denied.log`
+
+Binary files are materialized as raw bytes locally and written back with
+`encoding: "base64"` when needed. Large writes that the server rejects stay on
+disk locally and remain visible as `status: "writeback-pending"` in
+`.relay/state.json`; they are never silently dropped. Remote deletes stay
+per-file and only remove the local mirror when the tracked remote revision still
+matches.
+
 For direct VFS inspection without mounting:
 
 ```bash

--- a/docs/guides/vfs-cloud-setup.md
+++ b/docs/guides/vfs-cloud-setup.md
@@ -1,0 +1,392 @@
+# Relayfile Cloud VFS — Human Setup Guide
+
+This guide covers everything a human operator needs: first-time setup, connecting additional integrations, checking sync status, stopping and restarting the daemon, and diagnosing problems.
+
+## What You Are Getting
+
+When you run `relayfile setup` (or just `relayfile`), you get a **synced mirror** — not a kernel filesystem. Ordinary files appear under a local directory of your choice. A background loop keeps them in sync with the cloud and with provider APIs (GitHub, Notion, Linear, Slack). You can read and write those files with any tool that knows how to use files.
+
+The mirror has real limitations. Read [Known Limitations](#known-limitations) before relying on it for time-sensitive or high-volume writes.
+
+---
+
+## First-Time Setup
+
+### Interactive (recommended for humans)
+
+```bash
+relayfile
+```
+
+This runs the full setup wizard:
+
+1. Opens a browser to sign in to Relayfile Cloud.
+2. Prompts for a workspace name (default: `relayfile-<timestamp>`).
+3. Prompts for an integration provider (GitHub, Notion, Linear, Slack, or none).
+4. Prompts for a local directory (default: `./relayfile-mount`).
+5. Opens the integration OAuth consent page.
+6. Waits for the initial sync to complete, showing live progress.
+7. Starts the sync loop in the foreground.
+
+Press `Ctrl+C` at any time to stop. The local files remain; re-run `relayfile` or `relayfile mount <workspace> <dir>` to resume.
+
+### Non-interactive / CI
+
+```bash
+relayfile setup \
+  --cloud-token "$RELAYFILE_CLOUD_TOKEN" \
+  --provider github \
+  --workspace my-project \
+  --local-dir ./relayfile-mount \
+  --no-open \
+  --once
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--cloud-token` | `$RELAYFILE_CLOUD_TOKEN` | Skip browser login |
+| `--provider` | prompted | `github`, `notion`, `linear`, `slack`, or `none` |
+| `--workspace` | prompted | Workspace display name |
+| `--local-dir` | `./relayfile-mount` | Local mirror directory |
+| `--no-open` | false | Print URLs instead of opening a browser |
+| `--skip-mount` | false | Finish setup without starting the sync loop |
+| `--once` | false | Run one sync cycle then exit (CI/probe use) |
+| `--cloud-api-url` | `https://agentrelay.com/cloud` | Cloud control-plane URL |
+| `--login-timeout` | `5m` | OAuth callback wait |
+| `--connect-timeout` | `5m` | Integration readiness wait |
+
+### Re-running setup (idempotent)
+
+You can safely re-run `relayfile setup` with the same `--workspace` name. It reuses the existing workspace ID, refreshes the access token, and skips the integration connect step if the provider is already connected.
+
+### Exit codes
+
+| Code | Meaning |
+|-----:|---------|
+| 0 | Setup complete |
+| 10 | Cloud login failed (state mismatch, OAuth error) |
+| 11 | Cloud login timed out |
+| 20 | Workspace create/join failed |
+| 30 | Integration connect failed |
+| 31 | Integration not ready before deadline |
+| 40 | Initial sync not ready before deadline |
+| 50 | Mount initialization failed |
+
+Exit 40 is not fatal to the workspace — sync continues in the background. Re-attach with:
+
+```bash
+relayfile mount <workspace-id> ./relayfile-mount
+```
+
+---
+
+## Adding More Integrations
+
+After the first setup you can connect additional providers without remounting.
+
+```bash
+# Connect Notion
+relayfile integration connect notion
+
+# Connect a specific Slack variant
+relayfile integration connect slack
+
+# Connect without opening a browser (print the URL instead)
+relayfile integration connect linear --no-open
+
+# Specify a non-default workspace
+relayfile integration connect github --workspace my-other-project
+```
+
+New provider files appear under `<local-dir>/<provider>/` within ~30 seconds of the OAuth flow completing (sooner if a websocket invalidation fires).
+
+### List connected integrations
+
+```bash
+relayfile integration list
+relayfile integration list --json
+```
+
+Output:
+
+```
+provider     status    lag     last event
+github       ready     2s      just now
+notion       syncing   18s     5s ago
+linear       error     —       401 invalid_grant (3 min ago)
+```
+
+### Disconnect an integration
+
+```bash
+relayfile integration disconnect notion
+relayfile integration disconnect notion --yes   # skip confirmation
+```
+
+Disconnecting removes `<local-dir>/notion/` from the mirror and leaves a marker at `<local-dir>/.relay/disconnected/notion.json`. The integration can be reconnected at any time.
+
+---
+
+## Checking Status
+
+```bash
+relayfile status
+relayfile status my-project
+relayfile status --json          # machine-readable
+```
+
+Example output:
+
+```
+workspace ws_abc (my-project)   mode: poll   lag: 4s
+  github       ready    2,400 files    last event 2s ago
+  notion       ready      214 files    last event 4s ago
+  linear       error    last error: 401 invalid_grant (3 min ago)
+
+pending writebacks: 0    conflicts: 0    denied: 12
+  see .relay/permissions-denied.log for denied paths
+```
+
+Status reads from both the Cloud `/sync` endpoint and the local `.relay/state.json` file so it works even when offline (showing the last known state).
+
+### Webhook health warning
+
+If a provider's webhook stops delivering events, status shows:
+
+```
+notion webhook unhealthy — falling back to periodic sync (lag 78s)
+```
+
+This is not an error. Poll sync continues; the provider will recover its webhook independently.
+
+---
+
+## Starting and Stopping the Sync Loop
+
+### Foreground (default)
+
+```bash
+relayfile mount my-project ./relayfile-mount
+```
+
+Ctrl+C flushes pending writes (≤5 s), persists `.relay/state.json`, and exits cleanly.
+
+### Background daemon
+
+```bash
+relayfile mount --background my-project ./relayfile-mount
+```
+
+- Detaches from the terminal.
+- Writes PID to `./relayfile-mount/.relay/mount.pid`.
+- Rotates logs at `./relayfile-mount/.relay/mount.log` (10 MB × 3 files).
+
+### Stopping a background daemon
+
+```bash
+relayfile stop my-project
+```
+
+Or signal directly:
+
+```bash
+kill $(cat ./relayfile-mount/.relay/mount.pid)
+```
+
+### Restarting
+
+```bash
+relayfile stop my-project
+relayfile mount --background my-project ./relayfile-mount
+```
+
+### Single sync cycle (CI/probe)
+
+```bash
+relayfile mount --once my-project ./relayfile-mount
+```
+
+Reconciles once and exits. Useful in pipelines that need a fresh snapshot before a job runs.
+
+---
+
+## Force-Refreshing Files
+
+Force a full reconcile of a subtree, discarding stale local copies:
+
+```bash
+relayfile pull                          # entire workspace
+relayfile pull notion/Docs/Project.md  # single file
+relayfile pull github/repos/           # subtree
+```
+
+Files you have locally modified (dirty) are never discarded by `pull`. If a remote change conflicts with your local edit, `pull` moves your edit to `.relay/conflicts/` and refreshes the file from the remote.
+
+---
+
+## Checking Permissions
+
+See which paths are writable for each provider:
+
+```bash
+relayfile permissions
+relayfile permissions github/repos/acme/api/pulls/
+```
+
+Each provider also publishes its own rules at:
+
+```
+<local-dir>/<provider>/_PERMISSIONS.md
+```
+
+Read that file to understand exactly what paths the agent (and you) can write to.
+
+---
+
+## Dead-Letter Operations
+
+When a writeback fails permanently (schema violation, authorization error, repeated 5xx), it lands in the dead-letter queue.
+
+```bash
+# List failed operations
+relayfile ops list
+
+# Replay one after fixing the underlying issue
+relayfile ops replay op_abc123
+
+# Replay all
+relayfile ops list --json | jq -r '.[].opId' | xargs -I{} relayfile ops replay {}
+```
+
+Dead-lettered ops are also visible as JSON files at:
+
+```
+<local-dir>/.relay/dead-letter/<opId>.json
+```
+
+---
+
+## Conflict Resolution
+
+When two writers edit the same file before a sync cycle completes, the system detects a conflict:
+
+1. Your local edit is saved verbatim to `.relay/conflicts/<path>.<rev>.local`.
+2. The remote version replaces the original path.
+3. The CLI prints: `conflict at notion/Docs/A.md — your edit saved at .relay/conflicts/…`
+
+To resolve:
+
+1. Read both versions (the original path and `.relay/conflicts/…`).
+2. Edit the original path to reflect the merged intent.
+3. Save. The next sync cycle uploads your merge against the new revision.
+4. Once acknowledged, the conflict file moves to `.relay/conflicts/resolved/` automatically.
+
+---
+
+## Known Limitations
+
+The sync loop is a **synced mirror**, not a POSIX kernel filesystem. Differences to keep in mind:
+
+- **File handles are not stable.** If your editor holds a file open, the contents may change on disk during the next reconcile. Re-open the file to see updates.
+- **`mtime` is local write time, not source-of-truth time.** Use `.relay/state.json → lastReconcileAt` and `lagSeconds` for ordering decisions.
+- **Directory listings can be briefly stale.** A new file created remotely may not appear locally for up to 30 s (or until a websocket event fires).
+- **`inotify`/`fsevents` watchers will see synthetic create events** on every reconcile for new content. Downstream tools that require single-shot events should debounce ≥1 s.
+- **FUSE is opt-in.** The default mode is `--mode=poll` (synced mirror). FUSE is available with `--mode=fuse` but is not available in Docker containers without `--privileged`.
+
+These are deliberate design choices, not bugs. The mitigations are the `.relay/state.json` status file, `relayfile status`, and `relayfile pull`.
+
+---
+
+## Troubleshooting
+
+### Mount appears stalled
+
+```bash
+relayfile status           # check lag and provider errors
+cat .relay/state.json      # machine-readable sync state
+cat .relay/mount.log       # daemon log (background mode only)
+```
+
+If the mount has not reconciled for ≥10 minutes it logs `mount stalled: <reason>` but keeps running. Common causes: network interruption, expired token, provider API outage.
+
+### Token expired
+
+```
+error: cloud session expired. Run 'relayfile login' to sign in again.
+```
+
+Run `relayfile login`. The running mount continues serving local reads from disk until the process is restarted.
+
+If the refresh token itself expires (default 7 days), the mount enters degraded mode: local reads work, local writes are refused and logged to `.relay/permissions-denied.log` with reason `cloud_session_expired`. Fix:
+
+```bash
+relayfile login
+relayfile stop my-project
+relayfile mount --background my-project ./relayfile-mount
+```
+
+### Integration shows `error` status
+
+```bash
+relayfile integration list                     # see error message
+relayfile integration disconnect linear        # remove
+relayfile integration connect linear           # reconnect + re-OAuth
+```
+
+### Files missing after connect
+
+Providers start in `cataloging` then `syncing` state. Files appear incrementally — large workspaces (thousands of files) can take several minutes. Watch progress:
+
+```bash
+watch -n 5 relayfile status
+```
+
+### Permission denials
+
+```bash
+cat .relay/permissions-denied.log
+relayfile permissions github/repos/acme/api/
+```
+
+Agents may only write to paths declared writable in `_PERMISSIONS.md`. Read-only paths return 403 from the Cloud; the denial is logged but does not stop the mount.
+
+### FUSE not available
+
+```
+fuse mode is not available in this build; rerun with --mode=poll
+```
+
+Docker containers without `--privileged` cannot use FUSE. Use the default poll mode:
+
+```bash
+relayfile mount --mode=poll my-project ./relayfile-mount
+```
+
+---
+
+## File Layout Reference
+
+```
+~/.relayfile/
+  cloud-credentials.json    # Cloud login tokens (0600)
+  credentials.json          # Relayfile VFS workspace token (0600)
+  workspaces.json           # workspace name → ID mapping
+
+<local-dir>/
+  github/                   # GitHub files
+  notion/                   # Notion files
+  linear/                   # Linear files
+  slack/                    # Slack files
+  .relay/
+    state.json              # live sync state (machine-readable)
+    mount.pid               # PID of background daemon
+    mount.log               # daemon log (rotated)
+    conflicts/              # unresolved conflicts (human-fixable)
+      resolved/             # cleared conflicts (audit trail)
+    dead-letter/            # permanently failed writebacks
+    disconnected/           # markers for removed integrations
+    permissions-denied.log  # append-only denial log
+    integrations/
+      github.json           # Nango connection ID per provider
+      notion.json
+```

--- a/docs/mount-hardening-plan.md
+++ b/docs/mount-hardening-plan.md
@@ -11,7 +11,10 @@ The mount client (`cmd/relayfile-mount` + `internal/mountsync`) uses a **polling
 - Every N seconds (default 2s, with jitter), it runs `SyncOnce()`.
 - **Push phase**: walks the local directory, detects hash changes, and PUTs modified files with `If-Match` optimistic concurrency.
 - **Pull phase**: either fetches the full remote tree or uses an incremental event cursor to download changed/deleted files.
-- State is persisted to `.relayfile-mount-state.json` (revision, content hash, dirty flag per file).
+- Internal tracked state is persisted to `.relayfile-mount-state.json`, while the
+  user-facing synced-mirror status surface is written to `.relay/state.json`
+  with explicit `ready` / `stale` / `offline` / `conflict` /
+  `writeback-pending` states.
 - Conflict on write is detected via HTTP 409 and the file is marked `Dirty` for retry on the next cycle.
 
 ### Limitations
@@ -20,7 +23,7 @@ The mount client (`cmd/relayfile-mount` + `internal/mountsync`) uses a **polling
 |------|-----------------|---------|
 | Filesystem interface | Polling + `os.ReadFile` / `os.WriteFile` | Agent writes are invisible until the next poll; no instant notification; race window between poll cycles |
 | Cache coherence | SHA-256 hash comparison per file per cycle | No expiration, no TTL; stale reads possible between polls; full-tree walk is O(n) for large workspaces |
-| Conflict handling | HTTP 409 -> mark dirty, log, skip overwrite | No user-visible conflict artifact; no merge strategy; dirty flag silently retried forever |
+| Conflict handling | HTTP 409 -> local body is preserved in `.relay/conflicts/…`, remote is refreshed in place, status flips to `conflict` | User-visible and machine-readable, but still requires manual resolution before retry |
 
 ---
 

--- a/docs/productized-cloud-mount-contract.md
+++ b/docs/productized-cloud-mount-contract.md
@@ -1,0 +1,825 @@
+# Productized Cloud Mount — v1 Product Contract
+
+**Status:** v1 contract (locked)
+**Date:** 2026-05-02
+**Owners:** Relayfile CLI, Relayfile Cloud, Relayfile SDK, Agent Skills
+**Audience:** Implementers of `relayfile`, `@relayfile/sdk`, `agentrelay.com/cloud` routes, agent harnesses, and the `relayfile-workspace` skill.
+
+This document is the v1 contract for the productized Cloud mount path —
+the experience a user gets when they type `relayfile` (or run
+`relayfile setup`) and end up with a working, multi-integration workspace
+locally and inside their agent. It is normative: every requirement
+marked **MUST** is shipped behavior; **SHOULD** is the recommended
+default but may be configurable; **MAY** is optional.
+
+The product premise is fixed:
+
+> **The default local attachment is a synced mirror, not a kernel FUSE mount.**
+> Agents see ordinary files on disk. The product is honest about sync
+> state, conflicts, refresh, and writeback. FUSE remains optional and is
+> hardened separately.
+
+If the synced mirror cannot meet a guarantee that a real filesystem
+would, the contract calls it out and specifies the user-visible
+mitigation. We do not paper over the difference.
+
+---
+
+## 1. First-Run UX: `relayfile` and `relayfile setup`
+
+### 1.1 Invocation forms
+
+The CLI **MUST** support these equivalent first-run forms:
+
+```
+relayfile
+relayfile setup
+relayfile setup --provider github --workspace my-project --local-dir ./relayfile-mount
+relayfile setup --cloud-token $RELAYFILE_CLOUD_TOKEN --provider github \
+    --workspace ci-project --local-dir ./relayfile-mount --no-open --skip-mount
+```
+
+`relayfile` with no args **MUST** dispatch to `runSetup`. The flags
+below are normative for `setup`; defaults are listed in parentheses.
+
+| Flag                | Default                                | Purpose                                                           |
+|---------------------|----------------------------------------|-------------------------------------------------------------------|
+| `--cloud-api-url`   | `https://agentrelay.com/cloud`         | Cloud control plane URL                                           |
+| `--cloud-token`     | `$RELAYFILE_CLOUD_TOKEN`               | Skip browser login when set (CI/headless)                         |
+| `--workspace`       | prompted, default `relayfile-<ts>`     | Workspace display name                                            |
+| `--provider`        | prompted, default `github`             | Integration provider; `none` skips                                 |
+| `--local-dir`       | prompted, default `./relayfile-mount`  | Mirror directory                                                   |
+| `--no-open`         | `false`                                | Print URLs instead of opening a browser                           |
+| `--skip-mount`      | `false`                                | Finish setup without starting the mount loop                       |
+| `--once`            | `false`                                | Run a single sync cycle and exit (CI/probe)                       |
+| `--login-timeout`   | `5m`                                   | OAuth callback timeout                                             |
+| `--connect-timeout` | `5m`                                   | Integration readiness timeout                                      |
+
+### 1.2 Required ordered steps
+
+`relayfile setup` **MUST** execute these steps in this order, and every
+step **MUST** be idempotent on re-run:
+
+1. **Print intent.** A single line stating: "Relayfile setup. This signs
+   you in, connects an integration, and prepares a local VFS mount."
+2. **Cloud login.**
+   - If `--cloud-token`/`$RELAYFILE_CLOUD_TOKEN` is set, skip the browser
+     and persist the supplied token.
+   - Otherwise: bind a localhost callback (`http://127.0.0.1:<port>/callback`),
+     open `${cloud-api-url}/api/v1/cli/login?redirect_uri=…&state=…`,
+     verify state, and capture `access_token`, `refresh_token`,
+     `access_token_expires_at`, `refresh_token_expires_at`, `api_url`.
+   - Persist to `~/.relayfile/cloud-credentials.json` with `0600` perms
+     and the `cloudCredentials` schema in §5.1.
+3. **Workspace name.** Use `--workspace`, else prompt. Default suggestion:
+   `relayfile-<UTC YYYYMMDD-HHMMSS>`.
+4. **Provider choice.** Use `--provider`, else prompt with the catalog
+   defined in §6.2. `none` or `skip` are accepted to defer integration.
+5. **Local dir.** Use `--local-dir`, else prompt; default
+   `./relayfile-mount`. The directory **MUST** be created with `0o755`
+   and a `.relay/` subdir with `0o755`.
+6. **Workspace create + join.** `POST /api/v1/workspaces`, then
+   `POST /api/v1/workspaces/{id}/join` with
+   `{agentName: "relayfile-cli", scopes: ["fs:read", "fs:write"]}`.
+   Persist Relayfile VFS credentials to `~/.relayfile/credentials.json`
+   (§5.1) and add the workspace to `~/.relayfile/workspaces.json`,
+   marking it default.
+7. **Integration connect.** If a provider was chosen and not `none`:
+   `POST /api/v1/workspaces/{id}/integrations/connect-session` with
+   `{allowedIntegrations: [provider]}`. Print the `connectLink`, open it
+   unless `--no-open`, and poll
+   `GET /api/v1/workspaces/{id}/integrations/{provider}/status?connectionId=…`
+   every 2 s until `ready=true` or `--connect-timeout` elapses.
+8. **Initial sync gate.** Wait for the workspace's per-provider sync
+   status to reach `ready` (§7) before exiting setup, unless
+   `--skip-mount` is set. Show progress: `Syncing notion… 142/2,400 files
+   (lag 12 s)`. The default deadline is `--connect-timeout`; on timeout
+   the CLI **MUST** print: `Initial sync still running. Resume with:
+   relayfile mount <id> <dir>` and exit non-zero.
+9. **Mount.** Unless `--skip-mount`, fork the existing
+   `relayfile mount <workspaceId> <localDir>` loop in the foreground.
+   `--once` performs a single reconcile and exits.
+
+### 1.3 Output contract
+
+Each step **MUST** emit exactly one human-readable line on success. On
+failure, the CLI **MUST** print `error: <reason>` to stderr and exit with
+a non-zero code from this table:
+
+| Code | Meaning                                              |
+|-----:|------------------------------------------------------|
+| 0    | Setup complete (mount running or skipped)            |
+| 1    | Generic failure                                       |
+| 10   | Cloud login failed (state mismatch / oauth error)     |
+| 11   | Cloud login timed out                                 |
+| 20   | Workspace create/join failed                          |
+| 30   | Integration connect failed                            |
+| 31   | Integration not ready before deadline                 |
+| 40   | Initial sync not ready before deadline                |
+| 50   | Mount initialization failed                           |
+
+### 1.4 Idempotency
+
+Re-running `relayfile setup` against the same `--workspace` name
+**MUST**:
+
+- Reuse the locally tracked workspace ID if present in
+  `~/.relayfile/workspaces.json` rather than minting a duplicate.
+- Refresh the Relayfile VFS token via Cloud `join` before mount.
+- Skip integration connect if the integration status endpoint already
+  returns `ready=true`.
+
+---
+
+## 2. Adding More Providers After First Setup
+
+### 2.1 Multi-integration command
+
+The CLI **MUST** expose:
+
+```
+relayfile integration connect <provider> [--workspace NAME] [--no-open] [--timeout 5m]
+relayfile integration list      [--workspace NAME] [--json]
+relayfile integration disconnect <provider> [--workspace NAME] [--yes]
+```
+
+Behavior **MUST** match `setup`'s integration step (§1.2.7) for
+`connect`, including the readiness wait. `list` calls `GET
+/api/v1/workspaces/{id}/integrations` and prints
+`provider | status | lag | last_event_at`. `disconnect` calls
+`DELETE /api/v1/workspaces/{id}/integrations/{provider}/status`.
+
+Adding a provider **MUST NOT** require re-mounting. The running mount
+loop **MUST** observe new files at `/<provider>/…` after the next
+reconcile cycle (default 30 s) or the next websocket invalidation event,
+whichever comes first. The CLI **MUST** print:
+
+```
+notion connected. Files will appear under <local-dir>/notion within ~30s.
+```
+
+### 2.2 Provider order and namespaces
+
+The local mirror layout is fixed: each provider gets a top-level
+directory rooted at the workspace mount, mirroring the Cloud VFS:
+
+```
+<local-dir>/
+  github/
+  notion/
+  linear/
+  slack-sage/
+  .relay/
+```
+
+Adding a provider **MUST NOT** mutate other providers' subtrees.
+Removing a provider **MUST** delete only that subtree from the local
+mirror after a successful disconnect, and **MUST** leave a marker at
+`.relay/disconnected/<provider>.json` recording when it was removed.
+
+### 2.3 Permissions inheritance
+
+When adding a provider, the workspace's existing
+`permissions.readonly` and `permissions.ignored` lists **MUST** be
+preserved. The connect call **MUST NOT** clear or rewrite them.
+
+---
+
+## 3. Synced-Mirror Limitations and User-Visible Mitigations
+
+The default attachment is a poll-and-watch synced mirror. It is *not*
+POSIX, *not* atomic with the source of truth, and *not* a kernel
+filesystem. The contract makes the gap explicit and ships mitigations
+the user can see.
+
+### 3.1 Honest naming
+
+- `relayfile mount` **MUST** print on start:
+  `Mirror started at <local-dir>. Sync interval 30s ±20%. Type
+  'relayfile status' for live state.`
+- The default flag is `--mode=poll` and the help text **MUST** say
+  "synced mirror (recommended)" rather than implying real-time POSIX
+  semantics. `--mode=fuse` remains opt-in.
+
+### 3.2 Sync state file
+
+Every mirror directory **MUST** contain a machine-readable
+`.relay/state.json` updated atomically after each cycle:
+
+```json
+{
+  "workspaceId": "ws_abc",
+  "mode": "poll",
+  "lastReconcileAt": "2026-05-02T18:34:11Z",
+  "lastEventAt":     "2026-05-02T18:34:08Z",
+  "intervalMs": 30000,
+  "providers": [
+    { "provider": "notion", "status": "ready", "lagSeconds": 4,
+      "deadLetteredOps": 0, "lastError": null }
+  ],
+  "pendingWriteback": 0,
+  "pendingConflicts": 0,
+  "deniedPaths": 0
+}
+```
+
+Plus:
+
+- `.relay/conflicts/` — one file per unresolved conflict (§8.3).
+- `.relay/dead-letter/` — one file per dead-lettered writeback op (§8.4).
+- `.relay/permissions-denied.log` — append-only log of denied reads/writes.
+
+These directories **MUST NOT** be mirrored back to the Cloud and
+**MUST** be excluded by the file watcher (already enforced in
+`internal/mountsync/file_watcher.go`).
+
+### 3.3 `relayfile status`
+
+`relayfile status [WORKSPACE]` **MUST** print a one-screen summary built
+from the Cloud `/sync` endpoint and `.relay/state.json`:
+
+```
+workspace ws_abc (my-project)   mode: poll   lag: 4s
+  notion       ready    214 files   last event 4s ago
+  github       syncing  2,318/2,400 last event just now (lag 18s)
+  linear       error    last error: 401 invalid_grant (3 min ago)
+
+pending writebacks: 0    conflicts: 0    denied: 12 (see .relay/permissions-denied.log)
+```
+
+`--json` **MUST** emit the same shape for scripts.
+
+### 3.4 Writeback semantics from the mirror
+
+Local edits are **eventually** propagated. The contract is:
+
+1. The watcher debounces 100 ms and queues a write.
+2. The syncer batches writes; the bulk endpoint
+   (`POST /v1/workspaces/{id}/fs/bulk`) is used when ≥ `bulkFlushThreshold`
+   files are pending or the cycle ends.
+3. Each file write carries the `If-Match: <baseRevision>` header. A 409
+   produces a `ConflictError` and the file is moved to
+   `.relay/conflicts/<path>.<rev>.local` while the remote copy is
+   re-fetched into the original path. The CLI **MUST** print:
+   `conflict at notion/Docs/A.md — your edit saved at .relay/conflicts/…`.
+4. A 403/permission denial flips `WriteDenied=true` with a `DeniedHash`
+   so retries only fire after the user changes the file. The denial is
+   appended to `.relay/permissions-denied.log`.
+5. On success the syncer rewrites the tracked revision.
+
+### 3.5 Refresh and force-pull
+
+- `relayfile pull [PATH]` **MUST** force a reconcile of the given subtree
+  (default: workspace root), discarding local non-dirty files that no
+  longer exist remotely and re-fetching the rest.
+- Files marked dirty (locally modified, not yet acknowledged) **MUST NOT**
+  be discarded by `pull`; they end up in `.relay/conflicts/` only when a
+  remote write would otherwise overwrite them.
+
+### 3.6 What the mirror does not provide
+
+The CLI's `relayfile mount --help` and the agent skill's loaded
+documentation **MUST** state plainly:
+
+- File handles are not stable across syncs; an editor that holds a file
+  open during a remote update will see content change underneath it on
+  the next reconcile.
+- `mtime` reflects the local write time, not the source-of-truth event
+  time. Use `.relay/state.json` for ordering.
+- Directory listings can briefly omit a newly created remote file until
+  the next reconcile (default 30 s) or a websocket event invalidates the
+  cache.
+- `inotify`/`fsevents` watchers downstream of the mirror will see
+  synthetic create events on every reconcile of new content; debounce
+  ≥ 1 s if a downstream tool requires single-shot events.
+
+These limitations are accepted; mitigations are §3.2–§3.5.
+
+---
+
+## 4. Daemon and Background Behavior
+
+### 4.1 Foreground first
+
+`relayfile setup` and `relayfile mount` **MUST** run in the foreground
+by default — exactly as a developer expects from a CLI. Ctrl-C
+**MUST** flush pending writes for ≤ 5 s, persist `.relay/state.json`,
+and exit cleanly. There is no implicit daemon in v1.
+
+### 4.2 Background command
+
+The CLI **MUST** expose:
+
+```
+relayfile mount --background [WORKSPACE] [LOCAL_DIR]   # detach from terminal
+relayfile mount --pid-file PATH                          # write pid for supervision
+relayfile stop  [WORKSPACE]                              # signal the running mount
+```
+
+`--background` **MUST**:
+
+- On macOS/Linux: `fork()` + `setsid()`, redirect stdio to
+  `${localDir}/.relay/mount.log` (rotated at 10 MB × 3), and write the
+  pid to `${localDir}/.relay/mount.pid`.
+- On Windows: spawn a detached child process; same pid/log layout.
+
+The CLI **MUST NOT** install system services (launchd plist, systemd
+unit, Windows service) implicitly. A `relayfile install-service` command
+is out of scope for v1 and **MUST** be tracked separately if requested.
+
+### 4.3 Platform assumptions
+
+| Platform           | Supported in v1 |
+|--------------------|-----------------|
+| macOS 12+ (arm64/x64) | yes          |
+| Linux (glibc, kernel 5.4+) | yes     |
+| Windows 10/11 (x64)        | yes     |
+| WSL2                       | yes     |
+| Alpine / musl              | best-effort, untested |
+| Docker without `--privileged` | yes (poll only — FUSE refused with a clear error) |
+
+The CLI **MUST** detect when `RELAYFILE_MOUNT_FUSE=1` is set on a
+platform without FUSE and exit 50 with: `fuse mode is not available in
+this build; rerun with --mode=poll`.
+
+### 4.4 Supervision contract
+
+A running mount process **MUST**:
+
+- Re-establish the websocket on disconnect with exponential backoff
+  capped at 30 s.
+- Continue polling at the configured interval even when the websocket
+  is down (degrading gracefully to poll-only).
+- Persist `.relay/state.json` after every cycle and on graceful exit.
+- Detect token expiry and trigger §5 rejoin without dropping the
+  process.
+
+If the mount cannot make progress for ≥ 10 minutes (no successful
+reconcile), it **MUST** log
+`mount stalled: <reason>` to stderr/log, but **MUST NOT** exit unless
+the user sends SIGTERM. Stall reasons populate `.relay/state.json`.
+
+---
+
+## 5. Token Refresh and Workspace Rejoin Semantics
+
+Long-lived mounts span hours to weeks. Tokens do not. The contract has
+two layers: Cloud login tokens (user identity) and Relayfile VFS tokens
+(workspace access).
+
+### 5.1 Credential files
+
+- `~/.relayfile/cloud-credentials.json` (`0600`):
+  ```json
+  {
+    "apiUrl": "https://agentrelay.com/cloud",
+    "accessToken": "...",
+    "refreshToken": "...",
+    "accessTokenExpiresAt":  "2026-05-03T18:00:00Z",
+    "refreshTokenExpiresAt": "2026-05-09T18:00:00Z",
+    "updatedAt":             "2026-05-02T18:00:00Z"
+  }
+  ```
+- `~/.relayfile/credentials.json` (`0600`):
+  ```json
+  {
+    "server": "https://api.relayfile.dev",
+    "token":  "<JWT for workspace>",
+    "updatedAt": "2026-05-02T18:00:00Z"
+  }
+  ```
+- `~/.relayfile/workspaces.json`: catalog with `default` and per-name
+  `id`, `createdAt`, `lastUsedAt`.
+
+### 5.2 Cloud token refresh
+
+The CLI **MUST** treat a Cloud access token as expired when
+`now ≥ accessTokenExpiresAt - 60s`. Refresh **MUST** call
+`POST ${apiUrl}/api/v1/auth/token/refresh` with the refresh token and
+**MUST**:
+
+- Persist the new token set atomically (write temp file, rename).
+- Coalesce concurrent refresh attempts inside a single CLI process.
+- Surface a `403 invalid_grant` as `error: cloud session expired. Run
+  'relayfile login' to sign in again.` and exit 10. The mount process
+  **MUST** keep running on the existing VFS token until that token also
+  expires.
+
+### 5.3 Relayfile VFS token rejoin
+
+The Relayfile VFS token used by the mount **MUST** be refreshed by
+re-issuing the workspace `join` call:
+
+```
+POST ${cloud-api-url}/api/v1/workspaces/{id}/join
+  { "agentName": "relayfile-cli", "scopes": ["fs:read","fs:write"] }
+```
+
+Triggers:
+
+- The mount **MUST** preemptively rejoin when the JWT's `exp` is within
+  10 % of its lifetime, with a floor of 5 minutes.
+- Any 401/403 from a Relayfile API call **MUST** trigger a single
+  rejoin attempt before the call is retried. A second 401 fails the
+  cycle and is logged.
+
+The rejoin **MUST**:
+
+- Use the Cloud access token (refreshing it first if needed per §5.2).
+- Replace the on-disk `credentials.json` atomically.
+- Update the in-memory token of the running syncer/HTTP client without
+  killing the process or losing the websocket.
+
+The SDK (`@relayfile/sdk`'s `RelayfileSetup` / `WorkspaceHandle`) **MUST**
+expose this refresh as `await handle.refreshToken()` and **MUST** call
+it automatically when the token age exceeds 55 minutes.
+
+### 5.4 What the user can lose
+
+If the refresh token also expires (default 7 days), the mount **MUST**:
+
+- Continue serving local reads from disk (already-synced state).
+- Refuse local writes for affected paths and place them in
+  `.relay/permissions-denied.log` with reason `cloud_session_expired`.
+- Print one stderr line per minute (capped) directing the user to run
+  `relayfile login`. This is the only condition under which v1 mounts
+  enter a degraded read-only state.
+
+---
+
+## 6. Cloud Provider Catalog and Nango Config-Key Source of Truth
+
+### 6.1 Single source of truth
+
+The list of supported providers and their Nango `providerConfigKey`
+mapping **MUST** live in **one** place: the Cloud package
+`packages/web/lib/integrations/providers.ts`, exporting
+`WORKSPACE_INTEGRATION_PROVIDERS` and a pure function
+`getProviderConfigKey(provider)` (already used in
+`app/api/v1/workspaces/[workspaceId]/integrations/connect-session/route.ts`).
+
+The Relayfile CLI and the SDK **MUST NOT** hardcode their own provider
+list. Both **MUST** load the catalog at runtime from
+`GET ${cloud-api-url}/api/v1/integrations/catalog` (added in v1) which
+returns:
+
+```json
+{
+  "providers": [
+    { "id": "github",            "displayName": "GitHub",   "configKey": "github-sage",            "vfsRoot": "/github" },
+    { "id": "notion",            "displayName": "Notion",   "configKey": "notion-sage",            "vfsRoot": "/notion" },
+    { "id": "linear",            "displayName": "Linear",   "configKey": "linear-sage",            "vfsRoot": "/linear" },
+    { "id": "slack-sage",        "displayName": "Slack",    "configKey": "slack-sage",             "vfsRoot": "/slack" },
+    { "id": "slack-my-senior-dev","displayName":"Slack (MSD)","configKey":"slack-my-senior-dev",   "vfsRoot": "/slack-msd" },
+    { "id": "slack-nightcto",    "displayName":"Slack (NightCTO)","configKey":"slack-nightcto",    "vfsRoot": "/slack-nightcto" }
+  ],
+  "version": "<sha-of-providers.ts>"
+}
+```
+
+The CLI and SDK **MUST** cache the catalog for 1 hour and **MUST**
+revalidate when an integration `connect-session` returns
+`409 unknown_provider`.
+
+### 6.2 v1 provider list
+
+For v1 the catalog **MUST** include exactly the providers in
+`WORKSPACE_INTEGRATION_PROVIDERS`:
+`github`, `notion`, `linear`, `slack-sage`, `slack-my-senior-dev`,
+`slack-nightcto`. `slack` (the bare alias) **MUST** be accepted as
+input by the CLI prompt but normalized to `slack-sage` before any API
+call.
+
+### 6.3 Nango key constraints
+
+- The Cloud route **MUST** be the only caller of Nango's secret key.
+  CLI/SDK **MUST NEVER** receive a Nango secret directly.
+- `connect-session` responses **MUST** always include a `connectionId`
+  string (v1 already enforces this). The CLI **MUST** persist it under
+  `.relay/integrations/<provider>.json` so future readiness checks use
+  the connection id, not the workspace id, when available.
+- Adding a new provider in v1.x **MUST** require a single PR to
+  `providers.ts`; downstream catalog consumers pick it up
+  automatically on the next refresh.
+
+### 6.4 Provider deprecation
+
+Removing or renaming a provider **MUST**:
+
+- Bump the catalog `version`.
+- Mark the old id `deprecated: true` for at least 30 days before
+  removal.
+- Cause `relayfile integration list` to render a warning row when
+  any deprecated provider is connected.
+
+---
+
+## 7. Initial Sync and Readiness Semantics After OAuth
+
+### 7.1 Readiness states
+
+For each connected provider the Cloud `/sync` endpoint
+(`GET /api/v1/workspaces/{id}/sync`) returns one of:
+
+| Status      | Meaning                                                                |
+|-------------|-------------------------------------------------------------------------|
+| `pending`   | Nango connection accepted; initial cataloging not yet started           |
+| `cataloging`| Listing remote objects                                                  |
+| `syncing`   | Materializing files into the VFS                                        |
+| `ready`     | Initial sync complete; subsequent updates are incremental               |
+| `error`     | Last attempt failed; `lastError` is populated                           |
+| `degraded`  | Watermark older than 10 min and increasing; still serving stale data    |
+
+Each provider entry **MUST** include `lagSeconds`, `failureCodes`,
+`deadLetteredEnvelopes`, `deadLetteredOps`, and a stable monotonic
+`watermarkTs`.
+
+### 7.2 CLI behavior after connect
+
+After `connect-session` returns `ready=true`:
+
+1. The CLI **MUST** poll `/sync` every 2 s.
+2. The CLI **MUST** consider the integration ready when **all** of:
+   - Provider `status == "ready"`, **or**
+   - `status == "syncing"` with `lagSeconds < 30` and at least one file
+     materialized under `/<provider>/`.
+3. The default deadline is `--connect-timeout` (5 m). On timeout the
+   CLI **MUST** print: `notion still syncing in the background. Files
+   will continue to populate. See 'relayfile status'.` and exit 0 (the
+   workspace and mount are still usable; sync will catch up).
+4. While polling, the CLI **MUST** print a one-line progress update at
+   most every 5 s.
+
+### 7.3 Mount behavior on first connect
+
+The mount loop **MUST**:
+
+- Treat a provider in `cataloging`/`syncing` as authoritative — it does
+  not delete local files for a provider whose status is not `ready` even
+  if a remote tree page comes back empty. This prevents the mirror from
+  flapping while the source-of-truth is still being indexed.
+- Resume normal reconcile semantics once the provider transitions to
+  `ready`.
+
+### 7.4 Webhook readiness
+
+OAuth completion does not guarantee that the provider's webhook is
+delivering events. The Cloud **MUST** include in the `/sync` response a
+boolean `webhookHealthy` per provider. If `false` and `lagSeconds >
+60`, the CLI **MUST** display a warning: `notion webhook unhealthy —
+falling back to periodic sync (lag 78 s)`.
+
+---
+
+## 8. Writeback Safety, Schema Validation, Conflicts, Dead-Letter
+
+### 8.1 Writeback path conventions
+
+Each adapter declares two kinds of paths:
+
+- **Read-only paths.** Materialized from upstream. Local edits are
+  refused at the Cloud and recorded as denials.
+- **Writeback paths.** A write here triggers the adapter's
+  `writeback` handler, which calls the upstream API.
+
+Write-allowed paths **MUST** be advertised in
+`/<provider>/_PERMISSIONS.md` (already a convention) and in the catalog
+response (§6.1) under each provider's `vfsRoot`. The CLI surfaces them
+via `relayfile permissions [PATH]`.
+
+### 8.2 Schema validation
+
+For writeback paths whose adapter declares a schema (e.g. JSON files
+under `/github/repos/*/pulls/*/reviews/*.json`), the Cloud **MUST**
+validate the body before accepting the write. A schema violation
+returns `400 schema_validation_failed` with a structured `errors` array.
+
+The CLI **MUST**:
+
+- Surface the violation immediately on the offending file:
+  `error at github/repos/.../review.json: body.event must be one of
+  APPROVE,REQUEST_CHANGES,COMMENT (line 3)`.
+- Move the offending file to
+  `.relay/conflicts/<path>.invalid.<ts>` so the user can edit it
+  without breaking the next sync cycle.
+- Re-fetch the previous remote version into the original path.
+
+### 8.3 Conflict semantics
+
+A conflict is a 409 returned by `PUT /fs/file` or by an entry in
+`POST /fs/bulk`'s `errors[]` with `code: "conflict"`. The CLI **MUST**:
+
+1. Save the local body verbatim to
+   `.relay/conflicts/<path>.<localRev>.local`.
+2. Re-fetch the remote into `<path>` and update the tracked revision.
+3. Increment `pendingConflicts` in `.relay/state.json`.
+4. Print: `conflict at <path>. Yours saved at .relay/conflicts/<…>;
+   remote refreshed in place. Resolve by editing <path> and saving.`.
+
+A conflict is cleared when the user's next save succeeds against the
+new revision; the `.relay/conflicts/<…>.local` file is moved to
+`.relay/conflicts/resolved/` for audit.
+
+### 8.4 Dead-letter visibility
+
+If the Cloud returns a non-retryable error (4xx other than 409/429,
+or a 5xx after the configured retries), the writeback **MUST** be
+dead-lettered. The Cloud `/sync` response surfaces
+`deadLetteredOps` per provider. The CLI **MUST**:
+
+- Mirror each dead-lettered op as a JSON record in
+  `.relay/dead-letter/<id>.json`:
+  ```json
+  { "opId": "op_…", "path": "/github/.../review.json",
+    "code": "validation_error", "message": "body must include event",
+    "createdAt": "…", "lastAttemptedAt": "…", "attempts": 3,
+    "replayUrl": "https://…/v1/workspaces/<id>/ops/op_…/replay" }
+  ```
+- Provide `relayfile ops list` and `relayfile ops replay <opId>` that
+  call `POST /v1/workspaces/{id}/ops/{opId}/replay`. On success the
+  local `.relay/dead-letter/<id>.json` is deleted.
+
+### 8.5 Idempotency keys
+
+The CLI **MUST** include `X-Correlation-Id` on every API call (already
+implemented in `mountsync.HTTPClient.doJSON`). For writeback, the
+adapter contract requires an idempotency key derived from
+`(workspaceId, path, baseRevision, sha256(content))`; the Cloud rejects
+duplicates with `200 already_applied`. The CLI **MUST** treat that as
+success.
+
+---
+
+## 9. Agent Skill Contract
+
+This section defines what the `relayfile-workspace` skill — and any
+agent harness using the SDK — **MUST** rely on. It is the
+agent-visible portion of the contract.
+
+### 9.1 Mount discovery
+
+An agent **MUST** discover its workspace mount in this priority order:
+
+1. `$RELAYFILE_LOCAL_DIR` — always wins when set.
+2. The directory printed by `relayfile status --json` as
+   `.providers[*].localDir` (single workspace) or, for the default
+   workspace, `.localDir`.
+3. The first directory upward from CWD containing a `.relay/state.json`.
+
+The skill **MUST** fail loud if none of the above resolves:
+`relayfile mount not found. Run 'relayfile setup' or set
+RELAYFILE_LOCAL_DIR.`.
+
+### 9.2 Path conventions
+
+The agent **MUST** treat the following paths as authoritative:
+
+```
+<mount>/<provider>/...           # source-of-truth materialized files
+<mount>/<provider>/_PERMISSIONS.md  # writeback rules for this provider
+<mount>/.relay/state.json         # sync state
+<mount>/.relay/conflicts/         # unresolved conflicts (human-fixable)
+<mount>/.relay/dead-letter/       # failed writebacks
+<mount>/.relay/permissions-denied.log
+```
+
+The agent **MUST NOT**:
+
+- Write into `<mount>/.relay/`.
+- Delete or rename top-level provider directories.
+- Trust `mtime` — use `state.json.lastReconcileAt` and provider
+  `lagSeconds` for ordering decisions.
+
+### 9.3 Status awareness
+
+Before performing any non-trivial read or any write, an agent **SHOULD**:
+
+1. Read `.relay/state.json`.
+2. Skip or warn when the relevant provider's `status != "ready"` or
+   `lagSeconds > 60`.
+3. After writing a file, poll `state.json` until either
+   `pendingWriteback == 0` or the file appears in
+   `.relay/conflicts/`/`.relay/dead-letter/`.
+
+The skill loader **MUST** provide a helper
+`waitForWriteback(path, { timeoutMs })` that implements this poll.
+
+### 9.4 Safe edits
+
+Writes **MUST** follow this shape:
+
+1. `read` the current file (capture revision via `state.json` or
+   `getFile` SDK call).
+2. Mutate locally.
+3. Save. The mirror's watcher uploads with `If-Match` automatically.
+4. Wait for ack per §9.3.
+5. On conflict, re-read the remote, re-apply the diff, save again. Do
+   **not** delete the local conflict file unless the agent explicitly
+   chose to drop its edit.
+
+Writes that produce JSON **MUST** be validated against the adapter
+schema printed in `_PERMISSIONS.md` (or fetched from the catalog) before
+saving, to surface schema errors locally rather than via a dead-letter
+round-trip.
+
+### 9.5 Multi-agent coordination
+
+When two agents share a mount (the relayfile-workspace skill scenario),
+they **MUST** treat `.relay/conflicts/` as a coordination signal —
+seeing a conflict on a path another agent owns is the trigger to back
+off, not to overwrite. The contract explicitly permits using
+`agent-relay` channels for additional coordination but does not require
+it.
+
+---
+
+## 10. End-to-End Acceptance Tests
+
+The acceptance tests **MUST** live alongside existing CLI tests and run
+against realistic mocks of Cloud, Nango, and Relayfile services.
+
+### 10.1 Mock services
+
+- **Mock Cloud** — `httptest` server in Go (CLI tests) and a
+  `node:http` server in TS (SDK tests) implementing `/api/v1/cli/login`,
+  `/api/v1/auth/token/refresh`, `/api/v1/workspaces`,
+  `/api/v1/workspaces/{id}/join`,
+  `/api/v1/workspaces/{id}/integrations/connect-session`,
+  `/api/v1/workspaces/{id}/integrations/{provider}/status`,
+  `/api/v1/workspaces/{id}/sync`, `/api/v1/integrations/catalog`.
+- **Mock Nango** — already exists at
+  `tests/helpers/mock-nango-sdk-server.ts`. v1 reuses it and adds a
+  webhook simulator path.
+- **Mock Relayfile** — `httptest` server delivering `/v1/.../fs/tree`,
+  `/fs/file`, `/fs/bulk`, `/fs/events`, `/fs/export`, `/sync`, `/ops`.
+  This expands the existing fixtures in `cmd/relayfile/*_test.go` and
+  `internal/mountsync/*_test.go`.
+
+### 10.2 Required acceptance scenarios
+
+Each scenario **MUST** be a single test function that fails the build
+if the contract is violated. Listed by area with the file each test
+lives in.
+
+| # | Scenario                                                                | File                                              |
+|---|--------------------------------------------------------------------------|---------------------------------------------------|
+| A1 | `relayfile setup` happy path with `--cloud-token` (no browser): creates workspace, connects github, waits for sync ready, mount runs one cycle, exits 0 with `--once`. | `cmd/relayfile/setup_e2e_test.go`                |
+| A2 | `relayfile setup` with browser flow, state mismatch returns exit 10.    | `cmd/relayfile/setup_e2e_test.go`                |
+| A3 | `relayfile setup` re-run with same `--workspace` reuses local id, refreshes token, skips connect when integration status is already ready. | `cmd/relayfile/setup_e2e_test.go`                |
+| A4 | `relayfile integration connect notion` after setup: workspace gains `/notion` subtree without restarting mount. | `cmd/relayfile/integration_e2e_test.go`          |
+| A5 | Mirror conflict: local edit + remote edit with new revision yields `.relay/conflicts/<path>.<rev>.local` and a refreshed local file. | `internal/mountsync/syncer_conflict_test.go`     |
+| A6 | Schema validation failure on writeback: file lands in `.relay/conflicts/<path>.invalid.<ts>`, original restored, exit code 0 in CLI status. | `internal/mountsync/syncer_writeback_test.go`    |
+| A7 | Dead-letter surfacing: a 422 from Cloud during writeback creates `.relay/dead-letter/<opId>.json`; `relayfile ops replay` clears it on success. | `cmd/relayfile/ops_e2e_test.go`                  |
+| A8 | Token refresh: VFS token expires mid-mount; mount calls `/join` with the cloud access token, replaces credentials, continues without dropping websocket. | `internal/mountsync/syncer_refresh_test.go`      |
+| A9 | Cloud refresh token expired: mount enters read-only degraded state, prints recovery instruction once per minute, no exit. | `internal/mountsync/syncer_refresh_test.go`      |
+| A10 | Initial sync gate: Cloud reports `cataloging`; CLI waits, polls `/sync`, exits 0 once `ready`. With a forced timeout it exits 0 with the resume hint. | `cmd/relayfile/setup_e2e_test.go`                |
+| A11 | Webhook unhealthy: Cloud returns `webhookHealthy=false, lagSeconds=80`; `relayfile status` includes the warning row. | `cmd/relayfile/status_e2e_test.go`               |
+| A12 | Catalog refresh: a new provider appears in the mocked `/integrations/catalog`; CLI accepts it within 1 h or after a 409 forces revalidation. | `cmd/relayfile/catalog_test.go`                  |
+| A13 | Synced-mirror honesty: `relayfile mount` start banner mentions `synced mirror` and the 30 s interval; `--help` shows the limitations from §3.6. | `cmd/relayfile/mount_help_test.go`               |
+| A14 | Background mode: `relayfile mount --background` writes `mount.pid` and `mount.log`; `relayfile stop` signals it cleanly within 5 s. | `cmd/relayfile/background_test.go`               |
+| A15 | SDK parity: `RelayfileSetup.login + createWorkspace + connectNotion + waitForNotion + client()` against the same mock cloud yields a usable client. | `tests/sdk/setup-e2e.test.ts`                    |
+| A16 | Multi-agent coordination: two `WorkspaceHandle` instances writing to disjoint paths via the bulk endpoint never see false conflicts; writing to the same path produces a deterministic `.relay/conflicts/` entry on one side. | `tests/sdk/multi-agent.test.ts`                  |
+
+### 10.3 Test data realism rules
+
+Tests **MUST**:
+
+- Use real provider ids from §6.2 — no fake placeholders.
+- Use real Nango envelope shapes from
+  `tests/nango-webhook-router-fanout.test.ts` and
+  `tests/relayfile-provider-writeback.e2e.test.ts`.
+- Exercise the bulk write path (`/fs/bulk`) for any test that writes
+  more than one file, matching the CLI's actual batching behavior.
+- Run with `RELAYFILE_LOG=debug` and assert structured log lines for
+  the steps above. No test relies on stderr text alone.
+
+### 10.4 CI gate
+
+The `relayfile` repo's CI pipeline **MUST** run all A1–A16 scenarios on
+every PR that touches `cmd/relayfile/**`, `internal/mountsync/**`,
+`packages/sdk/src/setup*`, or `packages/sdk/src/cloud-login.ts`. A
+failure of any acceptance test blocks merge.
+
+---
+
+## Summary of Producible Artifacts (v1)
+
+The contract is implementable by shipping:
+
+1. CLI: `setup`, `integration {connect,list,disconnect}`, `pull`,
+   `status (extended)`, `permissions`, `ops {list,replay}`, `mount
+   --background`, `stop`. Behavior changes in `mountsync` for the
+   `.relay/state.json` writer, conflicts/dead-letter directories, and
+   token rejoin.
+2. SDK: `RelayfileSetup` already covers most of §5; adds
+   `WorkspaceHandle.refreshToken` automatic invocation,
+   `agentInvite()` carrying `vfsRoot` from the catalog, and a
+   `waitForWriteback(path)` helper.
+3. Cloud: `GET /api/v1/integrations/catalog`, extended `/sync` response
+   (`webhookHealthy`, `deadLetteredOps`), `POST /ops/{id}/replay`,
+   and unchanged `/connect-session` / `/join` semantics.
+4. Skill: `relayfile-workspace` skill loads §9 verbatim and provides
+   `waitForWriteback`, `readState`, and `enforceProviderReady` helpers.
+5. Tests: A1–A16 plus the existing test suite.
+
+PRODUCTIZED_CLOUD_MOUNT_CONTRACT_READY

--- a/docs/productized-cloud-mount-review-verdict.md
+++ b/docs/productized-cloud-mount-review-verdict.md
@@ -1,0 +1,419 @@
+# Productized Cloud Mount — Final Review Verdict
+
+**Date:** 2026-05-02
+**Reviewer scope:** `docs/productized-cloud-mount-contract.md` (v1 contract),
+`docs/evidence/productized-cloud-mount-final-evidence.md`, the changed
+relayfile files (`cmd/relayfile-cli/main.go`,
+`cmd/relayfile-cli/productized_cloud_mount_e2e_test.go`,
+`cmd/relayfile-cli/daemon_unix.go`/`daemon_windows.go`,
+`cmd/relayfile-cli/main_test.go`, `internal/mountsync/syncer.go`,
+`internal/mountsync/syncer_test.go`, `cmd/relayfile-mount/main.go`),
+the cloud-side test slice referenced in the evidence, and the
+verification output (Go, SDK typecheck, cloud test+typecheck) recorded
+with `RELAYFILE_PRODUCTIZED_MOUNT_VERIFY_OK` and
+`CLOUD_PRODUCTIZED_MOUNT_VERIFY_OK`.
+
+**Verdict:** **Conditional pass.** The product vision (synced-mirror-first
+guided setup with honest sync state, token rejoin, and conflict
+visibility) is implemented and end-to-end provable. Several normative
+contract surfaces (`pull`, `permissions`, `ops list/replay`, schema
+validation artifacts, webhook-unhealthy status rendering, catalog
+caching/409 revalidation, refresh-token-expiry degraded mode, A2/A6/A7/
+A9/A11–A14/A16 acceptance tests) are still missing or only partially
+covered. None of the gaps are blockers for an internal/early-access
+launch, but they MUST be resolved before a public v1 launch.
+
+---
+
+## 1. Does the implementation satisfy the original product vision?
+
+**Mostly yes.**
+
+What landed and matches the contract:
+
+- `relayfile` with no args dispatches to `runSetup`
+  (`cmd/relayfile-cli/main.go:304-311`), and `setup` accepts the
+  documented flags (`--cloud-api-url`, `--cloud-token`, `--workspace`,
+  `--provider`, `--local-dir`, `--no-open`, `--skip-mount`, `--once`,
+  `--login-timeout`, `--connect-timeout`) at `main.go:385-414`.
+- The required ordered steps (intent print → cloud login → workspace
+  name → provider → local dir → workspace create+join → integration
+  connect → initial sync gate → mount) are all present
+  (`runSetup`, `ensureCloudCredentials`, `ensureWorkspaceForSetup`,
+  `joinWorkspaceViaCloud`, `connectCloudIntegration`,
+  `waitForInitialSync`, `runMount`).
+- Idempotency on re-run: `ensureWorkspaceForSetup` reuses the locally
+  tracked id; `ensureCloudIntegration` skips connect when status
+  already returns ready; the join is re-issued each setup (refreshing
+  the VFS token). `setup` is therefore idempotent per §1.4.
+- Multi-integration commands exist (`relayfile integration connect | list
+  | disconnect`, `main.go:1075-1336`) and the mock E2E test exercises
+  `connect notion` after a `setup --provider github` and confirms both
+  appear in `integration list --json`.
+- Synced-mirror-first banner (`runMountLoop` at `main.go:3579`) prints
+  `Mirror started at <dir>. Sync interval <d> ±<n>%. Type 'relayfile
+  status' for live state.` matching §3.1.
+- `.relay/state.json`, `.relay/conflicts/`, `.relay/dead-letter/`, and
+  `.relay/permissions-denied.log` directory layout is created by the
+  syncer (`internal/mountsync/syncer.go:520-562`).
+- Background daemon: `relayfile mount --background` spawns a detached
+  child via `spawnBackgroundMountProcess` with `Setsid`
+  (`daemon_unix.go`), writes `mount.pid` and `mount.log`, and `relayfile
+  stop` SIGTERMs it (`main.go:1915-1939`). `relayfile logs` tails the
+  log file. Per-platform detach is implemented in
+  `daemon_unix.go`/`daemon_windows.go`.
+- Cloud token refresh at 60s pre-expiry (`cloudAccessTokenExpiredSoon`,
+  `main.go:600-608`); refresh `403 invalid_grant` is mapped to the
+  documented "cloud session expired. Run 'relayfile login' to sign in
+  again." (`refreshCloudCredentials`, `main.go:611-643`).
+- Workspace rejoin at 10% of JWT lifetime / 5 min floor
+  (`relayfileTokenNeedsRefresh`, `main.go:3162-3184`) and on
+  401/403 (`isMountAuthError` + `withAuthRefresh`,
+  `main.go:3205-3211`/`3526-3542`).
+
+What is missing or only partially landed against the contract:
+
+- **`relayfile pull [PATH]`** (§3.5) — not implemented. There is no
+  `pull` subcommand in `run`'s dispatch table.
+- **`relayfile permissions [PATH]`** (§8.1) — not implemented.
+- **`relayfile ops list` / `relayfile ops replay <opId>`** (§8.4) —
+  not implemented; the dead-letter directory is created but never
+  written to or surfaced.
+- **Schema validation surfacing** (§8.2): the syncer never recognizes
+  `400 schema_validation_failed`, never moves the offending file to
+  `.relay/conflicts/<path>.invalid.<ts>`, and never re-fetches the
+  prior remote into the original path.
+- **Webhook unhealthy warning row** (§7.4 / acceptance A11): the
+  `webhookHealthy` field is plumbed into `syncProviderStatus`
+  (`main.go:235`) but `runStatus` text output (`main.go:1888-1902`)
+  never renders the warning. The JSON path passes the field through.
+- **Catalog cache + 409 revalidation** (§6.1): `loadIntegrationCatalog`
+  fetches `/api/v1/integrations/catalog` per call with no 1-hour cache
+  and no special handling of `409 unknown_provider`.
+- **Per-minute degraded read-only stderr cadence** (§5.4 / A9): when
+  the refresh token itself expires the mount keeps running on the
+  in-memory token and logs once per failed refresh, but there is no
+  explicit "read-only degraded" mode with `cloud_session_expired`
+  reason in `.relay/permissions-denied.log` and no rate-limited
+  recovery message every minute.
+
+Summary: the product **shape** is correct and a user can run
+`relayfile setup` against a real Cloud and end up in the documented
+state. The product **surface area** the contract promises (pull,
+permissions, ops, schema-aware conflicts, webhook-aware status) is
+not all there yet.
+
+---
+
+## 2. Are synced-mirror drawbacks mitigated and visible?
+
+**Largely yes, with two visibility gaps.**
+
+Working as advertised:
+
+- The mount loop prints the synced-mirror banner with the cycle
+  interval and jitter on every start (`main.go:3579`). `--mode=poll`
+  is the default; FUSE remains opt-in.
+- `.relay/state.json` is rewritten by `writeSnapshot` after every
+  cycle, every local change, and on graceful exit. The schema in the
+  snapshot (`syncStateFile` at `main.go:240-260`, `daemonPIDState` at
+  `:275`) matches §3.2 (mode, lastReconcileAt, intervalMs, providers,
+  pendingWriteback, pendingConflicts, deniedPaths, daemon block).
+- `relayfile status` (`runStatus`, `main.go:1838-1912`) shows mode,
+  per-provider status/lag/last-event/last-error, daemon running/not
+  running, and pending writebacks/conflicts/denied counts. The E2E
+  test asserts the conflict count surfaces correctly after the fix
+  in `main.go` for nested `.relay/conflicts/<provider>/...` artifacts.
+- Conflict artifacts (`.relay/conflicts/<path>.<rev>.local`) are
+  produced by the syncer on 409 (proven by
+  `TestBulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote` and
+  by the productized E2E test).
+- `.relay/permissions-denied.log` and `WriteDenied`/`DeniedHash`
+  bookkeeping prevent retry storms after 403s
+  (`syncer.go:1649,1734,1769,1829-1830`).
+
+Visibility gaps:
+
+- The contract's webhook-unhealthy banner row (§7.4) is **not** part
+  of the human-readable `status` output. A user reading text output
+  will miss a webhook-degraded provider unless they read JSON.
+- `pendingDeadLetter` is not surfaced because no code path writes
+  dead-letter records. `relayfile status` always shows zero, even if
+  the Cloud returns `deadLetteredOps > 0` from `/sync`. The CLI does
+  not mirror `state.providers[*].deadLetteredOps` from the Cloud
+  response into a user-visible "dead-letter: N" row.
+
+These are not invisible-by-default UX failures (JSON consumers can
+read them), but they violate the §3.6/§7.4 promise that the synced
+mirror's limitations are surfaced to the human user.
+
+---
+
+## 3. Is token refresh / rejoin trustworthy for long-lived mounts?
+
+**Conditionally yes.** The mainline path is correct; a few hardening
+items remain.
+
+What is correct:
+
+- Pre-emptive rejoin at 10% of JWT lifetime with a 5-minute floor
+  (`relayfileTokenNeedsRefresh` at `main.go:3162`) — exactly §5.3's
+  trigger.
+- Reactive rejoin on 401/403 with one retry, then surface the error
+  (`withAuthRefresh` at `main.go:3526-3542`) — §5.3 requires "a single
+  rejoin attempt before the call is retried."
+- Cloud token refresh at access-token-expiry-minus-60s
+  (`cloudAccessTokenExpiredSoon`).
+- After a successful rejoin the in-memory `HTTPClient.Token()` is
+  swapped via `httpClient.SetToken(joined.Token)` and the websocket
+  reset (`syncer.ResetWebSocket()`), so the running process keeps its
+  loop without restart — also §5.3.
+- The rejoin uses the cloud access token (refreshing first via
+  `refreshCloudCredentialsIfNeeded`) and then re-issues `/join`. This
+  matches the documented order.
+- The E2E proof test forces this exact sequence: it rejects the
+  current Relayfile token, expires the cloud access token, and then
+  asserts `cloud.RefreshCount() >= 1 && cloud.JoinCount() >= 3` and
+  that the on-disk credentials file was updated to a new token. It
+  also proves the loop continues to materialize a new remote file
+  *after* the swap. This is the strongest part of the proof.
+
+What needs hardening before public launch:
+
+- **Concurrent refresh coalescing inside a single process** is not
+  enforced. `refreshMountAuth` has no mutex around the
+  load/refresh/join/save sequence; if a poll cycle and a file-watcher
+  callback both observe a 401 simultaneously they will both call
+  `/api/v1/auth/token/refresh` and `/join`. The contract (§5.2)
+  explicitly requires coalescing.
+- **Credential file atomicity** is required by §5.2 ("write temp
+  file, rename"). `saveCredentials` and `saveCloudCredentials` need
+  to be audited (and tests added) to confirm they use a temp+rename
+  pattern. The current code path was not exercised under crash/kill
+  in the E2E test.
+- **Refresh-token expiry → read-only degraded** (§5.4) is not
+  implemented. The mount continues serving cached reads (because the
+  Go process never crashes), but it does not actively refuse local
+  writes with a `cloud_session_expired` reason in
+  `.relay/permissions-denied.log` and does not emit the rate-limited
+  per-minute recovery hint. Acceptance A9 is not present in the
+  test suite.
+
+---
+
+## 4. Is Cloud/Nango provider readiness enough for many integrations?
+
+**Adequate for the v1 catalog, not yet for "many".**
+
+Strengths:
+
+- The Cloud is the only Nango secret holder; the CLI never sees a
+  Nango secret directly. `connect-session` returns a `connectionId`
+  the CLI persists and reuses (per §6.3, observed in
+  `productizedCloudMock.serveConnectSession`).
+- `loadIntegrationCatalog` calls
+  `GET /api/v1/integrations/catalog` and falls back to the v1 list
+  hardcoded in `fallbackIntegrationCatalog` (`main.go:689-698`).
+  This proves the catalog endpoint is the intended source of truth.
+- The provider list under §6.2 (github, notion, linear, slack-sage,
+  slack-my-senior-dev, slack-nightcto) is honored by the fallback,
+  and `slack` is normalized to `slack-sage` in `normalizeProviderID`.
+- The Cloud-side route and readiness slice (`tests/sdk-setup-client-routes.test.ts`,
+  `tests/nango-sync-relayfile.test.ts`,
+  `tests/nango-webhook-router-fanout.test.ts`,
+  `tests/relayfile-writeback-bridge.test.ts`) all pass.
+
+Gaps:
+
+- **No 1-hour CLI/SDK cache** (§6.1): every call hits the catalog
+  endpoint. Not a correctness bug, but it doesn't match the
+  contract and makes the CLI noisier than necessary.
+- **No 409 unknown_provider revalidation** (§6.1): the CLI does not
+  bust its catalog cache on a 409 from `connect-session`. With no
+  cache today this is moot; the moment a cache is added it has to
+  ship with the bust path.
+- **Provider deprecation rendering** (§6.4): `relayfile integration
+  list` does not render a warning row for deprecated providers. The
+  catalog response shape has space for `deprecated: true` but the CLI
+  ignores it.
+- **Webhook-readiness signal** (§7.4): plumbed into the struct but
+  not rendered. See §2 above.
+
+Net: adding new providers in v1.x via a single `providers.ts` PR
+will work, but the agent-visible degradation signals (deprecated,
+unhealthy webhook, catalog drift) are not yet wired through the CLI.
+
+---
+
+## 5. Is writeback safe enough for agents?
+
+**Mostly safe for the cases it covers; partial for the cases it does
+not.**
+
+Safe by design:
+
+- All `WriteFile`/`DeleteFile` carry `If-Match: <baseRevision>`
+  (`syncer.go:198,223`). Bulk writes carry per-file revisions.
+- 409 responses produce an artifact at
+  `.relay/conflicts/<path>.<localRev>.local`, the remote is re-fetched
+  in place, and `pendingConflicts` increments — confirmed both in the
+  unit test (`TestBulkWrite_PerFileConflictCreatesArtifactAndRefresh
+  esRemote`) and the productized E2E test.
+- 403/permission denial sets `WriteDenied` + `DeniedHash` so retries
+  only fire after the file content actually changes
+  (`syncer.go:1734`). Denials are appended to
+  `.relay/permissions-denied.log`.
+- `X-Correlation-Id` is included on every call; mountsync's HTTP
+  client and the syncer write the same id through the bulk path.
+
+Not yet safe enough:
+
+- **Schema validation feedback (§8.2)** is missing. A
+  `400 schema_validation_failed` from the Cloud will surface as a
+  generic error rather than the documented `<path>.invalid.<ts>`
+  artifact + remote-restored-in-place behavior. Agents writing JSON
+  payloads (e.g. PR review files) will not see structured field-level
+  errors, only text from a generic HTTP error.
+- **Dead-letter visibility (§8.4)** is missing. The directory is
+  created, but `relayfile ops list` and `relayfile ops replay` are not
+  implemented, and no `.relay/dead-letter/<id>.json` records are ever
+  written by the syncer. A non-retryable 422 will currently fail the
+  cycle silently (logged, not surfaced as a record).
+- **Idempotency-key derivation** (§8.5: `(workspaceId, path,
+  baseRevision, sha256(content))`): not visibly enforced by the syncer
+  beyond `X-Correlation-Id`. The Cloud's `200 already_applied`
+  short-circuit may not be exercised correctly by the current client.
+- **`relayfile permissions [PATH]`** (§8.1) is missing — agents have
+  no programmatic way to check whether a path is writeback-allowed
+  short of trying and waiting for the denial.
+
+For benign integrations (markdown notes, Linear comments) this is
+acceptable. For schema-strict integrations (GitHub PR reviews, Slack
+message formatting) this is a real gap.
+
+---
+
+## 6. Is the E2E proof truly end to end?
+
+**End-to-end for the golden path; not end-to-end for the contract as
+a whole.**
+
+Strong:
+
+- `TestProductizedCloudMountE2EProof` (~250 LOC, single test
+  function) chains: `setup --cloud-token --provider github --once` →
+  remote file appearance in mirror → `integration connect notion` →
+  `integration list --json` asserts both providers → start the real
+  `runMountLoop` → write a remote file, observe locally → write a
+  local file, observe remote round-trip via the bulk endpoint →
+  force a 409 conflict, observe `.relay/conflicts/<provider>/<path>
+  .<rev>.local` → `relayfile status --json` reports the conflict and
+  daemon metadata → expire cloud creds + reject the current Relayfile
+  token → assert `/auth/token/refresh` and `/join` are called and the
+  on-disk credential file flips → cancel the loop → re-run
+  `relayfile mount demo <dir> --once --websocket=false` against the
+  persisted config and prove a newly added remote file is picked up.
+- Both Cloud and Relayfile sides are real `httptest.Server`s, not
+  in-process stubs. The CLI under test calls them through the real
+  `runSetup`/`runMount`/`runIntegration*`/`runStatus` code paths.
+- Cloud-side mocks for Nango/webhook/writeback are exercised by the
+  passing slice (`tests/sdk-setup-client-routes.test.ts`,
+  `tests/nango-sync-relayfile.test.ts`,
+  `tests/nango-webhook-router-fanout.test.ts`,
+  `tests/relayfile-writeback-bridge.test.ts`).
+
+Weak:
+
+- The contract enumerates 16 acceptance scenarios A1–A16 in §10.2.
+  The proof effectively covers A1, A4, A5, A8, A10 (partially) in a
+  single test. **A2** (oauth state mismatch → exit 10), **A6**
+  (schema validation invalid artifact), **A7** (dead-letter +
+  ops replay), **A9** (refresh-token expiry degraded mode),
+  **A11** (webhook unhealthy banner), **A12** (catalog refresh +
+  409 revalidation), **A13** (mount help text + banner contents),
+  **A14** (background pidfile + `relayfile stop` lifecycle),
+  **A15** (SDK `RelayfileSetup` parity), and **A16** (multi-agent
+  coordination through bulk writes) are not covered.
+- The CI gate requirement in §10.4 (block merge on any A1–A16
+  failure) is not implementable today because most of A1–A16 do not
+  exist as separate tests. The single E2E test is the entire gate.
+- Run-restart resilience is proved with `--once`, not with
+  `--background` + `relayfile stop` lifecycle, so the production
+  daemon path is not exercised in the proof.
+- The E2E test does not assert structured log lines under
+  `RELAYFILE_LOG=debug` (a §10.3 requirement).
+
+---
+
+## 7. Residual risks before public launch
+
+In rough priority order:
+
+1. **Missing CLI commands required by the contract**: `relayfile pull`,
+   `relayfile permissions`, `relayfile ops list`, `relayfile ops replay`.
+   Until these ship, the contract's writeback recovery and force-pull
+   stories are not user-reachable. This is the largest gap.
+2. **Dead-letter pipeline is empty**: the directory exists but nothing
+   writes records or replays them. A 4xx from the Cloud during
+   writeback will be silently lost from the user's perspective.
+3. **Schema-validation conflict path missing**: structured 400s do not
+   become `<path>.invalid.<ts>` artifacts. Agents writing JSON to
+   schema-validated paths get poor failure UX.
+4. **`webhookHealthy` not rendered in human status output**: silent
+   webhook degradation slips through. Easy fix.
+5. **Catalog 1-hour cache + 409 revalidation not enforced**: violates
+   §6.1, will become visible the moment the catalog is iterated.
+6. **Refresh-token expiry → degraded read-only (A9) not implemented**:
+   long-lived mounts after a 7-day session will keep accepting writes
+   that silently fail rather than refusing them with a documented
+   reason and a per-minute recovery hint.
+7. **Concurrent refresh coalescing not enforced**: under
+   websocket-reconnect plus a poll cycle racing on a 401, two
+   simultaneous `/auth/token/refresh` + `/join` round-trips can fire.
+   Adds a soft race on Cloud and a brief window where two valid
+   workspace tokens exist.
+8. **Credential-file write atomicity** (`saveCredentials` /
+   `saveCloudCredentials`) needs an explicit temp+rename audit and a
+   crash-safety test. The contract requires it; the E2E test does
+   not exercise it.
+9. **Acceptance scenarios A2/A6/A7/A9/A11/A12/A13/A14/A15/A16 do not
+   exist as standalone tests**, so the §10.4 CI gate is effectively
+   one-test-fails-the-build rather than the contract-wide gate that
+   was promised.
+10. **SDK parity** (§9 / A15 / A16): `WorkspaceHandle.refreshToken`
+    auto-invocation at 55 minutes, `agentInvite()` carrying
+    `vfsRoot`, and the multi-agent disjoint-path bulk-write proof are
+    not part of this evidence package and need to be confirmed
+    separately before the SDK is considered launch-ready.
+11. **Mount stall detection** logs "mount stalled: …" after 10
+    minutes but does not include the stall reason in
+    `state.json.stallReason` for the no-progress branch (only the
+    failed-cycle branch). A consumer relying on `state.json` to detect
+    stalls will not see the 10-minute idle case until the next cycle
+    error overwrites the field.
+12. **Trajectory and evidence files are checked-in noise**
+    (`.trajectories/active/`, multiple `traj_*` files) — not a
+    correctness risk, but should be cleaned up or moved out of
+    tracked branches before tagging.
+
+None of items 1–12 individually block an internal beta where users
+are willing to read JSON, watch logs, and tolerate missing
+recovery commands. Items 1, 2, 3, 6, 7, 8, 9 should all be closed
+before a public v1 launch.
+
+---
+
+## Recommendation
+
+- **Internal / early-access launch:** **go**. The golden path is
+  proven end-to-end, the rejoin loop works under hostile token
+  conditions, and the synced-mirror story is honest and testable.
+- **Public v1 launch:** **no-go yet.** Land `pull`/`permissions`/
+  `ops {list,replay}`, ship the schema-validation conflict path,
+  render `webhookHealthy` in text status output, implement the
+  refresh-token-expired degraded mode, add the missing A2/A6/A7/
+  A9/A11–A16 acceptance tests, and audit credential-file atomicity
+  and refresh coalescing. With those in, the v1 contract is
+  defensible against a public release.
+
+PRODUCTIZED_CLOUD_MOUNT_REVIEW_COMPLETE

--- a/docs/skills/relayfile-workspace.md
+++ b/docs/skills/relayfile-workspace.md
@@ -1,0 +1,303 @@
+# Skill: relayfile-workspace
+
+**Version:** 1.0
+**Install path:** `.agents/skills/relayfile-workspace.md`
+**Trigger:** Agent is working in a directory that has a `.relay/state.json` file, or `$RELAYFILE_LOCAL_DIR` is set, or the agent needs to read/write provider-backed files (GitHub PRs, Notion pages, Linear issues, Slack messages).
+
+---
+
+## What This Skill Provides
+
+This skill teaches an agent how to use a Relayfile Cloud VFS synced mirror safely. It covers:
+
+- Discovering the mount path
+- Checking sync state before acting
+- Reading provider-backed files instead of calling provider APIs
+- Writing files through the safe edit pattern
+- Handling conflicts, writeback failures, and dead-letter operations
+- Multi-agent coordination conventions
+
+---
+
+## When to Load This Skill
+
+Load this skill when:
+
+- The agent's task involves reading GitHub PRs, Notion pages, Linear issues, or Slack messages
+- The agent needs to write back to a provider (post a review, update an issue, send a message)
+- `$RELAYFILE_LOCAL_DIR` is set in the environment
+- A `.relay/state.json` file exists in or above the current working directory
+
+Do not load this skill when working with local files unrelated to a provider.
+
+---
+
+## Core Rule: Prefer Files Over Provider APIs
+
+**Always read and write through the local VFS mirror. Never call provider APIs directly.**
+
+The VFS exists precisely so agents do not need provider credentials, OAuth tokens, or knowledge of provider-specific API shapes. A file read is simpler, reproducible, and works from the last sync even when offline.
+
+---
+
+## Phase 1: Discover the Mount
+
+Find the mount root before doing anything else. Use this priority order:
+
+```
+1. $RELAYFILE_LOCAL_DIR  (always wins when set)
+2. relayfile status --json | jq -r '.localDir'
+3. Walk upward from CWD — first directory containing .relay/state.json
+```
+
+If none resolves, fail loudly:
+
+```
+relayfile mount not found. Run 'relayfile setup' or set RELAYFILE_LOCAL_DIR.
+```
+
+Store the resolved path as `MOUNT` for all subsequent operations.
+
+---
+
+## Phase 2: Read Sync State
+
+Before any non-trivial read or any write, read `$MOUNT/.relay/state.json`.
+
+Key fields:
+
+| Field | What to check |
+|---|---|
+| `providers[*].status` | Must be `"ready"` before trusting data for that provider |
+| `providers[*].lagSeconds` | Warn if > 60; do not block unless > 300 |
+| `pendingWriteback` | If > 0, a previous write is in flight |
+| `pendingConflicts` | If > 0, inspect `.relay/conflicts/` before writing |
+
+**Helper — enforceProviderReady(provider):**
+
+```typescript
+// SDK
+await handle.enforceProviderReady("notion", { timeoutMs: 60_000 });
+
+// Shell equivalent
+while [ "$(jq -r '.providers[] | select(.provider=="notion") | .status' $MOUNT/.relay/state.json)" != "ready" ]; do
+  sleep 5
+done
+```
+
+Do not skip this check. A `cataloging` or `syncing` provider has incomplete data.
+
+---
+
+## Phase 3: Read Files
+
+Use standard file read operations.
+
+```bash
+# Read a GitHub PR
+cat $MOUNT/github/repos/acme/api/pulls/42/metadata.json
+
+# Read a Notion page
+cat $MOUNT/notion/pages/product-roadmap/content.md
+
+# List a subtree
+ls $MOUNT/linear/issues/
+
+# Check what's writable for a provider
+cat $MOUNT/github/_PERMISSIONS.md
+```
+
+**Do not trust `mtime` for ordering.** Use `state.json` → `lastReconcileAt` and `providers[*].lagSeconds` instead.
+
+---
+
+## Phase 4: Write Files (Safe Edit Pattern)
+
+Every write to a provider-backed path must follow this sequence:
+
+### 4.1 Check _PERMISSIONS.md
+
+```bash
+cat $MOUNT/<provider>/_PERMISSIONS.md
+```
+
+Confirm the target path is declared as a writeback path (not read-only) and note the expected schema.
+
+### 4.2 Validate payload locally
+
+For JSON writeback paths, validate against the schema in `_PERMISSIONS.md` before saving. A schema error causes the file to land in `.relay/conflicts/<path>.invalid.<ts>` — catching it locally avoids that round-trip.
+
+### 4.3 Read → Mutate → Write
+
+```bash
+# 1. Read current state
+current=$(cat $MOUNT/github/repos/acme/api/pulls/42/reviews/review.json 2>/dev/null || echo '{}')
+
+# 2. Compute new content
+new_content='{"body":"LGTM!","event":"APPROVE"}'
+
+# 3. Write atomically
+printf '%s' "$new_content" > $MOUNT/github/repos/acme/api/pulls/42/reviews/review.json
+```
+
+The mount watcher debounces 100 ms and queues the upload automatically. Do not call any provider API.
+
+### 4.4 Wait for writeback acknowledgement
+
+Poll `state.json` until `pendingWriteback == 0` or the path appears in `.relay/conflicts/` or `.relay/dead-letter/`.
+
+**SDK:**
+```typescript
+await handle.waitForWriteback(
+  "github/repos/acme/api/pulls/42/reviews/review.json",
+  { timeoutMs: 30_000 }
+);
+```
+
+**Shell:**
+```bash
+TARGET_PATH="github/repos/acme/api/pulls/42/reviews/review.json"
+TIMEOUT=30
+elapsed=0
+while [ $elapsed -lt $TIMEOUT ]; do
+  pending=$(jq '.pendingWriteback' $MOUNT/.relay/state.json)
+  in_conflict=$(ls $MOUNT/.relay/conflicts/ 2>/dev/null | grep -c "review.json" || echo 0)
+  in_deadletter=$(ls $MOUNT/.relay/dead-letter/ 2>/dev/null | wc -l)
+  if [ "$pending" -eq 0 ] && [ "$in_conflict" -eq 0 ]; then
+    echo "Write acknowledged"
+    break
+  fi
+  sleep 2; elapsed=$((elapsed + 2))
+done
+```
+
+### 4.5 Handle conflict on retry
+
+If a conflict appears at `.relay/conflicts/<path>.<rev>.local`:
+
+1. Read the remote version (current file at original path).
+2. Read your local version (the `.local` file in conflicts/).
+3. Merge intent into the original path.
+4. Write and wait for ack again (steps 4.3–4.4).
+5. Do not delete the conflict file. The system moves it to `resolved/` on success.
+
+---
+
+## Phase 5: Handle Dead-Letter Failures
+
+A dead-lettered write has permanently failed (schema error, authorization denied, repeated 5xx).
+
+```bash
+# Inspect
+cat $MOUNT/.relay/dead-letter/<opId>.json
+# Fields: opId, path, code, message, attempts, replayUrl
+
+# Fix the root cause, then replay
+relayfile ops replay <opId>
+
+# List all dead-lettered ops
+relayfile ops list
+```
+
+After a successful replay, the `.relay/dead-letter/<opId>.json` file is deleted automatically.
+
+---
+
+## Path Reference
+
+```
+$MOUNT/<provider>/...                  # provider-backed files (source of truth)
+$MOUNT/<provider>/_PERMISSIONS.md     # writeback rules and schema for this provider
+$MOUNT/.relay/state.json               # sync state (READ ONLY — do not write)
+$MOUNT/.relay/conflicts/               # unresolved conflicts (do not write, do not delete)
+$MOUNT/.relay/conflicts/resolved/      # cleared conflicts (audit trail)
+$MOUNT/.relay/dead-letter/             # permanently failed writebacks (do not write)
+$MOUNT/.relay/permissions-denied.log   # append-only denial log (read only)
+```
+
+**Never write to any path under `.relay/`.**
+**Never delete or rename top-level provider directories.**
+
+---
+
+## Provider Catalog
+
+| Provider ID | VFS root | Display name |
+|---|---|---|
+| `github` | `/github` | GitHub |
+| `notion` | `/notion` | Notion |
+| `linear` | `/linear` | Linear |
+| `slack-sage` | `/slack` | Slack |
+| `slack-my-senior-dev` | `/slack-msd` | Slack (MSD) |
+| `slack-nightcto` | `/slack-nightcto` | Slack (NightCTO) |
+
+The provider catalog is loaded from `GET /api/v1/integrations/catalog` and cached for 1 hour. Do not hardcode provider IDs in agent logic — use the catalog.
+
+---
+
+## Multi-Agent Conventions
+
+When two agents share the same mount:
+
+1. **Disjoint paths whenever possible.** Two agents writing to different files never conflict.
+2. **`.relay/conflicts/` is a stop signal.** If you see a conflict on a path another agent owns, back off. Do not overwrite.
+3. **Use agent-relay channels for coordination.** Post "done writing `<path>`" before another agent picks it up.
+4. **No file locking.** The VFS does not support distributed locks. Coordinate by convention.
+
+---
+
+## Sync-Mirror Limitations (Tell Users When Relevant)
+
+This is a synced mirror, not a POSIX kernel filesystem. State these limitations in your response when they are relevant:
+
+- **Lag:** New remote files appear within 30 s (default) or sooner on websocket event. Not real-time.
+- **File handle stability:** An editor holding a file open may see content change on disk during reconcile.
+- **`mtime` is unreliable:** Reflects local write time, not remote event time.
+- **Synthetic create events:** Downstream `inotify`/`fsevents` watchers see a create event on every reconcile for new content. Debounce ≥ 1 s if needed.
+
+Mitigations are `.relay/state.json`, `relayfile status`, and `relayfile pull`.
+
+---
+
+## SDK Quick Reference (TypeScript)
+
+```typescript
+import { WorkspaceHandle } from "@relayfile/sdk";
+
+// Connect to workspace (token auto-refreshes after 55 min)
+const handle = await WorkspaceHandle.connect({ workspaceId: "ws_abc" });
+
+// Read state
+const state = await handle.readState();
+
+// Enforce provider is ready
+await handle.enforceProviderReady("notion", { timeoutMs: 60_000 });
+
+// Write + wait
+await handle.writeFile(
+  "github/repos/acme/api/pulls/42/reviews/review.json",
+  JSON.stringify({ body: "LGTM!", event: "APPROVE" })
+);
+await handle.waitForWriteback(
+  "github/repos/acme/api/pulls/42/reviews/review.json",
+  { timeoutMs: 30_000 }
+);
+
+// Refresh token manually (normally automatic)
+await handle.refreshToken();
+```
+
+---
+
+## Error Quick Reference
+
+| Symptom | Cause | Action |
+|---|---|---|
+| File not under `<provider>/` | Provider not connected or still syncing | Check `state.json` status; run `relayfile integration connect <provider>` |
+| Write → `.relay/conflicts/*.invalid.*` | Schema validation failed | Fix payload per `_PERMISSIONS.md`, retry |
+| Write → `.relay/conflicts/*.local` | Concurrent edit conflict | Merge remote + local, re-save |
+| Write → `.relay/dead-letter/` | Permanent API failure | Inspect JSON, fix root cause, `relayfile ops replay <id>` |
+| `lagSeconds > 60` | Webhook degraded or network lag | Note staleness; `relayfile pull <path>` if fresh data required |
+| `status == "error"` | Provider auth failure | `relayfile integration disconnect <p>` then reconnect |
+| Path in `permissions-denied.log` | Read-only path | Use a writable path per `_PERMISSIONS.md` |
+| Mount not found | Env or daemon not set up | `relayfile setup` or set `$RELAYFILE_LOCAL_DIR` |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ require (
 require golang.org/x/text v0.14.0 // indirect
 
 require (
-	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/sys v0.28.0
 	nhooyr.io/websocket v1.8.17
 )

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fsnotify/fsnotify"
 	"nhooyr.io/websocket"
@@ -89,6 +91,7 @@ type RemoteFile struct {
 	Revision    string `json:"revision"`
 	ContentType string `json:"contentType"`
 	Content     string `json:"content"`
+	Encoding    string `json:"encoding,omitempty"`
 }
 
 type WriteResult struct {
@@ -111,6 +114,7 @@ type exportSnapshotClient interface {
 type HTTPClient struct {
 	baseURL    string
 	token      string
+	tokenMu    sync.RWMutex
 	httpClient *http.Client
 	maxRetries int
 	baseDelay  time.Duration
@@ -174,12 +178,19 @@ func (c *HTTPClient) ReadFile(ctx context.Context, workspaceID, path string) (Re
 }
 
 func (c *HTTPClient) WriteFile(ctx context.Context, workspaceID, path, baseRevision, contentType, content string) (WriteResult, error) {
+	return c.writeFile(ctx, workspaceID, path, baseRevision, contentType, content, "")
+}
+
+func (c *HTTPClient) writeFile(ctx context.Context, workspaceID, path, baseRevision, contentType, content, encoding string) (WriteResult, error) {
 	if contentType == "" {
 		contentType = "text/markdown"
 	}
 	body := map[string]any{
 		"contentType": contentType,
 		"content":     content,
+	}
+	if strings.TrimSpace(encoding) != "" {
+		body["encoding"] = strings.TrimSpace(encoding)
 	}
 	q := url.Values{}
 	q.Set("path", normalizeRemotePath(path))
@@ -223,6 +234,7 @@ func (c *HTTPClient) ExportFiles(ctx context.Context, workspaceID, path string) 
 		Revision    string `json:"revision"`
 		ContentType string `json:"contentType"`
 		Content     string `json:"content"`
+		Encoding    string `json:"encoding"`
 	}
 	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/v1/workspaces/%s/fs/export?%s", url.PathEscape(workspaceID), q.Encode()), nil, nil, &out)
 	if err != nil {
@@ -239,6 +251,7 @@ func (c *HTTPClient) ExportFiles(ctx context.Context, workspaceID, path string) 
 			Revision:    file.Revision,
 			ContentType: file.ContentType,
 			Content:     file.Content,
+			Encoding:    strings.TrimSpace(file.Encoding),
 		})
 	}
 	return files, nil
@@ -268,7 +281,7 @@ func (c *HTTPClient) doJSON(
 		if err != nil {
 			return err
 		}
-		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Authorization", "Bearer "+c.Token())
 		req.Header.Set("X-Correlation-Id", correlationID())
 		if body != nil {
 			req.Header.Set("Content-Type", "application/json")
@@ -325,6 +338,18 @@ func (c *HTTPClient) doJSON(
 	}
 }
 
+func (c *HTTPClient) Token() string {
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
+	return c.token
+}
+
+func (c *HTTPClient) SetToken(token string) {
+	c.tokenMu.Lock()
+	c.token = strings.TrimSpace(token)
+	c.tokenMu.Unlock()
+}
+
 type SyncerOptions struct {
 	WorkspaceID   string
 	RemoteRoot    string
@@ -335,6 +360,8 @@ type SyncerOptions struct {
 	WebSocket     *bool
 	RootCtx       context.Context
 	Logger        Logger
+	Mode          string
+	Interval      time.Duration
 }
 
 type Logger interface {
@@ -342,35 +369,46 @@ type Logger interface {
 }
 
 type Syncer struct {
-	client             RemoteClient
-	workspace          string
-	remoteRoot         string
-	localRoot          string
-	localDir           string
-	stateFile          string
-	eventProvider      string
-	scopes             []string
-	logger             Logger
-	denialLogPath      string // path to .relay/permissions-denied.log
-	state              mountState
-	loaded             bool
-	bootstrapped       bool
-	websocket          bool
-	rootCtx            context.Context
-	wsConn             *websocket.Conn
-	wsCancel           context.CancelFunc
-	bulkFlushThreshold int
-	mu                 sync.Mutex
+	client               RemoteClient
+	workspace            string
+	remoteRoot           string
+	localRoot            string
+	localDir             string
+	stateFile            string
+	publicStatePath      string
+	conflictsDir         string
+	resolvedConflictsDir string
+	deadLetterDir        string
+	eventProvider        string
+	scopes               []string
+	logger               Logger
+	denialLogPath        string // path to .relay/permissions-denied.log
+	state                mountState
+	loaded               bool
+	bootstrapped         bool
+	websocket            bool
+	rootCtx              context.Context
+	wsConn               *websocket.Conn
+	wsCancel             context.CancelFunc
+	bulkFlushThreshold   int
+	mode                 string
+	interval             time.Duration
+	mu                   sync.Mutex
 }
 
 type mountState struct {
-	Files        map[string]trackedFile `json:"files"`
-	EventsCursor string                 `json:"eventsCursor,omitempty"`
+	Files                     map[string]trackedFile `json:"files"`
+	EventsCursor              string                 `json:"eventsCursor,omitempty"`
+	LastReconcileAt           string                 `json:"lastReconcileAt,omitempty"`
+	LastSuccessfulReconcileAt string                 `json:"lastSuccessfulReconcileAt,omitempty"`
+	LastEventAt               string                 `json:"lastEventAt,omitempty"`
+	LastError                 *statusError           `json:"lastError,omitempty"`
 }
 
 type trackedFile struct {
 	Revision    string `json:"revision"`
 	ContentType string `json:"contentType"`
+	Encoding    string `json:"encoding,omitempty"`
 	Hash        string `json:"hash"`
 	Dirty       bool   `json:"dirty,omitempty"`
 	// Denied — the server denied reading this path. The local copy (if any)
@@ -386,8 +424,10 @@ type trackedFile struct {
 }
 
 type localSnapshot struct {
-	Content     string
+	RawContent  []byte
+	WireContent string
 	ContentType string
+	Encoding    string
 	Hash        string
 }
 
@@ -404,6 +444,51 @@ type websocketEvent struct {
 	Path      string `json:"path,omitempty"`
 	Revision  string `json:"revision,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type statusError struct {
+	Kind       string `json:"kind"`
+	StatusCode int    `json:"statusCode,omitempty"`
+	Code       string `json:"code,omitempty"`
+	Message    string `json:"message"`
+	At         string `json:"at"`
+}
+
+type publicState struct {
+	WorkspaceID               string                     `json:"workspaceId"`
+	RemoteRoot                string                     `json:"remoteRoot"`
+	LocalRoot                 string                     `json:"localRoot"`
+	Mode                      string                     `json:"mode"`
+	IntervalMs                int64                      `json:"intervalMs"`
+	LastReconcileAt           string                     `json:"lastReconcileAt,omitempty"`
+	LastSuccessfulReconcileAt string                     `json:"lastSuccessfulReconcileAt,omitempty"`
+	LastEventAt               string                     `json:"lastEventAt,omitempty"`
+	StaleAfter                string                     `json:"staleAfter,omitempty"`
+	Status                    string                     `json:"status"`
+	States                    publicStateFlags           `json:"states"`
+	PendingWriteback          int                        `json:"pendingWriteback"`
+	PendingConflicts          int                        `json:"pendingConflicts"`
+	DeniedPaths               int                        `json:"deniedPaths"`
+	LastError                 *statusError               `json:"lastError,omitempty"`
+	Files                     map[string]publicFileState `json:"files,omitempty"`
+}
+
+type publicStateFlags struct {
+	Stale               bool `json:"stale"`
+	Offline             bool `json:"offline"`
+	HasConflicts        bool `json:"hasConflicts"`
+	HasPendingWriteback bool `json:"hasPendingWriteback"`
+}
+
+type publicFileState struct {
+	Revision    string `json:"revision,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+	Encoding    string `json:"encoding,omitempty"`
+	Dirty       bool   `json:"dirty,omitempty"`
+	Denied      bool   `json:"denied,omitempty"`
+	WriteDenied bool   `json:"writeDenied,omitempty"`
+	ReadOnly    bool   `json:"readonly,omitempty"`
+	Status      string `json:"status"`
 }
 
 func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
@@ -431,6 +516,10 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if stateFile == "" {
 		stateFile = filepath.Join(localRoot, ".relayfile-mount-state.json")
 	}
+	publicStatePath := filepath.Join(localRoot, ".relay", "state.json")
+	conflictsDir := filepath.Join(localRoot, ".relay", "conflicts")
+	resolvedConflictsDir := filepath.Join(conflictsDir, "resolved")
+	deadLetterDir := filepath.Join(localRoot, ".relay", "dead-letter")
 	scopes := normalizeScopes(opts.Scopes)
 	if len(scopes) == 0 {
 		if httpClient, ok := client.(*HTTPClient); ok {
@@ -443,6 +532,15 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if err := os.MkdirAll(filepath.Join(localRoot, ".relay"), 0o755); err != nil {
 		return nil, err
 	}
+	if err := os.MkdirAll(conflictsDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(resolvedConflictsDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(deadLetterDir, 0o755); err != nil {
+		return nil, err
+	}
 	websocketEnabled := true
 	if opts.WebSocket != nil {
 		websocketEnabled = *opts.WebSocket
@@ -452,19 +550,25 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		rootCtx = context.Background()
 	}
 	return &Syncer{
-		client:             client,
-		workspace:          workspace,
-		remoteRoot:         remoteRoot,
-		localRoot:          localRoot,
-		localDir:           localRoot,
-		stateFile:          stateFile,
-		eventProvider:      eventProvider,
-		scopes:             scopes,
-		websocket:          websocketEnabled,
-		rootCtx:            rootCtx,
-		logger:             opts.Logger,
-		denialLogPath:      filepath.Join(localRoot, ".relay", "permissions-denied.log"),
-		bulkFlushThreshold: defaultBulkFlushThreshold,
+		client:               client,
+		workspace:            workspace,
+		remoteRoot:           remoteRoot,
+		localRoot:            localRoot,
+		localDir:             localRoot,
+		stateFile:            stateFile,
+		publicStatePath:      publicStatePath,
+		conflictsDir:         conflictsDir,
+		resolvedConflictsDir: resolvedConflictsDir,
+		deadLetterDir:        deadLetterDir,
+		eventProvider:        eventProvider,
+		scopes:               scopes,
+		websocket:            websocketEnabled,
+		rootCtx:              rootCtx,
+		logger:               opts.Logger,
+		denialLogPath:        filepath.Join(localRoot, ".relay", "permissions-denied.log"),
+		bulkFlushThreshold:   defaultBulkFlushThreshold,
+		mode:                 strings.TrimSpace(opts.Mode),
+		interval:             opts.Interval,
 		state: mountState{
 			Files: map[string]trackedFile{},
 		},
@@ -519,28 +623,37 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 		return nil
 	}
 
-	switch {
-	case op&(fsnotify.Write|fsnotify.Create) != 0:
-		if err := s.handleLocalWriteOrCreate(ctx, remotePath, localPath); err != nil {
+	saveWithStatus := func(run func() error) error {
+		if err := run(); err != nil {
+			s.markSyncError(err)
+			_ = s.saveState()
 			return err
 		}
+		s.markSyncSuccess()
 		return s.saveState()
+	}
+
+	switch {
+	case op&(fsnotify.Write|fsnotify.Create) != 0:
+		return saveWithStatus(func() error {
+			return s.handleLocalWriteOrCreate(ctx, remotePath, localPath)
+		})
 	case op&(fsnotify.Remove|fsnotify.Rename) != 0:
 		tracked, exists := s.state.Files[remotePath]
 		if exists && tracked.ReadOnly {
-			if err := s.revertReadonlyFile(ctx, remotePath, localPath, tracked, ""); err != nil {
-				return err
-			}
-			return s.saveState()
+			return saveWithStatus(func() error {
+				return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, "")
+			})
 		}
-		if err := s.pushSingleDelete(ctx, remotePath, localPath); err != nil {
-			return err
-		}
-		return s.saveState()
+		return saveWithStatus(func() error {
+			return s.pushSingleDelete(ctx, remotePath, localPath)
+		})
 	case op&fsnotify.Chmod != 0:
 		tracked, exists := s.state.Files[remotePath]
 		if exists && tracked.ReadOnly {
 			if err := s.applyLocalPermissions(localPath, false); err != nil && !errors.Is(err, os.ErrNotExist) {
+				s.markSyncError(err)
+				_ = s.saveState()
 				return err
 			}
 		}
@@ -556,11 +669,7 @@ func (s *Syncer) handleLocalWriteOrCreate(ctx context.Context, remotePath, local
 		}
 		return err
 	}
-	snapshot := localSnapshot{
-		Content:     string(snapshotContent),
-		ContentType: detectContentType(localPath),
-		Hash:        hashBytes(snapshotContent),
-	}
+	snapshot := newLocalSnapshot(localPath, snapshotContent)
 	tracked, exists := s.state.Files[remotePath]
 	if exists && tracked.ReadOnly {
 		return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, snapshot.ContentType)
@@ -616,17 +725,21 @@ func (s *Syncer) preparePendingBulkWrite(
 
 	if exists && tracked.Dirty {
 		remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
-		if readErr == nil && hashString(remoteFile.Content) == snapshot.Hash {
-			contentType := strings.TrimSpace(remoteFile.ContentType)
-			if contentType == "" {
-				contentType = snapshot.ContentType
+		if readErr == nil {
+			remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
+			if decodeErr == nil && hashBytes(remoteBytes) == snapshot.Hash {
+				contentType := strings.TrimSpace(remoteFile.ContentType)
+				if contentType == "" {
+					contentType = snapshot.ContentType
+				}
+				tracked.Revision = remoteFile.Revision
+				tracked.ContentType = contentType
+				tracked.Encoding = normalizeEncoding(remoteFile.Encoding)
+				tracked.Hash = snapshot.Hash
+				tracked.Dirty = false
+				s.state.Files[remotePath] = tracked
+				return nil, nil
 			}
-			tracked.Revision = remoteFile.Revision
-			tracked.ContentType = contentType
-			tracked.Hash = snapshot.Hash
-			tracked.Dirty = false
-			s.state.Files[remotePath] = tracked
-			return nil, nil
 		}
 	}
 
@@ -648,7 +761,8 @@ func (s *Syncer) flushPendingBulkWrites(ctx context.Context, pending []pendingBu
 		files = append(files, BulkWriteFile{
 			Path:        pendingWrite.remotePath,
 			ContentType: pendingWrite.snapshot.ContentType,
-			Content:     pendingWrite.snapshot.Content,
+			Content:     pendingWrite.snapshot.WireContent,
+			Encoding:    pendingWrite.snapshot.Encoding,
 		})
 	}
 
@@ -712,10 +826,12 @@ func (s *Syncer) reconcileBulkWrite(ctx context.Context, pendingWrite pendingBul
 	s.state.Files[pendingWrite.remotePath] = trackedFile{
 		Revision:    revision,
 		ContentType: tracked.ContentType,
+		Encoding:    normalizeEncoding(pendingWrite.snapshot.Encoding),
 		Hash:        pendingWrite.snapshot.Hash,
 		Dirty:       false,
 		ReadOnly:    false,
 	}
+	s.resolveConflictArtifacts(pendingWrite.remotePath)
 	return nil
 }
 
@@ -729,36 +845,10 @@ func (s *Syncer) handleWriteError(
 	err error,
 ) error {
 	if errors.Is(err, ErrConflict) {
-		s.logf("conflict writing %s; keeping local content", remotePath)
 		if conflicted != nil {
 			conflicted[remotePath] = struct{}{}
 		}
-		remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
-		switch {
-		case readErr == nil:
-			s.state.Files[remotePath] = trackedFile{
-				Revision:    remoteFile.Revision,
-				ContentType: snapshot.ContentType,
-				Hash:        snapshot.Hash,
-				Dirty:       true,
-				Denied:      false,
-				ReadOnly:    false,
-			}
-		case exists:
-			tracked.Hash = snapshot.Hash
-			tracked.ContentType = snapshot.ContentType
-			tracked.Dirty = true
-			s.state.Files[remotePath] = tracked
-		default:
-			s.state.Files[remotePath] = trackedFile{
-				Revision:    "",
-				ContentType: snapshot.ContentType,
-				Hash:        snapshot.Hash,
-				Dirty:       true,
-				ReadOnly:    false,
-			}
-		}
-		return nil
+		return s.materializeConflict(ctx, remotePath, localPath, snapshot, tracked)
 	}
 
 	var httpErr *HTTPError
@@ -786,6 +876,51 @@ func (s *Syncer) handleWriteError(
 	}
 
 	return err
+}
+
+func (s *Syncer) materializeConflict(ctx context.Context, remotePath, localPath string, snapshot localSnapshot, tracked trackedFile) error {
+	artifactPath, artifactErr := s.writeConflictArtifact(remotePath, tracked.Revision, snapshot.RawContent)
+	if artifactErr != nil {
+		return artifactErr
+	}
+
+	remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
+	if readErr != nil {
+		tracked.ContentType = snapshot.ContentType
+		tracked.Encoding = normalizeEncoding(snapshot.Encoding)
+		tracked.Hash = snapshot.Hash
+		tracked.Dirty = true
+		s.state.Files[remotePath] = tracked
+		return readErr
+	}
+
+	remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
+	if decodeErr != nil {
+		return decodeErr
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(localPath, remoteBytes, 0o644); err != nil {
+		return err
+	}
+	if err := s.applyLocalPermissions(localPath, s.canWritePath(remotePath)); err != nil {
+		return err
+	}
+
+	contentType := strings.TrimSpace(remoteFile.ContentType)
+	if contentType == "" {
+		contentType = snapshot.ContentType
+	}
+	s.state.Files[remotePath] = trackedFile{
+		Revision:    remoteFile.Revision,
+		ContentType: contentType,
+		Encoding:    normalizeEncoding(remoteFile.Encoding),
+		Hash:        hashBytes(remoteBytes),
+		ReadOnly:    !s.canWritePath(remotePath),
+	}
+	s.logf("conflict at %s; local saved at %s", remotePath, artifactPath)
+	return nil
 }
 
 func bulkWriteErrorAsError(writeErr BulkWriteError) error {
@@ -821,6 +956,10 @@ func (s *Syncer) revertReadonlyFile(ctx context.Context, remotePath, localPath s
 	s.logDenial("WRITE_DENIED", remotePath, "agent does not have write permission")
 	remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
 	if readErr == nil {
+		remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
+		if decodeErr != nil {
+			return decodeErr
+		}
 		contentType := strings.TrimSpace(remoteFile.ContentType)
 		if contentType == "" {
 			contentType = strings.TrimSpace(fallbackContentType)
@@ -831,7 +970,7 @@ func (s *Syncer) revertReadonlyFile(ctx context.Context, remotePath, localPath s
 		if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 			return err
 		}
-		if err := writeFileAtomic(localPath, []byte(remoteFile.Content), 0o444); err != nil {
+		if err := writeFileAtomic(localPath, remoteBytes, 0o444); err != nil {
 			return err
 		}
 		if err := os.Chmod(localPath, 0o444); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -839,7 +978,8 @@ func (s *Syncer) revertReadonlyFile(ctx context.Context, remotePath, localPath s
 		}
 		tracked.Revision = remoteFile.Revision
 		tracked.ContentType = contentType
-		tracked.Hash = hashString(remoteFile.Content)
+		tracked.Encoding = normalizeEncoding(remoteFile.Encoding)
+		tracked.Hash = hashBytes(remoteBytes)
 		s.logDenial("WRITE_REVERTED", remotePath, "file is read-only; content reverted to server version")
 	} else {
 		if err := s.applyLocalPermissions(localPath, false); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -883,6 +1023,10 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 		}
 		if errors.Is(err, ErrConflict) {
 			s.logf("conflict deleting %s; remote changed", remotePath)
+			remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
+			if readErr == nil {
+				return s.applyRemoteFile(remotePath, remoteFile, nil)
+			}
 			return nil
 		}
 		return err
@@ -912,19 +1056,25 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 	// Re-acquire lock for the remainder of the sync operation.
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.markReconcileStarted()
 
 	conflicted, err := s.pushLocal(ctx)
 	if err != nil {
+		s.markSyncError(err)
+		_ = s.saveState()
 		return err
 	}
 
 	shouldPoll := forcePoll || !s.bootstrapped || s.wsConn == nil
 	if shouldPoll {
 		if err := s.pullRemote(ctx, conflicted); err != nil {
+			s.markSyncError(err)
+			_ = s.saveState()
 			return err
 		}
 		s.bootstrapped = true
 	}
+	s.markSyncSuccess()
 	return s.saveState()
 }
 
@@ -947,7 +1097,7 @@ func (s *Syncer) connectWebSocket(ctx context.Context) error {
 	}
 	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
-			"Authorization": []string{"Bearer " + httpClient.token},
+			"Authorization": []string{"Bearer " + httpClient.Token()},
 		},
 	})
 	if err != nil {
@@ -986,6 +1136,10 @@ func (s *Syncer) readWebSocketLoop(ctx context.Context, conn *websocket.Conn) {
 }
 
 func (s *Syncer) applyWebSocketEvent(ctx context.Context, event websocketEvent) error {
+	eventAt := strings.TrimSpace(event.Timestamp)
+	if eventAt == "" {
+		eventAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
 	switch eventType := strings.TrimSpace(event.Type); eventType {
 	case "", "pong":
 		return nil
@@ -1011,6 +1165,7 @@ func (s *Syncer) applyWebSocketEvent(ctx context.Context, event websocketEvent) 
 		}
 		s.mu.Lock()
 		defer s.mu.Unlock()
+		s.state.LastEventAt = eventAt
 		if err := s.applyRemoteFile(remotePath, file, nil); err != nil {
 			return err
 		}
@@ -1022,6 +1177,7 @@ func (s *Syncer) applyWebSocketEvent(ctx context.Context, event websocketEvent) 
 		}
 		s.mu.Lock()
 		defer s.mu.Unlock()
+		s.state.LastEventAt = eventAt
 		if err := s.applyRemoteDelete(remotePath, nil); err != nil {
 			return err
 		}
@@ -1045,6 +1201,26 @@ func (s *Syncer) handleWebSocketDisconnect(conn *websocket.Conn) {
 		s.wsCancel = nil
 	}
 	s.wsConn = nil
+}
+
+func (s *Syncer) ResetWebSocket() {
+	s.mu.Lock()
+	conn := s.wsConn
+	cancel := s.wsCancel
+	s.wsConn = nil
+	s.wsCancel = nil
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if conn != nil {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}
+}
+
+func (s *Syncer) HTTPClient() (*HTTPClient, bool) {
+	client, ok := s.client.(*HTTPClient)
+	return client, ok
 }
 
 func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{}) error {
@@ -1210,6 +1386,9 @@ func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[strin
 			if eventID != "" {
 				currentCursor = eventID
 			}
+			if ts := strings.TrimSpace(event.Timestamp); ts != "" {
+				s.state.LastEventAt = ts
+			}
 			remotePath := normalizeRemotePath(event.Path)
 			if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 				continue
@@ -1304,6 +1483,10 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 			return nil
 		}
 	}
+	remoteBytes, err := decodeRemoteFileContent(file)
+	if err != nil {
+		return err
+	}
 	tracked := s.state.Files[remotePath]
 	canWrite := s.canWritePath(remotePath)
 	tracked.ReadOnly = !canWrite
@@ -1326,7 +1509,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
 	}
-	remoteHash := hashString(file.Content)
+	remoteHash := hashBytes(remoteBytes)
 	shouldWrite := true
 	if current, err := os.ReadFile(localPath); err == nil {
 		localHash := hashBytes(current)
@@ -1346,7 +1529,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		}
 	}
 	if shouldWrite {
-		if err := writeFileAtomic(localPath, []byte(file.Content), 0o644); err != nil {
+		if err := writeFileAtomic(localPath, remoteBytes, 0o644); err != nil {
 			return err
 		}
 	}
@@ -1361,6 +1544,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	s.state.Files[remotePath] = trackedFile{
 		Revision:    file.Revision,
 		ContentType: contentType,
+		Encoding:    normalizeEncoding(file.Encoding),
 		Hash:        remoteHash,
 		Dirty:       false,
 		Denied:      false,
@@ -1516,9 +1700,11 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 				// Revert to server content
 				remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
 				if readErr == nil {
-					if writeErr := os.WriteFile(localPath, []byte(remoteFile.Content), 0o444); writeErr == nil {
-						tracked.Hash = hashString(remoteFile.Content)
+					remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
+					if decodeErr == nil && os.WriteFile(localPath, remoteBytes, 0o444) == nil {
+						tracked.Hash = hashBytes(remoteBytes)
 						tracked.Revision = remoteFile.Revision
+						tracked.Encoding = normalizeEncoding(remoteFile.Encoding)
 						s.logDenial("WRITE_REVERTED", remotePath, "file is read-only; content reverted to server version")
 						s.logf("write denied, reverted: %s", remotePath)
 					}
@@ -1596,6 +1782,12 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 			}
 			if errors.Is(err, ErrConflict) {
 				s.logf("conflict deleting %s; remote changed", remotePath)
+				remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
+				if readErr == nil {
+					if applyErr := s.applyRemoteFile(remotePath, remoteFile, nil); applyErr != nil {
+						return nil, applyErr
+					}
+				}
 				continue
 			}
 			return nil, err
@@ -1666,11 +1858,7 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 		if err != nil {
 			return err
 		}
-		results[remotePath] = localSnapshot{
-			Content:     string(data),
-			ContentType: detectContentType(path),
-			Hash:        hashBytes(data),
-		}
+		results[remotePath] = newLocalSnapshot(path, data)
 		return nil
 	})
 	if err != nil {
@@ -1728,7 +1916,332 @@ func (s *Syncer) saveState() error {
 	if err := os.MkdirAll(filepath.Dir(s.stateFile), 0o755); err != nil {
 		return err
 	}
-	return writeFileAtomic(s.stateFile, data, 0o644)
+	if err := writeFileAtomic(s.stateFile, data, 0o644); err != nil {
+		return err
+	}
+	return s.savePublicState()
+}
+
+func (s *Syncer) savePublicState() error {
+	currentFiles, err := s.scanLocalFiles()
+	if err != nil {
+		return err
+	}
+	conflictsByPath, pendingConflicts, err := s.listConflictArtifacts()
+	if err != nil {
+		return err
+	}
+	deniedPaths := 0
+	pendingWriteback := 0
+	files := make(map[string]publicFileState, len(s.state.Files))
+
+	for remotePath, tracked := range s.state.Files {
+		fileStatus := "ready"
+		switch {
+		case conflictsByPath[remotePath] > 0:
+			fileStatus = "conflict"
+		case tracked.WriteDenied:
+			fileStatus = "write-denied"
+		case tracked.Denied:
+			fileStatus = "read-denied"
+		case tracked.Dirty:
+			fileStatus = "writeback-pending"
+		}
+		if snapshot, ok := currentFiles[remotePath]; ok {
+			if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
+				fileStatus = "writeback-pending"
+			}
+		} else if !tracked.Denied && !tracked.WriteDenied && tracked.Hash != "" && fileStatus == "ready" {
+			fileStatus = "writeback-pending"
+		}
+		if fileStatus == "writeback-pending" {
+			pendingWriteback++
+		}
+		if tracked.Denied || tracked.WriteDenied {
+			deniedPaths++
+		}
+		files[remotePath] = publicFileState{
+			Revision:    tracked.Revision,
+			ContentType: tracked.ContentType,
+			Encoding:    tracked.Encoding,
+			Dirty:       tracked.Dirty,
+			Denied:      tracked.Denied,
+			WriteDenied: tracked.WriteDenied,
+			ReadOnly:    tracked.ReadOnly,
+			Status:      fileStatus,
+		}
+	}
+	for remotePath, snapshot := range currentFiles {
+		if _, ok := files[remotePath]; ok {
+			continue
+		}
+		pendingWriteback++
+		files[remotePath] = publicFileState{
+			ContentType: snapshot.ContentType,
+			Encoding:    snapshot.Encoding,
+			Status:      "writeback-pending",
+		}
+	}
+
+	states := publicStateFlags{
+		Offline:             s.state.LastError != nil && s.state.LastError.Kind == "offline",
+		HasConflicts:        pendingConflicts > 0,
+		HasPendingWriteback: pendingWriteback > 0,
+	}
+	staleAfter := ""
+	if lastOK, err := parseStateTime(s.state.LastSuccessfulReconcileAt); err == nil && !lastOK.IsZero() && s.interval > 0 {
+		staleAfter = lastOK.Add(2 * s.interval).UTC().Format(time.RFC3339Nano)
+		states.Stale = time.Now().UTC().After(lastOK.Add(2 * s.interval))
+	}
+	status := "ready"
+	switch {
+	case states.Offline:
+		status = "offline"
+	case states.HasConflicts:
+		status = "conflict"
+	case states.HasPendingWriteback:
+		status = "writeback-pending"
+	case states.Stale:
+		status = "stale"
+	}
+
+	mode := s.mode
+	if mode == "" {
+		mode = "poll"
+	}
+	public := publicState{
+		WorkspaceID:               s.workspace,
+		RemoteRoot:                s.remoteRoot,
+		LocalRoot:                 s.localRoot,
+		Mode:                      mode,
+		IntervalMs:                s.interval.Milliseconds(),
+		LastReconcileAt:           s.state.LastReconcileAt,
+		LastSuccessfulReconcileAt: s.state.LastSuccessfulReconcileAt,
+		LastEventAt:               s.state.LastEventAt,
+		StaleAfter:                staleAfter,
+		Status:                    status,
+		States:                    states,
+		PendingWriteback:          pendingWriteback,
+		PendingConflicts:          pendingConflicts,
+		DeniedPaths:               deniedPaths,
+		LastError:                 s.state.LastError,
+		Files:                     files,
+	}
+	if err := os.MkdirAll(filepath.Dir(s.publicStatePath), 0o755); err != nil {
+		return err
+	}
+	publicBytes, err := json.Marshal(public)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(s.publicStatePath, publicBytes, 0o644)
+}
+
+func (s *Syncer) listConflictArtifacts() (map[string]int, int, error) {
+	counts := map[string]int{}
+	total := 0
+	err := filepath.WalkDir(s.conflictsDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if path == s.resolvedConflictsDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(s.conflictsDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "" {
+			return nil
+		}
+		remotePath := conflictArtifactToRemotePath(rel)
+		if remotePath == "" {
+			return nil
+		}
+		counts[remotePath]++
+		total++
+		return nil
+	})
+	return counts, total, err
+}
+
+func (s *Syncer) writeConflictArtifact(remotePath, baseRevision string, content []byte) (string, error) {
+	if err := os.MkdirAll(s.conflictsDir, 0o755); err != nil {
+		return "", err
+	}
+	artifactPath := conflictArtifactPath(s.conflictsDir, remotePath, baseRevision)
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		return "", err
+	}
+	return artifactPath, writeFileAtomic(artifactPath, content, 0o644)
+}
+
+func (s *Syncer) resolveConflictArtifacts(remotePath string) {
+	pattern := conflictArtifactGlob(s.conflictsDir, remotePath)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return
+	}
+	for _, match := range matches {
+		rel, err := filepath.Rel(s.conflictsDir, match)
+		if err != nil {
+			continue
+		}
+		target := filepath.Join(s.resolvedConflictsDir, rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			continue
+		}
+		if err := os.Rename(match, target); err != nil {
+			continue
+		}
+	}
+}
+
+func (s *Syncer) markReconcileStarted() {
+	s.state.LastReconcileAt = time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+func (s *Syncer) markSyncSuccess() {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	s.state.LastReconcileAt = now
+	s.state.LastSuccessfulReconcileAt = now
+	s.state.LastError = nil
+}
+
+func (s *Syncer) markSyncError(err error) {
+	s.state.LastReconcileAt = time.Now().UTC().Format(time.RFC3339Nano)
+	s.state.LastError = classifyStatusError(err)
+}
+
+func parseStateTime(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339Nano, value)
+}
+
+func conflictArtifactPath(baseDir, remotePath, baseRevision string) string {
+	rel := strings.TrimPrefix(normalizeRemotePath(remotePath), "/")
+	revision := sanitizeRevision(baseRevision)
+	return filepath.Join(baseDir, filepath.FromSlash(rel)+"."+revision+".local")
+}
+
+func conflictArtifactGlob(baseDir, remotePath string) string {
+	rel := strings.TrimPrefix(normalizeRemotePath(remotePath), "/")
+	return filepath.Join(baseDir, filepath.FromSlash(rel)+".*.local")
+}
+
+func conflictArtifactToRemotePath(rel string) string {
+	trimmed := strings.TrimSuffix(rel, ".local")
+	if trimmed == rel {
+		return ""
+	}
+	lastDot := strings.LastIndex(trimmed, ".")
+	if lastDot <= 0 {
+		return ""
+	}
+	return normalizeRemotePath(trimmed[:lastDot])
+}
+
+func sanitizeRevision(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	value = strings.ReplaceAll(value, "/", "_")
+	value = strings.ReplaceAll(value, string(filepath.Separator), "_")
+	return value
+}
+
+func newLocalSnapshot(path string, data []byte) localSnapshot {
+	contentType := detectContentType(path)
+	encoding := ""
+	wireContent := string(data)
+	if !utf8.Valid(data) || !isTextLikeContentType(contentType) {
+		encoding = "base64"
+		wireContent = base64.StdEncoding.EncodeToString(data)
+	}
+	return localSnapshot{
+		RawContent:  append([]byte(nil), data...),
+		WireContent: wireContent,
+		ContentType: contentType,
+		Encoding:    encoding,
+		Hash:        hashBytes(data),
+	}
+}
+
+func isTextLikeContentType(contentType string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case strings.HasPrefix(contentType, "text/"):
+		return true
+	case contentType == "application/json",
+		contentType == "application/xml",
+		contentType == "application/javascript",
+		contentType == "application/x-javascript",
+		contentType == "image/svg+xml":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeEncoding(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "", "utf-8", "utf8":
+		return ""
+	case "base64":
+		return value
+	default:
+		return value
+	}
+}
+
+func decodeRemoteFileContent(file RemoteFile) ([]byte, error) {
+	if normalizeEncoding(file.Encoding) != "base64" {
+		return []byte(file.Content), nil
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(file.Content); err == nil {
+		return decoded, nil
+	}
+	return base64.RawStdEncoding.DecodeString(file.Content)
+}
+
+func classifyStatusError(err error) *statusError {
+	if err == nil {
+		return nil
+	}
+	status := &statusError{
+		Kind:    "error",
+		Message: err.Error(),
+		At:      time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		status.StatusCode = httpErr.StatusCode
+		status.Code = httpErr.Code
+		if httpErr.StatusCode == http.StatusTooManyRequests || httpErr.StatusCode >= 500 {
+			status.Kind = "offline"
+		} else {
+			status.Kind = "http"
+		}
+		return status
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) || errors.Is(err, context.DeadlineExceeded) {
+		status.Kind = "offline"
+		return status
+	}
+	if errors.Is(err, ErrConflict) {
+		status.Kind = "conflict"
+	}
+	return status
 }
 
 func (s *Syncer) logf(format string, args ...any) {
@@ -1878,7 +2391,7 @@ func (c *HTTPClient) websocketURL(workspaceID string) (string, error) {
 	base.Path = fmt.Sprintf("/v1/workspaces/%s/fs/ws", url.PathEscape(workspaceID))
 	// TODO: Remove query-param token once server supports Authorization header on WS upgrade.
 	q := url.Values{}
-	q.Set("token", c.token)
+	q.Set("token", c.Token())
 	base.RawQuery = q.Encode()
 	return base.String(), nil
 }

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2162,7 +2162,7 @@ func newLocalSnapshot(path string, data []byte) localSnapshot {
 	contentType := detectContentType(path)
 	encoding := ""
 	wireContent := string(data)
-	if !utf8.Valid(data) || !isTextLikeContentType(contentType) {
+	if shouldEncodeLocalContentAsBase64(data, contentType) {
 		encoding = "base64"
 		wireContent = base64.StdEncoding.EncodeToString(data)
 	}
@@ -2173,6 +2173,26 @@ func newLocalSnapshot(path string, data []byte) localSnapshot {
 		Encoding:    encoding,
 		Hash:        hashBytes(data),
 	}
+}
+
+func shouldEncodeLocalContentAsBase64(data []byte, contentType string) bool {
+	if !utf8.Valid(data) || !isTextLikeContentType(contentType) {
+		return true
+	}
+	return containsNonTextControlBytes(data)
+}
+
+func containsNonTextControlBytes(data []byte) bool {
+	for _, b := range data {
+		switch b {
+		case '\t', '\n', '\r':
+			continue
+		}
+		if b < 0x20 || b == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 func isTextLikeContentType(contentType string) bool {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -30,6 +30,30 @@ import (
 
 var ErrConflict = errors.New("revision conflict")
 
+// ErrSchemaValidation is returned when the cloud rejects a writeback because
+// the body fails the adapter's declared schema (contract §8.2). The CLI
+// quarantines the offending local file and restores the prior remote
+// version instead of treating the failure as a fatal sync error.
+var ErrSchemaValidation = errors.New("schema validation failed")
+
+// SchemaValidationError carries the per-file schema-violation message the
+// cloud emits alongside `400 schema_validation_failed`.
+type SchemaValidationError struct {
+	Path    string
+	Message string
+}
+
+func (e *SchemaValidationError) Error() string {
+	if e == nil || strings.TrimSpace(e.Message) == "" {
+		return fmt.Sprintf("schema validation failed for %s", e.Path)
+	}
+	return fmt.Sprintf("schema validation failed for %s: %s", e.Path, e.Message)
+}
+
+func (e *SchemaValidationError) Is(target error) bool {
+	return target == ErrSchemaValidation
+}
+
 const defaultBulkFlushThreshold = 256
 
 type ConflictError struct {
@@ -851,6 +875,15 @@ func (s *Syncer) handleWriteError(
 		return s.materializeConflict(ctx, remotePath, localPath, snapshot, tracked)
 	}
 
+	var schemaErr *SchemaValidationError
+	if errors.As(err, &schemaErr) {
+		// Per contract §8.2, a schema-validation failure is a graceful
+		// per-file degradation: quarantine the local body, restore the
+		// last known remote, and let the user fix the offending file
+		// without aborting the cycle.
+		return s.materializeSchemaInvalid(ctx, remotePath, localPath, snapshot, tracked, schemaErr.Message)
+	}
+
 	var httpErr *HTTPError
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
 		if !exists {
@@ -923,6 +956,89 @@ func (s *Syncer) materializeConflict(ctx context.Context, remotePath, localPath 
 	return nil
 }
 
+// materializeSchemaInvalid implements contract §8.2: park the local body in
+// .relay/conflicts/<path>.invalid.<ts>, restore the prior remote into the
+// original path, and clear the dirty/pending flags so reconcile does not
+// keep retrying the same invalid body. If the remote does not yet exist
+// (the offending write was a CREATE), the local file is removed so the
+// invalid body does not stay in the mirror.
+func (s *Syncer) materializeSchemaInvalid(
+	ctx context.Context,
+	remotePath, localPath string,
+	snapshot localSnapshot,
+	tracked trackedFile,
+	violation string,
+) error {
+	artifactPath, artifactErr := s.writeSchemaInvalidArtifact(remotePath, time.Now().UTC(), snapshot.RawContent)
+	if artifactErr != nil {
+		return artifactErr
+	}
+
+	violationDescription := strings.TrimSpace(violation)
+	if violationDescription == "" {
+		violationDescription = "body did not match the adapter schema"
+	}
+
+	remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
+	if readErr != nil {
+		// No prior remote version to restore — typical for a CREATE that
+		// violated the schema. Remove the local file and stop tracking
+		// it so the next reconcile does not re-push.
+		_ = os.Remove(localPath)
+		delete(s.state.Files, remotePath)
+		s.logf("schema validation failed at %s (%s); local saved at %s; no prior remote version to restore",
+			remotePath, violationDescription, artifactPath)
+		return nil
+	}
+
+	remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
+	if decodeErr != nil {
+		return decodeErr
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return err
+	}
+	if err := writeFileAtomic(localPath, remoteBytes, 0o644); err != nil {
+		return err
+	}
+	if err := s.applyLocalPermissions(localPath, s.canWritePath(remotePath)); err != nil {
+		return err
+	}
+
+	contentType := strings.TrimSpace(remoteFile.ContentType)
+	if contentType == "" {
+		contentType = snapshot.ContentType
+	}
+	s.state.Files[remotePath] = trackedFile{
+		Revision:    remoteFile.Revision,
+		ContentType: contentType,
+		Encoding:    normalizeEncoding(remoteFile.Encoding),
+		Hash:        hashBytes(remoteBytes),
+		ReadOnly:    !s.canWritePath(remotePath),
+	}
+	_ = tracked
+	s.logf("schema validation failed at %s (%s); local saved at %s, remote restored",
+		remotePath, violationDescription, artifactPath)
+	return nil
+}
+
+func (s *Syncer) writeSchemaInvalidArtifact(remotePath string, ts time.Time, content []byte) (string, error) {
+	if err := os.MkdirAll(s.conflictsDir, 0o755); err != nil {
+		return "", err
+	}
+	artifactPath := schemaInvalidArtifactPath(s.conflictsDir, remotePath, ts)
+	if err := os.MkdirAll(filepath.Dir(artifactPath), 0o755); err != nil {
+		return "", err
+	}
+	return artifactPath, writeFileAtomic(artifactPath, content, 0o644)
+}
+
+func schemaInvalidArtifactPath(baseDir, remotePath string, ts time.Time) string {
+	rel := strings.TrimPrefix(normalizeRemotePath(remotePath), "/")
+	stamp := ts.UTC().Format("20060102T150405Z")
+	return filepath.Join(baseDir, filepath.FromSlash(rel)+".invalid."+stamp)
+}
+
 func bulkWriteErrorAsError(writeErr BulkWriteError) error {
 	statusCode := 0
 	switch strings.TrimSpace(writeErr.Code) {
@@ -934,6 +1050,11 @@ func bulkWriteErrorAsError(writeErr BulkWriteError) error {
 		statusCode = http.StatusPreconditionFailed
 	case "conflict":
 		return &ConflictError{Path: normalizeRemotePath(writeErr.Path)}
+	case "schema_validation_failed", "validation_error":
+		return &SchemaValidationError{
+			Path:    normalizeRemotePath(writeErr.Path),
+			Message: writeErr.Message,
+		}
 	}
 	if statusCode != 0 || writeErr.Code != "" || writeErr.Message != "" {
 		return &HTTPError{

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -210,6 +210,151 @@ func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	}
 }
 
+func TestSyncOnceWritesPublicStateFile(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	interval := 30 * time.Second
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_public_state",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		Mode:        "poll",
+		Interval:    interval,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	state := readPublicState(t, localDir)
+	if state.WorkspaceID != "ws_mount_public_state" {
+		t.Fatalf("expected workspace id in public state, got %+v", state)
+	}
+	if state.Status != "ready" {
+		t.Fatalf("expected ready status, got %+v", state)
+	}
+	if state.Mode != "poll" || state.IntervalMs != interval.Milliseconds() {
+		t.Fatalf("expected mode/interval in public state, got %+v", state)
+	}
+	if state.PendingWriteback != 0 || state.PendingConflicts != 0 || state.DeniedPaths != 0 {
+		t.Fatalf("expected clean public state, got %+v", state)
+	}
+	if fileState := state.Files["/notion/Docs/A.md"]; fileState.Status != "ready" {
+		t.Fatalf("expected mirrored file state ready, got %+v", fileState)
+	}
+}
+
+func TestBinaryFileRoundTripsThroughMirror(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/external/blob.bin": {
+				Path:        "/external/blob.bin",
+				Revision:    "rev_1",
+				ContentType: "application/octet-stream",
+				Content:     base64.StdEncoding.EncodeToString([]byte{0x00, 0x7f, 0xff, 0x10}),
+				Encoding:    "base64",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_binary_roundtrip",
+		RemoteRoot:  "/external",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial binary sync failed: %v", err)
+	}
+
+	localPath := filepath.Join(localDir, "blob.bin")
+	assertLocalFileBytes(t, localPath, []byte{0x00, 0x7f, 0xff, 0x10})
+
+	updated := []byte{0x01, 0x02, 0x03, 0x04}
+	if err := os.WriteFile(localPath, updated, 0o644); err != nil {
+		t.Fatalf("write binary local edit failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("binary roundtrip sync failed: %v", err)
+	}
+
+	remote := client.files["/external/blob.bin"]
+	if remote.Encoding != "base64" {
+		t.Fatalf("expected remote encoding=base64, got %+v", remote)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(remote.Content)
+	if err != nil {
+		t.Fatalf("decode remote base64 failed: %v", err)
+	}
+	if !bytes.Equal(decoded, updated) {
+		t.Fatalf("expected remote bytes %v, got %v", updated, decoded)
+	}
+	state := readPublicState(t, localDir)
+	if state.Files["/external/blob.bin"].Encoding != "base64" {
+		t.Fatalf("expected public state to track base64 encoding, got %+v", state.Files["/external/blob.bin"])
+	}
+}
+
+func TestLargeWriteFailureLeavesPendingWritebackVisible(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		bulkWriteResponseFunc: func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error) {
+			return BulkWriteResponse{}, &HTTPError{
+				StatusCode: http.StatusRequestEntityTooLarge,
+				Code:       "payload_too_large",
+				Message:    "payload too large",
+			}
+		},
+	}
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "Large.md"), []byte(strings.Repeat("A", 1024)), 0o644); err != nil {
+		t.Fatalf("seed large local file failed: %v", err)
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_large_write_failure",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		Mode:        "poll",
+		Interval:    30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("expected large write sync to fail")
+	}
+
+	assertLocalFileContent(t, filepath.Join(localDir, "Large.md"), strings.Repeat("A", 1024))
+	state := readPublicState(t, localDir)
+	if state.Status != "writeback-pending" {
+		t.Fatalf("expected writeback-pending state, got %+v", state)
+	}
+	if state.PendingWriteback != 1 {
+		t.Fatalf("expected one pending writeback, got %+v", state)
+	}
+	if state.LastError == nil || state.LastError.StatusCode != http.StatusRequestEntityTooLarge || state.LastError.Code != "payload_too_large" {
+		t.Fatalf("expected 413 surfaced in public state, got %+v", state.LastError)
+	}
+}
+
 func TestBulkWrite_SingleCallForNFiles(t *testing.T) {
 	client := &fakeClient{
 		files: map[string]RemoteFile{},
@@ -575,10 +720,12 @@ func TestBulkSeedThenSync(t *testing.T) {
 
 	localDir := t.TempDir()
 	client := NewHTTPClient(api.URL, token, api.Client())
+	disableWebSocket := false
 	syncer, err := NewSyncer(client, SyncerOptions{
 		WorkspaceID: workspaceID,
 		RemoteRoot:  "/notion",
 		LocalRoot:   localDir,
+		WebSocket:   &disableWebSocket,
 	})
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
@@ -841,7 +988,7 @@ func TestBulkWrite_PartialErrors(t *testing.T) {
 	}
 }
 
-func TestBulkWrite_PerFileErrorMarksDirtyForRetry(t *testing.T) {
+func TestBulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote(t *testing.T) {
 	partialError := true
 	client := &fakeClient{
 		files: map[string]RemoteFile{
@@ -902,14 +1049,14 @@ func TestBulkWrite_PerFileErrorMarksDirtyForRetry(t *testing.T) {
 	}
 
 	trackedA := syncer.state.Files["/notion/Docs/A.md"]
-	if !trackedA.Dirty {
-		t.Fatalf("expected failed path to remain dirty for retry, got %+v", trackedA)
-	}
 	if trackedA.Revision != "rev_remote" {
 		t.Fatalf("expected failed path to refresh tracked revision to remote state, got %+v", trackedA)
 	}
-	if trackedA.Hash != hashString("# local A") {
-		t.Fatalf("expected failed path to keep local hash for retry, got %+v", trackedA)
+	if trackedA.Dirty {
+		t.Fatalf("expected failed path to reconcile to remote clean state, got %+v", trackedA)
+	}
+	if trackedA.Hash != hashString("# remote newer") {
+		t.Fatalf("expected failed path to track remote hash after refresh, got %+v", trackedA)
 	}
 	trackedB := syncer.state.Files["/notion/Docs/B.md"]
 	if trackedB.Dirty || trackedB.Revision == "" {
@@ -921,25 +1068,33 @@ func TestBulkWrite_PerFileErrorMarksDirtyForRetry(t *testing.T) {
 	if client.files["/notion/Docs/B.md"].Content != "# local B" {
 		t.Fatalf("expected successful path to be written during partial failure cycle, got %q", client.files["/notion/Docs/B.md"].Content)
 	}
+	assertLocalFileContent(t, localA, "# remote newer")
+	conflictPath := filepath.Join(localDir, ".relay", "conflicts", "notion", "Docs", "A.md.rev_1.local")
+	assertLocalFileContent(t, conflictPath, "# local A")
 
-	callsBeforeRetry := client.bulkWriteCalls
+	state := readPublicState(t, localDir)
+	if state.Status != "conflict" || state.PendingConflicts != 1 {
+		t.Fatalf("expected conflict status in public state, got %+v", state)
+	}
+	if state.Files["/notion/Docs/A.md"].Status != "conflict" {
+		t.Fatalf("expected file state conflict, got %+v", state.Files["/notion/Docs/A.md"])
+	}
+
+	if err := os.WriteFile(localA, []byte("# local A resolved"), 0o644); err != nil {
+		t.Fatalf("write resolved local A failed: %v", err)
+	}
 	if err := syncer.SyncOnce(context.Background()); err != nil {
-		t.Fatalf("retry sync failed: %v", err)
+		t.Fatalf("resolved retry sync failed: %v", err)
 	}
-	if client.bulkWriteCalls != callsBeforeRetry+1 {
-		t.Fatalf("expected exactly one retry bulk call, got %d -> %d", callsBeforeRetry, client.bulkWriteCalls)
+	if client.files["/notion/Docs/A.md"].Content != "# local A resolved" {
+		t.Fatalf("expected resolved retry to write local A, got %q", client.files["/notion/Docs/A.md"].Content)
 	}
-	if got := len(client.bulkWriteBatches[client.bulkWriteCalls-1]); got != 1 {
-		t.Fatalf("expected retry batch to contain only the failed path, got %d entries", got)
+	if _, err := os.Stat(filepath.Join(localDir, ".relay", "conflicts", "resolved", "notion", "Docs", "A.md.rev_1.local")); err != nil {
+		t.Fatalf("expected conflict artifact moved to resolved, got %v", err)
 	}
-	if retryPath := normalizeRemotePath(client.bulkWriteBatches[client.bulkWriteCalls-1][0].Path); retryPath != "/notion/Docs/A.md" {
-		t.Fatalf("expected retry batch to target only /notion/Docs/A.md, got %q", retryPath)
-	}
-	if client.files["/notion/Docs/A.md"].Content != "# local A" {
-		t.Fatalf("expected retry cycle to eventually write local A, got %q", client.files["/notion/Docs/A.md"].Content)
-	}
-	if syncer.state.Files["/notion/Docs/A.md"].Dirty {
-		t.Fatalf("expected retry cycle to clear dirty state, got %+v", syncer.state.Files["/notion/Docs/A.md"])
+	state = readPublicState(t, localDir)
+	if state.PendingConflicts != 0 || state.Status != "ready" {
+		t.Fatalf("expected ready status after resolution, got %+v", state)
 	}
 }
 
@@ -988,6 +1143,10 @@ func TestBulkWrite_DeletesStayPerFile(t *testing.T) {
 	}
 	if client.deleteCalls[0].Path != "/notion/Docs/A.md" || client.deleteCalls[0].BaseRevision != "rev_1" {
 		t.Fatalf("expected delete to use tracked revision rev_1, got %+v", client.deleteCalls[0])
+	}
+	state := readPublicState(t, localDir)
+	if state.PendingWriteback != 0 || state.Status != "ready" {
+		t.Fatalf("expected delete cycle to settle cleanly, got %+v", state)
 	}
 }
 
@@ -2034,6 +2193,7 @@ func (c *fakeClient) WriteFile(ctx context.Context, workspaceID, path, baseRevis
 		Revision:    revision,
 		ContentType: contentType,
 		Content:     content,
+		Encoding:    "",
 	}
 	c.appendEvent(eventType, path, revision)
 	return WriteResult{TargetRevision: revision}, nil
@@ -2086,6 +2246,7 @@ func (c *fakeClient) WriteFilesBulk(ctx context.Context, workspaceID string, fil
 			Revision:    revision,
 			ContentType: contentType,
 			Content:     file.Content,
+			Encoding:    strings.TrimSpace(file.Encoding),
 		}
 		results = append(results, BulkWriteResult{
 			Path:        path,
@@ -2242,6 +2403,7 @@ func newMockMountsyncServer(
 				} else if current.ContentType == "" {
 					current.ContentType = "text/markdown"
 				}
+				current.Encoding = strings.TrimSpace(file.Encoding)
 				revisionCounter++
 				current.Revision = fmt.Sprintf("rev_%d", revisionCounter)
 				normalizedFiles[path] = current
@@ -2271,6 +2433,7 @@ func newMockMountsyncServer(
 			var payload struct {
 				Content     string `json:"content"`
 				ContentType string `json:"contentType"`
+				Encoding    string `json:"encoding"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				writeJSONResponse(t, w, http.StatusBadRequest, map[string]any{
@@ -2285,6 +2448,7 @@ func newMockMountsyncServer(
 			if payload.ContentType != "" {
 				file.ContentType = payload.ContentType
 			}
+			file.Encoding = strings.TrimSpace(payload.Encoding)
 			if file.Revision == "" {
 				file.Revision = "rev_1"
 			} else {
@@ -2488,6 +2652,30 @@ func assertStateMarksPathDenied(t *testing.T, stateFile, remotePath string) {
 	}
 	if entry.Denied == nil || !*entry.Denied {
 		t.Fatalf("expected state path %q marked denied", remotePath)
+	}
+}
+
+func readPublicState(t *testing.T, localDir string) publicState {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(localDir, ".relay", "state.json"))
+	if err != nil {
+		t.Fatalf("read public state failed: %v", err)
+	}
+	var state publicState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("unmarshal public state failed: %v", err)
+	}
+	return state
+}
+
+func assertLocalFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read local file %s failed: %v", path, err)
+	}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("expected %s to contain %v, got %v", path, want, data)
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -1098,6 +1098,140 @@ func TestBulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote(t *testing.T
 	}
 }
 
+func TestBulkWrite_SchemaValidationQuarantinesLocalAndRestoresRemote(t *testing.T) {
+	rejectOnce := true
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/github/repos/acme/api/pulls/42/reviews/draft.json": {
+				Path:        "/github/repos/acme/api/pulls/42/reviews/draft.json",
+				Revision:    "rev_1",
+				ContentType: "application/json",
+				Content:     `{"event":"APPROVE"}`,
+			},
+		},
+		revisionCounter: 1,
+		bulkWriteResponseFunc: func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error) {
+			if !rejectOnce {
+				return BulkWriteResponse{}, nil
+			}
+			rejectOnce = false
+			return BulkWriteResponse{
+				Written:    0,
+				ErrorCount: 1,
+				Errors: []BulkWriteError{{
+					Path:    "/github/repos/acme/api/pulls/42/reviews/draft.json",
+					Code:    "schema_validation_failed",
+					Message: "body.event must be one of APPROVE,REQUEST_CHANGES,COMMENT (line 3)",
+				}},
+			}, nil
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_schema_invalid",
+		RemoteRoot:  "/github",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	localPath := filepath.Join(localDir, "repos", "acme", "api", "pulls", "42", "reviews", "draft.json")
+	if err := os.WriteFile(localPath, []byte(`{"event":"PLEASE_APPROVE"}`), 0o644); err != nil {
+		t.Fatalf("write local draft failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync with schema validation failure failed: %v", err)
+	}
+
+	assertLocalFileContent(t, localPath, `{"event":"APPROVE"}`)
+
+	conflictsRoot := filepath.Join(localDir, ".relay", "conflicts", "github", "repos", "acme", "api", "pulls", "42", "reviews")
+	matches, err := filepath.Glob(filepath.Join(conflictsRoot, "draft.json.invalid.*"))
+	if err != nil {
+		t.Fatalf("glob conflict artifact failed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one .invalid.<ts> artifact, got %d (%v)", len(matches), matches)
+	}
+	body, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("read invalid artifact failed: %v", err)
+	}
+	if string(body) != `{"event":"PLEASE_APPROVE"}` {
+		t.Fatalf("expected invalid artifact to hold local body, got %q", body)
+	}
+
+	tracked := syncer.state.Files["/github/repos/acme/api/pulls/42/reviews/draft.json"]
+	if tracked.Dirty {
+		t.Fatalf("expected tracked entry to clear dirty flag after restore, got %+v", tracked)
+	}
+	if tracked.Revision != "rev_1" {
+		t.Fatalf("expected tracked entry to reflect restored remote revision, got %+v", tracked)
+	}
+}
+
+func TestBulkWrite_SchemaValidationOnCreateRemovesLocal(t *testing.T) {
+	rejectOnce := true
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		bulkWriteResponseFunc: func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error) {
+			if !rejectOnce {
+				return BulkWriteResponse{}, nil
+			}
+			rejectOnce = false
+			return BulkWriteResponse{
+				Written:    0,
+				ErrorCount: 1,
+				Errors: []BulkWriteError{{
+					Path:    "/github/repos/acme/api/pulls/42/reviews/draft.json",
+					Code:    "schema_validation_failed",
+					Message: "missing required property: event",
+				}},
+			}, nil
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_schema_create_invalid",
+		RemoteRoot:  "/github",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	localPath := filepath.Join(localDir, "repos", "acme", "api", "pulls", "42", "reviews", "draft.json")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local path failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(`{"unexpected":"shape"}`), 0o644); err != nil {
+		t.Fatalf("write local create body failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync with schema validation create failure failed: %v", err)
+	}
+
+	if _, err := os.Stat(localPath); !os.IsNotExist(err) {
+		t.Fatalf("expected invalid create body removed from mirror, got err=%v", err)
+	}
+	conflictsRoot := filepath.Join(localDir, ".relay", "conflicts", "github", "repos", "acme", "api", "pulls", "42", "reviews")
+	matches, err := filepath.Glob(filepath.Join(conflictsRoot, "draft.json.invalid.*"))
+	if err != nil {
+		t.Fatalf("glob conflict artifact failed: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one .invalid.<ts> artifact, got %d (%v)", len(matches), matches)
+	}
+	if _, ok := syncer.state.Files["/github/repos/acme/api/pulls/42/reviews/draft.json"]; ok {
+		t.Fatalf("expected tracked entry cleared for unrestorable schema-invalid create")
+	}
+}
+
 func TestBulkWrite_DeletesStayPerFile(t *testing.T) {
 	client := &fakeClient{
 		files: map[string]RemoteFile{

--- a/workflows/064-productized-cloud-mount.ts
+++ b/workflows/064-productized-cloud-mount.ts
@@ -1,0 +1,450 @@
+/**
+ * 064-productized-cloud-mount.ts
+ *
+ * Close the remaining product gaps for the Relayfile "just type relayfile"
+ * experience: Cloud login, many integrations, background synced mount, durable
+ * token refresh, agent-facing VFS skill, writeback safety, and E2E proof.
+ *
+ * The default product posture is a local synced mirror, not a kernel FUSE mount.
+ * FUSE remains an optional mode. The shipped happy path should feel like a
+ * local folder attached to remote integrations while preserving low context for
+ * agents and clear observability for humans.
+ *
+ * Run from the relayfile repo root:
+ *   agent-relay run workflows/064-productized-cloud-mount.ts
+ */
+import path from 'node:path';
+import { workflow } from '@agent-relay/sdk/workflows';
+import { ClaudeModels, CodexModels } from '@agent-relay/config';
+
+const RELAYFILE_ROOT = process.cwd();
+const CLOUD_ROOT = path.resolve(RELAYFILE_ROOT, '../cloud');
+const RELAYFILE_BRANCH = 'codex/productized-cloud-mount';
+const CLOUD_BRANCH = 'codex/productized-relayfile-integrations';
+
+async function main() {
+  const result = await workflow('064-productized-cloud-mount')
+    .description(
+      'Productize Relayfile Cloud onboarding so a user can run relayfile, connect one or more Nango-backed integrations, and leave agents with a durable low-context synced VFS mount.',
+    )
+    .pattern('dag')
+    .channel('wf-064-productized-cloud-mount')
+    .maxConcurrency(5)
+    .timeout(14_400_000)
+
+    .agent('product-architect', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      preset: 'analyst',
+      role: 'Defines the product acceptance contract, chooses v1 tradeoffs, and keeps the workflow focused on the low-friction user vision.',
+      retries: 1,
+    })
+    .agent('cli-daemon-impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      preset: 'worker',
+      role: 'Implements CLI setup refinements, background daemon/service lifecycle, local config, workspace token refresh, and status commands in relayfile.',
+      retries: 2,
+    })
+    .agent('mount-impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      preset: 'worker',
+      role: 'Hardens the local synced mirror: conflict handling, stale markers, status files, writeback visibility, and optional FUSE boundaries.',
+      retries: 2,
+    })
+    .agent('cloud-impl', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      preset: 'worker',
+      role: 'Implements cloud-side provider catalog, Nango config-key resolution, initial sync readiness, multi-integration connection, and refresh/rejoin support in ../cloud.',
+      retries: 2,
+    })
+    .agent('agent-skill-docs', {
+      cli: 'claude',
+      model: ClaudeModels.SONNET,
+      preset: 'worker',
+      role: 'Writes the agent-facing Relayfile VFS skill and concise human docs for setup, path conventions, status, writeback, and safe editing.',
+      retries: 1,
+    })
+    .agent('e2e-proof', {
+      cli: 'codex',
+      model: CodexModels.GPT_5_4,
+      preset: 'worker',
+      role: 'Builds deterministic mocks and packaged E2E proof for setup, multi-provider connect, daemon sync, refresh, writeback, and recovery.',
+      retries: 2,
+    })
+    .agent('reviewer', {
+      cli: 'claude',
+      model: ClaudeModels.OPUS,
+      preset: 'reviewer',
+      role: 'Reviews the final implementation against the product contract, evidence, security boundaries, and user experience.',
+      retries: 1,
+    })
+
+    .step('preflight', {
+      type: 'deterministic',
+      command: [
+        'set -e',
+        `test -d ${shell(RELAYFILE_ROOT)}`,
+        `test -d ${shell(CLOUD_ROOT)}`,
+        `echo "relayfile root: ${RELAYFILE_ROOT}"`,
+        `echo "cloud root: ${CLOUD_ROOT}"`,
+        '',
+        `cd ${shell(RELAYFILE_ROOT)}`,
+        'RELAYFILE_CURRENT=$(git rev-parse --abbrev-ref HEAD)',
+        'echo "relayfile branch: $RELAYFILE_CURRENT"',
+        'if [ "$RELAYFILE_CURRENT" = "main" ]; then',
+        `  git checkout -b ${shell(RELAYFILE_BRANCH)}`,
+        `  echo "created relayfile branch ${RELAYFILE_BRANCH}"`,
+        'else',
+        '  echo "using existing relayfile branch $RELAYFILE_CURRENT"',
+        'fi',
+        'if ! git diff --cached --quiet; then',
+        '  echo "ERROR: relayfile staging area is dirty; unstage before running this workflow"',
+        '  git diff --cached --stat',
+        '  exit 1',
+        'fi',
+        'node --version',
+        'npm --version',
+        'go version',
+        '',
+        `cd ${shell(CLOUD_ROOT)}`,
+        'CLOUD_CURRENT=$(git rev-parse --abbrev-ref HEAD)',
+        'echo "cloud branch: $CLOUD_CURRENT"',
+        'if [ "$CLOUD_CURRENT" = "main" ]; then',
+        `  git checkout -b ${shell(CLOUD_BRANCH)}`,
+        `  echo "created cloud branch ${CLOUD_BRANCH}"`,
+        'else',
+        '  echo "using existing cloud branch $CLOUD_CURRENT"',
+        'fi',
+        'if ! git diff --cached --quiet; then',
+        '  echo "ERROR: cloud staging area is dirty; unstage before running this workflow"',
+        '  git diff --cached --stat',
+        '  exit 1',
+        'fi',
+        'node --version',
+        'npm --version',
+        'echo PREFLIGHT_OK',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('collect-relayfile-context', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        'set -e',
+        `cd ${shell(RELAYFILE_ROOT)}`,
+        'echo "=== guided CLI and config ==="',
+        'sed -n "1,720p" cmd/relayfile-cli/main.go',
+        'sed -n "1,260p" cmd/relayfile-cli/main_test.go',
+        'echo',
+        'echo "=== standalone mount command ==="',
+        'sed -n "1,320p" cmd/relayfile-mount/main.go',
+        'sed -n "1,220p" cmd/relayfile-mount/fuse_mount.go 2>/dev/null || true',
+        'echo',
+        'echo "=== mount sync internals ==="',
+        'sed -n "1,520p" internal/mountsync/syncer.go',
+        'sed -n "1,320p" internal/mountsync/watcher.go',
+        'sed -n "1,260p" internal/mountsync/http_client_test.go',
+        'echo',
+        'echo "=== setup SDK and docs ==="',
+        'sed -n "1,680p" packages/sdk/typescript/src/setup.ts',
+        'sed -n "1,220p" packages/sdk/typescript/src/cloud-login.ts',
+        'sed -n "1,160p" packages/sdk/typescript/src/setup-types.ts',
+        'sed -n "1,180p" README.md',
+        'sed -n "1,180p" docs/cli-design.md',
+        'echo',
+        'echo "=== workflow inventory ==="',
+        'find workflows -maxdepth 1 -type f | sort',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('collect-cloud-context', {
+      type: 'deterministic',
+      dependsOn: ['preflight'],
+      command: [
+        'set -e',
+        `cd ${shell(CLOUD_ROOT)}`,
+        'echo "=== cloud routes and provider registry ==="',
+        'find packages -path "*api/v1/workspaces*" -type f | sort | sed -n "1,260p"',
+        'rg -n "cli/login|connect-session|connectionId|provider|Nango|provider_config|configKey|integration|initial sync|sync_queued|syncing|ready" packages tests 2>/dev/null | head -320 || true',
+        'echo',
+        'echo "=== likely setup route files ==="',
+        'sed -n "1,260p" packages/web/app/api/v1/cli/login/route.ts 2>/dev/null || true',
+        'sed -n "1,260p" packages/web/app/api/v1/workspaces/route.ts 2>/dev/null || true',
+        'sed -n "1,260p" "packages/web/app/api/v1/workspaces/[workspaceId]/join/route.ts" 2>/dev/null || true',
+        'sed -n "1,260p" "packages/web/app/api/v1/workspaces/[workspaceId]/integrations/connect-session/route.ts" 2>/dev/null || true',
+        'sed -n "1,260p" "packages/web/app/api/v1/workspaces/[workspaceId]/integrations/[provider]/status/route.ts" 2>/dev/null || true',
+        'echo',
+        'echo "=== package scripts ==="',
+        'cat package.json',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('define-product-contract', {
+      agent: 'product-architect',
+      dependsOn: ['collect-relayfile-context', 'collect-cloud-context'],
+      task: [
+        'Define the v1 product contract before implementation. Write docs/productized-cloud-mount-contract.md in the relayfile repo.',
+        '',
+        'Important product premise:',
+        '- The default local attachment is a synced mirror, not a kernel FUSE mount.',
+        '- This is acceptable for agents because they see ordinary files, but the product must be honest about sync state, conflicts, refresh, and writeback.',
+        '- FUSE can remain optional and separately hardened.',
+        '',
+        'Relayfile context:',
+        '{{steps.collect-relayfile-context.output}}',
+        '',
+        'Cloud context:',
+        '{{steps.collect-cloud-context.output}}',
+        '',
+        'The contract must include:',
+        '1. Exact first-run UX for `relayfile` and `relayfile setup`.',
+        '2. Multi-integration UX for adding providers after first setup.',
+        '3. Synced mirror limitations and user-visible mitigations.',
+        '4. Required daemon/background behavior and platform assumptions.',
+        '5. Token refresh and workspace rejoin semantics for long-lived mounts.',
+        '6. Cloud provider catalog and Nango config-key source of truth.',
+        '7. Initial sync/readiness semantics after OAuth.',
+        '8. Writeback safety, schema validation, conflicts, and dead-letter visibility.',
+        '9. Agent skill contract: mount discovery, path conventions, status, and safe edits.',
+        '10. E2E acceptance tests with realistic mocked Cloud/Nango/Relayfile services.',
+        '',
+        'End the document with PRODUCTIZED_CLOUD_MOUNT_CONTRACT_READY.',
+      ].join('\n'),
+      verification: { type: 'file_exists', value: 'docs/productized-cloud-mount-contract.md' },
+    })
+
+    .step('implement-cli-daemon-refresh', {
+      agent: 'cli-daemon-impl',
+      dependsOn: ['define-product-contract'],
+      task: [
+        'Implement the CLI/daemon/token-refresh slice in relayfile.',
+        '',
+        'Read docs/productized-cloud-mount-contract.md first.',
+        '',
+        'Own these areas:',
+        '- cmd/relayfile-cli/**',
+        '- packages/cli/** when npm wrapper changes are needed',
+        '- docs/environment-variables.md and CLI docs for commands/env vars',
+        '- tests directly covering CLI setup, connect, daemon, token refresh, and status UX',
+        '',
+        'Requirements:',
+        '1. Keep `relayfile` as the low-friction guided setup entrypoint.',
+        '2. Add or refine commands for background lifecycle: start/status/stop/logs or equivalent.',
+        '3. Support adding multiple integrations after first setup without recreating the workspace.',
+        '4. Persist Cloud tokens and refresh/rejoin workspace JWTs for long-lived mounts.',
+        '5. Ensure the foreground synced mirror remains available for CI and simple use.',
+        '6. Do not touch cloud repo files; coordinate through the documented contract.',
+        '',
+        'Run targeted tests after edits and end with CLI_DAEMON_REFRESH_READY plus the exact commands run.',
+      ].join('\n'),
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('implement-mount-safety-status', {
+      agent: 'mount-impl',
+      dependsOn: ['define-product-contract'],
+      task: [
+        'Implement the synced-mirror safety/status slice in relayfile.',
+        '',
+        'Read docs/productized-cloud-mount-contract.md first.',
+        '',
+        'Own these areas:',
+        '- internal/mountsync/**',
+        '- cmd/relayfile-mount/**',
+        '- internal/mountfuse/** only for optional-mode boundaries',
+        '- mount-related docs/tests/evidence',
+        '',
+        'Requirements:',
+        '1. Make sync state visible locally, preferably under a reserved `.relayfile/` status area or equivalent CLI status command.',
+        '2. Make stale/offline/conflict/writeback-pending states explicit and machine-readable.',
+        '3. Preserve revision conflict safety; never silently clobber remote or local edits.',
+        '4. Keep large/binary files and deleted files behavior documented and tested.',
+        '5. Keep FUSE optional; do not make product success depend on kernel-level mount availability.',
+        '',
+        'Run targeted mountsync/mount tests after edits and end with MOUNT_SAFETY_STATUS_READY plus the exact commands run.',
+      ].join('\n'),
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('implement-cloud-provider-readiness', {
+      agent: 'cloud-impl',
+      dependsOn: ['define-product-contract'],
+      task: [
+        'Implement the Cloud/Nango/provider-readiness slice in ../cloud.',
+        '',
+        'Read relayfile docs/productized-cloud-mount-contract.md first.',
+        '',
+        'Own these areas in the cloud repo:',
+        '- Cloud CLI login/token refresh endpoints used by relayfile setup',
+        '- workspace create/join/rejoin behavior for long-lived mounts',
+        '- provider catalog endpoint/source of truth for display name and Nango config key',
+        '- connect-session/status routes',
+        '- initial sync enqueue/readiness state after OAuth',
+        '- tests for all of the above',
+        '',
+        'Requirements:',
+        '1. The relayfile CLI must not hard-code Nango config keys.',
+        '2. Status must distinguish OAuth connected, initial sync queued/running/complete/failed, and writeback health.',
+        '3. Multi-provider connections must be idempotent and resumable.',
+        '4. Relayfile workspace JWT refresh/rejoin must be explicit enough for long-lived local daemons.',
+        '',
+        'Run targeted cloud tests after edits and end with CLOUD_PROVIDER_READINESS_READY plus the exact commands run.',
+      ].join('\n'),
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('write-agent-skill-and-docs', {
+      agent: 'agent-skill-docs',
+      dependsOn: ['define-product-contract'],
+      task: [
+        'Write the agent-facing skill and human docs for the productized Relayfile VFS experience.',
+        '',
+        'Read docs/productized-cloud-mount-contract.md first.',
+        '',
+        'Own these areas:',
+        '- docs/guides/**',
+        '- docs/cli-design.md',
+        '- README.md',
+        '- a proposed skill file or skill draft under docs/ that can later be installed into .agents/skills',
+        '',
+        'Requirements:',
+        '1. Keep the agent contract tiny: discover mount path, inspect status, read/write files, handle conflicts/writeback failures.',
+        '2. Document the synced-mirror drawbacks honestly without making the product feel scary.',
+        '3. Include path conventions for provider-backed files and reserved Relayfile metadata/status paths.',
+        '4. Include guidance for low-context agents: prefer file operations over provider APIs.',
+        '5. Include human commands for setup, connect another integration, status, stop/start daemon, and troubleshooting.',
+        '',
+        'End with AGENT_RELAYFILE_VFS_DOCS_READY.',
+      ].join('\n'),
+      verification: { type: 'exit_code', value: '0' },
+    })
+
+    .step('build-product-e2e-proof', {
+      agent: 'e2e-proof',
+      dependsOn: [
+        'implement-cli-daemon-refresh',
+        'implement-mount-safety-status',
+        'implement-cloud-provider-readiness',
+        'write-agent-skill-and-docs',
+      ],
+      task: [
+        'Build the deterministic end-to-end proof for the productized Relayfile setup.',
+        '',
+        'Read docs/productized-cloud-mount-contract.md and all changed files in relayfile and ../cloud.',
+        '',
+        'Requirements:',
+        '1. Use realistic local mock servers for Cloud, Relayfile VFS, and Nango/webhook/writeback behavior where real services are not available.',
+        '2. Prove first-run setup with at least two integrations.',
+        '3. Prove daemon/synced mirror startup, remote-to-local sync, local-to-remote writeback, conflict visibility, and status reporting.',
+        '4. Prove token refresh or workspace rejoin for a long-lived mount.',
+        '5. Prove recovery after process restart using persisted config.',
+        '6. Save final evidence under docs/evidence/productized-cloud-mount-final-evidence.md.',
+        '7. Include the literal marker PRODUCTIZED_CLOUD_MOUNT_E2E_READY in that evidence file.',
+        '',
+        'Run the E2E proof until green and end with PRODUCTIZED_CLOUD_MOUNT_E2E_READY.',
+      ].join('\n'),
+      verification: { type: 'file_exists', value: 'docs/evidence/productized-cloud-mount-final-evidence.md' },
+    })
+
+    .step('verify-relayfile', {
+      type: 'deterministic',
+      dependsOn: ['build-product-e2e-proof'],
+      command: [
+        'set -e',
+        `cd ${shell(RELAYFILE_ROOT)}`,
+        'go test ./...',
+        'npm run typecheck',
+        'test -f docs/productized-cloud-mount-contract.md',
+        'test -f docs/evidence/productized-cloud-mount-final-evidence.md',
+        'grep -q PRODUCTIZED_CLOUD_MOUNT_CONTRACT_READY docs/productized-cloud-mount-contract.md',
+        'grep -q PRODUCTIZED_CLOUD_MOUNT_E2E_READY docs/evidence/productized-cloud-mount-final-evidence.md',
+        'echo RELAYFILE_PRODUCTIZED_MOUNT_VERIFY_OK',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('verify-cloud', {
+      type: 'deterministic',
+      dependsOn: ['build-product-e2e-proof'],
+      command: [
+        'set -e',
+        `cd ${shell(CLOUD_ROOT)}`,
+        'npm test',
+        'npm run typecheck',
+        'echo CLOUD_PRODUCTIZED_MOUNT_VERIFY_OK',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .step('review-productized-mount', {
+      agent: 'reviewer',
+      dependsOn: ['verify-relayfile', 'verify-cloud'],
+      task: [
+        'Review the final productized Relayfile Cloud mount implementation.',
+        '',
+        'Read:',
+        '- relayfile docs/productized-cloud-mount-contract.md',
+        '- relayfile docs/evidence/productized-cloud-mount-final-evidence.md',
+        '- relayfile changed files',
+        '- cloud changed files',
+        '- verification output:',
+        '{{steps.verify-relayfile.output}}',
+        '{{steps.verify-cloud.output}}',
+        '',
+        'Write docs/productized-cloud-mount-review-verdict.md in the relayfile repo.',
+        '',
+        'Assess:',
+        '1. Does the implementation satisfy the original product vision?',
+        '2. Are synced-mirror drawbacks mitigated and visible?',
+        '3. Is token refresh/rejoin trustworthy for long-lived mounts?',
+        '4. Is Cloud/Nango provider readiness enough for many integrations?',
+        '5. Is writeback safe enough for agents?',
+        '6. Is the E2E proof truly end to end?',
+        '7. What residual risks remain before public launch?',
+        '',
+        'End with PRODUCTIZED_CLOUD_MOUNT_REVIEW_COMPLETE.',
+      ].join('\n'),
+      verification: { type: 'file_exists', value: 'docs/productized-cloud-mount-review-verdict.md' },
+    })
+
+    .step('final-artifact-gate', {
+      type: 'deterministic',
+      dependsOn: ['review-productized-mount'],
+      command: [
+        'set -e',
+        `cd ${shell(RELAYFILE_ROOT)}`,
+        'test -f docs/productized-cloud-mount-contract.md',
+        'test -f docs/evidence/productized-cloud-mount-final-evidence.md',
+        'test -f docs/productized-cloud-mount-review-verdict.md',
+        'grep -q PRODUCTIZED_CLOUD_MOUNT_REVIEW_COMPLETE docs/productized-cloud-mount-review-verdict.md',
+        'git diff --stat',
+        'echo PRODUCTIZED_CLOUD_MOUNT_WORKFLOW_COMPLETE',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+
+    .run({ cwd: RELAYFILE_ROOT });
+
+  console.log(result.status);
+}
+
+function shell(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add productized Cloud mount workflow, contract, review verdict, and evidence
- add background daemon lifecycle, status, token refresh/rejoin, multi-integration setup paths, and E2E proof coverage
- harden synced mirror status/conflict/writeback visibility and document the agent VFS skill

## Stack
- Stacked on #70 (`codex/relayfile-guided-cloud-setup`) because this builds on the guided setup entrypoint.

## Tests
- `go test ./...`
- `npm run typecheck`
- productized E2E evidence recorded in `docs/evidence/productized-cloud-mount-final-evidence.md`

## Hygiene
- Left unrelated `.trajectories` index/untracked trajectory noise unstaged.