### PR TITLE
docs: add integration runtime launch specs

### DIFF
--- a/docs/agent-workspace-discovery-readiness-spec.md
+++ b/docs/agent-workspace-discovery-readiness-spec.md
@@ -1,0 +1,253 @@
+# Agent Workspace Discovery And Readiness Spec
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Related:** AgentWorkforce/relayfile#79
+**Owners:** relayfile SDK, relayfile CLI, Agent Relay Cloud, agent skills
+
+## Problem
+
+Issue #79 documents two silent-failure classes in the agent workspace SDK:
+
+1. Agents cannot reliably discover which provider roots are mounted.
+2. `waitForConnection()` can report OAuth readiness before files are synced, so agents can read an empty mount without an actionable signal.
+
+The problem becomes more important with JIT integrations because provider roots and schemas will no longer be limited to a small hardcoded set like `/notion` and `/github`.
+
+## Goal
+
+Give agents a first-class way to answer:
+
+- Which integrations are connected?
+- Which VFS roots are available?
+- Are files synced enough to read?
+- Which schemas and writeback paths apply?
+- What should the agent do if the mount is empty or stale?
+
+## Non-Goals
+
+- Do not require initial sync to be instantaneous.
+- Do not hide polling or eventual consistency.
+- Do not require kernel FUSE behavior from the synced mirror.
+
+## Cloud API Contract
+
+### List Integrations
+
+```http
+GET /api/v1/workspaces/{workspaceId}/integrations
+```
+
+Response:
+
+```ts
+type WorkspaceIntegrationSummary = {
+  provider: string;
+  displayName: string;
+  runtime: "nango" | "composio" | "pipedream";
+  vfsRoot: string;
+  connectionId: string | null;
+  providerConfigKey?: string | null;
+  mountedPath: string;
+  ready: boolean;
+  auth: {
+    connected: boolean;
+    connectedAt: string | null;
+    lastAuthAt: string | null;
+  };
+  sync: {
+    state: "unknown" | "queued" | "running" | "complete" | "failed";
+    fileCount: number;
+    lastSyncedAt: string | null;
+    lagSeconds: number | null;
+    lastError: string | null;
+  };
+  schemas: Array<{
+    pathTemplate: string;
+    direction: "read" | "write";
+    schemaId: string;
+  }>;
+};
+```
+
+### Integration Status
+
+```http
+GET /api/v1/workspaces/{workspaceId}/integrations/{provider}/status
+```
+
+This endpoint should return the same fields for a single provider, including `vfsRoot`, `mountedPath`, `sync.fileCount`, and `sync.state`.
+
+## SDK Contract
+
+Add discovery helpers to `WorkspaceHandle`:
+
+```ts
+type WorkspaceIntegration = {
+  provider: string;
+  runtime: "nango" | "composio" | "pipedream";
+  vfsRoot: string;
+  mountedPath: string;
+  ready: boolean;
+  sync: {
+    state: "unknown" | "queued" | "running" | "complete" | "failed";
+    fileCount: number;
+    lagSeconds: number | null;
+    lastSyncedAt: string | null;
+    lastError: string | null;
+  };
+  schemas: Array<{
+    pathTemplate: string;
+    direction: "read" | "write";
+    schemaId: string;
+  }>;
+};
+
+class WorkspaceHandle {
+  listIntegrations(): Promise<WorkspaceIntegration[]>;
+
+  listMountedPaths(): Promise<Array<{
+    provider: string;
+    vfsRoot: string;
+    mountedPath: string;
+    fileCount: number;
+    syncState: WorkspaceIntegration["sync"]["state"];
+  }>>;
+
+  waitForIntegrationReady(
+    provider: string,
+    options?: {
+      minFiles?: number;
+      requireSyncComplete?: boolean;
+      timeoutMs?: number;
+      pollIntervalMs?: number;
+      onProgress?: (status: WorkspaceIntegration) => void;
+      signal?: AbortSignal;
+    },
+  ): Promise<WorkspaceIntegration>;
+
+  waitForNotion(
+    options?: Omit<Parameters<WorkspaceHandle["waitForIntegrationReady"]>[1], never>,
+  ): Promise<WorkspaceIntegration>;
+}
+```
+
+Backward compatibility:
+
+- `waitForConnection(provider)` may continue to mean OAuth readiness.
+- New agent code should prefer `waitForIntegrationReady(provider, { requireSyncComplete: true })`.
+- `waitForNotion()` should either return the status object or have a `mode` option. The safest path is to return status while staying promise-compatible for callers that ignore the return value.
+
+## CLI Contract
+
+```bash
+relayfile integration list --workspace my-agent --json
+relayfile mounted-paths --workspace my-agent --json
+relayfile wait notion --workspace my-agent --sync-complete --min-files 1 --timeout 5m
+```
+
+Human output:
+
+```text
+provider  root      sync      files  lag
+notion    /notion   complete  214    4s
+github    /github   running   42     18s
+```
+
+## Mount State Contract
+
+The local `.relay/state.json` file should mirror cloud discovery fields:
+
+```json
+{
+  "workspaceId": "rw_12345678",
+  "localDir": "/Users/me/relayfile-mount",
+  "providers": [
+    {
+      "provider": "notion",
+      "vfsRoot": "/notion",
+      "mountedPath": "/Users/me/relayfile-mount/notion",
+      "status": "ready",
+      "syncState": "complete",
+      "fileCount": 214,
+      "lagSeconds": 4
+    }
+  ]
+}
+```
+
+Agent skills should read this file before calling provider APIs or assuming root names.
+
+## Empty Mount Handling
+
+Agents need a deterministic signal for empty mounts:
+
+```ts
+const notion = await workspace.waitForIntegrationReady("notion", {
+  requireSyncComplete: true,
+  minFiles: 1,
+  timeoutMs: 5 * 60_000,
+  onProgress: (status) => {
+    console.log(`Notion sync ${status.sync.state}: ${status.sync.fileCount} files`);
+  },
+});
+```
+
+Failure should be typed:
+
+```ts
+class IntegrationSyncTimeoutError extends Error {
+  provider: string;
+  lastStatus: WorkspaceIntegration;
+}
+
+class IntegrationSyncFailedError extends Error {
+  provider: string;
+  lastError: string;
+  lastStatus: WorkspaceIntegration;
+}
+```
+
+## Phases
+
+### Phase 1 - Cloud Discovery Completeness
+
+- Ensure list/status endpoints return `vfsRoot`, `mountedPath`, `runtime`, `sync.state`, `sync.fileCount`, and schemas.
+- Cover built-in integrations.
+
+### Phase 2 - SDK Discovery Helpers
+
+- Add `listIntegrations`.
+- Add `listMountedPaths`.
+- Add `waitForIntegrationReady`.
+- Keep `waitForConnection` backward-compatible.
+
+### Phase 3 - CLI And Mount State
+
+- Add `relayfile mounted-paths`.
+- Add `relayfile wait`.
+- Mirror discovery fields into `.relay/state.json`.
+
+### Phase 4 - Agent Skill Update
+
+- Update relayfile agent skill to discover mounts instead of assuming provider roots.
+- Gate provider reads on `sync.state` and `fileCount`.
+
+## Acceptance Criteria
+
+- An agent can resume in a workspace and discover every connected provider without prior setup context.
+- An agent can wait until a provider has at least one synced file.
+- Empty mount after OAuth readiness no longer looks like success.
+- JIT provider roots appear through the same discovery surface.
+- Issue #79 can be closed only after SDK, CLI, and skill behavior are covered.
+
+## Workflow Inputs
+
+Recommended workflow slices:
+
+1. `cloud-integration-discovery-fields`
+2. `sdk-list-integrations-and-mounted-paths`
+3. `sdk-wait-for-integration-ready`
+4. `cli-mounted-paths-and-wait`
+5. `mount-state-provider-discovery`
+6. `agent-skill-discovery-update`

