### PR TITLE
docs(openapi): add fork endpoints, forkId params, and spec-currency enforcement

### DIFF
--- a/.claude/rules/openapi-spec.md
+++ b/.claude/rules/openapi-spec.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "openapi/**/*.yaml"
+  - "internal/httpapi/server.go"
+  - "internal/httpapi/**/*.go"
+---
+# OpenAPI Spec Currency
+
+Keep `openapi/relayfile-v1.openapi.yaml` in sync with the HTTP server in `internal/httpapi/server.go`.
+
+- When adding or removing an HTTP handler, add or remove the corresponding path entry in the spec in the same commit.
+- When adding a query parameter to a handler (e.g. `forkId` or similar), document it in the spec — either as a new `components/parameters` ref or inline on the endpoint.
+- When adding or changing a request or response body struct, update the matching schema in `components/schemas`.
+- When adding a new response status code to a handler, add it to the endpoint's `responses` map.
+- After making server-side changes, run `scripts/check-contract-surface.sh` to verify no silent drift.
+- The spec is the contract: no undocumented endpoints, no undocumented parameters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,3 +167,16 @@ Your trajectory helps others understand:
 
 Future agents can query past trajectories to learn from your decisions.
 <!-- prpm:snippet:end @agent-workforce/trail-snippet@1.1.2 -->
+
+# OpenAPI Spec
+
+`openapi/relayfile-v1.openapi.yaml` is the authoritative HTTP contract for this service.
+
+Keep it in sync with `internal/httpapi/server.go` at all times:
+
+- Adding a handler → add the path entry to the spec.
+- Adding a query parameter → add it to the endpoint or to `components/parameters`.
+- Adding a request/response field → update `components/schemas`.
+- Adding a new status code → add it to the endpoint's `responses` map.
+
+After server changes, run `scripts/check-contract-surface.sh` to check for drift.

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -18,6 +18,7 @@ servers:
     description: Staging
 tags:
   - name: Filesystem
+  - name: Forks
   - name: Events
   - name: Operations
   - name: Sync
@@ -79,13 +80,14 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 10
-            default: 2
+            maximum: 100
+            default: 10
         - name: cursor
           in: query
           required: false
           schema:
             type: string
+        - $ref: '#/components/parameters/ForkId'
       responses:
         '200':
           description: Tree listing
@@ -149,6 +151,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/WorkspaceId'
         - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/ForkId'
       requestBody:
         required: true
         content:
@@ -187,6 +190,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/WorkspaceId'
         - $ref: '#/components/parameters/CorrelationId'
+        - $ref: '#/components/parameters/ForkId'
         - name: format
           in: query
           required: false
@@ -241,6 +245,7 @@ paths:
           schema:
             type: string
             pattern: '^/.*'
+        - $ref: '#/components/parameters/ForkId'
       responses:
         '200':
           description: File read success
@@ -284,6 +289,7 @@ paths:
           schema:
             type: string
             pattern: '^/.*'
+        - $ref: '#/components/parameters/ForkId'
       requestBody:
         required: true
         content:
@@ -335,6 +341,7 @@ paths:
           schema:
             type: string
             pattern: '^/.*'
+        - $ref: '#/components/parameters/ForkId'
       responses:
         '202':
           description: Delete accepted and queued for provider write-back
@@ -467,6 +474,7 @@ paths:
             minimum: 1
             maximum: 1000
             default: 100
+        - $ref: '#/components/parameters/ForkId'
       responses:
         '200':
           description: Matching files page
@@ -480,6 +488,156 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v1/workspaces/{workspaceId}/forks:
+    post:
+      tags: [Forks]
+      operationId: createFork
+      summary: Create a fork (isolated copy) of the workspace for staged proposals
+      description: |
+        Creates a fork of the workspace state that can be read and written
+        independently without affecting the main workspace. Fork writes are
+        committed atomically via the commit endpoint or discarded entirely.
+
+        An optional `proposalId` may be supplied to make fork creation
+        idempotent: a second call with the same `proposalId` returns 409 instead
+        of creating a duplicate. An optional `ttlSeconds` controls how long the
+        fork lives before it expires (server default applies when omitted).
+      security:
+        - BearerAuth: [fs:write]
+      parameters:
+        - $ref: '#/components/parameters/WorkspaceId'
+        - $ref: '#/components/parameters/CorrelationId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              properties:
+                proposalId:
+                  type: string
+                  description: Idempotency key — reusing the same value returns 409 if a fork already exists for this proposal.
+                ttlSeconds:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  description: Fork lifetime in seconds. Omit to use the server default.
+      responses:
+        '200':
+          description: Fork created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForkHandle'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          description: A fork for this proposalId already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v1/workspaces/{workspaceId}/forks/{forkId}:
+    delete:
+      tags: [Forks]
+      operationId: discardFork
+      summary: Discard a fork and all staged changes
+      description: |
+        Permanently deletes the fork and all files staged within it.
+        This action is irreversible. Use when a proposal is rejected or
+        no longer needed.
+      security:
+        - BearerAuth: [fs:write]
+      parameters:
+        - $ref: '#/components/parameters/WorkspaceId'
+        - $ref: '#/components/parameters/CorrelationId'
+        - name: forkId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '204':
+          description: Fork discarded
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /v1/workspaces/{workspaceId}/forks/{forkId}/commit:
+    post:
+      tags: [Forks]
+      operationId: commitFork
+      summary: Commit staged fork changes into the main workspace
+      description: |
+        Atomically merges all files staged in the fork into the main workspace.
+        Each file in the fork is permission-checked against the caller's JWT
+        claims (path scope and permission policy) before the commit proceeds.
+
+        Returns a conflict if any parent directory was moved since the fork was
+        created (`parent_moved`), or 410 Gone if the fork has expired.
+      security:
+        - BearerAuth: [fs:write]
+      parameters:
+        - $ref: '#/components/parameters/WorkspaceId'
+        - $ref: '#/components/parameters/CorrelationId'
+        - name: forkId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        '200':
+          description: Fork committed successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForkCommitResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          description: Commit denied by path scope or permission policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Conflict — a parent directory was moved since the fork was created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForkCommitConflictResponse'
+        '410':
+          description: Fork has expired and can no longer be committed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '429':
           $ref: '#/components/responses/RateLimited'
         '500':
