### PR TITLE
docs: refresh launch README and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,9 @@ go run ./cmd/relayfile-cli mount "$RELAYFILE_WORKSPACE" ./relayfile-mount --once
 
 ## Hosted Agent Relay
 
-The OSS repo is enough to run relayfile locally. If you want an agent to get provider-backed files from hosted `agentrelay.com` without self-hosting OAuth, use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28).
+If you want Notion, Slack, Linear, GitHub, or other provider-backed files without running any infrastructure, use hosted Agent Relay. Agent Relay Cloud runs the workspace, relayfile API, scoped auth, Nango OAuth, provider sync workers, and writeback workers for you.
 
-Local OSS:
-
-```bash
-docker compose -f docker/docker-compose.yml up --build
-go run ./cmd/relayfile-cli seed ws_demo ./examples
-go run ./cmd/relayfile-cli mount ws_demo ./relayfile-mount
-```
-
-Hosted cloud with the skill:
+Use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28) when an agent should set up hosted files:
 
 ```bash
 relayfile setup \
@@ -101,16 +93,17 @@ relayfile setup \
   --no-open
 ```
 
-Both paths give the agent files. The difference is who runs the integration layer:
+That command connects to `agentrelay.com`, creates or joins a cloud workspace, completes provider auth, waits for sync, and mounts the resulting files for the agent. The local directory is just the agent's file interface; the integration stack is hosted.
 
-| Need | Use local OSS | Use hosted Agent Relay |
+Use the OSS repo when you want to run the file server yourself. Use hosted Agent Relay when you want the whole integration path managed:
+
+| Need | Local OSS | Hosted Agent Relay |
 |---|---:|---:|
-| Local VFS API | yes | yes, managed |
-| Local directory mirror | yes | yes |
-| Seed files from disk | yes | yes |
-| OAuth for Notion, Slack, Linear, GitHub | self-host it | managed |
-| Provider sync and writeback workers | self-host them | managed |
-| Nango | self-host if you want end-to-end OAuth | managed |
+| Run relayfile locally | yes | no |
+| Mount files for an agent | yes | yes |
+| Provider OAuth | self-host provider auth | managed |
+| Provider sync/writeback | self-host workers | managed |
+| Nango | self-host for end-to-end OAuth | managed |
 
 For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant adapters/providers, and Nango. Relayfile itself does not store third-party OAuth credentials.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# relayfile
+# Relay by Agent Relay: integration filesystem for agents
 
 Turn files into the integration surface for agents.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Relay by Agent Relay: integration filesystem for agents
+# File by Agent Relay: integration filesystem for agents
 
 Turn files into the integration surface for agents.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Try the local API:
 TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
 
 curl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Correlation-Id: quickstart-tree" \
   "http://localhost:9090/v1/workspaces/ws_demo/fs/tree?path=/"
 
 curl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Correlation-Id: quickstart-read" \
   "http://localhost:9090/v1/workspaces/ws_demo/fs/file?path=/docs/welcome.md"
 ```
 
@@ -47,14 +49,22 @@ Now any local tool or agent can use `./relayfile-mount` like a normal directory.
 
 ## Local Development Without Docker
 
+Start the local token issuer:
+
+```bash
+node docker/relayauth/server.js
+```
+
+In another terminal, start relayfile:
+
 ```bash
 RELAYFILE_BACKEND_PROFILE=durable-local \
 RELAYFILE_DATA_DIR=.data \
-RELAYFILE_JWT_SECRET=dev-secret \
+RELAYAUTH_JWKS_URL=http://127.0.0.1:9091/.well-known/jwks.json \
 go run ./cmd/relayfile
 ```
 
-In another terminal:
+In a third terminal:
 
 ```bash
 export RELAYFILE_WORKSPACE=ws_demo

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ go run ./cmd/relayfile-cli tree "$RELAYFILE_WORKSPACE" /
 go run ./cmd/relayfile-cli mount "$RELAYFILE_WORKSPACE" ./relayfile-mount --once
 ```
 
+## Ecosystem
+
+This repo is the file server and local mount layer. The wider Agent Relay file ecosystem also includes:
+
+- [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) (`../relayfile-adapters` in the local workspace): maps provider webhooks and objects into relayfile paths, normalizes events, and defines writeback behavior.
+- [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) (`../relayfile-providers` in the local workspace): handles provider auth, token lookup, API proxying, webhook subscriptions, and connection health.
+
+Hosted Agent Relay runs these pieces for you. Fully self-hosted provider-backed files need relayfile plus the adapter and provider repos for the systems you expose.
+
 ## Hosted Agent Relay
 
 If you want Notion, Slack, Linear, GitHub, or other provider-backed files without running any infrastructure, use hosted Agent Relay. Agent Relay Cloud runs the workspace, relayfile API, scoped auth, Nango OAuth, provider sync workers, and writeback workers for you.
@@ -105,7 +114,7 @@ Use the OSS repo when you want to run the file server yourself. Use hosted Agent
 | Provider sync/writeback | self-host workers | managed |
 | Nango | self-host for end-to-end OAuth | managed |
 
-For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant adapters/providers, and Nango. Relayfile itself does not store third-party OAuth credentials.
+For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant [adapters](https://github.com/AgentWorkforce/relayfile-adapters), [providers](https://github.com/AgentWorkforce/relayfile-providers), and Nango. Relayfile itself does not store third-party OAuth credentials.
 
 ## Bring Existing Connections
 
@@ -130,6 +139,8 @@ Pipedream:
 
 - [Getting started](docs/guides/getting-started.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
+- [Adapters](https://github.com/AgentWorkforce/relayfile-adapters)
+- [Providers](https://github.com/AgentWorkforce/relayfile-providers)
 - [API reference](docs/api-reference.md)
 - [Docker quickstart](docker/README.md)
 - [OpenAPI spec](openapi/relayfile-v1.openapi.yaml)

--- a/README.md
+++ b/README.md
@@ -1,298 +1,132 @@
 # relayfile
 
-Turn any API into a filesystem that AI agents can read and write.
+Turn files into the integration surface for agents.
 
-Agents don't call APIs. They read and write files. Relayfile handles webhooks, auth, and writeback so agents never need to know about the services behind the files.
+Relayfile exposes a workspace as a simple virtual file tree. Agents read with `cat`, write by saving files, and relayfile records the operations, permissions, events, and writeback queue behind that tree.
 
-```bash
-# Agent reads a GitHub PR
-cat /relayfile/github/repos/acme/api/pulls/42/metadata.json
+## Run Locally
 
