### PR TITLE
Add agent workspace governance and JIT integration specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ relayfile permissions github/repos/acme/api/pulls/
 | [docs/guides/cloud-integration.md](docs/guides/cloud-integration.md) | Cloud workflow model for orchestrators |
 | [docs/guides/collaboration.md](docs/guides/collaboration.md) | Multi-human and human+agent collaboration patterns |
 | [docs/skills/relayfile-workspace.md](docs/skills/relayfile-workspace.md) | Installable agent skill (copy to `.agents/skills/`) |
+| [docs/agent-workspace-governance-and-jit-integrations.md](docs/agent-workspace-governance-and-jit-integrations.md) | Consolidated agent workspace governance and just-in-time integration contract |
+| [docs/per-user-governance-contract.md](docs/per-user-governance-contract.md) | Cross-repo contract for per-user governance with relayauth |
 | [docs/cli-design.md](docs/cli-design.md) | CLI command reference and design |
 | [docs/productized-cloud-mount-contract.md](docs/productized-cloud-mount-contract.md) | v1 product contract (normative) |
 | [docs/api-reference.md](docs/api-reference.md) | REST API reference |

--- a/docs/agent-workspace-governance-and-jit-integrations.md
+++ b/docs/agent-workspace-governance-and-jit-integrations.md
@@ -1,0 +1,715 @@
+# Agent Workspace Governance and JIT Integration Contract
+
+**Status:** Draft for stacked PR review
+**Date:** 2026-05-04
+**Owners:** Relayfile, Relayauth, Cloud, Relayfile Adapters, Relayfile Providers, Sage
+**Audience:** Implementers of `relayfile`, `../relayauth`, `../cloud`, `../relayfile-adapters`, `../relayfile-providers`, and `../sage`.
+
+This document consolidates three threads:
+
+1. The programmatic Cloud + Relayfile + Relayauth interface introduced by
+   [cloud#406](https://github.com/AgentWorkforce/cloud/pull/406),
+   [relayfile#70](https://github.com/AgentWorkforce/relayfile/pull/70), and
+   [relayfile#71](https://github.com/AgentWorkforce/relayfile/pull/71).
+2. The missing enterprise governance work tracked by
+   [relayauth#37](https://github.com/AgentWorkforce/relayauth/issues/37).
+3. The agent usability and readiness gaps tracked by
+   [relayfile#79](https://github.com/AgentWorkforce/relayfile/issues/79).
+
+It also adds a new contract for dynamic just-in-time integrations: an end
+customer can define which provider objects they want, Relayfile Cloud can
+generate a bounded integration plan, validate it with the customer's connected
+account, run a Nango dry run inside a sandbox, and then promote the result into
+a governed Relayfile VFS projection.
+
+The core product claim is:
+
+> Relayfile gives agents a file-native interface, while Cloud and Relayauth
+> provide MCP-style per-user governance. Static integrations and just-in-time
+> customer-defined integrations must share the same authorization, readiness,
+> audit, and writeback contracts.
+
+---
+
+## 1. Current Programmatic Interface
+
+The current v1 flow is Cloud-first. Programmatic clients should not call Nango
+or Relayauth directly for provider setup. They call Cloud, and Cloud mints the
+Relayfile token through Relayauth.
+
+### 1.1 SDK login and token refresh
+
+`cloudApiUrl` is optional and defaults to `https://agentrelay.com/cloud`.
+
+```ts
+import { RelayfileSetup } from "@relayfile/sdk";
+
+const setup = await RelayfileSetup.login({
+  onLoginUrl: async (url) => {
+    await sendToUser(`Sign in to Relayfile Cloud: ${url}`);
+  },
+  onTokens: async (tokens) => {
+    await saveTokenSet(tokens);
+  },
+});
+```
+
+On resume, callers should restore the saved Cloud token set:
+
+```ts
+const setup = RelayfileSetup.fromCloudTokens(await loadTokenSet(), {
+  onTokens: async (tokens) => {
+    await saveTokenSet(tokens);
+  },
+});
+```
+
+Headless services may use:
+
+```ts
+const setup = new RelayfileSetup({
+  accessToken: async () => process.env.RELAYFILE_CLOUD_TOKEN!,
+});
+```
+
+This is not the preferred interactive product path; it is for CI or service
+accounts that already have a Cloud bearer token.
+
+### 1.2 Workspace create or join
+
+```ts
+const workspace = await setup.createWorkspace({
+  name: "acme-notion-room",
+  agentName: "lead-agent",
+  scopes: [
+    "relayfile:fs:read:/notion/*",
+    "relayfile:fs:write:/notion/*",
+  ],
+});
+```
+
+Cloud calls Relayauth during `join` and returns a Relayfile JWT plus the
+Relayfile and Relaycast connection details.
+
+### 1.3 Connect Notion
+
+```ts
+const notion = await workspace.connectNotion();
+
+if (notion.connectLink) {
+  await sendToUser(`Connect Notion: ${notion.connectLink}`);
+}
+
+await workspace.waitForNotion({
+  connectionId: notion.connectionId,
+  timeoutMs: 5 * 60_000,
+});
+```
+
+The raw Cloud API shape is:
+
+```http
+POST /api/v1/workspaces/{workspaceId}/integrations/connect-session
+Authorization: Bearer <relayfile-jwt>
+
+{ "allowedIntegrations": ["notion"] }
+```
+
+The response must include a `connectLink` and `connectionId`. The status check
+is:
+
+```http
+GET /api/v1/workspaces/{workspaceId}/integrations/notion/status?connectionId=<id>
+Authorization: Bearer <relayfile-jwt>
+```
+
+### 1.4 Mount environment
+
+```ts
+const env = workspace.mountEnv({
+  localDir: "/workspace/relayfile",
+  remotePath: "/",
+});
+```
+
+Agents read connected Notion data under the provider root returned by the Cloud
+catalog. For Notion v1 this root is `/notion`.
+
+---
+
+## 2. Known Gaps to Close
+
+### 2.1 Governance gaps
+
+[relayauth#37](https://github.com/AgentWorkforce/relayauth/issues/37) tracks
+the missing governance layer. The required properties are:
+
+1. Per-agent Relayauth identities and tokens.
+2. Child-token issuance with strict subset checks against the parent token.
+3. Sponsor chains that trace every agent action back to a human.
+4. Token, session, identity, and provider-connection revocation.
+5. Scope families for `relayfile:fs`, `relayfile:ops`, `relayfile:sync`, and
+   `relayfile:integration`.
+6. Structured audit events that Relayfile can correlate with VFS and writeback
+   operation logs.
+
+### 2.2 Agent workspace usability gaps
+
+[relayfile#79](https://github.com/AgentWorkforce/relayfile/issues/79) tracks
+the missing SDK/readiness layer. The required properties are:
+
+1. `workspace.listIntegrations()`.
+2. `workspace.listMountedPaths()`.
+3. `waitForConnection()` returning mounted path and sync status, not only a
+   boolean.
+4. A sync progress callback or polling helper.
+5. A resume-safe way to discover already-connected integrations.
+6. Invites with expiry and independently revocable per-agent tokens.
+
+These are not cosmetic. Without them, an agent can connect Notion but still
+guess `/notion` by convention and race an empty mount immediately after OAuth.
+
+---
+
+## 3. Unified Integration Status Contract
+
+Static integrations and just-in-time integrations must expose the same status
+shape.
+
+```ts
+interface WorkspaceIntegrationStatus {
+  provider: string;
+  kind: "static" | "jit";
+  displayName: string;
+  connectionId: string | null;
+  providerConfigKey: string | null;
+  vfsRoot: string;
+  mountedPath: string;
+  oauth: {
+    connected: boolean;
+    connectedAt: string | null;
+    lastAuthAt: string | null;
+    userId?: string;
+    orgId?: string;
+  };
+  sync: {
+    state: "pending" | "cataloging" | "syncing" | "ready" | "error" | "degraded";
+    lagSeconds: number;
+    watermarkTs: string | null;
+    firstMaterializedAt: string | null;
+    fileCount: number;
+    lastError: string | null;
+    webhookHealthy: boolean | null;
+  };
+  permissions: {
+    readable: boolean;
+    writable: boolean;
+    requiredScopes: string[];
+  };
+}
+```
+
+The SDK must expose:
+
+```ts
+await workspace.listIntegrations();
+await workspace.listMountedPaths();
+await workspace.waitForIntegration("notion", {
+  until: "materialized",
+  onSyncProgress: (status) => report(status),
+});
+```
+
+`waitForNotion()` may remain as a convenience wrapper, but it must resolve to
+an integration status object rather than `void`.
+
+---
+
+## 4. Per-Agent Governance Contract
+
+Every invited agent must receive its own Relayauth identity and token. The
+current v1 `agentInvite()` behavior, where the lead token can be reused, must
+be replaced for governed workspaces.
+
+```ts
+const reviewer = await workspace.createAgentInvite({
+  agentName: "review-agent",
+  scopes: ["relayfile:fs:read:/notion/*"],
+  ttlSeconds: 3600,
+});
+```
+
+Required behavior:
+
+1. Cloud calls Relayauth to mint a child identity or child token.
+2. Relayauth verifies the requested scopes are a subset of the parent effective
+   scopes.
+3. The child token expiry is no later than the parent token expiry.
+4. The sponsor chain is extended.
+5. The invite includes `expiresAt`, `agentId`, and revocation metadata.
+6. Attempted escalation emits an audit event and fails closed.
+
+---
+
+## 5. Dynamic Just-in-Time Integrations
+
+### 5.1 Problem
+
+Today the provider catalog is largely predeclared:
+
+1. `../cloud` defines Nango provider config keys and the integration catalog.
+2. `../relayfile-adapters` defines VFS mappings, webhook normalization, and
+   writeback paths.
+3. `../sage/nango-integrations` currently owns concrete Nango sync definitions
+   for product integrations such as `github-sage`, `linear-sage`,
+   `notion-sage`, and `slack-sage`.
+4. Cloud-side workers route Nango webhooks and materialize records into
+   Relayfile.
+
+That works for first-party integrations, but it does not let an end customer
+say:
+
+```text
+For my connected HubSpot account, sync companies, contacts, and deals with
+these fields and these writeback actions.
+```
+
+The customer should not need a code PR to Relayfile Adapters for every object
+selection. Relayfile should be able to compile a customer-defined integration
+plan, verify it against the customer's own connected account, run it through a
+Nango dry run in a sandbox, and promote it only after the generated projection
+is safe and inspectable.
+
+Long term, Sage should consume the projected VFS and discovery APIs. It should
+not remain the owner of provider config keys, Nango sync definitions, or object
+selection policy.
+
+### 5.1.1 Current ownership to migrate
+
+The current split is:
+
+| Concern | Current Location | Target Owner |
+| --- | --- | --- |
+| Static provider IDs and Nango config keys | `../cloud/packages/web/lib/integrations/providers.ts` | Cloud |
+| Nango config-key environment overrides | `../cloud/packages/web/lib/integrations/nango-service.ts` | Cloud |
+| Workspace connection records | Cloud `workspace_integrations` storage | Cloud |
+| Nango sync definitions | `../sage/nango-integrations/*/syncs` | Cloud-managed generated artifacts |
+| VFS path/resource/writeback mapping DSL | `../relayfile-adapters/docs/MAPPING_YAML_SPEC.md` and adapter-core runtime | Relayfile Adapters |
+| Provider proxy/connection health primitives | `../relayfile-providers/packages/nango` | Relayfile Providers |
+
+The migration goal is to move provider object definitions out of Sage and into
+Cloud-managed integration specs backed by Relayfile Adapter mapping semantics.
+
+### 5.2 JIT integration lifecycle
+
+```text
+Customer intent
+  -> DraftIntegration manifest
+  -> Provider connection or connect session
+  -> Sandbox compilation
+  -> Nango dry run
+  -> VFS preview
+  -> Human/customer approval
+  -> Promote to workspace integration
+  -> Initial sync and writeback policies
+```
+
+### 5.3 Consolidated integration spec
+
+Static and JIT integrations should converge on a single `IntegrationSpec`
+shape. Static specs may live in source control. JIT specs are workspace-scoped
+runtime artifacts.
+
+```ts
+interface IntegrationSpec {
+  id: string;
+  kind: "static" | "jit";
+  version: string;
+  provider: string;
+  providerConfigKey?: string;
+  displayName: string;
+  vfsRoot: string;
+  connectionPolicy: "sponsor-user" | "tenant-delegated" | "explicit";
+  requiredOAuthScopes: string[];
+  objects: IntegrationObjectSpec[];
+  writebacks: IntegrationWritebackSpec[];
+  permissions: {
+    readScopes: string[];
+    writeScopes: string[];
+  };
+}
+
+interface IntegrationObjectSpec {
+  name: string;
+  nangoModel?: string;
+  syncName?: string;
+  listEndpoint?: string;
+  getEndpoint?: string;
+  pathTemplate: string;
+  fields?: string[];
+  cursor?: string;
+  materializeAs: "metadata-json" | "content-md" | "record-json";
+}
+
+interface IntegrationWritebackSpec {
+  name: string;
+  match: string;
+  endpoint: string;
+  payloadSchemaRef?: string;
+  dryRunSafe: boolean;
+}
+```
+
+Provider config keys are Cloud-resolved. Product code should pass
+workspace/provider intent and must not hardcode raw Nango config keys unless it
+is Cloud integration infrastructure.
+
+### 5.4 Draft manifest
+
+```ts
+interface DraftIntegrationManifest {
+  name: string;
+  displayName: string;
+  provider: string;
+  providerConfigKey?: string;
+  connectionId?: string;
+  vfsRoot?: string;
+  source:
+    | { kind: "openapi"; url: string }
+    | { kind: "docs"; url: string; crawlPaths?: string[] }
+    | { kind: "samples"; files: string[] }
+    | { kind: "nango-template"; templateId: string };
+  objects: Array<{
+    name: string;
+    listEndpoint?: string;
+    getEndpoint?: string;
+    nangoModel?: string;
+    pathTemplate: string;
+    fields?: string[];
+    cursor?: string;
+    materializeAs: "metadata-json" | "content-md" | "record-json";
+  }>;
+  writebacks?: Array<{
+    name: string;
+    match: string;
+    endpoint: string;
+    payloadSchemaRef?: string;
+    dryRunSafe: boolean;
+  }>;
+}
+```
+
+The manifest is intentionally close to the existing
+`../relayfile-adapters/docs/MAPPING_YAML_SPEC.md` model. The difference is
+that JIT manifests are tenant/workspace scoped, generated or edited at runtime,
+and cannot be promoted without sandbox validation.
+
+### 5.5 Draft APIs
+
+Cloud owns the hosted API:
+
+```http
+POST /api/v1/workspaces/{workspaceId}/integration-drafts
+GET  /api/v1/workspaces/{workspaceId}/integration-drafts/{draftId}
+POST /api/v1/workspaces/{workspaceId}/integration-drafts/{draftId}/connect
+POST /api/v1/workspaces/{workspaceId}/integration-drafts/{draftId}/dryrun
+GET  /api/v1/workspaces/{workspaceId}/integration-drafts/{draftId}/preview
+POST /api/v1/workspaces/{workspaceId}/integration-drafts/{draftId}/promote
+```
+
+The SDK should expose:
+
+```ts
+const draft = await workspace.createIntegrationDraft(manifest);
+const connect = await draft.connect();
+await sendToUser(connect.connectLink);
+const dryrun = await draft.dryRun({ maxObjects: 25 });
+const preview = await draft.preview();
+await draft.promote({ approvedBy: "user_jane" });
+```
+
+### 5.6 Sandbox dry run
+
+Cloud must run every JIT draft through an isolated sandbox before promotion.
+
+The sandbox should use Nango dry-run semantics. The CLI form available locally
+is:
+
+```bash
+nango dryrun <sync-or-action-name> <connection_id> \
+  --environment <env> \
+  --metadata '<json>' \
+  --checkpoint '<json>' \
+  --validate
+```
+
+Cloud may call an equivalent API instead of shelling out, but the behavior and
+artifact shape must remain the same.
+
+The dry run must:
+
+1. Use the customer's selected provider connection.
+2. Invoke Nango dry-run behavior through the Nango CLI or equivalent API.
+3. Limit network access to Nango, the target provider, Relayfile Cloud, and
+   configured package registries needed for the run.
+4. Cap object count, runtime, memory, and output size.
+5. Redact provider tokens and secrets from logs.
+6. Produce a deterministic artifact bundle:
+   - normalized mapping YAML
+   - generated provider config metadata
+   - object model schemas
+   - sample VFS tree
+   - dry-run logs
+   - validation errors
+   - required OAuth scopes
+   - proposed writeback policies
+
+Promotion is forbidden unless the dry run succeeds or a workspace admin
+explicitly approves a degraded promotion mode.
+
+The dry-run result must include a typed diff:
+
+```ts
+interface IntegrationDryRunResult {
+  draftId: string;
+  status: "succeeded" | "failed" | "degraded";
+  recordsFetched: number;
+  projectedFiles: Array<{ path: string; contentType: string; size: number }>;
+  writebacksAvailable: string[];
+  requiredOAuthScopes: string[];
+  validationErrors: Array<{ code: string; message: string; path?: string }>;
+  artifactId: string;
+}
+```
+
+### 5.7 VFS preview
+
+Before promotion, the customer and agent must be able to inspect a preview:
+
+```text
+/.relay/previews/{draftId}/tree.json
+/.relay/previews/{draftId}/sample/<provider>/...
+/.relay/previews/{draftId}/_PERMISSIONS.md
+/.relay/previews/{draftId}/dryrun.log
+```
+
+Preview files are read-only and must not trigger provider writeback.
+
+### 5.8 Promotion
+
+Promotion creates a workspace-scoped integration record:
+
+```ts
+interface JitIntegrationRecord {
+  id: string;
+  kind: "jit";
+  workspaceId: string;
+  orgId: string;
+  createdByUserId: string;
+  provider: string;
+  providerConfigKey: string;
+  connectionId: string;
+  vfsRoot: string;
+  manifestHash: string;
+  mappingArtifactId: string;
+  dryRunArtifactId: string;
+  status: "pending" | "syncing" | "ready" | "error" | "revoked";
+}
+```
+
+The `vfsRoot` must be collision-safe. If a provider root already exists,
+Cloud should default to:
+
+```text
+/custom/{integrationSlug}
+```
+
+The promoted JIT integration must then appear in:
+
+```ts
+await workspace.listIntegrations();
+await workspace.listMountedPaths();
+GET /api/v1/workspaces/{workspaceId}/integrations
+GET /api/v1/workspaces/{workspaceId}/sync
+```
+
+Activation state must include:
+
+1. Integration spec version.
+2. Provider config key.
+3. Connection ID.
+4. Dry-run artifact ID.
+5. Deployed integration or generated artifact ID.
+6. Enabled object set.
+7. Manifest hash.
+
+### 5.9 Writeback policy for JIT integrations
+
+JIT writebacks must use the same machine-readable policy model as static
+adapters. A writeback is allowed only when:
+
+1. The promoted manifest defines the writeback.
+2. The writeback was included in the dry-run artifact.
+3. The caller's Relayauth token includes the required Relayfile scope.
+4. The provider connection is active.
+5. The payload validates against the promoted schema.
+
+If `dryRunSafe=false`, the dry run must validate schema and endpoint shape but
+must not execute the provider mutation.
+
+---
+
+## 6. Repository Ownership
+
+### 6.1 `relayfile`
+
+Owns the cross-repo product contract and the agent-facing SDK surface.
+
+Required changes:
+
+1. Add this spec and keep it linked from the README.
+2. Add SDK types and helpers for integration listing, mounted path discovery,
+   materialized readiness, sync progress, per-agent invites, and JIT drafts.
+3. Extend mount state files to include mounted paths, integration kind, file
+   count, first materialization timestamp, and preview roots.
+4. Enforce writeback policy consistently for static and JIT integrations.
+
+### 6.2 `../cloud`
+
+Owns hosted workspace control plane, provider connection state, static catalog,
+JIT draft APIs, sandbox orchestration, Nango dry runs, and promotion.
+
+Required changes:
+
+1. Add integration draft persistence.
+2. Add sandbox dry-run workers.
+3. Store generated mapping/dry-run artifacts.
+4. Promote validated drafts into workspace integration records.
+5. Return static and JIT integrations through the same list/status/sync APIs.
+6. Record provider connection ownership by user, org, and workspace.
+
+### 6.3 `../relayauth`
+
+Owns identity, scopes, child-token delegation, revocation, and audit. See
+[relayauth#37](https://github.com/AgentWorkforce/relayauth/issues/37).
+
+Required changes:
+
+1. Support `relayfile:fs`, `relayfile:ops`, `relayfile:sync`, and
+   `relayfile:integration` scope families.
+2. Provide child-token issuance with subset enforcement.
+3. Emit delegation, scope, denial, and revocation audit events.
+
+### 6.4 `../relayfile-adapters`
+
+Owns static and generated mapping semantics.
+
+Required changes:
+
+1. Promote the mapping YAML spec into the shared contract for generated JIT
+   adapters.
+2. Add validation for JIT manifests and generated mapping artifacts.
+3. Generate `_PERMISSIONS.md` and machine-readable writeback policies from the
+   same source.
+
+### 6.5 `../relayfile-providers`
+
+Owns provider execution and Nango/Composio/Nango-like provider clients.
+
+Required changes:
+
+1. Add a provider execution context that includes org, workspace, user,
+   sponsor, provider connection, required OAuth scopes, and correlation ID.
+2. Deny execution for missing, revoked, or under-scoped provider connections.
+3. Expose a dry-run execution path that Cloud can call from the sandbox.
+
+### 6.6 `../sage`
+
+Owns agent product usage of the workspace and should stop hardcoding provider
+object assumptions once discovery and JIT integrations are available.
+
+Required changes:
+
+1. Discover integrations via `workspace.listIntegrations()` or Cloud list APIs.
+2. Prefer mounted path/status data over static provider assumptions.
+3. Request JIT drafts when the customer asks for objects not covered by the
+   static catalog.
+4. Present dry-run previews and approval prompts to the customer.
+
+---
+
+## 7. Acceptance Criteria
+
+### 7.1 Programmatic Notion connection
+
+Given a fresh Cloud login, a caller can create a workspace, connect Notion,
+wait for materialized readiness, discover the mounted path, and mount the
+workspace without hardcoding `/notion`.
+
+### 7.2 Resume safety
+
+Given an existing workspace, `joinWorkspace()` plus `listIntegrations()` must
+tell the agent which providers are connected, which roots are mounted, which
+are ready, and which are still syncing.
+
+### 7.3 Empty mount prevention
+
+`waitForNotion({ until: "materialized" })` must not resolve until either:
+
+1. At least one file is materialized under the Notion mounted path.
+2. The integration reaches `ready` with a confirmed empty result set.
+3. The timeout elapses and the returned status explains the ongoing sync state.
+
+### 7.4 Per-agent revocation
+
+An invited agent can be individually revoked without rotating the lead agent's
+token or the whole workspace token set.
+
+### 7.5 JIT integration dry run
+
+Given a customer-defined object manifest and a customer provider connection,
+Cloud can run a sandboxed Nango dry run, produce a preview VFS tree, and deny
+promotion when schemas, paths, OAuth scopes, or provider calls fail validation.
+
+### 7.6 JIT integration promotion
+
+After approval, the promoted JIT integration appears in integration listing,
+sync status, mounted path discovery, `_PERMISSIONS.md`, and writeback policy
+enforcement.
+
+---
+
+## 8. Open Questions
+
+1. Should JIT integration roots live under `/custom/{slug}` or may customers
+   request first-class roots like `/hubspot` when no static provider exists?
+2. Should Nango dry-run output be stored forever, retained for a fixed window,
+   or retained only until promotion?
+3. Should generated JIT mappings be portable back into
+   `../relayfile-adapters` as static adapters after repeated use?
+4. Should writeback mutations ever execute during dry run, or should mutation
+   validation always be schema-only?
+5. Which service owns sandbox execution long term: Cloud, Relayfile Cloud, or a
+   shared Agent Relay sandbox service?
+6. Should the JIT compiler be allowed to use an LLM to infer object mappings,
+   or must v1 require explicit customer/admin manifests?
+
+---
+
+## 9. Positioning
+
+Use this external framing:
+
+> Relayfile gives agents one filesystem contract. Cloud and Relayauth provide
+> per-user governance. Static integrations are prebuilt; JIT integrations let
+> customers define the objects they need, validate them against their own
+> connected account, preview the resulting VFS, and promote only after a
+> sandboxed dry run succeeds.
+
+Avoid this framing:
+
+> Relayfile has no integration context cost.
+
+Relayfile reduces tool-schema context, but it still needs discovery, readiness,
+sync state, provider policies, and generated mapping artifacts. Those must be
+machine-readable and agent-discoverable.

--- a/docs/agent-workspace-governance-and-jit-integrations.md
+++ b/docs/agent-workspace-governance-and-jit-integrations.md
@@ -295,7 +295,7 @@ The current split is:
 | Workspace connection records | Cloud `workspace_integrations` storage | Cloud |
 | Nango sync definitions | `../sage/nango-integrations/*/syncs` | Cloud-managed generated artifacts |
 | VFS path/resource/writeback mapping DSL | `../relayfile-adapters/docs/MAPPING_YAML_SPEC.md` and adapter-core runtime | Relayfile Adapters |
-| Provider proxy/connection health primitives | `../relayfile-providers/packages/nango` | Relayfile Providers |
+| Provider proxy/connection health primitives | `../relayfile-providers/packages/nango`, `../relayfile-providers/packages/composio`, and `../relayfile-providers/packages/pipedream` | Relayfile Providers |
 
 The migration goal is to move provider object definitions out of Sage and into
 Cloud-managed integration specs backed by Relayfile Adapter mapping semantics.
@@ -305,9 +305,9 @@ Cloud-managed integration specs backed by Relayfile Adapter mapping semantics.
 ```text
 Customer intent
   -> DraftIntegration manifest
-  -> Provider connection or connect session
+  -> Native provider connection or broker connect session
   -> Sandbox compilation
-  -> Nango dry run
+  -> Nango dry run or broker-backed unauthenticated Nango dry run
   -> VFS preview
   -> Human/customer approval
   -> Promote to workspace integration
@@ -321,16 +321,27 @@ shape. Static specs may live in source control. JIT specs are workspace-scoped
 runtime artifacts.
 
 ```ts
+type IntegrationBroker = "native" | "nango" | "composio" | "pipedream";
+
 interface IntegrationSpec {
   id: string;
   kind: "static" | "jit";
   version: string;
   provider: string;
   providerConfigKey?: string;
+  broker: IntegrationBroker;
+  brokerAppId?: string;
+  brokerToolkitSlug?: string;
+  brokerConnectionId?: string;
   displayName: string;
   vfsRoot: string;
   connectionPolicy: "sponsor-user" | "tenant-delegated" | "explicit";
   requiredOAuthScopes: string[];
+  schedule?: {
+    enabled: boolean;
+    interval: string;
+    timezone?: string;
+  };
   objects: IntegrationObjectSpec[];
   writebacks: IntegrationWritebackSpec[];
   permissions: {
@@ -364,6 +375,14 @@ Provider config keys are Cloud-resolved. Product code should pass
 workspace/provider intent and must not hardcode raw Nango config keys unless it
 is Cloud integration infrastructure.
 
+`broker="native"` means Relayfile Cloud owns the provider catalog, connection
+flow, sync implementation, and adapter mapping. `broker="nango"` means Nango
+owns the provider auth/sync primitive directly. `broker="composio"` or
+`broker="pipedream"` means the broker owns the long-tail app catalog,
+customer connection flow, and action/tool execution surface, while Cloud still
+owns scheduling, sandbox validation, VFS projection, writeback policy, and
+audit.
+
 ### 5.4 Draft manifest
 
 ```ts
@@ -372,13 +391,23 @@ interface DraftIntegrationManifest {
   displayName: string;
   provider: string;
   providerConfigKey?: string;
+  broker?: IntegrationBroker;
+  brokerAppId?: string;
+  brokerToolkitSlug?: string;
+  brokerActions?: string[];
   connectionId?: string;
   vfsRoot?: string;
+  schedule?: {
+    enabled: boolean;
+    interval: string;
+    timezone?: string;
+  };
   source:
     | { kind: "openapi"; url: string }
     | { kind: "docs"; url: string; crawlPaths?: string[] }
     | { kind: "samples"; files: string[] }
-    | { kind: "nango-template"; templateId: string };
+    | { kind: "nango-template"; templateId: string }
+    | { kind: "broker-catalog"; broker: IntegrationBroker; appId: string };
   objects: Array<{
     name: string;
     listEndpoint?: string;
@@ -404,7 +433,75 @@ The manifest is intentionally close to the existing
 that JIT manifests are tenant/workspace scoped, generated or edited at runtime,
 and cannot be promoted without sandbox validation.
 
-### 5.5 Draft APIs
+### 5.5 Integration broker layer
+
+Relayfile should not register every long-tail OAuth app and object model by
+hand. Cloud may delegate app discovery, customer connection, token custody, and
+tool/action execution to integration brokers such as Composio and Pipedream.
+This gives customers broad catalog coverage without exposing thousands of tools
+to the agent context or requiring Relayfile to ship a first-party adapter for
+every app on day one.
+
+The broker layer must be explicit in the promoted integration record:
+
+```ts
+interface BrokerConnection {
+  broker: "composio" | "pipedream";
+  appId: string;
+  toolkitSlug?: string;
+  connectedAccountId: string;
+  externalUserId: string;
+  workspaceId: string;
+  orgId: string;
+  ownerUserId: string;
+  status: "pending" | "active" | "error" | "revoked";
+  grantedScopes?: string[];
+}
+
+interface BrokerExecutionPlan {
+  broker: "composio" | "pipedream";
+  readActions: string[];
+  writeActions: string[];
+  triggerSubscriptions?: string[];
+  objectMappings: IntegrationObjectSpec[];
+  writebacks: IntegrationWritebackSpec[];
+}
+```
+
+For brokered integrations, Nango should be used as the scheduled runner and
+dry-run harness, not necessarily as the customer OAuth owner:
+
+```text
+Nango schedule tick
+  -> unauthenticated sync reads broker credentials from connection metadata
+  -> sync calls Composio or Pipedream proxy/action APIs
+  -> broker executes against the customer's connected account
+  -> sync normalizes records into the Relayfile mapping artifact
+  -> Cloud materializes the Relayfile VFS and records audit state
+```
+
+`../relayfile-providers/packages/nango` already includes a
+`NangoUnauthProvider` pattern that reads credentials from Nango connection
+metadata and injects auth headers before proxy execution. That provider is the
+bridge for broker-backed scheduled syncs. The Nango connection should store
+only the broker execution credential or reference needed by Cloud workers; it
+must not expose provider OAuth tokens to agents.
+
+`../relayfile-providers/packages/composio` already exposes catalog,
+connected-account, action execution, trigger subscription, proxy, health, and
+webhook primitives. `../relayfile-providers/packages/pipedream` already
+exposes Connect tokens, accounts, app/component listing, trigger deployment,
+workflow invocation, proxy, health, and webhook primitives. Cloud should depend
+on those provider packages for broker operations instead of duplicating broker
+client code.
+
+The claim should be precise: brokered JIT gives Relayfile broad connectable
+catalog coverage immediately. It does not mean every app has a polished
+first-party filesystem projection immediately. Each brokered integration still
+needs a bounded object selection, generated mapping, dry-run evidence,
+approval, mounted path, and writeback policy before agents can use it.
+
+### 5.6 Draft APIs
 
 Cloud owns the hosted API:
 
@@ -428,7 +525,7 @@ const preview = await draft.preview();
 await draft.promote({ approvedBy: "user_jane" });
 ```
 
-### 5.6 Sandbox dry run
+### 5.7 Sandbox dry run
 
 Cloud must run every JIT draft through an isolated sandbox before promotion.
 
@@ -450,12 +547,15 @@ The dry run must:
 
 1. Use the customer's selected provider connection.
 2. Invoke Nango dry-run behavior through the Nango CLI or equivalent API.
-3. Limit network access to Nango, the target provider, Relayfile Cloud, and
-   configured package registries needed for the run.
-4. Cap object count, runtime, memory, and output size.
-5. Redact provider tokens and secrets from logs.
-6. Produce a deterministic artifact bundle:
+3. For brokered integrations, execute through Composio or Pipedream using the
+   broker connection selected by the customer.
+4. Limit network access to Nango, the target provider or broker, Relayfile
+   Cloud, and configured package registries needed for the run.
+5. Cap object count, runtime, memory, and output size.
+6. Redact provider tokens, broker tokens, and secrets from logs.
+7. Produce a deterministic artifact bundle:
    - normalized mapping YAML
+   - broker execution plan, when applicable
    - generated provider config metadata
    - object model schemas
    - sample VFS tree
@@ -463,6 +563,10 @@ The dry run must:
    - validation errors
    - required OAuth scopes
    - proposed writeback policies
+
+For brokered integrations, the dry run must also verify that every selected
+read action returns data with a stable enough schema to map into files, and
+that every selected write action has a declared payload schema and policy gate.
 
 Promotion is forbidden unless the dry run succeeds or a workspace admin
 explicitly approves a degraded promotion mode.
@@ -473,6 +577,7 @@ The dry-run result must include a typed diff:
 interface IntegrationDryRunResult {
   draftId: string;
   status: "succeeded" | "failed" | "degraded";
+  broker?: IntegrationBroker;
   recordsFetched: number;
   projectedFiles: Array<{ path: string; contentType: string; size: number }>;
   writebacksAvailable: string[];
@@ -482,7 +587,7 @@ interface IntegrationDryRunResult {
 }
 ```
 
-### 5.7 VFS preview
+### 5.8 VFS preview
 
 Before promotion, the customer and agent must be able to inspect a preview:
 
@@ -495,7 +600,7 @@ Before promotion, the customer and agent must be able to inspect a preview:
 
 Preview files are read-only and must not trigger provider writeback.
 
-### 5.8 Promotion
+### 5.9 Promotion
 
 Promotion creates a workspace-scoped integration record:
 
@@ -508,6 +613,8 @@ interface JitIntegrationRecord {
   createdByUserId: string;
   provider: string;
   providerConfigKey: string;
+  broker?: IntegrationBroker;
+  brokerConnectionId?: string;
   connectionId: string;
   vfsRoot: string;
   manifestHash: string;
@@ -538,12 +645,13 @@ Activation state must include:
 1. Integration spec version.
 2. Provider config key.
 3. Connection ID.
-4. Dry-run artifact ID.
-5. Deployed integration or generated artifact ID.
-6. Enabled object set.
-7. Manifest hash.
+4. Broker and broker connection ID, when applicable.
+5. Dry-run artifact ID.
+6. Deployed integration or generated artifact ID.
+7. Enabled object set.
+8. Manifest hash.
 
-### 5.9 Writeback policy for JIT integrations
+### 5.10 Writeback policy for JIT integrations
 
 JIT writebacks must use the same machine-readable policy model as static
 adapters. A writeback is allowed only when:
@@ -551,11 +659,15 @@ adapters. A writeback is allowed only when:
 1. The promoted manifest defines the writeback.
 2. The writeback was included in the dry-run artifact.
 3. The caller's Relayauth token includes the required Relayfile scope.
-4. The provider connection is active.
+4. The provider or broker connection is active.
 5. The payload validates against the promoted schema.
 
 If `dryRunSafe=false`, the dry run must validate schema and endpoint shape but
 must not execute the provider mutation.
+
+For brokered writebacks, Relayfile should invoke the promoted Composio or
+Pipedream action ID from the dry-run artifact. It must not let agents provide
+arbitrary broker action names at write time.
 
 ---
 
@@ -576,8 +688,9 @@ Required changes:
 
 ### 6.2 `../cloud`
 
-Owns hosted workspace control plane, provider connection state, static catalog,
-JIT draft APIs, sandbox orchestration, Nango dry runs, and promotion.
+Owns hosted workspace control plane, provider and broker connection state,
+static catalog, JIT draft APIs, sandbox orchestration, Nango dry runs,
+brokered scheduled syncs, and promotion.
 
 Required changes:
 
@@ -587,6 +700,8 @@ Required changes:
 4. Promote validated drafts into workspace integration records.
 5. Return static and JIT integrations through the same list/status/sync APIs.
 6. Record provider connection ownership by user, org, and workspace.
+7. Add a broker registry for Composio and Pipedream app catalogs, connect
+   sessions, account health, action execution plans, and trigger/webhook state.
 
 ### 6.3 `../relayauth`
 
@@ -614,7 +729,7 @@ Required changes:
 
 ### 6.5 `../relayfile-providers`
 
-Owns provider execution and Nango/Composio/Nango-like provider clients.
+Owns provider execution and Nango/Composio/Pipedream provider clients.
 
 Required changes:
 
@@ -622,6 +737,11 @@ Required changes:
    sponsor, provider connection, required OAuth scopes, and correlation ID.
 2. Deny execution for missing, revoked, or under-scoped provider connections.
 3. Expose a dry-run execution path that Cloud can call from the sandbox.
+4. Treat Composio and Pipedream as integration brokers, not agent-visible tool
+   surfaces: expose catalog, connection, proxy/action, trigger, health, and
+   webhook primitives behind bounded Cloud APIs.
+5. Keep `NangoUnauthProvider` as the bridge for scheduled broker-backed syncs
+   where Nango runs the job but the customer OAuth account lives in the broker.
 
 ### 6.6 `../sage`
 
@@ -677,6 +797,15 @@ After approval, the promoted JIT integration appears in integration listing,
 sync status, mounted path discovery, `_PERMISSIONS.md`, and writeback policy
 enforcement.
 
+### 7.7 Brokered long-tail integration
+
+Given a customer selects a Composio or Pipedream app that Relayfile does not
+support as a static integration, Cloud can create a broker connect session,
+generate a bounded object/action manifest, run a broker-backed unauthenticated
+Nango dry run, schedule the promoted sync, materialize files under a
+collision-safe root, and enforce writeback policy through the promoted broker
+action IDs.
+
 ---
 
 ## 8. Open Questions
@@ -693,6 +822,9 @@ enforcement.
    shared Agent Relay sandbox service?
 6. Should the JIT compiler be allowed to use an LLM to infer object mappings,
    or must v1 require explicit customer/admin manifests?
+7. For brokered integrations, should Cloud store broker connection IDs only,
+   or mirror a normalized `broker_connections` table for faster governance,
+   revocation, and audit queries?
 
 ---
 

--- a/docs/agent-workspace-governance-and-jit-integrations.md
+++ b/docs/agent-workspace-governance-and-jit-integrations.md
@@ -322,6 +322,7 @@ runtime artifacts.
 
 ```ts
 type IntegrationBroker = "native" | "nango" | "composio" | "pipedream";
+type IntegrationSyncRunner = "nango" | "cloud-cron" | "broker-webhook";
 
 interface IntegrationSpec {
   id: string;
@@ -339,6 +340,7 @@ interface IntegrationSpec {
   requiredOAuthScopes: string[];
   schedule?: {
     enabled: boolean;
+    runner: IntegrationSyncRunner;
     interval: string;
     timezone?: string;
   };
@@ -399,6 +401,7 @@ interface DraftIntegrationManifest {
   vfsRoot?: string;
   schedule?: {
     enabled: boolean;
+    runner: IntegrationSyncRunner;
     interval: string;
     timezone?: string;
   };
@@ -468,8 +471,9 @@ interface BrokerExecutionPlan {
 }
 ```
 
-For brokered integrations, Nango should be used as the scheduled runner and
-dry-run harness, not necessarily as the customer OAuth owner:
+Brokered integrations support two background sync modes. The first mode uses
+Nango as the scheduled runner and dry-run harness, but not necessarily as the
+customer OAuth owner:
 
 ```text
 Nango schedule tick
@@ -486,6 +490,31 @@ metadata and injects auth headers before proxy execution. That provider is the
 bridge for broker-backed scheduled syncs. The Nango connection should store
 only the broker execution credential or reference needed by Cloud workers; it
 must not expose provider OAuth tokens to agents.
+
+The second mode bypasses Nango for steady-state background syncs:
+
+```text
+Cloud cron or relaycron schedule tick
+  -> Cloud loads the promoted IntegrationSpec and BrokerConnection
+  -> Cloud calls Composio or Pipedream provider package directly
+  -> broker executes read actions against the customer's connected account
+  -> Cloud normalizes records into the Relayfile mapping artifact
+  -> Cloud materializes the Relayfile VFS and records audit state
+```
+
+This mode is the preferred path when the broker already owns connection
+refresh, proxy execution, triggers, and account health. It lets Relayfile run
+background integrations without creating or operating a Nango sync for every
+long-tail brokered app. Nango remains useful for providers where it is the
+native integration layer, for compatibility with existing static integrations,
+or as an optional dry-run harness when the generated artifact is Nango-shaped.
+
+The runner must be explicit. `schedule.runner="nango"` means Nango emits the
+sync tick. `schedule.runner="cloud-cron"` means Cloud or `relaycron` emits the
+tick and uses Relayfile Providers directly. `schedule.runner="broker-webhook"`
+means Composio or Pipedream trigger/webhook subscriptions drive incremental
+sync, with Cloud responsible for debouncing, normalization, materialization,
+and replay.
 
 `../relayfile-providers/packages/composio` already exposes catalog,
 connected-account, action execution, trigger subscription, proxy, health, and
@@ -690,7 +719,7 @@ Required changes:
 
 Owns hosted workspace control plane, provider and broker connection state,
 static catalog, JIT draft APIs, sandbox orchestration, Nango dry runs,
-brokered scheduled syncs, and promotion.
+Cloud-owned broker sync runners, broker webhooks, and promotion.
 
 Required changes:
 
@@ -702,6 +731,8 @@ Required changes:
 6. Record provider connection ownership by user, org, and workspace.
 7. Add a broker registry for Composio and Pipedream app catalogs, connect
    sessions, account health, action execution plans, and trigger/webhook state.
+8. Add a Cloud-owned broker sync runner for promoted integrations whose
+   `schedule.runner` is `cloud-cron` or `broker-webhook`.
 
 ### 6.3 `../relayauth`
 
@@ -742,6 +773,8 @@ Required changes:
    webhook primitives behind bounded Cloud APIs.
 5. Keep `NangoUnauthProvider` as the bridge for scheduled broker-backed syncs
    where Nango runs the job but the customer OAuth account lives in the broker.
+6. Support direct Cloud execution for brokered background syncs where Cloud
+   calls Composio or Pipedream without a Nango sync in the loop.
 
 ### 6.6 `../sage`
 
@@ -801,10 +834,10 @@ enforcement.
 
 Given a customer selects a Composio or Pipedream app that Relayfile does not
 support as a static integration, Cloud can create a broker connect session,
-generate a bounded object/action manifest, run a broker-backed unauthenticated
-Nango dry run, schedule the promoted sync, materialize files under a
-collision-safe root, and enforce writeback policy through the promoted broker
-action IDs.
+generate a bounded object/action manifest, validate it in a sandbox, schedule
+the promoted sync through either Nango, Cloud cron, or broker webhooks,
+materialize files under a collision-safe root, and enforce writeback policy
+through the promoted broker action IDs.
 
 ---
 

--- a/docs/per-user-governance-contract.md
+++ b/docs/per-user-governance-contract.md
@@ -1,0 +1,579 @@
+# Per-User Governance Contract
+
+**Status:** Draft for cross-repo implementation
+**Date:** 2026-05-04
+**Owners:** Relayfile, Relayauth, Relayfile Cloud, Relayfile Providers, Relayfile Adapters
+**Audience:** Implementers of `relayfile`, `../relayauth`, `../cloud`, `../relayfile-providers`, and `../relayfile-adapters`.
+
+This document specifies how Relayfile and Relayauth provide MCP-style per-user
+governance through a filesystem interface. It responds to the production-agent
+problem usually framed as "MCP vs CLI": CLI is efficient when the developer is
+the user, but customer-facing agents need per-user authorization, tenant
+isolation, revocation, explicit action boundaries, and structured audit.
+
+Relayfile's answer is:
+
+> MCP governs per-user tool calls. Relayfile governs per-user filesystem paths
+> and writeback operations.
+
+The product goal is to keep the agent interface small and file-native while
+matching the governance properties that make MCP viable for multi-tenant
+products.
+
+---
+
+## 1. Problem
+
+A customer-facing agent must act for a specific human user inside a specific
+tenant. For example:
+
+```text
+User Jane at Acme asks an agent to read a GitHub PR, create a Jira issue,
+and notify a Slack channel.
+```
+
+The system must answer these questions for every action:
+
+1. Which agent performed the action?
+2. Which human user authorized or sponsored the action?
+3. Which tenant and workspace owned the data?
+4. Which provider connection supplied the provider credentials?
+5. Which scoped capability allowed the operation?
+6. Which provider-side action was executed?
+7. How can the action be audited, replayed, denied, or revoked?
+
+CLI-style ambient credentials do not answer these questions at the protocol
+boundary. Direct MCP can answer them, but often at the cost of loading many
+provider-specific tool schemas into the model context. Relayfile must answer
+them without making the agent carry a large tool surface.
+
+---
+
+## 2. Goals
+
+1. Support per-user provider connections for GitHub, Slack, Notion, Linear,
+   Jira, and future providers.
+2. Ensure provider secrets and refresh tokens remain server-side only.
+3. Authorize Relayfile reads, writes, operations, and writebacks with
+   Relayauth scopes.
+4. Preserve tenant isolation with `orgId` and `workspaceId` on every token,
+   provider connection, VFS request, writeback operation, and audit entry.
+5. Mint separate scoped tokens for each agent and sub-agent.
+6. Ensure sub-agent scopes are strict subsets of the parent agent's effective
+   scopes.
+7. Make provider-backed paths fail-closed by default.
+8. Record structured audit events that trace every action to a human sponsor.
+9. Support revocation of tokens, sessions, identities, provider connections,
+   and workspace/provider policies.
+10. Keep the agent-facing interface file-native: `ls`, `cat`, file writes,
+    `_PERMISSIONS.md`, `.relay/state.json`, and SDK helpers.
+
+---
+
+## 3. Non-Goals
+
+1. This spec does not require Relayfile to become an MCP server.
+2. This spec does not require exposing provider OAuth tokens to agents.
+3. This spec does not require a full CRDT or offline-first editing model.
+4. This spec does not require every provider to support every action on day one.
+5. This spec does not replace `docs/productized-cloud-mount-contract.md`; it
+   adds the governance layer required for customer-facing deployments.
+
+---
+
+## 4. Identity Model
+
+Every governed Relayfile action has three identities:
+
+| Identity | Meaning | Source of Truth |
+| --- | --- | --- |
+| Agent identity | The agent process making the request | Relayauth `sub` |
+| User identity | The human sponsor or authorizing user | Relayauth `sponsorId` and Cloud user record |
+| Tenant identity | The organization/workspace boundary | Relayauth `org`, `wks`, Cloud workspace |
+
+The canonical Relayauth access token for Relayfile must include:
+
+```json
+{
+  "sub": "agent_review_bot",
+  "org": "org_acme",
+  "wks": "ws_acme_support",
+  "sponsorId": "user_jane",
+  "sponsorChain": ["user_jane", "agent_lead", "agent_review_bot"],
+  "scopes": [
+    "relayfile:fs:read:/github/repos/acme/api/pulls/*",
+    "relayfile:fs:write:/github/repos/acme/api/pulls/*/reviews/*",
+    "relayfile:ops:read:/github/*"
+  ],
+  "aud": ["relayfile"],
+  "exp": 1772004000,
+  "jti": "tok_example"
+}
+```
+
+Relayfile must reject a token when:
+
+1. The token audience does not include `relayfile`.
+2. The token workspace does not match the requested workspace.
+3. The token organization does not match the workspace's organization.
+4. The token is expired, revoked, malformed, or signed by an unknown key.
+5. No scope authorizes the requested operation.
+
+---
+
+## 5. Provider Connection Model
+
+Provider connections are owned by a user in a tenant and workspace.
+
+```ts
+interface ProviderConnection {
+  id: string;
+  orgId: string;
+  workspaceId: string;
+  userId: string;
+  provider: string;
+  providerAccountId: string;
+  providerConfigKey: string;
+  grantedOAuthScopes: string[];
+  status: "pending" | "ready" | "revoked" | "error";
+  createdAt: string;
+  updatedAt: string;
+  revokedAt?: string;
+  revokedBy?: string;
+  lastRefreshAt?: string;
+}
+```
+
+Rules:
+
+1. Provider access tokens and refresh tokens must remain server-side.
+2. Agents must never receive provider OAuth credentials.
+3. A writeback operation must resolve a provider connection by
+   `orgId`, `workspaceId`, `provider`, and user/sponsor policy.
+4. A provider connection may be user-owned or tenant-admin delegated.
+5. A tenant-admin delegated connection must be explicit in audit metadata.
+6. A revoked provider connection must deny new reads, writes, refreshes, and
+   writebacks for paths that require that connection.
+
+---
+
+## 6. Scope Mapping
+
+Relayfile converts filesystem and operation requests into Relayauth scopes.
+
+| Relayfile Request | Required Scope |
+| --- | --- |
+| Read `/github/repos/acme/api/pulls/42/metadata.json` | `relayfile:fs:read:/github/repos/acme/api/pulls/42/metadata.json` |
+| Write `/github/repos/acme/api/pulls/42/reviews/review.json` | `relayfile:fs:write:/github/repos/acme/api/pulls/42/reviews/review.json` |
+| Delete `/tmp/generated.md` | `relayfile:fs:delete:/tmp/generated.md` |
+| Read operation log for GitHub | `relayfile:ops:read:/github/*` |
+| Replay a failed GitHub writeback | `relayfile:ops:replay:/github/*` |
+| Trigger provider refresh | `relayfile:sync:trigger:/github/*` |
+| Manage provider integration | `relayfile:integration:manage:/github/*` |
+
+Relayauth filesystem matching rules apply:
+
+1. `*` matches all paths.
+2. `/prefix/*` matches descendants under the prefix.
+3. Exact paths match only themselves.
+4. Mid-path wildcards and `..` are invalid.
+
+Relayfile must use normalized absolute paths before scope evaluation.
+
+---
+
+## 7. Writeback Policy
+
+`_PERMISSIONS.md` remains the human/agent-readable contract, but server
+enforcement must use a machine-readable writeback policy emitted by adapters.
+
+```ts
+interface WritebackPolicy {
+  pathPattern: string;
+  provider: string;
+  providerAction: string;
+  relayfileScope: string;
+  requiredOAuthScopes: string[];
+  payloadSchemaRef: string;
+  connectionResolution: "sponsor-user" | "tenant-delegated" | "explicit";
+  idempotencyKeyFields: string[];
+  conflictBehavior: "etag-required" | "append-only" | "replace";
+}
+```
+
+Example:
+
+```json
+{
+  "pathPattern": "/github/repos/{owner}/{repo}/pulls/{number}/reviews/review.json",
+  "provider": "github",
+  "providerAction": "pull_request.review.create",
+  "relayfileScope": "relayfile:fs:write:/github/repos/*",
+  "requiredOAuthScopes": ["pull_requests:write"],
+  "payloadSchemaRef": "github.pull_request_review.v1",
+  "connectionResolution": "sponsor-user",
+  "idempotencyKeyFields": ["workspaceId", "path", "baseRevision"],
+  "conflictBehavior": "etag-required"
+}
+```
+
+Rules:
+
+1. A writeback path must have a matching `WritebackPolicy`.
+2. Relayfile must deny writes to provider-backed paths when no policy matches.
+3. Relayfile must validate the payload before enqueueing writeback.
+4. Relayfile must verify the Relayauth scope before enqueueing writeback.
+5. The writeback worker must verify the provider connection is active before
+   executing the provider API call.
+6. The writeback worker must include the policy ID, provider action, agent ID,
+   sponsor ID, provider connection ID, workspace ID, and correlation ID in the
+   operation record.
+
+---
+
+## 8. Request Flow
+
+### 8.1 Read Flow
+
+```text
+Agent reads /github/repos/acme/api/pulls/42/metadata.json
+  -> mount or SDK sends Relayfile API request with Relayauth token
+  -> Relayfile verifies token signature, audience, org, workspace, expiry
+  -> Relayfile checks relayfile:fs:read:/github/repos/acme/api/pulls/42/metadata.json
+  -> Relayfile checks provider connection and sync status
+  -> Relayfile returns file content
+  -> Relayauth/Relayfile audit records token validation and scope check
+```
+
+### 8.2 Writeback Flow
+
+```text
+Agent writes /github/repos/acme/api/pulls/42/reviews/review.json
+  -> mount detects local write and uploads content
+  -> Relayfile verifies token and checks relayfile:fs:write:<path>
+  -> Relayfile resolves WritebackPolicy for the path
+  -> Relayfile validates payload schema
+  -> Relayfile resolves provider connection for sponsor user or tenant delegate
+  -> Relayfile queues writeback with correlation metadata
+  -> writeback worker executes provider action server-side
+  -> operation is acked, dead-lettered, or moved to conflict state
+  -> audit records scope check, provider action, result, and sponsor chain
+```
+
+---
+
+## 9. Delegation and Agent Invites
+
+Every invited agent must receive its own Relayauth identity and token.
+
+```ts
+interface AgentInviteRequest {
+  agentName: string;
+  requestedScopes: string[];
+  ttlSeconds: number;
+  relaycastScopes?: string[];
+}
+```
+
+Rules:
+
+1. The child token's scopes must be a subset of the parent token's effective
+   scopes.
+2. The child token's expiry must be less than or equal to the parent token's
+   expiry.
+3. The child sponsor chain must append the child agent to the parent chain.
+4. Attempted escalation must fail and emit an audit event.
+5. The invite payload must not reuse the lead agent's Relayfile token.
+
+This supersedes the v1 caveat in `docs/agent-workspace-golden-path.md` that
+allows lead-token reuse.
+
+---
+
+## 10. Audit Contract
+
+Relayfile and Relayauth must produce enough structured audit data to answer:
+
+```text
+Which human authorized this provider action, through which agent, against
+which tenant workspace, using which provider connection, and which scope
+allowed or denied it?
+```
+
+Every governed Relayfile operation must carry:
+
+```ts
+interface GovernanceAuditContext {
+  requestId: string;
+  correlationId: string;
+  orgId: string;
+  workspaceId: string;
+  agentId: string;
+  sponsorId: string;
+  sponsorChain: string[];
+  tokenId: string;
+  requestedScope: string;
+  matchedScope?: string;
+  path: string;
+  provider?: string;
+  providerConnectionId?: string;
+  providerAction?: string;
+  writebackPolicyId?: string;
+  result: "allowed" | "denied" | "error";
+  reason?: string;
+}
+```
+
+Required events:
+
+1. Token issued.
+2. Token refreshed.
+3. Token revoked.
+4. Scope checked.
+5. Scope denied.
+6. Provider connection created.
+7. Provider connection revoked.
+8. Relayfile file read.
+9. Relayfile file write accepted.
+10. Relayfile file write denied.
+11. Writeback queued.
+12. Writeback executed.
+13. Writeback failed.
+14. Writeback replayed.
+
+Relayauth remains the authority for token, identity, scope, role, policy, and
+revocation audit. Relayfile remains the authority for VFS, sync, writeback,
+conflict, dead-letter, and replay audit. Both systems must share
+`correlationId`.
+
+---
+
+## 11. Revocation
+
+The governed system must support these revocation surfaces:
+
+| Revocation | Owner | Effect |
+| --- | --- | --- |
+| Token revocation | Relayauth | Presented token is denied after revocation propagation |
+| Session revocation | Relayauth | All tokens in the session are denied |
+| Identity suspension | Relayauth | Agent cannot authenticate or authorize actions |
+| Role/policy change | Relayauth | Effective scopes narrow on next authorization check |
+| Provider connection revocation | Cloud/Provider layer | Provider-backed reads/writes requiring the connection are denied |
+| Workspace integration disconnect | Cloud/Relayfile | Provider root becomes unavailable or read-only per policy |
+| Writeback cancellation | Relayfile | Pending operation is marked canceled/denied before provider execution |
+
+Revocation must be fail-closed. If Relayfile cannot determine whether a token,
+identity, workspace, provider connection, or policy is active, provider-backed
+writeback must be denied.
+
+---
+
+## 12. Repository Ownership
+
+### 12.1 `relayfile` repository
+
+Owns the filesystem data plane and this cross-repo contract.
+
+Required changes:
+
+1. Add Relayauth verification and scope enforcement at every REST and mount
+   boundary.
+2. Normalize every VFS path before scope checks.
+3. Make provider-backed paths fail-closed when no Relayauth scope or
+   writeback policy matches.
+4. Add `relayfile:ops:*`, `relayfile:sync:*`, and `relayfile:integration:*`
+   scope checks for non-file APIs.
+5. Store governance metadata on operation logs, writeback ops, conflicts,
+   dead letters, and replay records.
+6. Extend SDK and mount clients to preserve correlation IDs and surface
+   governance denial reasons.
+7. Generate agent-readable `_PERMISSIONS.md` from the same policy source used
+   for server enforcement.
+
+### 12.2 `../relayauth` repository
+
+Owns identity, token, scope, RBAC, policy, revocation, and audit semantics.
+
+Required changes:
+
+1. Ensure the token format supports `org`, `wks`, `sponsorId`,
+   `sponsorChain`, `jti`, `aud`, `exp`, and delegated `parentTokenId`.
+2. Ensure scope matching supports all Relayfile scope families used here:
+   `fs`, `ops`, `sync`, and `integration`.
+3. Provide APIs for child-token issuance with subset enforcement.
+4. Emit audit events for attempted delegation escalation.
+5. Expose token/session/identity revocation APIs that Relayfile can honor.
+6. Keep public packages platform-agnostic; Cloudflare-specific storage and
+   Durable Object implementation belongs in `../cloud/packages/relayauth`.
+
+### 12.3 `../cloud` repository
+
+Owns the hosted control plane for workspaces, users, provider connections,
+OAuth connect sessions, and Cloudflare-specific Relayauth deployment.
+
+Required changes:
+
+1. Persist `ProviderConnection` records with `orgId`, `workspaceId`, `userId`,
+   `provider`, `providerAccountId`, `grantedOAuthScopes`, and revocation state.
+2. Bind workspace integrations to provider connection IDs rather than only
+   provider names.
+3. Resolve provider credentials server-side during writeback by sponsor user or
+   explicit tenant-delegated policy.
+4. Ensure `connect-session` records the connecting user and tenant.
+5. Add provider-connection revocation and disconnect endpoints.
+6. Store and expose audit events for provider connection lifecycle.
+7. Implement Cloudflare storage adapters for any new Relayauth token,
+   identity, revocation, or audit interfaces.
+
+If Relayfile Cloud ownership moves to `../relayfile-cloud`, the hosted
+workspace/provider-connection requirements in this section move with that
+service. The current active route surface referenced by the productized mount
+contract lives in `../cloud`.
+
+### 12.4 `../relayfile-providers` repository
+
+Owns provider-token retrieval and provider API proxy execution.
+
+Required changes:
+
+1. Accept a typed provider execution context:
+
+   ```ts
+   interface ProviderExecutionContext {
+     orgId: string;
+     workspaceId: string;
+     userId: string;
+     sponsorId: string;
+     providerConnectionId: string;
+     provider: string;
+     requestedOAuthScopes: string[];
+     correlationId: string;
+   }
+   ```
+
+2. Deny provider API execution if the provider connection is revoked, missing,
+   or missing required OAuth scopes.
+3. Never allow agents to supply raw provider tokens.
+4. Emit provider errors in a structured form suitable for Relayfile dead-letter
+   records.
+
+### 12.5 `../relayfile-adapters` repository
+
+Owns provider-to-VFS mapping and provider writeback action definitions.
+
+Required changes:
+
+1. Emit machine-readable `WritebackPolicy` definitions for every writable path.
+2. Generate `_PERMISSIONS.md` from the same policy definitions.
+3. Include provider action names and payload schema references in writeback
+   outputs.
+4. Preserve provider object IDs in VFS metadata so audit and replay can refer
+   to provider-side objects, not only paths.
+
+### 12.6 `../relaycast` repository
+
+Relaycast does not own Relayfile authorization, but agent invite and
+coordination flows must preserve identity.
+
+Required changes:
+
+1. Relaycast invite payloads should carry child agent identity metadata, not
+   reused parent Relayfile tokens.
+2. Relaycast events should preserve `correlationId` when a message coordinates
+   a Relayfile operation.
+
+---
+
+## 13. Acceptance Criteria
+
+### 13.1 Per-user provider action
+
+Given:
+
+1. Jane belongs to Acme.
+2. Jane connects GitHub and Slack through Relayfile Cloud.
+3. A review agent receives a Relayauth token scoped to Acme's GitHub PRs and
+   Slack support channel.
+
+When the agent reads a GitHub PR and writes a Slack message:
+
+1. Relayfile allows only paths covered by the token.
+2. Relayfile executes provider calls with Jane's Acme provider connections.
+3. The agent never receives provider OAuth tokens.
+4. Audit records identify Jane, the agent, Acme, the workspace, the provider
+   connection, the path, the requested scope, and the provider action.
+
+### 13.2 Cross-tenant denial
+
+Given a token for `org_acme` and `ws_acme`, any request against `ws_globex` or
+Globex provider paths must be denied, even if the path string resembles an
+allowed Acme path.
+
+### 13.3 Sub-agent narrowing
+
+Given a lead token with:
+
+```text
+relayfile:fs:read:/github/*
+relayfile:fs:write:/github/*/reviews/*
+```
+
+When the lead invites a sub-agent requesting:
+
+```text
+relayfile:fs:read:/github/*
+relayfile:fs:write:/slack/*
+```
+
+Then Relayauth must reject issuance and emit an attempted escalation audit
+event.
+
+### 13.4 Provider revocation
+
+Given Jane revokes her Slack connection, new writes to Slack-backed paths that
+require Jane's connection must be denied. Pending writebacks using that
+connection must be canceled, denied, or dead-lettered with a revocation reason.
+
+### 13.5 Missing policy denial
+
+Given a provider-backed write path with no matching `WritebackPolicy`,
+Relayfile must deny the write before enqueueing provider work, even if the
+agent has broad `relayfile:fs:write:*`.
+
+---
+
+## 14. Open Questions
+
+1. Should reads from provider-backed cached files require an active provider
+   connection, or should previously synced content remain readable until a
+   workspace policy revokes it?
+2. Should tenant-admin delegated provider connections be visible to agents as a
+   separate provider root, or only as metadata in `_PERMISSIONS.md`?
+3. Should provider OAuth scopes be modeled as Relayauth scopes, or kept as
+   provider-connection metadata checked by the provider layer?
+4. What is the maximum acceptable revocation propagation time for mounted local
+   mirrors?
+5. Should provider-backed paths be unreadable or visibly stubbed after
+   revocation?
+6. Should Relayfile expose a MCP compatibility server later, backed by the same
+   governance model, for clients that require MCP?
+
+---
+
+## 15. Positioning
+
+The external claim should be:
+
+> Relayfile provides MCP-style per-user governance through a filesystem
+> interface. Users authorize provider connections once; Relayauth mints scoped
+> agent tokens; Relayfile enforces path-level capabilities and server-side
+> writeback; every operation is attributable to a human, tenant, provider
+> connection, and agent.
+
+The claim should not be:
+
+> Relayfile has no context cost.
+
+Relayfile reduces integration-specific tool context by replacing many tool
+schemas with one filesystem contract, but agents still need path conventions,
+sync state, writeback policies, and denial handling.


### PR DESCRIPTION
## Summary

- add a consolidated agent workspace governance + JIT integration contract
- connect the current Cloud/Relayfile/Relayauth programmatic setup flow to the missing governance/readiness work in relayauth#37 and relayfile#79
- specify a Cloud-owned just-in-time integration lifecycle: customer manifest -> provider connect -> sandboxed Nango dryrun -> VFS preview -> promotion
- keep the earlier per-user governance contract and link both docs from the README

## Stack

Stacked on #71 (`codex/productized-cloud-mount-relayfile`) because the spec references the programmatic setup and productized mount surfaces introduced there and in cloud#406 / relayfile#70.

## Notes

The JIT section explicitly calls out that Nango provider config keys live in Cloud today, while concrete Nango sync definitions still live under `../sage/nango-integrations`; the target state moves those product object definitions into Cloud-managed generated artifacts backed by Relayfile Adapter mapping semantics.

## Tests

- `git diff --check -- README.md docs/agent-workspace-governance-and-jit-integrations.md docs/per-user-governance-contract.md`
