### PR TITLE
feat(cli): add start + restart commands

### DIFF
--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -140,6 +140,44 @@ func TestA14StopReportsErrorWhenNoDaemonRunning(t *testing.T) {
 	}
 }
 
+func TestRestartReturnsErrorWhenDaemonStopFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := writeDaemonPIDState(mountPIDFile(localDir), daemonPIDState{
+		PID:         1 << 30,
+		WorkspaceID: "ws_demo",
+		LocalDir:    localDir,
+	}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := runRestart([]string{"demo"}, &stdout)
+	if err == nil {
+		t.Fatalf("expected restart to fail when daemon stop fails")
+	}
+	if !strings.Contains(err.Error(), "failed to stop background mount for demo") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "Stopped background mount") {
+		t.Fatalf("restart reported stop success despite signal failure: %q", stdout.String())
+	}
+}
+
 // TestA2RunCloudLoginReturnsStateMismatchSentinel exercises productized
 // cloud-mount contract A2: when the OAuth callback's `state` parameter does
 // not match the value the CLI generated, runCloudLogin must return the

--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -140,7 +140,7 @@ func TestA14StopReportsErrorWhenNoDaemonRunning(t *testing.T) {
 	}
 }
 
-func TestRestartReturnsErrorWhenDaemonStopFails(t *testing.T) {
+func TestRestartClearsStaleDaemonPID(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -168,13 +168,19 @@ func TestRestartReturnsErrorWhenDaemonStopFails(t *testing.T) {
 	var stdout bytes.Buffer
 	err := runRestart([]string{"demo"}, &stdout)
 	if err == nil {
-		t.Fatalf("expected restart to fail when daemon stop fails")
+		t.Fatalf("expected restart to reach mount and fail without credentials")
 	}
-	if !strings.Contains(err.Error(), "failed to stop background mount for demo") {
+	if !strings.Contains(err.Error(), "token is required") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Contains(stdout.String(), "Stopped background mount") {
-		t.Fatalf("restart reported stop success despite signal failure: %q", stdout.String())
+		t.Fatalf("restart reported stop success for stale pid: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Cleared stale background mount state") {
+		t.Fatalf("restart did not report stale pid cleanup: %q", stdout.String())
+	}
+	if _, err := os.Stat(mountPIDFile(localDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale pid file to be removed, got err=%v", err)
 	}
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3002,15 +3002,22 @@ func runRestart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	localDir := strings.TrimSpace(record.LocalDir)
+	if localDir == "" {
+		return fmt.Errorf("workspace %s has no recorded local mirror directory; run relayfile start %s <LOCAL_DIR>", record.Name, record.Name)
+	}
 
 	// Stop the current daemon if it's running. Tolerate "not running" so
 	// `restart` works as a safe "ensure running" verb.
-	if pid := readDaemonPID(record.LocalDir); pid != 0 {
-		if process, perr := os.FindProcess(pid); perr == nil {
-			if serr := signalDaemonStop(process); serr == nil {
-				fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
-			}
+	if pid := readDaemonPID(localDir); pid != 0 {
+		process, err := os.FindProcess(pid)
+		if err != nil {
+			return fmt.Errorf("failed to find background mount for %s (pid %d): %w", record.Name, pid, err)
 		}
+		if err := signalDaemonStop(process); err != nil {
+			return fmt.Errorf("failed to stop background mount for %s (pid %d): %w", record.Name, pid, err)
+		}
+		fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
 		// Give the process a brief moment to release pid/log files before
 		// the new daemon claims them. 500ms is enough on every platform we
 		// support; the existing daemon shuts down on SIGTERM in well under
@@ -3019,7 +3026,7 @@ func runRestart(args []string, stdout io.Writer) error {
 	}
 
 	// Start the new daemon. Default is --background; --foreground overrides.
-	mountArgs := []string{record.Name, record.LocalDir}
+	mountArgs := []string{record.Name, localDir}
 	if !*foreground {
 		mountArgs = append(mountArgs, "--background")
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3015,14 +3015,22 @@ func runRestart(args []string, stdout io.Writer) error {
 			return fmt.Errorf("failed to find background mount for %s (pid %d): %w", record.Name, pid, err)
 		}
 		if err := signalDaemonStop(process); err != nil {
-			return fmt.Errorf("failed to stop background mount for %s (pid %d): %w", record.Name, pid, err)
+			if isProcessAlreadyGone(err) {
+				if rerr := os.Remove(mountPIDFile(localDir)); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+					return fmt.Errorf("failed to clear stale background mount state for %s (pid %d): %w", record.Name, pid, rerr)
+				}
+				fmt.Fprintf(stdout, "Cleared stale background mount state for %s (pid %d)\n", record.Name, pid)
+			} else {
+				return fmt.Errorf("failed to stop background mount for %s (pid %d): %w", record.Name, pid, err)
+			}
+		} else {
+			fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
+			// Give the process a brief moment to release pid/log files before
+			// the new daemon claims them. 500ms is enough on every platform we
+			// support; the existing daemon shuts down on SIGTERM in well under
+			// 100ms in practice.
+			time.Sleep(500 * time.Millisecond)
 		}
-		fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
-		// Give the process a brief moment to release pid/log files before
-		// the new daemon claims them. 500ms is enough on every platform we
-		// support; the existing daemon shuts down on SIGTERM in well under
-		// 100ms in practice.
-		time.Sleep(500 * time.Millisecond)
 	}
 
 	// Start the new daemon. Default is --background; --foreground overrides.
@@ -3031,6 +3039,10 @@ func runRestart(args []string, stdout io.Writer) error {
 		mountArgs = append(mountArgs, "--background")
 	}
 	return runMount(mountArgs)
+}
+
+func isProcessAlreadyGone(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
 }
 
 func runLogs(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3002,34 +3002,48 @@ func runRestart(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	// Reject workspaces that have no recorded local mirror — passing an
+	// empty positional `localDir` to runMount would cause it to fall back
+	// to `"."` and mirror into the caller's current working directory.
 	localDir := strings.TrimSpace(record.LocalDir)
 	if localDir == "" {
-		return fmt.Errorf("workspace %s has no recorded local mirror directory; run relayfile start %s <LOCAL_DIR>", record.Name, record.Name)
+		return fmt.Errorf(
+			"workspace %s has no recorded local mirror directory; run "+
+				"`relayfile start %s <LOCAL_DIR>` first to register one",
+			record.Name, record.Name,
+		)
 	}
 
 	// Stop the current daemon if it's running. Tolerate "not running" so
-	// `restart` works as a safe "ensure running" verb.
+	// `restart` works as a safe "ensure running" verb. If the signal fails
+	// because the process is already gone (stale pid file), clean up and
+	// proceed; any other failure aborts the restart so we don't race a
+	// second daemon against the first on the same pid file.
 	if pid := readDaemonPID(localDir); pid != 0 {
-		process, err := os.FindProcess(pid)
-		if err != nil {
-			return fmt.Errorf("failed to find background mount for %s (pid %d): %w", record.Name, pid, err)
+		process, perr := os.FindProcess(pid)
+		if perr != nil {
+			return fmt.Errorf("failed to find background mount for %s (pid %d): %w", record.Name, pid, perr)
 		}
-		if err := signalDaemonStop(process); err != nil {
-			if isProcessAlreadyGone(err) {
+		if serr := signalDaemonStop(process); serr != nil {
+			if isProcessAlreadyGone(serr) {
 				if rerr := os.Remove(mountPIDFile(localDir)); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
 					return fmt.Errorf("failed to clear stale background mount state for %s (pid %d): %w", record.Name, pid, rerr)
 				}
 				fmt.Fprintf(stdout, "Cleared stale background mount state for %s (pid %d)\n", record.Name, pid)
 			} else {
-				return fmt.Errorf("failed to stop background mount for %s (pid %d): %w", record.Name, pid, err)
+				return fmt.Errorf("failed to stop background mount for %s (pid %d): %w", record.Name, pid, serr)
 			}
 		} else {
 			fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
-			// Give the process a brief moment to release pid/log files before
-			// the new daemon claims them. 500ms is enough on every platform we
-			// support; the existing daemon shuts down on SIGTERM in well under
-			// 100ms in practice.
-			time.Sleep(500 * time.Millisecond)
+			// Wait for the old daemon to actually release its pid file. A
+			// fixed sleep is fragile: if the old process takes longer to
+			// exit, its `defer os.Remove(pidFile)` would race the new
+			// daemon's pid write and silently delete it, leaving `status`,
+			// `stop`, and a later `restart` reporting "no daemon" against a
+			// process that was, in fact, running.
+			if werr := waitForDaemonExit(localDir, pid, 5*time.Second); werr != nil {
+				return fmt.Errorf("old daemon (pid %d) for %s did not exit cleanly: %w", pid, record.Name, werr)
+			}
 		}
 	}
 
@@ -3041,8 +3055,44 @@ func runRestart(args []string, stdout io.Writer) error {
 	return runMount(mountArgs)
 }
 
+// isProcessAlreadyGone reports whether a signal-delivery failure means the
+// target process has already exited. Treats both `os.ErrProcessDone` (the
+// modern Go check) and `syscall.ESRCH` (raw signal failure) as "gone".
 func isProcessAlreadyGone(err error) bool {
 	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}
+
+// waitForDaemonExit polls the pid file and the process itself, returning
+// nil once both have gone away. The pid-file check covers the clean-exit
+// case (the daemon's `defer os.Remove(pidFile)` runs). The process check
+// covers the case where the pid file lingers — for example if the daemon
+// was SIGKILL'd by something else after we sent SIGTERM.
+//
+// Returns an error only if the deadline is reached with the daemon still
+// alive AND the pid file still pointing at it. The default deadline (5s)
+// is generous: a healthy daemon shuts down in <100ms on every platform.
+func waitForDaemonExit(localDir string, oldPid int, timeout time.Duration) error {
+	const pollInterval = 50 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+	for {
+		pidNow := readDaemonPID(localDir)
+		// Pid file gone, or it's been claimed by a different pid (which
+		// shouldn't happen mid-restart but is harmless if it does).
+		if pidNow == 0 || pidNow != oldPid {
+			return nil
+		}
+		// Process check: signal 0 reports liveness without delivering anything.
+		if process, perr := os.FindProcess(oldPid); perr == nil {
+			if serr := process.Signal(syscall.Signal(0)); serr != nil {
+				// Signal 0 failed — process is gone even if the pid file lingered.
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("daemon still alive after %s", timeout)
+		}
+		time.Sleep(pollInterval)
+	}
 }
 
 func runLogs(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -340,8 +340,13 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runWriteback(args[1:], stdout)
 	case "pull":
 		return runPull(args[1:], stdout)
-	case "mount":
+	case "mount", "start":
+		// `start` is the friendlier alias for `mount`. Same flags, same
+		// behavior — `mount` retains the historical name; `start` pairs
+		// naturally with `stop` and `restart`.
 		return runMount(args[1:])
+	case "restart":
+		return runRestart(args[1:], stdout)
 	case "tree", "ls":
 		return runTree(args[1:], stdout)
 	case "read", "cat":
@@ -387,12 +392,14 @@ Usage:
   relayfile writeback retry --opId OP [WORKSPACE]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
+  relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount)
+  relayfile stop [WORKSPACE]
+  relayfile restart [WORKSPACE] [--foreground]
   relayfile tree [WORKSPACE] [PATH] [--depth N]
   relayfile read [WORKSPACE] PATH
   relayfile seed [WORKSPACE] [DIR]
   relayfile export [WORKSPACE] --format FORMAT [--output FILE]
   relayfile status [WORKSPACE]
-  relayfile stop [WORKSPACE]
   relayfile logs [WORKSPACE]
   relayfile observer [WORKSPACE] [--no-open]
 
@@ -409,12 +416,14 @@ Subcommands:
               Re-enqueue a local dead-lettered writeback op
   pull        Trigger an immediate sync refresh for one or all providers
   mount       Mirror a remote workspace to a local directory; add --background to detach
+  start       Alias for mount; pairs naturally with stop and restart
+  stop        Stop a background mount
+  restart     Stop and start a workspace's mount in one step (--foreground to attach)
   tree        List a remote workspace path
   read        Print a remote file's content
   seed        Upload a directory tree with bulk writes
   export      Export a workspace as json, tar, or patch
   status      Show sync status and local mirror state for a workspace
-  stop        Stop a background mount
   logs        Print the background mount log
   observer    Open the hosted file observer for a workspace`)
 }
@@ -2959,6 +2968,62 @@ func runStop(args []string, stdout io.Writer) error {
 	}
 	fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
 	return nil
+}
+
+// runRestart stops a running daemon (if any) and starts a fresh background
+// mount using the workspace's recorded localDir. This is the operationally
+// correct way to recover from a stalled daemon: the new daemon's initial
+// recursive walk re-subscribes to every directory in the mirror, which is
+// what the watcher needs after a sync-down created new nested subtrees
+// (see watcher.go addDirRecursive).
+//
+// Forwarded flags: any flag accepted by `mount` can be passed after the
+// workspace name and is propagated to the start phase. The restart always
+// runs in `--background` mode (the natural default for a long-running
+// mount); pass `--foreground` to override and run attached.
+func runRestart(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("restart", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	foreground := fs.Bool("foreground", false, "run the restarted mount in the foreground instead of detaching")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"foreground": false,
+	})); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			fmt.Fprintln(stdout, "usage: relayfile restart [WORKSPACE] [--foreground]")
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() > 1 {
+		return errors.New("usage: relayfile restart [WORKSPACE] [--foreground]")
+	}
+
+	record, err := resolveWorkspaceRecord(firstArg(fs))
+	if err != nil {
+		return err
+	}
+
+	// Stop the current daemon if it's running. Tolerate "not running" so
+	// `restart` works as a safe "ensure running" verb.
+	if pid := readDaemonPID(record.LocalDir); pid != 0 {
+		if process, perr := os.FindProcess(pid); perr == nil {
+			if serr := signalDaemonStop(process); serr == nil {
+				fmt.Fprintf(stdout, "Stopped background mount for %s (pid %d)\n", record.Name, pid)
+			}
+		}
+		// Give the process a brief moment to release pid/log files before
+		// the new daemon claims them. 500ms is enough on every platform we
+		// support; the existing daemon shuts down on SIGTERM in well under
+		// 100ms in practice.
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Start the new daemon. Default is --background; --foreground overrides.
+	mountArgs := []string{record.Name, record.LocalDir}
+	if !*foreground {
+		mountArgs = append(mountArgs, "--background")
+	}
+	return runMount(mountArgs)
 }
 
 func runLogs(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -771,6 +771,33 @@ func TestStatusIncludesLocalMirrorAndDaemonCounts(t *testing.T) {
 	}
 }
 
+func TestRestartRequiresRecordedLocalMirror(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := runRestart([]string{"demo"}, &stdout)
+	if err == nil {
+		t.Fatalf("expected restart to fail without a recorded local mirror")
+	}
+	if !strings.Contains(err.Error(), "no recorded local mirror directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLogsPrintsTailForWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -19,6 +19,8 @@ type FileWatcher struct {
 	onChange func(relativePath string, op fsnotify.Op)
 	mu       sync.Mutex
 	debounce map[string]*time.Timer // debounce rapid events per file
+	closed   bool
+	wg       sync.WaitGroup
 }
 
 func NewFileWatcher(localDir string, onChange func(string, fsnotify.Op)) (*FileWatcher, error) {
@@ -101,14 +103,28 @@ func (fw *FileWatcher) shouldSkip(rel string) bool {
 
 func (fw *FileWatcher) queueChange(rel string, op fsnotify.Op) {
 	fw.mu.Lock()
-	if t, ok := fw.debounce[rel]; ok {
-		t.Stop()
+	if fw.closed {
+		fw.mu.Unlock()
+		return
 	}
+	if t, ok := fw.debounce[rel]; ok {
+		if t.Stop() {
+			fw.wg.Done()
+		}
+	}
+	fw.wg.Add(1)
 	fw.debounce[rel] = time.AfterFunc(100*time.Millisecond, func() {
-		fw.onChange(rel, op)
+		defer fw.wg.Done()
+
 		fw.mu.Lock()
+		if fw.closed {
+			delete(fw.debounce, rel)
+			fw.mu.Unlock()
+			return
+		}
 		delete(fw.debounce, rel)
 		fw.mu.Unlock()
+		fw.onChange(rel, op)
 	})
 	fw.mu.Unlock()
 }
@@ -153,5 +169,17 @@ func (fw *FileWatcher) addDirRecursive(base string) error {
 }
 
 func (fw *FileWatcher) Close() error {
-	return fw.watcher.Close()
+	fw.mu.Lock()
+	fw.closed = true
+	for rel, timer := range fw.debounce {
+		if timer.Stop() {
+			fw.wg.Done()
+		}
+		delete(fw.debounce, rel)
+	}
+	fw.mu.Unlock()
+
+	err := fw.watcher.Close()
+	fw.wg.Wait()
+	return err
 }

--- a/internal/mountsync/watcher_test.go
+++ b/internal/mountsync/watcher_test.go
@@ -83,6 +83,23 @@ func assertNoWatcherEvents(t *testing.T, events <-chan watcherEvent, timeout tim
 	}
 }
 
+func TestWatcherCloseCancelsPendingDebounce(t *testing.T) {
+	localDir := t.TempDir()
+	events := make(chan watcherEvent, 1)
+	watcher, err := NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
+		events <- watcherEvent{path: filepath.ToSlash(relativePath), op: op}
+	})
+	if err != nil {
+		t.Fatalf("create file watcher: %v", err)
+	}
+
+	watcher.queueChange("notes.md", fsnotify.Write)
+	if err := watcher.Close(); err != nil {
+		t.Fatalf("close watcher: %v", err)
+	}
+	assertNoWatcherEvents(t, events, 150*time.Millisecond)
+}
+
 func TestWatcherDetectsFileWrite(t *testing.T) {
 	localDir := t.TempDir()
 	target := filepath.Join(localDir, "notes.md")
@@ -272,7 +289,9 @@ func TestWatcherNewSubdirectory(t *testing.T) {
 // never subscribed to.
 //
 // Concrete production case: the Notion adapter mirrors a page like
-//   /notion/pages/demos--<hex>/blocks/<id>.json
+//
+//	/notion/pages/demos--<hex>/blocks/<id>.json
+//
 // in one MkdirAll-style operation. The bug surfaced as "agent edits the
 // file in their local mount but no writeback queues."
 func TestWatcherNewNestedSubdirectoryTree(t *testing.T) {


### PR DESCRIPTION
## Summary

Symmetrize the daemon lifecycle vocabulary. Adds:

- `relayfile start [WORKSPACE] [LOCAL_DIR]` — alias for `mount`
- `relayfile restart [WORKSPACE] [--foreground]` — stop + start --background in one step

`mount` and `stop` already existed but the absence of `start`/`restart` was confusing — `mount` reads as the integration-mounting metaphor, while `start`/`stop`/`restart` is the daemon-lifecycle metaphor. Both should work; this PR wires the latter.

## Why now

PR #86 (recursive subdir add) and PR #88 (state-driven HandleLocalChange) both make the daemon behave correctly *after* a fresh start. The natural recovery instruction "stop and start the daemon" should be one verb (`restart`), not `pkill -f "relayfile-cli.*mount" && relayfile mount …`.

## Behavior

`restart` is tolerant: it stops the daemon if running and skips silently if not, so it doubles as a safe "ensure running" verb. Defaults to `--background`; pass `--foreground` to attach.

```bash
$ relayfile restart acme-demo
Stopped background mount for acme-demo (pid 96562)
Mirror started in background at /Users/khaliqgant/relayfile-mount. Logs: /Users/khaliqgant/relayfile-mount/.relay/mount.log
```

The 500ms sleep between stop and start lets the prior process release its pid + log files before the new daemon claims them.

## Test plan

- [x] `go build ./cmd/...` clean
- [x] `go test ./cmd/...` passes
- [x] Usage output shows the new commands and the `start` alias
- [ ] Reviewer: run `relayfile restart <workspace>` against a healthy mount, verify it stops cleanly and the new daemon picks up immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)