### PR TITLE
feat(cli): support relayfile --version

### DIFF
--- a/packages/cli/scripts/run.js
+++ b/packages/cli/scripts/run.js
@@ -5,6 +5,13 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
+const args = process.argv.slice(2);
+if (args[0] === "--version") {
+  const { version } = require("../package.json");
+  process.stdout.write(`${version}\n`);
+  process.exit(0);
+}
+
 const PLATFORM_MAP = {
   darwin: "darwin",
   linux: "linux",
@@ -44,7 +51,7 @@ if (!binPath) {
   process.exit(1);
 }
 
-const result = spawnSync(binPath, process.argv.slice(2), {
+const result = spawnSync(binPath, args, {
   stdio: "inherit",
 });
 


### PR DESCRIPTION
## Summary
- `relayfile --version` previously fell through to the Go binary, which has no `--version` flag, so users got no output (or an error).
- The npm `bin` shim (`packages/cli/scripts/run.js`) now intercepts `--version` and prints the version from `packages/cli/package.json` before spawning the binary. The reported version stays in sync with the published npm package automatically — release tooling already bumps `package.json`, so no extra wiring needed.
- Only `--version` is intercepted; `-v` is left alone to avoid clashing with a future verbose flag in the Go CLI.

## Test plan
- [x] `node packages/cli/scripts/run.js --version` prints `0.6.5` and exits 0
- [ ] After release, `npm i -g relayfile && relayfile --version` prints the installed version
- [ ] `relayfile <other-command>` still passes args through to the Go binary unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)