-# Agent writes a review
-echo '{"body": "LGTM!", "event": "APPROVE"}' \
-  > /relayfile/github/repos/acme/api/pulls/42/reviews/review.json
-
-# Done. The review is posted to GitHub. The agent didn't authenticate or call any API.
-```
-
-## How It Works
-
-```
-External Services          relayfile             Your Agents
-─────────────────     ─────────────────     ─────────────────
-                       ┌──────────────┐
-  GitHub ──webhook──▶  │              │     cat /github/...
-  Slack  ──webhook──▶  │  Virtual     │◀──  echo '...' > /slack/...
-  Notion ──webhook──▶  │  Filesystem  │     ls /notion/...
-  Linear ──webhook──▶  │              │
-                       └──────┬───────┘
-                              │
-                        Adapters map paths
-                        Providers handle auth
-                        relayauth scopes access
-```
-
-1. **Webhooks arrive** from GitHub, Slack, Notion, etc.
-2. [**Adapters**](https://github.com/AgentWorkforce/relayfile-adapters) normalize the payload and map it to a VFS path
-3. [**Providers**](https://github.com/AgentWorkforce/relayfile-providers) handle OAuth tokens and API proxying
-4. **Agents read and write files** — that's their entire integration
-5. When an agent writes to a writeback path, the adapter posts the change back to the source API
-
-## Quick Start (Docker)
+Fastest path:
 
 ```bash
-cd docker && docker compose up --build
+cd docker
+docker compose up --build
 ```
 
-This starts relayfile on `:9090` and relayauth on `:9091`, seeds a `ws_demo` workspace with sample files, and prints a dev token. See [`docker/README.md`](docker/README.md) for details.
+This starts:
 
-## Getting Started
+| Service | URL | Purpose |
+|---|---|---|
+| relayfile | `http://localhost:9090` | VFS API |
+| relayauth | `http://localhost:9091` | local dev token issuer |
+| seed | exits after setup | creates `ws_demo` sample files |
 
-**Relayfile Cloud** — everything managed. Run the CLI, sign in with the hosted browser flow, choose an integration, and Relayfile mirrors it as ordinary files on disk for your agent:
+Try the local API:
 
 ```bash
-relayfile
+TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
+
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9090/v1/workspaces/ws_demo/fs/tree?path=/"
+
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9090/v1/workspaces/ws_demo/fs/file?path=/docs/welcome.md"
 ```
 
-This runs a guided wizard: Cloud login, workspace name, integration provider, local directory, and OAuth consent. Files appear under `./relayfile-mount/<provider>/` within 30 seconds of OAuth completing.
+Mount the workspace as ordinary local files:
 
-For non-interactive / CI setup:
+```bash
+cd ..
+RELAYFILE_TOKEN="$TOKEN" go run ./cmd/relayfile-mount \
+  --base-url http://localhost:9090 \
+  --workspace ws_demo \
+  --local-dir ./relayfile-mount
+```
+
+Now any local tool or agent can use `./relayfile-mount` like a normal directory.
+
+## Local Development Without Docker
+
+```bash
+RELAYFILE_BACKEND_PROFILE=durable-local \
+RELAYFILE_DATA_DIR=.data \
+RELAYFILE_JWT_SECRET=dev-secret \
+go run ./cmd/relayfile
+```
+
+In another terminal:
+
+```bash
+export RELAYFILE_WORKSPACE=ws_demo
+export RELAYFILE_TOKEN="$(./scripts/generate-dev-token.sh "$RELAYFILE_WORKSPACE")"
+
+go run ./cmd/relayfile-cli login \
+  --server http://127.0.0.1:8080 \
+  --token "$RELAYFILE_TOKEN"
+
+go run ./cmd/relayfile-cli seed "$RELAYFILE_WORKSPACE" ./examples
+go run ./cmd/relayfile-cli tree "$RELAYFILE_WORKSPACE" /
+go run ./cmd/relayfile-cli mount "$RELAYFILE_WORKSPACE" ./relayfile-mount --once
+```
+
+## Hosted Agent Relay
+
+The OSS repo is enough to run relayfile locally. If you want an agent to get provider-backed files from hosted `agentrelay.com` without self-hosting OAuth, use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28).
+
+Local OSS:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+go run ./cmd/relayfile-cli seed ws_demo ./examples
+go run ./cmd/relayfile-cli mount ws_demo ./relayfile-mount
+```
+
+Hosted cloud with the skill:
 
 ```bash
 relayfile setup \
-  --cloud-token "$RELAYFILE_CLOUD_TOKEN" \
-  --provider github \
-  --workspace my-project \
+  --provider notion \
+  --workspace my-agent \
   --local-dir ./relayfile-mount \
-  --no-open \
-  --once
+  --no-open
 ```
 
-> **Note:** The default attachment is a **synced mirror**, not a kernel FUSE mount. Files are ordinary files on disk; a daemon polls the Cloud every 30 s and handles writeback. FUSE is available via `--mode=fuse` but is not required. See [docs/guides/vfs-cloud-setup.md](docs/guides/vfs-cloud-setup.md) for the full human guide including limitations, conflict resolution, and troubleshooting.
+Both paths give the agent files. The difference is who runs the integration layer:
 
-After setup you can add more integrations without remounting:
+| Need | Use local OSS | Use hosted Agent Relay |
+|---|---:|---:|
+| Local VFS API | yes | yes, managed |
+| Local directory mirror | yes | yes |
+| Seed files from disk | yes | yes |
+| OAuth for Notion, Slack, Linear, GitHub | self-host it | managed |
+| Provider sync and writeback workers | self-host them | managed |
+| Nango | self-host if you want end-to-end OAuth | managed |
 
-```bash
-relayfile integration connect notion
-relayfile integration connect linear
-relayfile integration list
-```
+For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant adapters/providers, and Nango. Relayfile itself does not store third-party OAuth credentials.
 
-Check live sync state at any time:
+## Bring Existing Connections
 
-```bash
-relayfile status
-```
+Relayfile tracks provider identity as `connectionId` metadata. The core OSS server can ingest events and queue writebacks with a `connectionId`, but the OAuth provider must be able to use that ID.
 
-Run the sync loop in the background:
+Nango:
 
-```bash
-relayfile mount --background my-project ./relayfile-mount
-relayfile stop my-project
-```
+- In your own self-hosted stack, point the Nango provider at your Nango host/secret and link the workspace to the existing `connectionId` and `providerConfigKey` before triggering sync.
+- Hosted `agentrelay.com` currently exposes the connect-session flow through the CLI, not a public import command for arbitrary existing Nango connections. If the connection is not in Agent Relay's Nango project, re-connect through the hosted flow or run your own Nango-backed stack.
 
-**Self-hosted:**
+Composio:
 
-```bash
-# 1. Start the server
-RELAYFILE_JWT_SECRET=my-secret go run ./cmd/relayfile
+- Use your Composio API key and the existing connected account ID as the Relayfile `connectionId`.
+- The Composio provider can list/get connected accounts and proxy/write through that account.
 
-# 2. Generate a token
-export RELAYFILE_AGENT_NAME=compose-agent
-SIGNING_KEY=my-secret ./scripts/generate-dev-token.sh
+Pipedream:
 
