### PR TITLE
fix(sdk): normalizeError must not assume ErrorEvent global

### DIFF
--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RelayFileClient } from "./client.js";
-import { RelayFileSync } from "./sync.js";
+import { RelayFileSync, normalizeError } from "./sync.js";
 import type { FilesystemEvent } from "./types.js";
 
 class MockWebSocket {
@@ -549,5 +549,38 @@ describe("RelayFileSync", () => {
     expect(sockets).toHaveLength(2);
 
     await sync.stop();
+  });
+});
+
+describe("normalizeError", () => {
+  // Regression: under Node 22.22.1 the previous implementation referenced the
+  // browser-only `ErrorEvent` global via `instanceof`, which threw
+  // `ReferenceError: ErrorEvent is not defined` when the WebSocket emitted an
+  // error event. The duck-typed implementation must work even when no
+  // `ErrorEvent` global exists.
+  it("unwraps the inner Error from a plain ErrorEvent-shaped object without an ErrorEvent global", () => {
+    const originalErrorEvent = (globalThis as { ErrorEvent?: unknown }).ErrorEvent;
+    // Simulate the Node runtime that triggered the bug: no `ErrorEvent` global.
+    delete (globalThis as { ErrorEvent?: unknown }).ErrorEvent;
+    try {
+      const inner = new Error("boom");
+      const result = normalizeError({ type: "error", error: inner });
+      expect(result).toBe(inner);
+    } finally {
+      if (originalErrorEvent !== undefined) {
+        (globalThis as { ErrorEvent?: unknown }).ErrorEvent = originalErrorEvent;
+      }
+    }
+  });
+
+  it("returns the event unchanged when there is no wrapped Error", () => {
+    const event = { type: "error", message: "transient" };
+    expect(normalizeError(event)).toBe(event);
+  });
+
+  it("returns non-object inputs unchanged", () => {
+    expect(normalizeError(undefined)).toBeUndefined();
+    expect(normalizeError(null)).toBeNull();
+    expect(normalizeError("nope")).toBe("nope");
   });
 });

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -197,8 +197,22 @@ function normalizeFilesystemEvent(message: RelayFileSyncWireEvent): FilesystemEv
   };
 }
 
-function normalizeError(event: Event | ErrorEvent): Event | Error {
-  return event instanceof ErrorEvent && event.error instanceof Error ? event.error : event;
+// Exported for testing. `ErrorEvent` is a DOM/browser global that is not
+// available on every Node 22 runtime (for example Node 22.22.1), so we
+// duck-type the shape rather than referencing the global directly. Using
+// `instanceof ErrorEvent` here would throw
+// `ReferenceError: ErrorEvent is not defined` whenever the underlying
+// WebSocket emits an error event under Node.
+export function normalizeError(event: unknown): unknown {
+  if (
+    event !== null &&
+    typeof event === "object" &&
+    "error" in event &&
+    (event as { error: unknown }).error instanceof Error
+  ) {
+    return (event as { error: Error }).error;
+  }
+  return event;
 }
 
 export class RelayFileSync {
@@ -477,7 +491,7 @@ export class RelayFileSync {
         return;
       }
       debugLog("ws error", event);
-      this.emit("error", normalizeError(event));
+      this.emit("error", normalizeError(event) as Error | Event);
     });
 
     socket.addEventListener("close", (event) => {


### PR DESCRIPTION
## Summary

`@relayfile/sdk@0.6.12` (just published off `fix/sdk-onwrite-ws-auth-and-polling`) crashes the host process the first time the WebSocket emits an `error` event under Node 22.22.1, because `normalizeError` in `packages/sdk/typescript/src/sync.ts` referenced the browser-only `ErrorEvent` global via `instanceof`. On Node builds where that global isn't defined, evaluating `event instanceof ErrorEvent` throws `ReferenceError: ErrorEvent is not defined`.

This PR replaces the unsafe global reference with a duck-typed check that unwraps `{ error: Error }` payloads when present and otherwise returns the event as-is. Functionally equivalent for the cases that matter, but no longer dependent on a DOM global. We deliberately do not shim/polyfill `ErrorEvent` — that would pollute the global namespace for SDK consumers.

- Surface: `RelayFileSync` error handler under any Node runtime without an `ErrorEvent` global (Node 22.22.1 confirmed; `demos/cortical-demo` repro).
- Regressed in: 0.6.12.

## Repro (before this PR)

1. Boot the cortical-demo orchestrator (uses `@relayfile/sdk`'s `onWrite`) on Node v22.22.1.
2. WebSocket emits an error event (any reason — token rotation, transient disconnect, etc.).
3. Process crashes with:

```
ReferenceError: ErrorEvent is not defined
    at normalizeError (.../node_modules/@relayfile/sdk/dist/sync.js:89:29)
    at WebSocket.<anonymous> (.../node_modules/@relayfile/sdk/dist/sync.js:341:32)
```

## Fix

```ts
export function normalizeError(event: unknown): unknown {
  if (
    event !== null &&
    typeof event === "object" &&
    "error" in event &&
    (event as { error: unknown }).error instanceof Error
  ) {
    return (event as { error: Error }).error;
  }
  return event;
}
```

## Test plan

- [x] `npx vitest run src/sync.test.ts` (14 passed, 3 new) — includes a regression test that deletes `globalThis.ErrorEvent` before calling `normalizeError({ type: 'error', error: new Error('boom') })` and asserts the inner `Error` is returned.
- [x] `npx tsc --noEmit` clean for `packages/sdk/typescript`.
- [ ] Re-run cortical-demo against the patched SDK and force a WS error event; confirm the process no longer crashes.

## Notes

- No version bump in this PR — the publish workflow owns version bumps for this repo.
- Branched off `main`; the bug shipped in 0.6.12 minutes before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)