--- a/docs/byo-schema-jit-integrations-spec.md
+++ b/docs/byo-schema-jit-integrations-spec.md
@@ -1,0 +1,328 @@
+# BYO Schema And JIT Integrations Spec
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Related:** AgentWorkforce/cloud#457, `docs/canonical-file-schema-ownership-boundary.md`
+**Owners:** Agent Relay Cloud, relayfile core, relayfile adapters, relayfile SDK
+
+## Problem
+
+Cloud#457 defines a Nango-specific programmatic JIT sync path:
+
+```bash
+relayfile sync push my-sync.ts --provider-config-key acme-tickets
+```
+
+That is a good v2 for Nango syncs, but the product needs a more general shape: users should be able to bring their own schema and map provider records into relayfile files, regardless of whether the runtime is Nango, Composio, Pipedream, or a future integration runtime.
+
+## Product Principle
+
+A JIT integration is:
+
+```text
+runtime + connection + schema + mapping + writeback contract
+```
+
+Nango is one runtime. The user-facing object is the integration definition.
+
+## Goal
+
+Allow users to define provider-backed file surfaces with JSON Schema and mapping code, then attach them to a workspace.
+
+Example:
+
+```bash
+relayfile integration push ./acme-tickets.integration.ts \
+  --workspace support-bot \
+  --provider acme-tickets \
+  --runtime nango \
+  --connection-id conn_existing_123
+```
+
+The result:
+
+```text
+./relayfile-mount/acme-tickets/tickets/TCK-123.json
+./relayfile-mount/acme-tickets/tickets/TCK-123/comments/new.json
+```
+
+Agents see normal files. The custom integration owns how records become files and how writeback files become provider actions.
+
+## Non-Goals
+
+- Do not allow arbitrary code to run in Agent Relay lambdas without sandboxing.
+- Do not make relayfile core provider-aware.
+- Do not make user schemas silently override canonical schemas for built-in providers.
+- Do not require BYO schemas for built-in integrations.
+
+## Integration Definition
+
+The source artifact should be TypeScript first, with JSON output as the transport format.
+
+```ts
+import { defineIntegration } from "@relayfile/integration-runtime";
+
+export default defineIntegration({
+  id: "acme-tickets",
+  provider: "acme-tickets",
+  runtime: "nango",
+
+  connection: {
+    providerConfigKey: "acme-tickets",
+  },
+
+  files: [
+    {
+      path: "/acme-tickets/tickets/{id}.json",
+      schema: {
+        type: "object",
+        required: ["id", "title", "status"],
+        additionalProperties: false,
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" },
+          status: { enum: ["open", "closed"] },
+          assignee: { type: ["string", "null"] },
+        },
+      },
+      sync: {
+        model: "Ticket",
+        map: (record) => ({
+          path: `/acme-tickets/tickets/${record.id}.json`,
+          contentType: "application/json",
+          content: {
+            id: record.id,
+            title: record.title,
+            status: record.status,
+            assignee: record.assignee ?? null,
+          },
+        }),
+      },
+    },
+  ],
+
+  writebacks: [
+    {
+      path: "/acme-tickets/tickets/{id}/comments/new.json",
+      schema: {
+        type: "object",
+        required: ["body"],
+        additionalProperties: false,
+        properties: {
+          body: { type: "string", minLength: 1 },
+        },
+      },
+      action: async ({ params, content, runtime }) => {
+        await runtime.proxy({
+          method: "POST",
+          endpoint: `/tickets/${params.id}/comments`,
+          body: content,
+        });
+      },
+    },
+  ],
+});
+```
+
+## Compiled Manifest
+
+Cloud should persist a compiled manifest, not arbitrary source code:
+
+```ts
+type JitIntegrationManifest = {
+  manifestVersion: "2026-05-07";
+  id: string;
+  provider: string;
+  runtime: "nango" | "composio" | "pipedream";
+  files: Array<{
+    pathTemplate: string;
+    schemaId: string;
+    schema: object;
+    sync?: {
+      model?: string;
+      endpoint?: string;
+      method?: string;
+    };
+  }>;
+  writebacks: Array<{
+    pathTemplate: string;
+    schemaId: string;
+    schema: object;
+    action: {
+      runtime: string;
+      endpointTemplate: string;
+      method: string;
+    };
+  }>;
+};
+```
+
+Generated functions should be deployed to the runtime-specific sandbox:
+
+- Nango: programmatic sync deployment per cloud#457.
+- Composio: action/proxy executor or hosted adapter worker.
+- Pipedream: Connect/account proxy plus workflow/action invocation.
+
+## Schema Registry
+
+Built-in schemas live in `schemas/` in the relayfile repo.
+
+User schemas need a workspace-scoped registry:
+
+```ts
+type WorkspaceSchema = {
+  id: string;
+  workspaceId: string;
+  provider: string;
+  pathTemplate: string;
+  direction: "read" | "write";
+  schema: object;
+  version: number;
+  status: "draft" | "active" | "deprecated";
+};
+```
+
+Rules:
+
+- Built-in schemas are global and versioned with relayfile.
+- BYO schemas are workspace-scoped unless explicitly promoted.
+- BYO schemas cannot replace a built-in provider/path without an explicit override flag.
+- Writeback schemas are required before a BYO writeback path becomes active.
+
+## API Contract
+
+### Push Integration
+
+```http
+POST /api/v1/workspaces/{workspaceId}/jit-integrations
+```
+
+Request:
+
+```json
+{
+  "provider": "acme-tickets",
+  "runtime": "nango",
+  "connectionId": "conn_existing_123",
+  "manifest": {
+    "manifestVersion": "2026-05-07",
+    "id": "acme-tickets",
+    "files": [],
+    "writebacks": []
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "integrationId": "jit_acme_tickets",
+  "provider": "acme-tickets",
+  "runtime": "nango",
+  "status": "deploying",
+  "diagnosticsUrl": "/api/v1/workspaces/rw_123/jit-integrations/jit_acme_tickets/diagnostics"
+}
+```
+
+### Validate Schema
+
+```http
+POST /api/v1/workspaces/{workspaceId}/schemas/validate
+```
+
+Request:
+
+```json
+{
+  "path": "/acme-tickets/tickets/TCK-123.json",
+  "direction": "read",
+  "content": {
+    "id": "TCK-123",
+    "title": "Broken login",
+    "status": "open"
+  }
+}
+```
+
+## CLI Contract
+
+```bash
+relayfile integration validate ./acme-tickets.integration.ts
+
+relayfile integration push ./acme-tickets.integration.ts \
+  --workspace support-bot \
+  --runtime nango \
+  --connection-id conn_existing_123
+
+relayfile integration diagnostics acme-tickets --workspace support-bot
+```
+
+Keep Nango-specific sugar as a compatibility alias:
+
+```bash
+relayfile sync push my-sync.ts --provider-config-key acme-tickets
+```
+
+This should compile down to the same JIT integration machinery with `runtime=nango`.
+
+## Security Requirements
+
+- Source code must be compiled and sandboxed before execution.
+- Runtime secrets must never be exposed to the CLI or agent.
+- Manifests must be validated before activation.
+- Writeback actions must be declared and schema-validated.
+- Diagnostics must redact secrets, connection IDs where appropriate, and Authorization headers.
+
+## Phases
+
+### Phase 1 - Manifest And Schema Registry
+
+- Define manifest JSON.
+- Add workspace schema registry.
+- Add validation endpoint and tests.
+
+### Phase 2 - Nango JIT Compatibility
+
+- Implement cloud#457 on top of the manifest shape.
+- `relayfile sync push` becomes a Nango-specific alias.
+- Nango compile/deploy errors surface through diagnostics.
+
+### Phase 3 - BYO Read Paths
+
+- Activate custom read file paths.
+- Sync records into relayfile using user schemas.
+- List integrations returns BYO roots and schemas.
+
+### Phase 4 - BYO Writeback Paths
+
+- Activate custom writeback paths.
+- Validate writes against user schemas before enqueue.
+- Route actions through runtime driver.
+
+### Phase 5 - Non-Nango Runtimes
+
+- Add Composio driver support.
+- Add Pipedream driver support.
+- Prove one integration on each runtime.
+
+## Acceptance Criteria
+
+- A user can push a Nango-backed custom integration and see files under a custom provider root.
+- A malformed schema fails before deployment.
+- A malformed sync implementation returns actionable diagnostics.
+- A write to an invalid writeback file is rejected with schema details.
+- Agent-facing filesystem behavior is identical for built-in and BYO integrations.
+
+## Workflow Inputs
+
+Recommended workflow slices:
+
+1. `jit-manifest-schema`
+2. `workspace-schema-registry`
+3. `jit-validate-cli`
+4. `nango-jit-push-compat`
+5. `jit-read-path-runtime`
+6. `jit-writeback-runtime`
+7. `composio-jit-driver`
+8. `pipedream-jit-driver`