-# 3. Mount a workspace
-relayfile mount my-workspace ./files --token $TOKEN
-```
+- Use your Pipedream Connect project credentials and the existing account ID as the Relayfile `connectionId`.
+- For proxy calls, also provide the external user ID through headers, query, or a resolver callback.
 
-Development tokens should include `workspace_id`, `agent_name`, and `aud: ["relayfile"]`.
+## Docs
 
-## Authentication & Permissions
-
-Tokens are scoped JWTs issued by [relayauth](https://github.com/AgentWorkforce/relayauth). The VFS paths *are* the permission boundaries — you control exactly what each agent can see and do:
-
-```bash
-# Read-only access to specific Notion pages
-RELAYAUTH_SCOPES_JSON='["relayfile:fs:read:/notion/pages/product-roadmap/*", "relayfile:fs:read:/notion/pages/eng-specs/*"]'
-
-# Code review agent: read PRs, write only reviews
-RELAYAUTH_SCOPES_JSON='["relayfile:fs:read:/github/repos/acme/api/pulls/*", "relayfile:fs:write:/github/repos/acme/api/pulls/*/reviews/*"]'
-
-# Support agent: read + reply in Slack support channel only
-RELAYAUTH_SCOPES_JSON='["relayfile:fs:read:/slack/channels/support/*", "relayfile:fs:write:/slack/channels/support/messages/*"]'
-
-# Observer: see everything, change nothing
-RELAYAUTH_SCOPES_JSON='["relayfile:fs:read:*"]'
-```
-
-Scope format: `plane:resource:action:path` — supports wildcards and path prefixes.
-
-## Ecosystem
-
-| Repo | What it does |
-|------|-------------|
-| **[relayfile](https://github.com/AgentWorkforce/relayfile)** | Go server + TypeScript/Python SDKs |
-| **[relayauth](https://github.com/AgentWorkforce/relayauth)** | Token issuance + scoped permissions |
-| **[relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters)** | GitHub, GitLab, Slack, Teams, Linear, Notion adapters |
-| **[relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers)** | Nango, Composio, Pipedream, Clerk, Supabase, n8n providers |
-| **[cloud](https://github.com/AgentWorkforce/cloud)** | Cloudflare Workers deployment (managed service) |
-
-## SDK
-
-```bash
-npm install @relayfile/sdk    # TypeScript
-pip install relayfile          # Python
-```
-
-```ts
-import { RelayFileClient } from "@relayfile/sdk";
-
-const client = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! });
-
-// Read
-const file = await client.getFile("ws_123", "/github/repos/acme/api/pulls/42/metadata.json");
-
-// Write (triggers writeback to GitHub automatically)
-await client.putFile("ws_123", "/github/repos/acme/api/pulls/42/reviews/review.json", {
-  content: JSON.stringify({ body: "LGTM!", event: "APPROVE" }),
-});
-
-// List
-const tree = await client.listFiles("ws_123", "/github/repos/acme/api/pulls/");
-```
-
-## API
-
-Filesystem:
-- `GET /v1/workspaces/{id}/fs/tree` — list files
-- `GET /v1/workspaces/{id}/fs/file` — read file
-- `PUT /v1/workspaces/{id}/fs/file` — write file
-- `DELETE /v1/workspaces/{id}/fs/file` — delete file
-- `GET /v1/workspaces/{id}/fs/query` — structured metadata query
-
-Webhooks & Writeback:
-- `POST /v1/workspaces/{id}/webhooks/ingest` — receive webhooks
-- `GET /v1/workspaces/{id}/writeback/pending` — pending writebacks
-- `POST /v1/workspaces/{id}/writeback/{wbId}/ack` — acknowledge writeback
-
-Operations:
-- `GET /v1/workspaces/{id}/ops` — operation log
-- `POST /v1/workspaces/{id}/ops/{opId}/replay` — replay failed operation
-
-Full spec: [`openapi/relayfile-v1.openapi.yaml`](openapi/relayfile-v1.openapi.yaml)
-
-## Self-Hosted
-
-```bash
-# In-memory (development)
-go run ./cmd/relayfile
-
-# Durable local (persisted to disk)
-RELAYFILE_BACKEND_PROFILE=durable-local RELAYFILE_DATA_DIR=.data go run ./cmd/relayfile
-
-# Production (Postgres)
-RELAYFILE_BACKEND_PROFILE=production RELAYFILE_PRODUCTION_DSN=postgres://localhost/relayfile go run ./cmd/relayfile
-```
-
-Docker Compose:
-
-```bash
-cp compose.env.example .env
-docker compose up --build -d
-```
-
-## Mount
-
-Mount a workspace as a local directory:
-
-```bash
-# Synced mirror (default, recommended)
-relayfile mount ws_123 ./files
-
-# One-shot sync (CI/probe)
-relayfile mount ws_123 ./files --once
-
-# Background daemon
-relayfile mount --background ws_123 ./files
-relayfile stop ws_123
-
-# FUSE mount (opt-in, requires FUSE support)
-relayfile mount ws_123 ./files --mode=fuse
-
-# Self-hosted: polling sync without Cloud
-go run ./cmd/relayfile-mount --workspace ws_123 --local-dir ./files --interval 2s --token $TOKEN
-```
-
-The default mode is a **synced mirror** (`--mode=poll`). It is not a real-time POSIX filesystem. Known differences: file handles are not stable across syncs, `mtime` reflects local write time only, directory listings can lag by up to 30 s. See [docs/guides/vfs-cloud-setup.md#known-limitations](docs/guides/vfs-cloud-setup.md#known-limitations).
-
-**For agents:** See [docs/guides/agent-vfs-usage.md](docs/guides/agent-vfs-usage.md) and the installable skill at [docs/skills/relayfile-workspace.md](docs/skills/relayfile-workspace.md).
-
-## CLI Inspection
-
-Inspect the remote VFS directly without mounting:
-
-```bash
-relayfile login --server https://api.relayfile.dev --token "$RELAYFILE_TOKEN"
-relayfile workspace use ws_123
-relayfile tree /github --depth 5
-relayfile read /github/repos/acme/api/pulls/42/metadata.json
-relayfile tree /github --depth 5 --json
-relayfile read /external/blob.bin --output blob.bin
-```
-
-You can also set `RELAYFILE_WORKSPACE=ws_123` instead of storing a default.
-
-Open the hosted observer for the active workspace:
-
-```bash
-relayfile observer
-relayfile observer ws_123 --no-open
-```
-
-Inspect and recover dead-lettered writeback operations:
-
-```bash
-relayfile ops list
-relayfile ops replay op_abc123
-```
-
-Check which paths are writable for a provider:
-
-```bash
-relayfile permissions
-relayfile permissions github/repos/acme/api/pulls/
-```
-
-## Documentation
-
-| Guide | Audience |
-|-------|----------|
-| [docs/guides/getting-started.md](docs/guides/getting-started.md) | First steps with self-hosted Relayfile |
-| [docs/guides/vfs-cloud-setup.md](docs/guides/vfs-cloud-setup.md) | Human guide: Cloud setup, integrations, status, daemon, troubleshooting |
-| [docs/guides/agent-vfs-usage.md](docs/guides/agent-vfs-usage.md) | Agent guide: mount discovery, reads, writes, conflicts, writeback |
-| [docs/guides/cloud-integration.md](docs/guides/cloud-integration.md) | Cloud workflow model for orchestrators |
-| [docs/guides/collaboration.md](docs/guides/collaboration.md) | Multi-human and human+agent collaboration patterns |
-| [docs/skills/relayfile-workspace.md](docs/skills/relayfile-workspace.md) | Installable agent skill (copy to `.agents/skills/`) |
-| [docs/cli-design.md](docs/cli-design.md) | CLI command reference and design |
-| [docs/productized-cloud-mount-contract.md](docs/productized-cloud-mount-contract.md) | v1 product contract (normative) |
-| [docs/api-reference.md](docs/api-reference.md) | REST API reference |
-
-## Changelogs
-
-Each publishable package keeps its own `CHANGELOG.md`:
-
-- [`relayfile`](packages/cli/CHANGELOG.md) — CLI
-- [`@relayfile/core`](packages/core/CHANGELOG.md)
-- [`@relayfile/sdk`](packages/sdk/typescript/CHANGELOG.md)
-- [`@relayfile/local-mount`](packages/local-mount/CHANGELOG.md)
-- [`@relayfile/file-observer`](packages/file-observer/CHANGELOG.md)
-
-**Process** — landed in every PR, finalized at release:
-
-1. PRs that touch a package add an entry under its `## [Unreleased]` section (Keep a Changelog format: `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`). Include the PR number as a link reference at the bottom of the file.
-2. At release, the `Publish Package` workflow runs [`scripts/finalize-changelogs.mjs`](scripts/finalize-changelogs.mjs), which renames `[Unreleased]` to `[x.y.z] - YYYY-MM-DD`, opens a fresh empty `[Unreleased]` above, and rewrites the compare-link references. Prereleases skip this step so their entries accumulate until the final release.
-3. Packages without user-visible changes in a given release leave `[Unreleased]` as `_No unreleased changes._`. The finalizer rewrites the dated section's body to `_No user-visible changes in this release._` so the release heading still reads naturally.
-
-## License
-
-MIT
+- [Getting started](docs/guides/getting-started.md)
+- [Cloud integration](docs/guides/cloud-integration.md)
+- [API reference](docs/api-reference.md)
+- [Docker quickstart](docker/README.md)
+- [OpenAPI spec](openapi/relayfile-v1.openapi.yaml)

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ This starts:
 | Service | URL | Description |
 |---------|-----|-------------|
 | relayfile | http://localhost:9090 | VFS API server (Go, in-memory) |
