### PR TITLE
sdk: add webhookHealthy to SyncProviderStatus

### DIFF
--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -331,6 +331,10 @@ class SyncProviderStatus:
     failure_codes: dict[str, int] | None = None
     dead_lettered_envelopes: int | None = None
     dead_lettered_ops: int | None = None
+    # Productized cloud-mount contract §7.4: cloud SHOULD set this to
+    # False when webhook delivery is degraded. Optional for backward
+    # compatibility with deployments that do not yet emit it.
+    webhook_healthy: bool | None = None
 
 
 @dataclass

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -242,6 +242,11 @@ export interface SyncProviderStatus {
   failureCodes?: Record<string, number>;
   deadLetteredEnvelopes?: number;
   deadLetteredOps?: number;
+  // Productized cloud-mount contract §7.4: cloud SHOULD set this to
+  // false when webhook delivery is degraded so consumers can render the
+  // "falling back to periodic sync" warning. Optional for backward
+  // compatibility with deployments that do not yet emit it.
+  webhookHealthy?: boolean;
 }
 
 export interface SyncStatusResponse {


### PR DESCRIPTION
## Summary

Adds the `webhookHealthy?: boolean` field to `SyncProviderStatus` in both the TypeScript and Python SDK types so cloud and relayfile-CLI consumers can drop their permissive-cast workarounds.

## Why

Productized cloud-mount contract §7.4 mandates that the cloud `/sync` response surfaces a per-provider `webhookHealthy` so the CLI can render the "falling back to periodic sync" warning when webhook delivery is degraded. The cloud already emits the field (cloud#406) and the relayfile CLI already consumes it (relayfile#71), but the SDK type didn't declare it — forcing both sides to read it via index-access casts.

## Compatibility

Non-breaking type-only change:
- TS: \`webhookHealthy?: boolean\` (optional)
- Python: \`webhook_healthy: bool | None = None\` (default None)

Older relayfile/cloud deployments that don't emit the field still deserialize cleanly.

## Tests

- \`npm test\` in \`packages/sdk/typescript\` — 81/81 pass
- Python types are dataclass-only; the client returns raw \`dict[str, Any]\` for sync status, so no parser update needed

## Follow-up after merge

- Maintainer triggers the manual publish workflow (workflow_dispatch on \`.github/workflows/publish.yml\`) to release the new minor.
- Cloud's \`packages/web/lib/integrations/provider-status.ts\` can drop the \`(value as { webhookHealthy?: unknown }).webhookHealthy\` cast once the new SDK lands in cloud's package-lock.

## Test plan

- [x] SDK typescript tests
- [ ] Reviewer can sanity-check the type against the contract excerpt at \`docs/productized-cloud-mount-contract.md#74\`