@@ -1423,6 +1581,16 @@ components:
         type: string
         minLength: 8
         maxLength: 128
+    ForkId:
+      name: forkId
+      in: query
+      required: false
+      description: |
+        When provided, operations read from or write to this fork rather than
+        the main workspace. Obtain a forkId by calling `POST /forks`.
+      schema:
+        type: string
+        minLength: 1
     IfMatch:
       name: If-Match
       in: header
@@ -1503,6 +1671,12 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     InternalError:
       description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Gone:
+      description: Resource has expired and is no longer available
       content:
         application/json:
           schema:
@@ -2514,6 +2688,55 @@ components:
             $ref: '#/components/schemas/BulkWriteError'
         correlationId:
           type: string
+
+    ForkHandle:
+      type: object
+      additionalProperties: false
+      required: [forkId, proposalId, workspaceId, expiresAt, parentRevision]
+      properties:
+        forkId:
+          type: string
+          description: Unique identifier for this fork. Pass as the `forkId` query parameter on filesystem endpoints.
+        proposalId:
+          type: string
+          description: Idempotency key supplied at creation time (empty string if none was provided).
+        workspaceId:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+          description: UTC time after which the fork expires and can no longer be committed.
+        parentRevision:
+          type: string
+          description: Workspace revision at the time the fork was created.
+
+    ForkCommitResponse:
+      type: object
+      additionalProperties: false
+      required: [revision, writtenCount, deletedCount]
+      properties:
+        revision:
+          type: string
+          description: New workspace revision after the commit.
+        writtenCount:
+          type: integer
+          minimum: 0
+          description: Number of files written to the workspace.
+        deletedCount:
+          type: integer
+          minimum: 0
+          description: Number of files deleted from the workspace.
+
+    ForkCommitConflictResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          additionalProperties: false
+          required: [currentRevision]
+          properties:
+            currentRevision:
+              type: string
+              description: Current revision of the moved parent directory.
 
     ConflictErrorResponse:
       allOf:


### PR DESCRIPTION
## Summary

- **OpenAPI spec gaps fixed**: three fork endpoints (`POST /forks`, `DELETE /forks/{forkId}`, `POST /forks/{forkId}/commit`) were fully implemented in `internal/httpapi/server.go` but entirely absent from the spec
- **`forkId` query param documented** on all six fork-aware filesystem endpoints: `fs/tree`, `fs/file` (GET/PUT/DELETE), `fs/bulk`, `fs/export`, `fs/query`
- **`depth` default corrected**: spec said `2`, server uses `10` (with max `100`, not `10`)
- **New schemas**: `ForkHandle`, `ForkCommitResponse`, `ForkCommitConflictResponse`, `Gone` (410) response, `ForkId` component parameter
- **Spec-currency enforcement**: new `.claude/rules/openapi-spec.md` and `AGENTS.md` section instruct agents to keep the spec in sync whenever `server.go` or the `openapi/` directory is touched

## Changes

| File | What changed |
|------|-------------|
| `openapi/relayfile-v1.openapi.yaml` | Fork paths, forkId params, schema additions, depth fix |
| `.claude/rules/openapi-spec.md` | New Claude rule scoped to `openapi/**` and `internal/httpapi/**` |
| `AGENTS.md` | OpenAPI spec maintenance guidance for all agents |

## Test plan

- [ ] Verify `scripts/check-contract-surface.sh` passes on this branch
- [ ] Confirm the three fork endpoints are reachable and match the documented request/response shapes against `internal/httpapi/server.go`
- [ ] Confirm `forkId` param flows correctly through `fs/tree`, `fs/file`, `fs/bulk`, `fs/export`, `fs/query`
- [ ] Confirm depth default of `10` matches `parseBoundedInt(r.URL.Query().Get("depth"), 10, 1, 100)` in server.go

https://claude.ai/code/session_019EWJdxPwPwifR9ZUWaB1B6

---
_Generated by [Claude Code](https://claude.ai/code/session_019EWJdxPwPwifR9ZUWaB1B6)_