### PR TITLE
fix(sdk): heartbeat watchdog + handler isolation for onWrite live events

### DIFF
--- a/packages/sdk/typescript/src/onWrite.test.ts
+++ b/packages/sdk/typescript/src/onWrite.test.ts
@@ -285,6 +285,47 @@ describe("onWrite", () => {
     errorSpy.mockRestore();
   });
 
+  it("keeps delivering subsequent events to the same pattern after a handler throws", async () => {
+    // Regression for the "live event drop" bug: a single throwing handler
+    // must not break the per-pattern chain. Previously, an unhandled rejection
+    // in the chained promise would cause subsequent events for the same
+    // pattern to be silently swallowed.
+    const client = makeClient();
+    const sockets: MockWebSocket[] = [];
+    const received: string[] = [];
+
+    onWrite(
+      "/linear/issues/**",
+      (event) => {
+        if (event.path.endsWith("PROJ-1")) {
+          throw new Error("first event boom");
+        }
+        received.push(event.path);
+      },
+      {
+        client,
+        workspaceId: "ws_acme",
+        token: "tok_test",
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      }
+    );
+
+    emitFilesystemEvent(sockets[0]!, "/linear/issues/PROJ-1");
+    await flushPromises();
+    emitFilesystemEvent(sockets[0]!, "/linear/issues/PROJ-2");
+    await flushPromises();
+    emitFilesystemEvent(sockets[0]!, "/linear/issues/PROJ-3");
+    await flushPromises();
+
+    // PROJ-1 threw; PROJ-2 and PROJ-3 must still have been delivered.
+    expect(received).toEqual(["/linear/issues/PROJ-2", "/linear/issues/PROJ-3"]);
+    expect(client.recordHandlerError).toHaveBeenCalledTimes(1);
+  });
+
   it("reconnects with the 1s then 2s backoff schedule", async () => {
     vi.useFakeTimers();
     const client = makeClient();

--- a/packages/sdk/typescript/src/onWrite.ts
+++ b/packages/sdk/typescript/src/onWrite.ts
@@ -25,6 +25,11 @@ export interface OnWriteOptions {
   baseUrl?: string;
   token?: string;
   webSocketFactory?: (url: string) => RelayFileSyncSocket;
+  // Override the WebSocket ping/heartbeat cadence. Lower values catch silent
+  // socket death faster at the cost of slightly more chatter; the default is
+  // tuned for production (30s ping, 60s pong timeout).
+  pingIntervalMs?: number;
+  pongTimeoutMs?: number;
 }
 
 interface OnWriteRegistration {
@@ -46,6 +51,24 @@ const DEFAULT_RECONNECT_MAX_DELAY_MS = 30000;
 const dispatchers = new WeakMap<OnWriteClient, OnWriteDispatcher>();
 let nextRegistrationId = 1;
 let defaultClient: OnWriteClient | undefined;
+
+const debugEnabled = ((): boolean => {
+  try {
+    const value = (globalThis as EnvironmentLike).process?.env?.RELAYFILE_SDK_DEBUG;
+    return value === "1" || value === "true";
+  } catch {
+    return false;
+  }
+})();
+
+function debugLog(...args: unknown[]): void {
+  if (!debugEnabled) {
+    return;
+  }
+  if (typeof console !== "undefined" && typeof console.error === "function") {
+    console.error("[relayfile-sdk:onWrite]", ...args);
+  }
+}
 
 export function pathMatches(pattern: string, path: string): boolean {
   const patternSegments = normalizePattern(pattern);
@@ -103,8 +126,12 @@ export function onWrite(
     signal: options.signal,
     baseUrl: options.baseUrl,
     token: options.token,
-    webSocketFactory: options.webSocketFactory
+    webSocketFactory: options.webSocketFactory,
+    pingIntervalMs: options.pingIntervalMs,
+    pongTimeoutMs: options.pongTimeoutMs
   });
+
+  debugLog("registered", { id: registration.id, pattern: normalizedPattern, workspaceId });
 
   return () => {
     dispatcher?.unregister(registration.id);
@@ -129,7 +156,8 @@ class OnWriteDispatcher {
 
   register(
     registration: OnWriteRegistration,
-    options: Required<Pick<OnWriteOptions, "workspaceId">> & Pick<OnWriteOptions, "signal" | "baseUrl" | "token" | "webSocketFactory">
+    options: Required<Pick<OnWriteOptions, "workspaceId">> &
+      Pick<OnWriteOptions, "signal" | "baseUrl" | "token" | "webSocketFactory" | "pingIntervalMs" | "pongTimeoutMs">
   ): void {
     this.registrations.push(registration);
     if (options.signal) {
@@ -153,7 +181,10 @@ class OnWriteDispatcher {
     }
   }
 
-  private ensureSync(options: Required<Pick<OnWriteOptions, "workspaceId">> & Pick<OnWriteOptions, "baseUrl" | "token" | "webSocketFactory">): void {
+  private ensureSync(
+    options: Required<Pick<OnWriteOptions, "workspaceId">> &
+      Pick<OnWriteOptions, "baseUrl" | "token" | "webSocketFactory" | "pingIntervalMs" | "pongTimeoutMs">
+  ): void {
     if (this.sync) {
       return;
     }
@@ -168,6 +199,8 @@ class OnWriteDispatcher {
         maxDelayMs: DEFAULT_RECONNECT_MAX_DELAY_MS
       },
       webSocketFactory: options.webSocketFactory,
+      pingIntervalMs: options.pingIntervalMs,
+      pongTimeoutMs: options.pongTimeoutMs,
       onEvent: (event) => {
         void this.dispatch(event);
       }
@@ -185,10 +218,27 @@ class OnWriteDispatcher {
         continue;
       }
 
+      debugLog("dispatch", {
+        registrationId: registration.id,
+        pattern: registration.pattern,
+        path: writeEvent.path,
+        operation: writeEvent.operation
+      });
+
+      // patternChains serializes handlers per pattern. runHandler is the only
+      // thing chained here and it already swallows handler errors, so the
+      // chain itself can never reject — but we still defensively `.catch`
+      // before chaining so a future refactor of runHandler cannot silently
+      // break the chain (which is the failure mode hypothesis 3 in the bug
+      // report).
       const previous = this.patternChains.get(registration.pattern) ?? Promise.resolve();
       const next = previous
         .catch(() => undefined)
-        .then(() => this.runHandler(registration, writeEvent));
+        .then(() => this.runHandler(registration, writeEvent))
+        .catch((error) => {
+          // Belt-and-braces: should be unreachable because runHandler catches.
+          debugLog("patternChain unexpectedly rejected", { pattern: registration.pattern, error });
+        });
       this.patternChains.set(registration.pattern, next);
       void next.finally(() => {
         if (this.patternChains.get(registration.pattern) === next) {

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -142,6 +142,65 @@ describe("RelayFileSync", () => {
     expect(sync.getState()).toBe("closed");
   });
 
+  it("force-reconnects when no frames arrive within the pong timeout (silent socket death)", async () => {
+    // Reproduces the "live event drop" failure mode: TCP/WS dies silently —
+    // no `error`, no `close` — and the JS layer happily considers the socket
+    // open. The watchdog should notice via `lastFrameAt` and force a fresh
+    // connection so we resume receiving broadcasts.
+    vi.useFakeTimers();
+    try {
+      const sockets: MockWebSocket[] = [];
+      const sync = new RelayFileSync({
+        client: makeClient(),
+        workspaceId: "ws_acme",
+        baseUrl: "https://relay.test",
+        token: "ws_token",
+        pingIntervalMs: 50,
+        pongTimeoutMs: 100,
+        reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      });
+
+      sync.start();
+      sockets[0]!.emit("open", {});
+
+      // First tick (t=50): ping is sent; lastPingSentAt becomes non-zero,
+      // lastFrameAt is still the open timestamp. No reconnect yet because
+      // sinceFrame (~50) < pongTimeoutMs (100).
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sockets[0]!.sent).toContain(JSON.stringify({ type: "ping" }));
+      expect(sockets).toHaveLength(1);
+
+      // Subsequent ticks with no inbound frames eventually push sinceFrame
+      // past pongTimeoutMs and the watchdog forces a reconnect. Advance well
+      // past the threshold + the reconnect delay so we observe the new socket.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+      // Once the new socket is open and we feed it a frame, the watchdog
+      // sees liveness and does NOT flap on the next tick.
+      sockets[1]!.emit("open", {});
+      sockets[1]!.emit("message", {
+        data: JSON.stringify({ type: "pong", ts: "2026-05-07T00:00:00Z" })
+      });
+      const beforeStable = sockets.length;
+      await vi.advanceTimersByTimeAsync(60);
+      sockets[1]!.emit("message", {
+        data: JSON.stringify({ type: "pong", ts: "2026-05-07T00:00:01Z" })
+      });
+      await vi.advanceTimersByTimeAsync(60);
+      expect(sockets).toHaveLength(beforeStable);
+
+      await sync.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reconnects after an unexpected close", async () => {
     const sockets: MockWebSocket[] = [];
     const sync = new RelayFileSync({

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -201,6 +201,69 @@ describe("RelayFileSync", () => {
     }
   });
 
+  // Pins Codex P2 from PR #93: forceReconnect (watchdog or failed-ping path)
+  // swaps in a fresh socket BEFORE the OS-layer close event for the doomed
+  // socket actually fires. If the close handler treated that stale event as
+  // authoritative it would clearPingTimer() — killing the new socket's
+  // heartbeat — and possibly schedule another reconnect after the timer
+  // had already fired. The handler must early-return when this.socket
+  // !== socket.
+  it("ignores stale close events for sockets already replaced by forceReconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const sockets: MockWebSocket[] = [];
+      const sync = new RelayFileSync({
+        client: makeClient(),
+        workspaceId: "ws_acme",
+        baseUrl: "https://relay.test",
+        token: "ws_token",
+        pingIntervalMs: 50,
+        pongTimeoutMs: 100,
+        reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      });
+
+      sync.start();
+      sockets[0]!.emit("open", {});
+
+      // Force the watchdog to swap in socket #2 by starving socket #0 of
+      // frames past pongTimeoutMs.
+      await vi.advanceTimersByTimeAsync(50);  // first ping sent on #0
+      await vi.advanceTimersByTimeAsync(200); // watchdog trips → socket #1 created
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+      // New socket comes up and is healthy.
+      sockets[1]!.emit("open", {});
+      sockets[1]!.emit("message", {
+        data: JSON.stringify({ type: "pong", ts: "2026-05-07T00:00:00Z" })
+      });
+      const stableCount = sockets.length;
+      const sentOnNewBeforeStaleClose = sockets[1]!.sent.length;
+
+      // Now the OLD socket finally emits its close — long after it was
+      // replaced. Pre-fix, this would clearPingTimer() (killing the live
+      // socket's heartbeat) and scheduleReconnect() (creating a duplicate
+      // reconnect cycle). With the guard, both side effects must be skipped.
+      sockets[0]!.emit("close", { code: 4000, reason: "ping-send-failed" });
+
+      // The next ping interval should still tick on the live socket — proof
+      // that clearPingTimer was NOT called by the stale-close handler.
+      await vi.advanceTimersByTimeAsync(60);
+      expect(sockets[1]!.sent.length).toBeGreaterThan(sentOnNewBeforeStaleClose);
+
+      // No extra reconnect was scheduled — socket count is still stable.
+      expect(sockets.length).toBe(stableCount);
+
+      await sync.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reconnects after an unexpected close", async () => {
     const sockets: MockWebSocket[] = [];
     const sync = new RelayFileSync({

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -201,6 +201,61 @@ describe("RelayFileSync", () => {
     }
   });
 
+  // Pins CodeRabbit P1 on PR #93. The pongTimeoutMs option is documented as
+  // "how long to wait after sending a ping" — that timeout MUST be measured
+  // from `lastPingSentAt`, not from `lastFrameAt`. With ping=50, pong=200,
+  // a ping at t=50 must be allowed to remain unanswered until at least
+  // t=250 (50 + 200), not reconnect at t=200 (lastFrameAt + pongTimeoutMs).
+  it("measures pongTimeoutMs from the unanswered ping, not from the last frame", async () => {
+    vi.useFakeTimers();
+    try {
+      const sockets: MockWebSocket[] = [];
+      const sync = new RelayFileSync({
+        client: makeClient(),
+        workspaceId: "ws_acme",
+        baseUrl: "https://relay.test",
+        token: "ws_token",
+        pingIntervalMs: 50,
+        pongTimeoutMs: 200,
+        reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      });
+
+      sync.start();
+      sockets[0]!.emit("open", {});
+
+      // First ping sent at ~t=50.
+      await vi.advanceTimersByTimeAsync(50);
+      expect(sockets[0]!.sent.length).toBe(1);
+
+      // At t=200 (50ms after open + 150ms of silence) the LEGACY logic
+      // would have measured `now - lastFrameAt = 200` against
+      // `pongTimeoutMs = 200` and tripped. The fixed logic measures from
+      // the ping at t=50: sincePing = 150 < 200 → still waiting, no
+      // reconnect.
+      await vi.advanceTimersByTimeAsync(150);
+      expect(sockets).toHaveLength(1);
+
+      // We also must NOT pile up additional pings while the first is
+      // outstanding — sent.length should still be 1.
+      expect(sockets[0]!.sent.length).toBe(1);
+
+      // At t=300 (250ms after the ping at t=50) sincePing crosses
+      // pongTimeoutMs and the watchdog trips. Add a few ms past that for
+      // the reconnect timer (delay 5ms) to actually fire.
+      await vi.advanceTimersByTimeAsync(120);
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+      await sync.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // Pins Codex P2 from PR #93: forceReconnect (watchdog or failed-ping path)
   // swaps in a fresh socket BEFORE the OS-layer close event for the doomed
   // socket actually fires. If the close handler treated that stale event as

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -480,12 +480,26 @@ export class RelayFileSync {
 
   private startPingLoop(socket: RelayFileSyncSocket): void {
     this.clearPingTimer();
-    // The "ping loop" doubles as the heartbeat watchdog: every tick we first
-    // check whether we have observed a frame recently, and if not we force a
-    // reconnect. This is the load-bearing fix for the silent socket-death
-    // failure mode where the server keeps broadcasting frames the JS layer
-    // never receives (e.g. NAT/LB idle drop, half-open TCP) and neither
-    // `error` nor `close` ever fires.
+    // The "ping loop" doubles as the heartbeat watchdog. The contract for
+    // pongTimeoutMs is "how long to wait, after sending a ping, before
+    // assuming the socket is dead." So the timeout window must be measured
+    // from `lastPingSentAt` — the moment we sent the unanswered ping — not
+    // from the last inbound frame. (CodeRabbit P1 on PR #93: with
+    // pingIntervalMs=30_000 + pongTimeoutMs=45_000, measuring from
+    // lastFrameAt would reconnect at t=60s — only 30s after the first
+    // ping went out, which violates the documented "wait 45s after a
+    // ping" semantics.)
+    //
+    // An unanswered ping = `lastPingSentAt > lastFrameAt`. Any inbound
+    // frame (event OR pong) advances lastFrameAt past lastPingSentAt and
+    // proves the socket is alive. While a ping is unanswered we DO NOT
+    // pile up another — that would just race the timeout window and make
+    // tuning meaningless.
+    //
+    // Load-bearing for the silent socket-death failure mode where the
+    // server keeps broadcasting frames the JS layer never receives (e.g.
+    // NAT/LB idle drop, half-open TCP) and neither `error` nor `close`
+    // ever fires.
     this.pingTimer = setInterval(() => {
       if (this.socket !== socket || this.stopped) {
         this.clearPingTimer();
@@ -493,19 +507,22 @@ export class RelayFileSync {
       }
 
       const now = Date.now();
-      // Only enforce the timeout once we've sent at least one ping on this
-      // socket: the first tick has no expectation of inbound traffic yet.
-      if (this.lastPingSentAt > 0) {
-        const sinceFrame = now - this.lastFrameAt;
-        if (sinceFrame > this.pongTimeoutMs) {
+      const hasOutstandingPing = this.lastPingSentAt > this.lastFrameAt;
+
+      if (hasOutstandingPing) {
+        const sincePing = now - this.lastPingSentAt;
+        if (sincePing > this.pongTimeoutMs) {
           debugLog("watchdog tripped — forcing reconnect", {
             workspaceId: this.workspaceId,
-            sinceFrameMs: sinceFrame,
+            sincePingMs: sincePing,
             pongTimeoutMs: this.pongTimeoutMs
           });
           this.forceReconnect(socket, "heartbeat-timeout");
           return;
         }
+        // Within the timeout — still waiting for the pong/frame. Don't
+        // pile up a second ping while one is outstanding.
+        return;
       }
 
       try {

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -355,9 +355,22 @@ export class RelayFileSync {
     });
 
     socket.addEventListener("close", (event) => {
-      if (this.socket === socket) {
-        this.socket = undefined;
+      // forceReconnect (called from the watchdog or a failed ping send) nulls
+      // out this.socket and opens a replacement before the OS-layer close
+      // event for the old socket actually fires. If this handler treated a
+      // stale close as authoritative it would (a) clearPingTimer() and kill
+      // the new socket's heartbeat and (b) potentially scheduleReconnect()
+      // a second time (the timer guard would skip it most of the time, but
+      // not after the timer has already fired). Either way: don't touch
+      // shared state when the socket we're attached to is no longer current.
+      if (this.socket !== socket) {
+        debugLog("ws close (stale, ignored)", {
+          code: event?.code,
+          reason: event?.reason,
+        });
+        return;
       }
+      this.socket = undefined;
       this.clearPingTimer();
       debugLog("ws close", { code: event?.code, reason: event?.reason, stopped: this.stopped });
       this.emit("close", event);

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -23,6 +23,11 @@ export interface RelayFileSyncOptions {
   preferPolling?: boolean;
   pollIntervalMs?: number;
   pingIntervalMs?: number;
+  // How long to wait after sending a ping before declaring the socket "muted"
+  // and forcing a reconnect. Defaults to 2x pingIntervalMs. Catches silent
+  // socket death (NAT/LB idle drop, half-open TCP) where the OS never delivers
+  // a close/error to the JS layer but frames have stopped arriving.
+  pongTimeoutMs?: number;
   reconnect?: boolean | RelayFileSyncReconnectOptions;
   signal?: AbortSignal;
   webSocketFactory?: (url: string) => RelayFileSyncSocket;
@@ -70,6 +75,24 @@ const DEFAULT_POLL_INTERVAL_MS = 5000;
 const DEFAULT_PING_INTERVAL_MS = 30000;
 const DEFAULT_RECONNECT_MIN_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
+
+const debugEnabled = ((): boolean => {
+  try {
+    const value = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env?.RELAYFILE_SDK_DEBUG;
+    return value === "1" || value === "true";
+  } catch {
+    return false;
+  }
+})();
+
+function debugLog(...args: unknown[]): void {
+  if (!debugEnabled) {
+    return;
+  }
+  if (typeof console !== "undefined" && typeof console.error === "function") {
+    console.error("[relayfile-sdk:sync]", ...args);
+  }
+}
 
 function normalizeReconnectOptions(
   reconnect: RelayFileSyncOptions["reconnect"]
@@ -139,6 +162,7 @@ export class RelayFileSync {
   private readonly token?: string;
   private readonly pollIntervalMs: number;
   private readonly pingIntervalMs: number;
+  private readonly pongTimeoutMs: number;
   private readonly reconnect: RelayFileSyncReconnectConfig;
   private readonly preferPolling: boolean;
   private readonly signal?: AbortSignal;
@@ -162,6 +186,13 @@ export class RelayFileSync {
   private pollingPromise?: Promise<void>;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private pingTimer?: ReturnType<typeof setInterval>;
+  // Tracks the last time *any* WebSocket frame was received (event, pong, or
+  // otherwise). The watchdog uses this to detect silent socket death.
+  private lastFrameAt = 0;
+  // Tracks when the most recent ping was sent. We only enforce the pong
+  // timeout once a ping has actually gone out; otherwise a quiet workspace
+  // (no broadcasts and no pings yet) would falsely trip the watchdog.
+  private lastPingSentAt = 0;
   private reconnectAttempts = 0;
   private readonly abortHandler?: () => void;
 
@@ -173,6 +204,10 @@ export class RelayFileSync {
     this.cursor = options.cursor;
     this.pollIntervalMs = Math.max(1, Math.floor(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS));
     this.pingIntervalMs = Math.max(1, Math.floor(options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS));
+    // Default the pong timeout to 2x ping interval so a single missed pong
+    // does not cause a flap, but two consecutive misses force a reconnect.
+    const defaultPongTimeoutMs = this.pingIntervalMs * 2;
+    this.pongTimeoutMs = Math.max(1, Math.floor(options.pongTimeoutMs ?? defaultPongTimeoutMs));
     this.reconnect = normalizeReconnectOptions(options.reconnect);
     this.preferPolling = options.preferPolling ?? false;
     this.signal = options.signal;
@@ -290,8 +325,14 @@ export class RelayFileSync {
         return;
       }
       this.reconnectAttempts = 0;
+      // Reset frame/ping bookkeeping for the freshly opened socket so the
+      // watchdog has a clean baseline. lastPingSentAt=0 disables the pong
+      // timeout until we actually send our first ping.
+      this.lastFrameAt = Date.now();
+      this.lastPingSentAt = 0;
       this.setState("open");
       this.startPingLoop(socket);
+      debugLog("ws open", { workspaceId: this.workspaceId });
       this.emit("open", event);
     });
 
@@ -299,6 +340,9 @@ export class RelayFileSync {
       if (this.socket !== socket || this.stopped) {
         return;
       }
+      // Stamp lastFrameAt for *any* inbound frame so the watchdog sees both
+      // application events and pongs as proof of life.
+      this.lastFrameAt = Date.now();
       this.handleSocketMessage(event);
     });
 
@@ -306,6 +350,7 @@ export class RelayFileSync {
       if (this.socket !== socket || this.stopped) {
         return;
       }
+      debugLog("ws error", event);
       this.emit("error", normalizeError(event));
     });
 
@@ -314,6 +359,7 @@ export class RelayFileSync {
         this.socket = undefined;
       }
       this.clearPingTimer();
+      debugLog("ws close", { code: event?.code, reason: event?.reason, stopped: this.stopped });
       this.emit("close", event);
       if (this.stopped) {
         this.setState("closed");
@@ -406,6 +452,7 @@ export class RelayFileSync {
     }
 
     if (parsed.type === "pong") {
+      debugLog("pong", { timestamp: parsed.timestamp ?? parsed.ts });
       this.emit("pong", {
         type: "pong",
         timestamp: parsed.timestamp ?? parsed.ts
@@ -413,22 +460,78 @@ export class RelayFileSync {
       return;
     }
 
-    this.emit("event", normalizeFilesystemEvent(parsed));
+    const normalized = normalizeFilesystemEvent(parsed);
+    debugLog("event", { type: normalized.type, path: normalized.path, revision: normalized.revision });
+    this.emit("event", normalized);
   }
 
   private startPingLoop(socket: RelayFileSyncSocket): void {
     this.clearPingTimer();
+    // The "ping loop" doubles as the heartbeat watchdog: every tick we first
+    // check whether we have observed a frame recently, and if not we force a
+    // reconnect. This is the load-bearing fix for the silent socket-death
+    // failure mode where the server keeps broadcasting frames the JS layer
+    // never receives (e.g. NAT/LB idle drop, half-open TCP) and neither
+    // `error` nor `close` ever fires.
     this.pingTimer = setInterval(() => {
       if (this.socket !== socket || this.stopped) {
         this.clearPingTimer();
         return;
       }
+
+      const now = Date.now();
+      // Only enforce the timeout once we've sent at least one ping on this
+      // socket: the first tick has no expectation of inbound traffic yet.
+      if (this.lastPingSentAt > 0) {
+        const sinceFrame = now - this.lastFrameAt;
+        if (sinceFrame > this.pongTimeoutMs) {
+          debugLog("watchdog tripped — forcing reconnect", {
+            workspaceId: this.workspaceId,
+            sinceFrameMs: sinceFrame,
+            pongTimeoutMs: this.pongTimeoutMs
+          });
+          this.forceReconnect(socket, "heartbeat-timeout");
+          return;
+        }
+      }
+
       try {
         socket.send(JSON.stringify({ type: "ping" }));
+        this.lastPingSentAt = now;
       } catch (error) {
+        debugLog("ping send failed", error);
         this.emit("error", error instanceof Error ? error : new Error("Failed to send WebSocket ping."));
+        // A failed send strongly implies the socket is dead. Force a
+        // reconnect rather than waiting for the next tick to notice.
+        this.forceReconnect(socket, "ping-send-failed");
       }
     }, this.pingIntervalMs);
+  }
+
+  // Tear down a socket that the watchdog or a failed send has decided is
+  // dead. We close it (so any later async events from the OS layer become
+  // no-ops via the `this.socket !== socket` guards) and trigger the standard
+  // reconnect path. Catches errors from `close()` because some socket
+  // implementations throw when closing an already-broken connection.
+  private forceReconnect(socket: RelayFileSyncSocket, reason: string): void {
+    this.clearPingTimer();
+    if (this.socket === socket) {
+      this.socket = undefined;
+    }
+    try {
+      socket.close(4000, reason);
+    } catch (error) {
+      debugLog("socket.close threw during forceReconnect", error);
+    }
+    if (this.stopped) {
+      this.setState("closed");
+      return;
+    }
+    if (!this.reconnect.enabled) {
+      this.startPolling();
+      return;
+    }
+    this.scheduleReconnect();
   }
 
   private scheduleReconnect(): void {
@@ -438,6 +541,7 @@ export class RelayFileSync {
     this.reconnectAttempts += 1;
     this.setState("reconnecting");
     const delayMs = this.computeReconnectDelayMs(this.reconnectAttempts);
+    debugLog("scheduling reconnect", { attempt: this.reconnectAttempts, delayMs });
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = undefined;
       if (this.stopped) {


### PR DESCRIPTION
## Symptom

`onWrite(pattern, handler)` from `@relayfile/sdk` receives its first live WebSocket frame after subscribe and then falls silent — even when the cloud workspace is actively receiving and broadcasting new events. Repro: subscribe to `/linear/**`, then PUT a file via the cloud HTTP API. The first write produces a handler invocation; subsequent writes silently never invoke the handler. The Node process stays alive; the SDK still believes the socket is open. This breaks the cortical-demo orchestrator and every other agent using `onWrite` for reactive workflows.

## Root cause

`RelayFileSync` sent client→server pings every 30s but never enforced a pong timeout. When the underlying TCP/WS dies silently — NAT/LB idle drop, half-open TCP — the OS layer never delivers `error` or `close` to the JS handler. The SDK stays in `state="open"` with the dead socket bound; the cloud keeps broadcasting frames into a black hole; no reconnect ever fires. The bug report's hypothesis (1) was correct: silent WS close + missed reconnect.

I also looked at hypotheses (2) and (3):

- (2) cursor dedup-after-catchup: not applicable — the WS path in `RelayFileSync` does no event-id deduplication; it emits every wire event verbatim. The "initial getEvents catch-up burst" the report describes does not actually exist in `RelayFileSync` (it only calls `getEvents` in polling fallback), so there is no cursor window to drop frames against.
- (3) patternChain deadlock from a throwing handler: already mitigated — `runHandler` wraps the user handler in `try/catch` and `recordHandlerError` itself is wrapped. The chain could not reject. Hardened defensively anyway with an extra `.catch` after `runHandler` so a future refactor cannot regress this invariant, plus added a test asserting that a throwing handler on event 1 does not block delivery of event 2 on the same pattern.

## Fix

**`RelayFileSync`** (`packages/sdk/typescript/src/sync.ts`):

- Track `lastFrameAt` on every inbound frame (event or pong) and `lastPingSentAt` on every outbound ping.
- The existing ping loop now doubles as a watchdog: each tick, if `lastPingSentAt > 0` and `now - lastFrameAt > pongTimeoutMs`, route through a new `forceReconnect(socket, reason)` helper that closes the dead socket with code 4000 and triggers the standard reconnect path. A failed `socket.send` of a ping also routes through `forceReconnect` rather than just emitting an error.
- New option `pongTimeoutMs`, defaults to `2 * pingIntervalMs` so a single missed pong does not flap but two consecutive misses force reconnect.

**`onWrite`** (`packages/sdk/typescript/src/onWrite.ts`):

- Plumb `pingIntervalMs` and `pongTimeoutMs` through `OnWriteOptions` for consumer/test tuning.
- Defensive `.catch` after `runHandler` in the patternChain (belt-and-braces, runHandler already swallows).

**Debug logging** (`RELAYFILE_SDK_DEBUG=1`): both modules now emit `[relayfile-sdk:sync]` / `[relayfile-sdk:onWrite]` lines covering ws open/close/error, reconnect scheduling, watchdog trips, ping/pong, event receipt, and dispatch. This was the diagnostic hatch the bug report asked for — next time a customer reports "events stop arriving" we can ask them to set this env var and see exactly where in the pipeline the events are lost without a code change.

## Test coverage

Added two tests:

- `sync.test.ts` - "force-reconnects when no frames arrive within the pong timeout (silent socket death)": uses `vi.useFakeTimers()`, opens a socket, advances past `pongTimeoutMs` without delivering any inbound frames, asserts a second socket is created (watchdog tripped + reconnect fired), then asserts that feeding pongs to the new socket does NOT cause it to flap.
- `onWrite.test.ts` - "keeps delivering subsequent events to the same pattern after a handler throws": handler throws on PROJ-1, must still deliver PROJ-2 and PROJ-3 to the same pattern.

Full SDK suite: `npx vitest run` → 96 tests pass.

## Verification (manual repro from the bug report)

After this fix, a `node watch.mjs` subscriber that hits a silent socket death should produce a fresh `[relayfile-sdk:sync] watchdog tripped` log entry within `pongTimeoutMs` (60s default), reconnect, and resume delivering handler invocations for every cloud write.

## Migration / defaults

Defaults are tuned for production:
- `pingIntervalMs`: 30000 (unchanged)
- `pongTimeoutMs`: 60000 (new; derived as `2 * pingIntervalMs`)

Consumers do not need to change anything. If a caller has a quieter workspace where 30s ping cadence is too noisy, both knobs are now exposed on `OnWriteOptions`. The watchdog is conservative — it requires at least one outgoing ping before enforcing the timeout, so it cannot flap on a freshly-opened idle socket.

No version bump — the publish workflow owns version changes (per repo convention).

## Test plan

- [x] `npx vitest run` in `packages/sdk/typescript` (96 passed)
- [x] `npm run build --workspace=packages/sdk/typescript` (clean tsc)
- [ ] Manual repro: rebuild `@relayfile/sdk`, run `node watch.mjs` against `rw_517d60b6`, fire 5+ cloud `PUT /v1/workspaces/.../fs/file` writes spaced 60s+ apart, confirm every write produces a handler invocation
- [ ] Manual: set `RELAYFILE_SDK_DEBUG=1`, force a network blip (kill local wifi for >60s), confirm watchdog log + reconnect

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)