--- a/docs/existing-provider-connection-import-spec.md
+++ b/docs/existing-provider-connection-import-spec.md
@@ -1,0 +1,242 @@
+# Existing Provider Connection Import Spec
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Related:** `docs/provider-runtime-abstraction-spec.md`
+**Owners:** Agent Relay Cloud, relayfile providers, relayfile CLI, relayfile SDK
+
+## Problem
+
+Users may already have provider connections in Nango, Composio, or Pipedream. Today hosted Agent Relay primarily exposes a new Nango connect-session flow. That is not enough for users who want to reuse existing connections.
+
+Relayfile core can carry `connectionId` metadata, but the hosted product needs an explicit import flow that verifies the connection and links it to a workspace.
+
+## Goal
+
+Allow a user to attach an existing provider connection to a workspace without re-authorizing OAuth when the runtime can validate and use the connection.
+
+## Non-Goals
+
+- Do not import raw OAuth tokens into relayfile.
+- Do not migrate connections across Nango/Composio/Pipedream accounts automatically.
+- Do not promise that hosted Agent Relay can use a connection from a runtime account it cannot access.
+
+## User Flows
+
+### Import Existing Nango Connection
+
+```bash
+relayfile integration import notion \
+  --workspace my-agent \
+  --runtime nango \
+  --connection-id conn_existing_123 \
+  --provider-config-key notion-relay
+```
+
+Requirements:
+
+- Agent Relay must have access to the Nango project containing `conn_existing_123`.
+- Cloud validates the connection with Nango.
+- Cloud stores `runtime=nango`, `connectionId`, and `providerConfigKey`.
+- Cloud triggers initial sync.
+
+### Import Existing Composio Connection
+
+```bash
+relayfile integration import slack \
+  --workspace my-agent \
+  --runtime composio \
+  --connection-id ca_existing_123
+```
+
+Requirements:
+
+- Agent Relay must have a Composio API key that can read `ca_existing_123`.
+- Cloud validates with `getConnectedAccount` or equivalent health check.
+- Cloud stores `runtime=composio` and `connectionId`.
+
+### Import Existing Pipedream Connection
+
+```bash
+relayfile integration import google-drive \
+  --workspace my-agent \
+  --runtime pipedream \
+  --connection-id apn_existing_123 \
+  --external-user-id user_123
+```
+
+Requirements:
+
+- Agent Relay must have Pipedream Connect project credentials that can read the account.
+- Cloud validates the account.
+- Cloud stores `runtime=pipedream`, `connectionId`, and `externalUserId`.
+
+## API Contract
+
+```http
+POST /api/v1/workspaces/{workspaceId}/integrations/import
+```
+
+Request:
+
+```ts
+type ImportIntegrationRequest = {
+  provider: string;
+  runtime: "nango" | "composio" | "pipedream";
+  connectionId: string;
+  providerConfigKey?: string;
+  externalUserId?: string;
+  schemaId?: string;
+  metadata?: Record<string, unknown>;
+};
+```
+
+Response:
+
+```ts
+type ImportIntegrationResponse = {
+  workspaceId: string;
+  provider: string;
+  runtime: "nango" | "composio" | "pipedream";
+  connectionId: string;
+  vfsRoot: string;
+  ready: boolean;
+  sync: {
+    state: "queued" | "running" | "complete" | "failed";
+    fileCount: number;
+    lastError: string | null;
+  };
+};
+```
+
+## SDK Contract
+
+```ts
+await workspace.importIntegration({
+  provider: "notion",
+  runtime: "nango",
+  connectionId: "conn_existing_123",
+  providerConfigKey: "notion-relay",
+});
+
+await workspace.importIntegration({
+  provider: "slack",
+  runtime: "composio",
+  connectionId: "ca_existing_123",
+});
+
+await workspace.importIntegration({
+  provider: "google-drive",
+  runtime: "pipedream",
+  connectionId: "apn_existing_123",
+  externalUserId: "user_123",
+});
+```
+
+## Validation Rules
+
+### Nango
+
+- `connectionId` is required.
+- `providerConfigKey` is required unless cloud can infer it from provider catalog.
+- Cloud must verify the connection exists and is active.
+- If the connection is in a different Nango project, return `connection_not_accessible`.
+
+### Composio
+
+- `connectionId` is required and maps to connected account ID.
+- Cloud must verify the connected account exists and is healthy.
+- If an integration/auth config ID is needed, it goes in metadata.
+
+### Pipedream
+
+- `connectionId` is required and maps to account ID.
+- `externalUserId` is required for proxy paths that need it.
+- Cloud must verify the account exists and is healthy.
+
+## Error Codes
+
+```ts
+type ImportErrorCode =
+  | "unknown_runtime"
+  | "unknown_provider"
+  | "connection_not_found"
+  | "connection_not_accessible"
+  | "connection_unhealthy"
+  | "missing_provider_config_key"
+  | "missing_external_user_id"
+  | "schema_not_found"
+  | "sync_enqueue_failed";
+```
+
+## Security Requirements
+
+- Never log Authorization headers, OAuth tokens, refresh tokens, or runtime API keys.
+- Treat `connectionId` as sensitive in diagnostics unless the user explicitly requests verbose local output.
+- Import requires workspace write/admin access.
+- Disconnect must call the runtime driver only when Agent Relay owns or can safely revoke that connection. For imported connections, default to unlink-only unless `--revoke` is explicit.
+
+## Disconnect Semantics
+
+```bash
+relayfile integration disconnect notion --workspace my-agent
+```
+
+Default:
+
+- Remove workspace link.
+- Remove local mirror subtree.
+- Do not revoke the upstream runtime connection.
+
+Explicit revoke:
+
+```bash
+relayfile integration disconnect notion --workspace my-agent --revoke
+```
+
+Runtime driver may revoke/delete the upstream connection if supported.
+
+## Phases
+
+### Phase 1 - Import API
+
+- Add endpoint.
+- Add validation and error codes.
+- Implement Nango import.
+
+### Phase 2 - CLI And SDK
+
+- Add `relayfile integration import`.
+- Add `workspace.importIntegration`.
+- Add tests for successful and failed import.
+
+### Phase 3 - Composio And Pipedream
+
+- Add runtime driver validation.
+- Add metadata handling.
+- Add docs and examples.
+
+### Phase 4 - Sync And Disconnect Semantics
+
+- Trigger initial sync after import.
+- Add unlink vs revoke semantics.
+- Ensure local mirror handles imported providers.
+
+## Acceptance Criteria
+
+- A user can import an existing Nango connection and see files after sync.
+- A user can import an existing Composio connected account.
+- A user can import an existing Pipedream account with external user ID.
+- Import failures are actionable and typed.
+- Disconnect does not accidentally revoke an external connection unless explicitly requested.
+
+## Workflow Inputs
+
+Recommended workflow slices:
+
+1. `integration-import-api-nango`
+2. `integration-import-cli-sdk`
+3. `integration-import-composio`
+4. `integration-import-pipedream`
+5. `integration-import-sync-trigger`
+6. `integration-disconnect-unlink-vs-revoke`

