### PR TITLE
fix(mountsync): dispatch HandleLocalChange by file state, not fsnotify op

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -626,6 +626,29 @@ func (s *Syncer) Reconcile(ctx context.Context) error {
 	return s.sync(ctx, true)
 }
 
+// HandleLocalChange routes a local filesystem event to the appropriate
+// writeback action.
+//
+// Routing is state-driven (does the file exist on disk?) rather than
+// op-driven (what flag did fsnotify deliver?). This is load-bearing on
+// macOS and behind several editors that perform atomic save-via-rename
+// or end a save with a Chmod:
+//
+//   - Vim, VSCode, JetBrains, and similar editors typically emit
+//     Write → Rename → Chmod or just Rename → Chmod. With per-path
+//     debouncing in queueChange, only the *last* op survives the 100ms
+//     window. If we routed by op alone, a save ending in Chmod would
+//     hit the no-op Chmod branch and silently never queue a writeback.
+//
+//   - An atomic rename-replace leaves the file present on disk. Routing
+//     a Rename op to `pushSingleDelete` would wrongly delete the cloud
+//     file even though the user just *saved* it.
+//
+// Instead: stat the local path, and dispatch by whether the file still
+// exists. The downstream handlers (`handleLocalWriteOrCreate`,
+// `pushSingleDelete`) hash-check internally and short-circuit if there
+// is no actual content change, so spurious events (Chmod-only on an
+// unmodified file) do not generate noise on the wire.
 func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op fsnotify.Op) error {
 	relativePath = filepath.ToSlash(strings.TrimSpace(filepath.Clean(relativePath)))
 	if relativePath == "" || relativePath == "." {
@@ -644,10 +667,6 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 	}
 	localPath := filepath.Join(s.localDir, filepath.FromSlash(relativePath))
 
-	if info, statErr := os.Stat(localPath); statErr == nil && info.IsDir() {
-		return nil
-	}
-
 	saveWithStatus := func(run func() error) error {
 		if err := run(); err != nil {
 			s.markSyncError(err)
@@ -658,14 +677,27 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 		return s.saveState()
 	}
 
-	switch {
-	case op&(fsnotify.Write|fsnotify.Create) != 0:
-		return saveWithStatus(func() error {
-			return s.handleLocalWriteOrCreate(ctx, remotePath, localPath)
-		})
-	case op&(fsnotify.Remove|fsnotify.Rename) != 0:
+	info, statErr := os.Stat(localPath)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return statErr
+	}
+	fileExists := statErr == nil && !info.IsDir()
+	isDir := statErr == nil && info.IsDir()
+
+	if isDir {
+		return nil
+	}
+
+	if !fileExists {
+		// File is gone. If we tracked it (i.e. it once lived in the cloud),
+		// push the delete. If it never existed cloud-side, ignore — the
+		// event is from a transient file (e.g. an editor backup) we do not
+		// own. ReadOnly tracked files are reverted, not deleted.
 		tracked, exists := s.state.Files[remotePath]
-		if exists && tracked.ReadOnly {
+		if !exists {
+			return nil
+		}
+		if tracked.ReadOnly {
 			return saveWithStatus(func() error {
 				return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, "")
 			})
@@ -673,17 +705,16 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 		return saveWithStatus(func() error {
 			return s.pushSingleDelete(ctx, remotePath, localPath)
 		})
-	case op&fsnotify.Chmod != 0:
-		tracked, exists := s.state.Files[remotePath]
-		if exists && tracked.ReadOnly {
-			if err := s.applyLocalPermissions(localPath, false); err != nil && !errors.Is(err, os.ErrNotExist) {
-				s.markSyncError(err)
-				_ = s.saveState()
-				return err
-			}
-		}
 	}
-	return nil
+
+	// File exists. Treat any non-directory event as a potential update —
+	// `handleLocalWriteOrCreate` reads the file, hash-checks against the
+	// tracked snapshot, and short-circuits if nothing actually changed.
+	// This handles Write/Create/Rename(atomic-replace)/Chmod uniformly:
+	// the source of truth is the file's content, not the event flag.
+	return saveWithStatus(func() error {
+		return s.handleLocalWriteOrCreate(ctx, remotePath, localPath)
+	})
 }
 
 func (s *Syncer) handleLocalWriteOrCreate(ctx context.Context, remotePath, localPath string) error {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -122,6 +122,155 @@ func TestHandleLocalChangeIgnoresAlreadyTrackedContent(t *testing.T) {
 	}
 }
 
+// TestHandleLocalChangePushesOnChmodOnlyEvent pins the regression that
+// motivated the state-driven dispatch: editors (Vim, VSCode, JetBrains)
+// often end a save sequence with a Chmod event, and the per-path
+// debounce in the watcher only retains the *last* op within its 100ms
+// window. Pre-fix, an op of `fsnotify.Chmod` alone hit a no-op branch
+// and silently failed to queue a writeback for the new content. Now we
+// dispatch by file state — the file exists with new content, so we
+// hash-check and push the update.
+func TestHandleLocalChangePushesOnChmodOnlyEvent(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_chmod_only",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	// Modify the file content as an editor would, then deliver only
+	// fsnotify.Chmod (the surviving op after debounce-collapse on macOS).
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.WriteFile(localFile, []byte("# A — edited"), 0o644); err != nil {
+		t.Fatalf("edit local file: %v", err)
+	}
+
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/A.md", fsnotify.Chmod); err != nil {
+		t.Fatalf("handle chmod-only event failed: %v", err)
+	}
+
+	if client.bulkWriteCalls == 0 && client.writeFileCalls == 0 {
+		t.Fatalf("expected chmod-only event with new content to push update; bulk=%d write=%d",
+			client.bulkWriteCalls, client.writeFileCalls)
+	}
+	remote := client.files["/notion/Docs/A.md"]
+	if remote.Content != "# A — edited" {
+		t.Fatalf("expected remote content to reflect local edit, got %q", remote.Content)
+	}
+}
+
+// TestHandleLocalChangeTreatsAtomicRenameAsUpdate pins the second
+// regression: editors that save-via-rename (Vim's default, many IDEs)
+// can deliver a Rename event for the target path even though the file
+// is still present afterward. Pre-fix, the Remove|Rename branch
+// blindly called pushSingleDelete and removed the cloud file. Now we
+// stat the path; if it exists, we route as an update.
+func TestHandleLocalChangeTreatsAtomicRenameAsUpdate(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_atomic_rename",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	// Simulate atomic save-via-rename: write the new content (as if a
+	// .swp file had just been renamed over the target), then deliver
+	// only fsnotify.Rename for the target path.
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.WriteFile(localFile, []byte("# A — atomically saved"), 0o644); err != nil {
+		t.Fatalf("write replacement content: %v", err)
+	}
+
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/A.md", fsnotify.Rename); err != nil {
+		t.Fatalf("handle atomic rename failed: %v", err)
+	}
+
+	// Must have pushed the update, not deleted the file.
+	if _, exists := client.files["/notion/Docs/A.md"]; !exists {
+		t.Fatalf("atomic rename should not have deleted the cloud file")
+	}
+	remote := client.files["/notion/Docs/A.md"]
+	if remote.Content != "# A — atomically saved" {
+		t.Fatalf("expected remote content to reflect the atomically-renamed content, got %q",
+			remote.Content)
+	}
+}
+
+// TestHandleLocalChangeDeletesWhenFileGone confirms that an actual
+// removal — file no longer present on disk — still routes to a delete
+// post-fix. The Remove|Rename branch is gone, but the state-driven
+// dispatch must still treat a missing local file as a delete signal.
+func TestHandleLocalChangeDeletesWhenFileGone(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_actual_delete",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.Remove(localFile); err != nil {
+		t.Fatalf("remove local file: %v", err)
+	}
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/A.md", fsnotify.Remove); err != nil {
+		t.Fatalf("handle remove failed: %v", err)
+	}
+	if _, exists := client.files["/notion/Docs/A.md"]; exists {
+		t.Fatalf("expected cloud file to be deleted after local removal")
+	}
+}
+
 func TestReconcileUsesExportSnapshotForInitialPull(t *testing.T) {
 	base := &fakeClient{
 		files: map[string]RemoteFile{


### PR DESCRIPTION
## Summary

Live edits made through the local mount weren't queueing writebacks even with PR #86 in place. Editors (Vim, VSCode, JetBrains) on macOS routinely end a save sequence with a `Chmod` event, and editors that save-via-rename deliver `Rename` events on a file that's still on disk afterward. Both surfaces routed wrongly:

- `Chmod` → no-op branch (silent loss; this was the production failure mode tonight)
- `Rename` (with file still present) → `pushSingleDelete` (would have deleted the cloud file)

`HandleLocalChange` now dispatches by **file state** instead of fsnotify op. Stat the path; if the file exists, route as a potential update — the existing hash-check inside `handleLocalWriteOrCreate` short-circuits if nothing actually changed, so spurious events stay silent on the wire.

## Production failure mode

```
$ relayfile writeback status acme-demo --json
{ "pending": 0, "failed": 0, "deadLettered": [] }   ← empty
$ relayfile ops list --workspace acme-demo --json   ← empty
$ stat ~/relayfile-mount/.../content.md
   mtime updated, content changed   ← edit was real
```

Daemon process alive, file change real, watcher saw the event, but no writeback queued. Daemon-restart picked up the drift via the initial reconcile, which is what tipped us off that the live path was broken.

## Diff (logic)

```diff
-	switch {
-	case op&(fsnotify.Write|fsnotify.Create) != 0:
-		return saveWithStatus(handleLocalWriteOrCreate)
-	case op&(fsnotify.Remove|fsnotify.Rename) != 0:
-		return saveWithStatus(pushSingleDelete)
-	case op&fsnotify.Chmod != 0:
-		// only re-applies permissions on RO files; no-op otherwise
-	}
+	info, statErr := os.Stat(localPath)
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) { return statErr }
+	fileExists := statErr == nil && !info.IsDir()
+	if isDir { return nil }
+	if !fileExists {
+		// tracked → push delete (or revert if RO); untracked → ignore
+	}
+	// File exists. Treat any non-directory event as a potential update.
+	return saveWithStatus(handleLocalWriteOrCreate)
```

## Why op was unreliable

The watcher's `queueChange` debounces per path with a 100ms window, retaining only the **last** op. Editors typically emit `Write → Rename → Chmod` (or just `Rename → Chmod`), so the surviving op is whatever fired last in the close-write sequence. The op flag is informational at best; the file content is the source of truth.

## Tests

Three new regression tests in `syncer_test.go`:

- **`TestHandleLocalChangePushesOnChmodOnlyEvent`** — file content changed, only `fsnotify.Chmod` delivered. Pre-fix: silent no-op. Post-fix: pushes update.
- **`TestHandleLocalChangeTreatsAtomicRenameAsUpdate`** — content replaced, only `fsnotify.Rename` delivered, file present on disk. Pre-fix: deletes cloud file. Post-fix: pushes update.
- **`TestHandleLocalChangeDeletesWhenFileGone`** — actual removal still routes to delete, confirms we didn't regress legitimate Remove.

All 4 `HandleLocalChange*` tests pass. Full mountsync suite passes (~2.7s).

## Companion

PR #86 (recursive subdir watch) shipped the dir-watching half. This PR ships the event-handling half. Together: edits inside any synced path — including nested subdirs created by sync-down — reliably queue writebacks regardless of which fsnotify op the editor's save sequence happens to leave as the surviving one.

## Test plan

- [x] All mountsync tests green
- [ ] Reviewer: smoke-test by running `relayfile mount`, editing a content.md in the mount with Vim or VSCode, and confirming a writeback queues within 30s without daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)