-| relayauth | http://localhost:9091 | Token signing service (Node) |
+| relayauth | http://localhost:9091 | RS256 token signing service and JWKS endpoint (Node) |
 | seed | (runs once) | Creates `ws_demo` workspace with sample files |
 
 The `seed` container mints a dev token and writes three sample files. Watch its logs for the token and a ready-to-paste `curl` command.
@@ -26,10 +26,14 @@ The `seed` container mints a dev token and writes three sample files. Watch its 
 TOKEN=$(docker compose logs seed | grep 'token' | tail -1 | awk '{print $NF}')
 
 # List files
-curl -H "Authorization: Bearer $TOKEN" http://localhost:9090/v1/workspaces/ws_demo/fs/tree
+curl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Correlation-Id: docker-tree" \
+  http://localhost:9090/v1/workspaces/ws_demo/fs/tree
 
 # Read a file
-curl -H "Authorization: Bearer $TOKEN" "http://localhost:9090/v1/workspaces/ws_demo/fs/file?path=/docs/welcome.md"
+curl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Correlation-Id: docker-read" \
+  "http://localhost:9090/v1/workspaces/ws_demo/fs/file?path=/docs/welcome.md"
 
 # Mint a new token
 curl -X POST http://localhost:9091/sign \

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       RELAYFILE_ADDR: :8080
       RELAYFILE_BACKEND_PROFILE: memory
-      RELAYFILE_JWT_SECRET: ${RELAYFILE_JWT_SECRET:-dev-secret}
+      RELAYAUTH_JWKS_URL: http://relayauth:9091/.well-known/jwks.json
       RELAYFILE_INTERNAL_HMAC_SECRET: ${RELAYFILE_INTERNAL_HMAC_SECRET:-dev-internal-secret}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]

--- a/docker/relayauth/server.js
+++ b/docker/relayauth/server.js
@@ -2,7 +2,11 @@ const http = require("node:http");
 const crypto = require("node:crypto");
 
 const PORT = 9091;