--- a/docs/integration-runtime-roadmap.md
+++ b/docs/integration-runtime-roadmap.md
@@ -1,0 +1,40 @@
+# Integration Runtime Roadmap
+
+**Status:** Proposed
+**Date:** 2026-05-07
+
+This is the launch follow-up roadmap for hosted Agent Relay provider files. It splits the work into separate specs that can become workflows.
+
+## Specs
+
+1. [Provider Runtime Abstraction](provider-runtime-abstraction-spec.md)
+   - Makes Nango one runtime driver instead of the integration product boundary.
+   - Adds `runtime=nango|composio|pipedream` to workspace integrations.
+
+2. [Existing Provider Connection Import](existing-provider-connection-import-spec.md)
+   - Lets users attach existing Nango, Composio, and Pipedream connections.
+   - Defines import validation, CLI/SDK shape, and unlink-vs-revoke semantics.
+
+3. [BYO Schema And JIT Integrations](byo-schema-jit-integrations-spec.md)
+   - Generalizes cloud#457 from Nango-specific sync push into `runtime + connection + schema + mapping`.
+   - Defines workspace-scoped schemas, JIT manifests, read paths, and writeback paths.
+
+4. [Agent Workspace Discovery And Readiness](agent-workspace-discovery-readiness-spec.md)
+   - Resolves relayfile#79.
+   - Adds integration discovery, mounted path discovery, and sync-complete readiness so agents do not silently read empty mounts.
+
+## Recommended Order
+
+1. Implement provider runtime abstraction with the existing Nango path as the regression target.
+2. Add existing connection import for Nango, then Composio and Pipedream.
+3. Fix SDK/CLI discovery and readiness so agents can safely consume dynamic provider roots.
+4. Land Nango JIT compatibility from cloud#457 on top of the manifest model.
+5. Extend BYO schema/JIT to non-Nango runtimes.
+
+## Closing Conditions
+
+- Hosted Agent Relay supports at least Nango, Composio, and Pipedream as runtime kinds.
+- Users can reuse existing provider connections when Agent Relay can validate them.
+- Users can define custom schemas and path mappings for new provider roots.
+- Agents can discover provider roots and wait for non-empty synced mounts.
+- relayfile#79 is closed with tests and skill docs updated.