-const SECRET = process.env.RELAYFILE_JWT_SECRET || "dev-secret";
+const KEY_ID = process.env.RELAYAUTH_KEY_ID || "dev-relayauth-key";
+const { privateKey, publicKey } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const jwk = publicKey.export({ format: "jwk" });
 
 function b64url(buf) {
   return Buffer.from(buf)
@@ -13,11 +17,12 @@ function b64url(buf) {
 }
 
 function sign(payload) {
-  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const header = b64url(JSON.stringify({ alg: "RS256", typ: "JWT", kid: KEY_ID }));
   const body = b64url(JSON.stringify(payload));
-  const sig = b64url(
-    crypto.createHmac("sha256", SECRET).update(`${header}.${body}`).digest()
-  );
+  const signer = crypto.createSign("RSA-SHA256");
+  signer.update(`${header}.${body}`);
+  signer.end();
+  const sig = b64url(signer.sign(privateKey));
   return `${header}.${body}.${sig}`;
 }
 
@@ -25,6 +30,15 @@ const server = http.createServer((req, res) => {
   if (req.method === "GET" && req.url === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
     return res.end('{"status":"ok"}');
+  }
+
+  if (req.method === "GET" && req.url === "/.well-known/jwks.json") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    return res.end(
+      JSON.stringify({
+        keys: [{ ...jwk, kid: KEY_ID, alg: "RS256", use: "sig" }],
+      })
+    );
   }
 
   if (req.method === "POST" && req.url === "/sign") {

--- a/docker/seed.sh
+++ b/docker/seed.sh
@@ -6,32 +6,33 @@ RELAYAUTH=http://relayauth:9091
 WS=ws_demo
 
 echo "==> Minting dev token via relayauth..."
-TOKEN=$(curl -sS "$RELAYAUTH/sign" \
+TOKEN=$(curl -fsS "$RELAYAUTH/sign" \
   -H "Content-Type: application/json" \
   -d "{\"workspace_id\":\"$WS\",\"agent_name\":\"dev-agent\",\"scopes\":[\"relayfile:fs:read:*\",\"relayfile:fs:write:*\",\"relayfile:sync:read:*\",\"relayfile:ops:read:*\"]}" \
   | sed 's/.*"token":"\([^"]*\)".*/\1/')
 
 echo "==> Seeding sample files into workspace $WS..."
 
-curl -sS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/docs/welcome.md" \
+curl -fsS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/docs/welcome.md" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/octet-stream" \
+  -H "Content-Type: application/json" \
+  -H "If-Match: 0" \
   -H "X-Correlation-Id: seed-$(date +%s)-1" \
-  -d '# Welcome
-Your relayfile workspace is running.
-Write files here and agents will see them instantly.'
+  -d '{"contentType":"text/markdown","content":"# Welcome\nYour relayfile workspace is running.\nWrite files here and agents will see them instantly."}'
 
-curl -sS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/github/repos/demo/pulls/1/metadata.json" \
+curl -fsS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/github/repos/demo/pulls/1/metadata.json" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/octet-stream" \
+  -H "Content-Type: application/json" \
+  -H "If-Match: 0" \
   -H "X-Correlation-Id: seed-$(date +%s)-2" \
-  -d '{"number":1,"title":"Add quickstart","state":"open","author":"dev"}'
+  -d '{"contentType":"application/json","content":"{\"number\":1,\"title\":\"Add quickstart\",\"state\":\"open\",\"author\":\"dev\"}"}'
 
-curl -sS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/config/agents.json" \
+curl -fsS -X PUT "$RELAYFILE/v1/workspaces/$WS/fs/file?path=/config/agents.json" \
   -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/octet-stream" \
+  -H "Content-Type: application/json" \
+  -H "If-Match: 0" \
   -H "X-Correlation-Id: seed-$(date +%s)-3" \
-  -d '{"agents":[{"name":"dev-agent","scopes":["relayfile:fs:read:*","relayfile:fs:write:*"]}]}'
+  -d '{"contentType":"application/json","content":"{\"agents\":[{\"name\":\"dev-agent\",\"scopes\":[\"relayfile:fs:read:*\",\"relayfile:fs:write:*\"]}]}"}'
 
 echo ""
 echo "=== Ready ==="
@@ -41,4 +42,4 @@ echo "  workspace : $WS"
 echo "  token     : $TOKEN"
 echo ""
 echo "Try it:"
-echo "  curl -H \"Authorization: Bearer $TOKEN\" http://localhost:${RELAYFILE_PORT:-9090}/v1/workspaces/$WS/fs/tree"
+echo "  curl -H \"Authorization: Bearer $TOKEN\" -H \"X-Correlation-Id: quickstart-tree\" http://localhost:${RELAYFILE_PORT:-9090}/v1/workspaces/$WS/fs/tree"

--- a/docs/guides/cloud-integration.md
+++ b/docs/guides/cloud-integration.md
@@ -43,8 +43,8 @@ To self-host the same end-to-end shape, run these pieces together:
 
 - relayfile API
 - relayauth or compatible scoped JWT issuer
-- provider adapters for the systems you expose as files
-- provider workers for sync and writeback
+- [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) (`../relayfile-adapters` locally) for the systems you expose as files
+- [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) (`../relayfile-providers` locally) for auth, API proxying, webhook subscriptions, connection health, sync, and writeback
 - Nango for OAuth-backed provider credentials and provider sync state
 
 Relayfile should remain the VFS and operation log. Nango or an equivalent provider layer should own OAuth credentials.

--- a/docs/guides/cloud-integration.md
+++ b/docs/guides/cloud-integration.md
@@ -1,22 +1,10 @@
 # Cloud Integration
 
-Relayfile can run as local OSS infrastructure or as the file layer inside hosted Agent Relay. The agent experience is the same: read files, write files, let the integration layer handle provider APIs.
+Hosted Agent Relay is the managed cloud path for provider-backed files. Agent Relay Cloud runs the workspace, relayfile API, scoped auth, Nango OAuth, provider sync workers, and writeback workers. The user's machine only needs a local mount when an agent or tool wants ordinary filesystem access.
 
-## Local OSS vs Hosted Agent Relay
+## Hosted Agent Relay
 
-| Task | Local OSS | Hosted Agent Relay |
-|---|---|---|
-| Start relayfile | `docker compose -f docker/docker-compose.yml up --build` | managed |
-| Create workspace | seeded `ws_demo` or CLI/API | `relayfile setup --workspace ...` |
-| Mount files locally | `relayfile mount ws_demo ./relayfile-mount` | `relayfile setup --local-dir ./relayfile-mount` |
-| Seed arbitrary local files | `relayfile seed ws_demo ./dir` | `relayfile seed <workspace> ./dir` |
-| Connect Notion/Slack/Linear/GitHub | self-host provider stack | hosted OAuth flow |
-| OAuth provider | run Nango yourself | managed Nango |
-| Agent instructions | normal filesystem tools | use the setup skill |
-
-## Hosted Setup With The Skill
-
-Use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28) when an agent needs provider-backed files from hosted `agentrelay.com`.
+Use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28) when an agent needs provider-backed files from `agentrelay.com`.
 
 ```bash
 relayfile setup \
@@ -26,7 +14,7 @@ relayfile setup \
   --no-open
 ```
 
-The skill covers the full hosted flow: cloud login, workspace creation, Nango OAuth, initial sync, local mount verification, writeback checks, and dead-letter recovery.
+The skill covers the full hosted flow: cloud login, workspace creation, provider OAuth, initial sync, local mount verification, writeback checks, and recovery guidance. No relayfile server, relayauth service, Nango instance, adapter, or worker has to run on the user's machine.
 
 After setup, hand the agent the mount path:
 
@@ -35,6 +23,19 @@ export RELAYFILE_LOCAL_DIR="$PWD/relayfile-mount"
 ```
 
 The agent should read and write under `$RELAYFILE_LOCAL_DIR/<provider>/...` instead of calling provider APIs directly.
+
+## Local OSS vs Hosted Cloud
+
+Use local OSS for development, tests, or fully self-hosted deployments. Use hosted Agent Relay when the user wants provider-backed files to work without operating the stack.
+
+| Task | Local OSS | Hosted Agent Relay |
+|---|---|---|
+| Run relayfile API | user runs it | managed by Agent Relay Cloud |
+| Issue scoped relayfile tokens | user runs relayauth or compatible issuer | managed |
+| Mount files locally | `relayfile mount ws_demo ./relayfile-mount` | `relayfile setup --local-dir ./relayfile-mount` |
+| Connect Notion/Slack/Linear/GitHub | user runs provider stack | hosted OAuth flow |
+| Provider sync/writeback | user runs workers | managed |
+| Nango | user self-hosts/configures it | managed |
 
 ## Fully Self-Hosted Cloud-Like Setup
 

--- a/docs/guides/cloud-integration.md
+++ b/docs/guides/cloud-integration.md
@@ -1,98 +1,86 @@
-# RelayFile Cloud Integration
+# Cloud Integration
 
-RelayFile is the shared filesystem layer for Agent Relay cloud workflows. It gives each workflow run a workspace-backed tree that humans, automations, and cloud agents can mount at the same time.
+Relayfile can run as local OSS infrastructure or as the file layer inside hosted Agent Relay. The agent experience is the same: read files, write files, let the integration layer handle provider APIs.
 
-## How RelayFile Fits Into Cloud Workflows
+## Local OSS vs Hosted Agent Relay
 
-A typical Agent Relay flow looks like this:
+| Task | Local OSS | Hosted Agent Relay |
+|---|---|---|
+| Start relayfile | `docker compose -f docker/docker-compose.yml up --build` | managed |
+| Create workspace | seeded `ws_demo` or CLI/API | `relayfile setup --workspace ...` |
+| Mount files locally | `relayfile mount ws_demo ./relayfile-mount` | `relayfile setup --local-dir ./relayfile-mount` |
+| Seed arbitrary local files | `relayfile seed ws_demo ./dir` | `relayfile seed <workspace> ./dir` |
+| Connect Notion/Slack/Linear/GitHub | self-host provider stack | hosted OAuth flow |
+| OAuth provider | run Nango yourself | managed Nango |
+| Agent instructions | normal filesystem tools | use the setup skill |
 
-1. A workflow run starts in the cloud.
-2. The orchestration layer creates or resolves a RelayFile workspace for that run.
-3. Agents mount the workspace into their sandbox snapshot.
-4. Humans can mount the same workspace locally.
-5. Everyone reads and writes the same project tree through RelayFile.
+## Hosted Setup With The Skill
 
-This makes the filesystem a first-class workflow artifact instead of a side effect hidden inside one machine or one agent process.
-
-In practice, that means a workflow can create files once and keep them available across retries, sandbox restarts, and human review without copying artifacts between systems.
-
-## Automatic Workspace Creation Per Workflow Run
-
-Cloud orchestrators can create a fresh workspace for every workflow run so that:
-
-- each run is isolated from other runs
-- files remain attached to the run that produced them
-- replay and audit tooling can refer back to a stable workspace ID
-
-The user-facing CLI model is:
+Use the `setting-up-relayfile` skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28) when an agent needs provider-backed files from hosted `agentrelay.com`.
 
 ```bash
-relayfile workspace create workflow-2026-03-24-1234
-relayfile seed workflow-2026-03-24-1234 ./bootstrap
+relayfile setup \
+  --provider notion \
+  --workspace my-agent \
+  --local-dir ./relayfile-mount \
+  --no-open
 ```
 
-In hosted automation, the same lifecycle is usually driven by the control plane rather than by a human at a terminal.
+The skill covers the full hosted flow: cloud login, workspace creation, Nango OAuth, initial sync, local mount verification, writeback checks, and dead-letter recovery.
 
-Typical control-plane sequence:
-
-1. create or resolve a workspace for the workflow run
-2. inject credentials into the sandbox
-3. start `relayfile-mount` against that workspace
-4. let agents read and write normal files under the mounted directory
-5. keep the workspace available for human inspection or downstream jobs
-
-## relayfile-mount In Sandbox Snapshots
-
-Inside a cloud sandbox, `relayfile-mount` acts as the local bridge between the sandbox filesystem and the RelayFile API.
-
-Typical sandbox mount:
+After setup, hand the agent the mount path:
 
 ```bash
-go run ./cmd/relayfile-mount \
-  --base-url https://relayfile.agent-relay.com \
-  --workspace ws_123 \
-  --remote-path / \
-  --local-dir /workspace \
-  --token "$RELAYFILE_TOKEN"
+export RELAYFILE_LOCAL_DIR="$PWD/relayfile-mount"
 ```
 
-The sandbox sees ordinary files under `/workspace`, but the source of truth is the RelayFile workspace. That means:
+The agent should read and write under `$RELAYFILE_LOCAL_DIR/<provider>/...` instead of calling provider APIs directly.
 
-- sandbox snapshots can be short-lived without losing shared files
-- agents can restart and reconnect to the same workspace
-- multiple agents can work against the same directory tree without shipping tarballs around
+## Fully Self-Hosted Cloud-Like Setup
 
-## How Agents Share Files Via RelayFile
+To self-host the same end-to-end shape, run these pieces together:
 
-RelayFile turns file exchange into normal filesystem work:
+- relayfile API
+- relayauth or compatible scoped JWT issuer
+- provider adapters for the systems you expose as files
+- provider workers for sync and writeback
+- Nango for OAuth-backed provider credentials and provider sync state
 
-- Agent A writes `/notes/plan.md`
-- Agent B mounts the same workspace and sees `/notes/plan.md`
-- A human reviews or edits the same file locally
-- writeback, event feeds, and operation logs preserve the sync history
+Relayfile should remain the VFS and operation log. Nango or an equivalent provider layer should own OAuth credentials.
 
-This is especially useful for:
+## Existing Connection IDs
 
-- generated code or patch files
-- logs and structured artifacts
-- prompts, plans, and handoff notes
-- exported bundles and review outputs
+Relayfile stores provider identity as `connectionId` metadata on files, webhook envelopes, operations, and writeback work. That lets you bring existing provider connections when the provider layer can use the ID.
 
-## Shared Human And Agent Workspaces
+### Nango
 
-A practical pattern is:
+For self-hosted deployments, use the same Nango project that already contains the connection. Configure the Nango provider with the right host, secret key, and `providerConfigKey`, then link your relayfile workspace to the existing Nango `connectionId` before sync.
 
-1. Human mounts `project-x` locally.
-2. Cloud agent mounts `project-x` inside its sandbox.
-3. Human edits requirements or reviews generated code.
-4. Agent writes implementation changes back into the same tree.
-5. Both sides see updates after the next sync cycle.
+The hosted Agent Relay CLI currently exposes a connect-session flow, not a public import command for arbitrary Nango connections. If a connection lives in a different Nango project, hosted Agent Relay cannot use it without a migration or a fresh hosted OAuth connection.
 
-That avoids manual upload, download, and copy-paste loops.
+Operationally, a self-hosted cloud-compatible link needs:
+
+```text
+workspace_id         relayfile workspace id
+provider             provider id, for example notion or github
+connection_id        existing Nango connection id
+provider_config_key  Nango provider config key
+metadata_json        readiness/sync metadata, if your worker uses it
+```
+
+Then trigger the provider's initial sync so relayfile receives files.
+
+### Composio
+
+Use the existing Composio connected account ID as relayfile's `connectionId`. Configure the Composio provider with your API key, verify the account with `getConnectedAccount` or `healthCheck`, and have your adapter/proxy calls use that ID for read/writeback.
+
+### Pipedream
+
+Use the existing Pipedream account ID as relayfile's `connectionId`. Configure the Pipedream provider with your Connect project credentials. Proxy calls also need the external user id, supplied through `x-pd-external-user-id`, `external_user_id`, or a resolver callback.
 
 ## Operational Notes
 
-- Use a unique workspace per workflow run when isolation matters more than continuity.
-- Reuse a long-lived workspace when a team wants a shared persistent project tree.
-- Use the sync, ops, and admin endpoints from [docs/api-reference.md](../api-reference.md) to inspect ingestion health, dead letters, and replay status.
-- For external providers, submit inbound events through `POST /v1/workspaces/{workspaceId}/webhooks/ingest` and consume outbound work through the writeback queue endpoints.
+- Use one workspace per isolated task or run.
+- Reuse a workspace when humans and agents need a shared persistent project tree.
+- Keep OAuth credentials out of relayfile. Store them in Nango, Composio, Pipedream, or your own provider layer.
+- Use [API reference](../api-reference.md) endpoints for tree reads, file writes, webhook ingestion, writeback status, and operation replay.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -15,6 +15,7 @@ This starts relayfile on `http://localhost:9090`, relayauth on `http://localhost
 TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
 
 curl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Correlation-Id: quickstart-tree" \
   "http://localhost:9090/v1/workspaces/ws_demo/fs/tree?path=/"
 ```
 
@@ -32,16 +33,22 @@ Your agent can now read and write files under `./relayfile-mount`.
 
 ## Run The Server Directly
 
-For local development without Docker:
+For local development without Docker, start the local token issuer:
+
+```bash
+node docker/relayauth/server.js
+```
+
+In another terminal, start relayfile:
 
 ```bash
 RELAYFILE_BACKEND_PROFILE=durable-local \
 RELAYFILE_DATA_DIR=.data \
-RELAYFILE_JWT_SECRET=dev-secret \
+RELAYAUTH_JWKS_URL=http://127.0.0.1:9091/.well-known/jwks.json \
 go run ./cmd/relayfile
 ```
 
-In another terminal:
+In a third terminal:
 
 ```bash
 export RELAYFILE_WORKSPACE=ws_demo

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -2,6 +2,8 @@
 
 Relayfile gives agents a file tree instead of an API surface. Start locally, seed files, mount them, and let the agent use normal filesystem tools.
 
+This repo is the file server and mount layer. For the rest of the ecosystem, see [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) (`../relayfile-adapters` locally) for path mapping, webhook normalization, and writeback behavior, and [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) (`../relayfile-providers` locally) for provider auth, API proxying, subscriptions, and connection health.
+
 ## Local OSS Quickstart
 
 ```bash
@@ -99,7 +101,7 @@ Relayfile alone is the VFS API. For provider-backed files end to end, self-host:
 
 - relayfile
 - relayauth or another JWT issuer compatible with relayfile scopes
-- the adapters/providers you need
+- the [adapters](https://github.com/AgentWorkforce/relayfile-adapters) and [providers](https://github.com/AgentWorkforce/relayfile-providers) you need
 - Nango, if you want OAuth-backed provider sync/writeback without using hosted Agent Relay
 
 Keep third-party credentials in the provider layer. Relayfile should receive normalized files, webhooks, writeback operations, and `connectionId` metadata; it should not become the OAuth credential store.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,178 +1,103 @@
-# Getting Started With RelayFile
+# Getting Started
 
-RelayFile gives multiple machines and agents a shared workspace-backed filesystem. A common flow is:
+Relayfile gives agents a file tree instead of an API surface. Start locally, seed files, mount them, and let the agent use normal filesystem tools.
 
-1. Start a RelayFile server locally or point the CLI at a hosted deployment.
-2. Log in and create a workspace.
-3. Seed the workspace from an existing project.
-4. Mount that workspace on one or more machines.
-5. Watch edits propagate through the shared tree.
-
-## Prerequisites
-
-- For local development, install Go so you can run `go run ./cmd/relayfile`.
-- For hosted usage, you only need the RelayFile CLI plus a server URL and token.
-- If you want to mount the same workspace on multiple machines, each machine needs network access to the same RelayFile server.
-
-RelayFile works in two common modes:
-
-- local development: run the server from this repository with Go
-- hosted usage: point the CLI at a shared RelayFile deployment and skip the local server step
-
-## Start The Server Locally
-
-Run the API server from the repository root:
+## Local OSS Quickstart
 
 ```bash
-go run ./cmd/relayfile
+cd docker
+docker compose up --build
 ```
 
-By default the service listens on `http://127.0.0.1:8080`.
+This starts relayfile on `http://localhost:9090`, relayauth on `http://localhost:9091`, and creates a sample workspace named `ws_demo`.
 
-If you want durable local state instead of in-memory state, use:
+```bash
+TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
+
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:9090/v1/workspaces/ws_demo/fs/tree?path=/"
+```
+
+Mount the workspace:
+
+```bash
+cd ..
+RELAYFILE_TOKEN="$TOKEN" go run ./cmd/relayfile-mount \
+  --base-url http://localhost:9090 \
+  --workspace ws_demo \
+  --local-dir ./relayfile-mount
+```
+
+Your agent can now read and write files under `./relayfile-mount`.
+
+## Run The Server Directly
+
+For local development without Docker:
 
 ```bash
 RELAYFILE_BACKEND_PROFILE=durable-local \
 RELAYFILE_DATA_DIR=.data \
+RELAYFILE_JWT_SECRET=dev-secret \
 go run ./cmd/relayfile
 ```
 
-If you are using a hosted deployment instead, skip this step and replace `http://127.0.0.1:8080` in the examples below with your hosted server URL.
-
-## Log In And Create A Workspace
-
-Log in once so the CLI can store the server URL and token:
+In another terminal:
 
 ```bash
-relayfile login --server http://127.0.0.1:8080 --token dev-token
+export RELAYFILE_WORKSPACE=ws_demo
+export RELAYFILE_TOKEN="$(./scripts/generate-dev-token.sh "$RELAYFILE_WORKSPACE")"
+
+go run ./cmd/relayfile-cli login \
+  --server http://127.0.0.1:8080 \
+  --token "$RELAYFILE_TOKEN"
+
+go run ./cmd/relayfile-cli seed "$RELAYFILE_WORKSPACE" ./examples
+go run ./cmd/relayfile-cli tree "$RELAYFILE_WORKSPACE" /
+go run ./cmd/relayfile-cli mount "$RELAYFILE_WORKSPACE" ./relayfile-mount
 ```
 
-Create a workspace for the project you want to sync:
+## Common Local Commands
 
 ```bash
-relayfile workspace create my-project
-relayfile workspace use my-project
+# Read remote tree and files without mounting
+go run ./cmd/relayfile-cli tree ws_demo /
+go run ./cmd/relayfile-cli read ws_demo /docs/welcome.md
+
+# One-shot sync for CI
+go run ./cmd/relayfile-cli mount ws_demo ./relayfile-mount --once
+
+# Export a workspace
+go run ./cmd/relayfile-cli export ws_demo --format tar --output ws_demo.tar
 ```
 
-List available workspaces:
+## Hosted Provider Files
+
+If the user wants Notion, Slack, Linear, or GitHub files from hosted `agentrelay.com`, use the hosted setup skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28):
 
 ```bash
-relayfile workspace list
+relayfile setup \
+  --provider notion \
+  --workspace my-agent \
+  --local-dir ./relayfile-mount \
+  --no-open
 ```
 
-If your environment already assigns you a workspace ID, you can use that directly instead of creating one:
+That path gives the agent the same file-shaped workflow, but Agent Relay runs the cloud workspace, Nango OAuth, sync workers, and provider writeback.
 
-```bash
-relayfile workspace use ws_123
-```
+## Fully Self-Hosted Provider Files
 
-`RELAYFILE_WORKSPACE=ws_123` also overrides the stored default for scripts and agent sessions.
+Relayfile alone is the VFS API. For provider-backed files end to end, self-host:
 
-If you are using a hosted deployment, the same login flow works with your hosted base URL:
+- relayfile
+- relayauth or another JWT issuer compatible with relayfile scopes
+- the adapters/providers you need
+- Nango, if you want OAuth-backed provider sync/writeback without using hosted Agent Relay
 
-```bash
-relayfile login --server https://api.relayfile.dev --token YOUR_TOKEN
-```
-
-Open the hosted observer for the selected workspace:
-
-```bash
-relayfile observer
-```
-
-## Seed Files From A Project
-
-Upload an existing local directory into the workspace:
-
-```bash
-relayfile seed my-project ./src
-```
-
-Useful variants:
-
-```bash
-relayfile seed my-project .
-relayfile seed my-project ./src --exclude node_modules --exclude .git
-relayfile seed my-project ./src --dry-run
-```
-
-`seed` is the fastest way to populate a workspace before collaborators or agents mount it.
-
-## Mount On Two Machines
-
-After seeding, mount the same workspace on each machine that should participate.
-
-Machine A:
-
-```bash
-relayfile mount my-project ./src
-```
-
-Machine B:
-
-```bash
-relayfile mount my-project ./src
-```
-
-Both mounts point at the same remote workspace. RelayFile continuously syncs changes between the local directory and the server-backed virtual tree.
-
-If you want a one-shot sync instead of a long-running mount:
-
-```bash
-relayfile mount my-project ./src --once
-```
-
-## Watch Files Sync
-
-With both mounts running:
-
-1. Edit `./src/README.md` on Machine A.
-2. Save the file.
-3. Wait for the next sync cycle.
-4. The updated file appears on Machine B.
-
-With the default polling interval, changes usually arrive in about 1-2 seconds.
-
-If you want to watch the workspace status while testing:
-
-```bash
-relayfile status
-```
-
-The synced mirror also writes a machine-readable local status file at
-`<mount>/.relay/state.json`. That file is the authoritative local surface for:
-
-- sync freshness (`status`, `lastSuccessfulReconcileAt`, `staleAfter`)
-- pending local writeback (`pendingWriteback`, per-file `status`)
-- unresolved conflicts under `<mount>/.relay/conflicts/`
-- denied paths and the append-only `<mount>/.relay/permissions-denied.log`
-
-Binary files are materialized as raw bytes locally and written back with
-`encoding: "base64"` when needed. Large writes that the server rejects stay on
-disk locally and remain visible as `status: "writeback-pending"` in
-`.relay/state.json`; they are never silently dropped. Remote deletes stay
-per-file and only remove the local mirror when the tracked remote revision still
-matches.
-
-For direct VFS inspection without mounting:
-
-```bash
-relayfile tree / --depth 2
-relayfile tree /github --depth 5 --json
-relayfile read /github/repos/acme/api/pulls/42/metadata.json
-relayfile read /external/blob.bin --output blob.bin
-```
-
-For low-level API testing, you can also inspect the event feed directly:
-
-```bash
-curl -sS \
-  -H "Authorization: Bearer dev-token" \
-  "http://127.0.0.1:8080/v1/workspaces/my-project/fs/events?path=/&limit=20"
-```
+Keep third-party credentials in the provider layer. Relayfile should receive normalized files, webhooks, writeback operations, and `connectionId` metadata; it should not become the OAuth credential store.
 
 ## Next Steps
 
-- Collaboration patterns: [docs/guides/collaboration.md](collaboration.md)
-- Cloud workflow integration: [docs/guides/cloud-integration.md](cloud-integration.md)
-- REST contract details: [docs/api-reference.md](../api-reference.md)
+- [Cloud integration](cloud-integration.md)
+- [Agent VFS usage](agent-vfs-usage.md)
+- [API reference](../api-reference.md)
+- [Environment variables](../environment-variables.md)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -79,7 +79,9 @@ go run ./cmd/relayfile-cli export ws_demo --format tar --output ws_demo.tar
 
 ## Hosted Provider Files
 
-If the user wants Notion, Slack, Linear, or GitHub files from hosted `agentrelay.com`, use the hosted setup skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28):
+If the user wants Notion, Slack, Linear, GitHub, or other provider-backed files without running infrastructure, use hosted Agent Relay. Agent Relay Cloud runs the workspace, relayfile API, scoped auth, Nango OAuth, sync workers, and writeback workers.
+
+Use the hosted setup skill from [AgentWorkforce/skills#28](https://github.com/AgentWorkforce/skills/pull/28):
 
 ```bash
 relayfile setup \
@@ -89,7 +91,7 @@ relayfile setup \
   --no-open
 ```
 
-That path gives the agent the same file-shaped workflow, but Agent Relay runs the cloud workspace, Nango OAuth, sync workers, and provider writeback.
+That path connects to `agentrelay.com`, completes provider auth, waits for sync, and mounts provider files locally for the agent. The local directory is only the agent's file interface; the integration stack is hosted.
 
 ## Fully Self-Hosted Provider Files
 

--- a/scripts/generate-dev-token.sh
+++ b/scripts/generate-dev-token.sh
@@ -2,22 +2,16 @@
 set -euo pipefail
 
 workspace_id="${1:-${RELAYFILE_WORKSPACE:-ws_live}}"
-secret="${RELAYFILE_JWT_SECRET:-dev-secret}"
 agent_name="${RELAYFILE_AGENT_NAME:-compose-agent}"
-exp_epoch="${RELAYFILE_TOKEN_EXP:-4102444800}"
+relayauth_url="${RELAYAUTH_URL:-http://127.0.0.1:9091}"
 
-b64url() {
-  openssl base64 -A | tr '+/' '-_' | tr -d '='
-}
-
-header='{"alg":"HS256","typ":"JWT"}'
 payload=$(cat <<JSON
-{"workspace_id":"${workspace_id}","agent_name":"${agent_name}","scopes":["fs:read","fs:write","sync:read","sync:trigger","ops:read","ops:replay","admin:read","admin:replay"],"exp":${exp_epoch},"aud":["relayfile"]}
+{"workspace_id":"${workspace_id}","agent_name":"${agent_name}","scopes":["fs:read","fs:write","sync:read","sync:trigger","ops:read","ops:replay","admin:read","admin:replay"]}
 JSON
 )
 
-h=$(printf '%s' "${header}" | b64url)
-p=$(printf '%s' "${payload}" | b64url)
-s=$(printf '%s' "${h}.${p}" | openssl dgst -sha256 -hmac "${secret}" -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+response=$(curl -fsS "${relayauth_url}/sign" \
+  -H "Content-Type: application/json" \
+  -d "${payload}")
 
-echo "${h}.${p}.${s}"
+printf '%s\n' "${response}" | sed 's/.*"token":"\([^"]*\)".*/\1/'


### PR DESCRIPTION
## Summary
- Make the README concise and local-first for OSS users
- Update getting started and cloud integration guides for local vs hosted flows
- Document self-host Nango expectations and existing provider connection IDs

## Validation
- git diff --check