--- a/docs/provider-runtime-abstraction-spec.md
+++ b/docs/provider-runtime-abstraction-spec.md
@@ -1,0 +1,306 @@
+# Provider Runtime Abstraction Spec
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Related:** AgentWorkforce/cloud#456, AgentWorkforce/cloud#457
+**Owners:** Agent Relay Cloud, relayfile providers, relayfile CLI, relayfile SDK
+
+## Problem
+
+Hosted Agent Relay currently treats provider-backed relayfile integrations as a Nango-shaped system. The public setup path creates a Nango connect session, stores `connectionId` and `providerConfigKey`, and runs Nango record sync into relayfile.
+
+That is correct for the current cloud-mount path, but it is too narrow for the product. Users should be able to bring provider connections from Nango, Composio, Pipedream, or future runtimes while keeping the same agent-facing filesystem contract.
+
+## Goal
+
+Make Nango one runtime driver behind a provider-runtime interface, not the integration product boundary.
+
+After this work, hosted Agent Relay should be able to attach a workspace integration with:
+
+```json
+{
+  "workspaceId": "rw_12345678",
+  "provider": "notion",
+  "runtime": "nango",
+  "connectionId": "conn_existing_123",
+  "providerConfigKey": "notion-relay"
+}
+```
+
+or:
+
+```json
+{
+  "workspaceId": "rw_12345678",
+  "provider": "slack",
+  "runtime": "composio",
+  "connectionId": "ca_existing_123"
+}
+```
+
+or:
+
+```json
+{
+  "workspaceId": "rw_12345678",
+  "provider": "google-drive",
+  "runtime": "pipedream",
+  "connectionId": "apn_existing_123",
+  "externalUserId": "user_123"
+}
+```
+
+## Non-Goals
+
+- Do not replace Nango for the existing `notion-relay`, `github-relay`, `linear-relay`, and `slack-relay` paths.
+- Do not make relayfile store OAuth tokens.
+- Do not require every runtime to support every provider.
+- Do not block the Nango-specific JIT work in cloud#457.
+
+## Data Model
+
+`workspace_integrations` needs to become runtime-aware. The exact migration can be additive:
+
+```ts
+type WorkspaceIntegrationRuntime = "nango" | "composio" | "pipedream";
+
+type WorkspaceIntegrationRecord = {
+  workspaceId: string;
+  provider: string;
+  runtime: WorkspaceIntegrationRuntime;
+  connectionId: string;
+  providerConfigKey?: string | null;
+  externalUserId?: string | null;
+  installationId?: string | null;
+  schemaId?: string | null;
+  metadata: Record<string, unknown>;
+};
+```
+
+Recommended DB additions:
+
+```sql
+ALTER TABLE workspace_integrations
+  ADD COLUMN runtime text NOT NULL DEFAULT 'nango',
+  ADD COLUMN external_user_id text,
+  ADD COLUMN schema_id text;
+```
+
+Keep `provider_config_key` for Nango and for any runtime that has an equivalent auth config key. Runtime-specific values that do not deserve top-level columns should stay in `metadata_json`.
+
+## Runtime Driver Contract
+
+Cloud should route all provider operations through a driver interface:
+
+```ts
+export type RuntimeKind = "nango" | "composio" | "pipedream";
+
+export type RuntimeConnection = {
+  workspaceId: string;
+  provider: string;
+  runtime: RuntimeKind;
+  connectionId: string;
+  providerConfigKey?: string | null;
+  externalUserId?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+export type ConnectSessionRequest = {
+  workspaceId: string;
+  provider: string;
+  redirectUrl?: string;
+};
+
+export type ConnectSessionResponse = {
+  connectUrl?: string;
+  connectionId?: string;
+  expiresAt?: string;
+};
+
+export type RuntimeProxyRequest = {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  endpoint: string;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  body?: unknown;
+};
+
+export interface ProviderRuntimeDriver {
+  kind: RuntimeKind;
+
+  createConnectSession(
+    request: ConnectSessionRequest,
+  ): Promise<ConnectSessionResponse>;
+
+  importConnection(connection: RuntimeConnection): Promise<void>;
+
+  healthCheck(connection: RuntimeConnection): Promise<boolean>;
+
+  proxy(
+    connection: RuntimeConnection,
+    request: RuntimeProxyRequest,
+  ): Promise<unknown>;
+
+  disconnect(connection: RuntimeConnection): Promise<void>;
+}
+```
+
+Nango's existing connect-session logic becomes `NangoRuntimeDriver`. Composio and Pipedream can start with `importConnection`, `healthCheck`, and `proxy`; hosted OAuth creation can follow.
+
+## API Contract
+
+### Create Hosted Connect Session
+
+```http
+POST /api/v1/workspaces/{workspaceId}/integrations/connect-session
+```
+
+Request:
+
+```json
+{
+  "provider": "notion",
+  "runtime": "nango"
+}
+```
+
+Response:
+
+```json
+{
+  "runtime": "nango",
+  "provider": "notion",
+  "connectLink": "https://connect.nango.dev/...",
+  "connectionId": "conn_123",
+  "expiresAt": "2026-05-07T14:00:00Z"
+}
+```
+
+Backward compatibility: existing clients sending `allowedIntegrations` should still route to Nango.
+
+### Import Existing Connection
+
+```http
+POST /api/v1/workspaces/{workspaceId}/integrations/import
+```
+
+Request:
+
+```json
+{
+  "provider": "slack",
+  "runtime": "composio",
+  "connectionId": "ca_existing_123",
+  "metadata": {
+    "integrationId": "auth_config_123"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "workspaceId": "rw_12345678",
+  "provider": "slack",
+  "runtime": "composio",
+  "connectionId": "ca_existing_123",
+  "ready": true
+}
+```
+
+### List Integrations
+
+The existing list endpoint should return runtime metadata:
+
+```json
+{
+  "integrations": [
+    {
+      "provider": "notion",
+      "runtime": "nango",
+      "connectionId": "conn_123",
+      "providerConfigKey": "notion-relay",
+      "vfsRoot": "/notion",
+      "ready": true,
+      "sync": {
+        "state": "complete",
+        "fileCount": 214,
+        "lastSyncedAt": "2026-05-07T13:00:00Z"
+      }
+    }
+  ]
+}
+```
+
+## CLI Contract
+
+Existing setup remains:
+
+```bash
+relayfile setup --provider notion
+```
+
+New runtime-aware forms:
+
+```bash
+relayfile integration connect notion --runtime nango
+
+relayfile integration import slack \
+  --runtime composio \
+  --connection-id ca_existing_123
+
+relayfile integration import google-drive \
+  --runtime pipedream \
+  --connection-id apn_existing_123 \
+  --external-user-id user_123
+```
+
+## Phases
+
+### Phase 1 - Data Model And Driver Boundary
+
+- Add `runtime`, `external_user_id`, and `schema_id` fields.
+- Add driver interface and `NangoRuntimeDriver`.
+- Route existing Nango calls through the driver.
+- Preserve existing API and CLI behavior.
+
+Acceptance:
+
+- Existing `relayfile setup --provider notion` still works.
+- Existing Nango rows default to `runtime='nango'`.
+- Tests prove no direct Nango calls remain outside the Nango driver except low-level driver implementation.
+
+### Phase 2 - Import Existing Connections
+
+- Add `POST /integrations/import`.
+- Add `relayfile integration import`.
+- Implement import/health-check for Nango, Composio, and Pipedream.
+
+Acceptance:
+
+- Nango import validates `connectionId + providerConfigKey`.
+- Composio import validates connected account ID.
+- Pipedream import validates account ID and requires external user ID when proxy calls need it.
+
+### Phase 3 - Runtime-Aware Sync And Writeback
+
+- Add runtime-aware sync dispatch.
+- Extend writeback routing to use runtime metadata.
+- Keep relayfile core runtime-agnostic.
+
+Acceptance:
+
+- A Nango-backed Notion workspace and a Composio-backed Slack workspace can coexist.
+- Agent-facing VFS behavior is identical: files are under provider roots and writes enter the writeback queue.
+
+## Workflow Inputs
+
+Recommended workflow slices:
+
+1. `provider-runtime-driver-boundary`
+2. `workspace-integrations-runtime-migration`
+3. `integration-import-api`
+4. `integration-import-cli`
+5. `runtime-aware-sync-and-writeback`
+6. `nango-regression-suite`


### PR DESCRIPTION
## Summary
- Add provider runtime abstraction spec for Nango, Composio, Pipedream, and future runtimes
- Add existing provider connection import spec for bringing pre-created connections
- Add BYO schema/JIT integration spec aligned with programmatic JIT sync work
- Add workspace discovery/readiness spec for relayfile issue #79
- Add roadmap index for turning the specs into workflows

## Validation
- git diff --cached --check
- git diff --check