### PR TITLE
fix(sdk): drop stale RELAYFILE_TOKEN env shadow + recover from ws error with no successor close

### DIFF
--- a/packages/sdk/typescript/src/onWrite.test.ts
+++ b/packages/sdk/typescript/src/onWrite.test.ts
@@ -360,6 +360,58 @@ describe("onWrite", () => {
     expect(sockets[0]!.url).toContain("token=client-token");
   });
 
+  it("auto-derives from client.getToken even when RELAYFILE_TOKEN env is set", async () => {
+    // Bug 5 (cortical-demo): when the caller's environment had RELAYFILE_TOKEN
+    // set (the default for any workspace started via WorkspaceHandle.mountEnv,
+    // which writes the token at join-time and never refreshes it), the
+    // dispatcher used to fall back to that stale literal instead of calling
+    // `client.getToken()`. Result: ~1 hour after workspace-join, the
+    // RELAYFILE_TOKEN literal was expired, the WS upgrade failed with an
+    // auth error, and the dispatcher silently stalled.
+    //
+    // Fix: when the caller provides a client (either explicitly or via the
+    // default-client path), client.getToken() is the source of truth — the
+    // env literal is no longer a fallback that can shadow it. The default
+    // client itself wires RELAYFILE_TOKEN into its own tokenProvider, so
+    // env-only callers still work; this test asserts that an EXPLICIT client
+    // wins over RELAYFILE_TOKEN.
+    const originalEnv = process.env.RELAYFILE_TOKEN;
+    process.env.RELAYFILE_TOKEN = "stale-from-env-mountenv";
+    try {
+      const getToken = vi.fn().mockResolvedValue("fresh-from-client");
+      const client = {
+        getEvents: vi.fn().mockResolvedValue({ events: [], nextCursor: null }),
+        recordHandlerError: vi.fn().mockResolvedValue(undefined),
+        getToken
+      } as unknown as OnWriteClient;
+      const sockets: MockWebSocket[] = [];
+
+      onWrite("/notion/pages/calls/*/transcript", () => undefined, {
+        client,
+        workspaceId: "ws_acme",
+        // NB: NO `token` option passed; RELAYFILE_TOKEN must NOT shadow auto-derive.
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(getToken).toHaveBeenCalled();
+      expect(sockets).toHaveLength(1);
+      expect(sockets[0]!.url).toContain("token=fresh-from-client");
+      expect(sockets[0]!.url).not.toContain("stale-from-env-mountenv");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.RELAYFILE_TOKEN;
+      } else {
+        process.env.RELAYFILE_TOKEN = originalEnv;
+      }
+    }
+  });
+
   it("accepts a function-form token option and re-invokes it on reconnect", async () => {
     // Production callers should pass a factory rather than a literal so the
     // token can rotate without restarting the dispatcher. The factory must

--- a/packages/sdk/typescript/src/onWrite.ts
+++ b/packages/sdk/typescript/src/onWrite.ts
@@ -209,15 +209,31 @@ class OnWriteDispatcher {
 
     // Token resolution order:
     //  1. options.token (literal or factory) — back-compat for callers that
-    //     mint their own auth.
-    //  2. RELAYFILE_TOKEN env var.
-    //  3. fall through to undefined → RelayFileSync auto-derives from
-    //     `client.getToken()` (the recommended path; same JWT as REST).
-    // (Bug 1 fix: previously, omitting `token` here passed `undefined` and
-    // the WS handshake silently failed with no auth, dropping us into
-    // backwards-walking polling forever.)
-    const token: RelayFileSyncTokenProvider | undefined =
-      options.token ?? readEnv("RELAYFILE_TOKEN") ?? undefined;
+    //     mint their own auth out-of-band.
+    //  2. fall through to undefined → RelayFileSync auto-derives from
+    //     `client.getToken()` on every (re)connect. This is the recommended
+    //     path: it is the same JWT the REST surface is using AND it is
+    //     re-resolved on every reconnect, so an expired/rotated token gets
+    //     refreshed automatically by whatever provider the client wraps
+    //     (e.g. WorkspaceHandle's getOrRefreshToken).
+    //
+    // Bug 5: previously this fell through to a `readEnv("RELAYFILE_TOKEN")`
+    // literal when the caller omitted `options.token`. That env value is
+    // captured once at workspace-join time (e.g. by
+    // `WorkspaceHandle.mountEnv()`) and never refreshed, so it expires
+    // ~1 hour later and the WS upgrade then fails with an auth error
+    // (visible only as a JS-layer "ws error" with no successor close,
+    // leaving the dispatcher stalled forever). The env literal also
+    // shadowed the auto-derive fix from PR #96 whenever a caller happened
+    // to have RELAYFILE_TOKEN set in their environment, which is the
+    // common case for any workspace started via mountEnv. Auto-derive must
+    // win over the env literal whenever a client is available.
+    //
+    // The default-client path (constructed by `getDefaultClient()` when
+    // `options.client` is omitted) already wires RELAYFILE_TOKEN into the
+    // client's tokenProvider, so callers that depend on the env-only flow
+    // continue to work — `client.getToken()` returns the env value.
+    const token: RelayFileSyncTokenProvider | undefined = options.token;
 
     this.sync = RelayFileSync.connect({
       client: this.client,

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -523,6 +523,83 @@ describe("RelayFileSync", () => {
     }
   });
 
+  it("forces recovery when a ws error fires with no successor close", async () => {
+    // Bug A (cortical-demo): some WebSocket implementations — notably Node's
+    // built-in WebSocket on auth-rejected upgrades, and proxies that abruptly
+    // RST after the handshake — emit `error` and then never deliver the
+    // matching `close`. Pre-fix, the dispatcher would emit the error and then
+    // sit idle forever (no reconnect, no polling). The error handler now arms
+    // a short grace timer; if no close arrives, it forces the same recovery
+    // path the close handler would have taken.
+    const sockets: MockWebSocket[] = [];
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+      webSocketFactory: (url) => {
+        const socket = new MockWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      }
+    });
+
+    const errors: unknown[] = [];
+    sync.on("error", (err) => errors.push(err));
+    sync.start();
+    expect(sockets).toHaveLength(1);
+
+    sockets[0]!.emit("open", {});
+    // Emit error WITHOUT a follow-up close — the failure mode the bug
+    // report reproduces. The grace window is 250ms so wait a touch longer.
+    sockets[0]!.emit("error", { type: "error" });
+    expect(errors).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    // After the grace window expires the SDK must have torn down socket[0]
+    // and opened a replacement (or, if reconnect were disabled, dropped to
+    // polling). With reconnect enabled the assertion is "second socket
+    // exists" — i.e. recovery happened.
+    expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+    await sync.stop();
+  });
+
+  it("does NOT double-recover when a normal close follows the ws error", async () => {
+    // Companion to the above: when the error IS followed by a close (the
+    // well-behaved path), the close handler must clear the grace timer so
+    // we end up with a single replacement socket, not two.
+    const sockets: MockWebSocket[] = [];
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+      webSocketFactory: (url) => {
+        const socket = new MockWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      }
+    });
+
+    sync.start();
+    sockets[0]!.emit("open", {});
+    sockets[0]!.emit("error", { type: "error" });
+    // Close arrives before the grace timer fires.
+    sockets[0]!.emit("close", { code: 1006, reason: "dropped" });
+
+    // Wait long enough that the grace timer (250ms) would have fired AND
+    // the reconnect backoff (5ms) has already produced socket[1].
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Exactly one replacement, not two — the grace timer was cleared.
+    expect(sockets).toHaveLength(2);
+
+    await sync.stop();
+  });
+
   it("reconnects after an unexpected close", async () => {
     const sockets: MockWebSocket[] = [];
     const sync = new RelayFileSync({

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -566,6 +566,48 @@ describe("RelayFileSync", () => {
     await sync.stop();
   });
 
+  it("falls back to polling when the ws errors before reaching OPEN", async () => {
+    // CodeRabbit feedback on PR #99: a socket that errors during the
+    // upgrade handshake (auth rejected, proxy RST, server cold start
+    // returning 502) should NOT trigger an infinite WS reconnect loop —
+    // the same handshake will fail on every retry. Drop into polling
+    // instead so the caller still gets events and the underlying error
+    // surfaces via onPollingFallback.
+    const sockets: MockWebSocket[] = [];
+    const fallback = vi.fn();
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      pollIntervalMs: 5,
+      reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+      onPollingFallback: fallback,
+      webSocketFactory: (url) => {
+        const socket = new MockWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      }
+    });
+
+    sync.start();
+    expect(sockets).toHaveLength(1);
+
+    // Emit error WITHOUT a preceding open — handshake-stage failure.
+    sockets[0]!.emit("error", { type: "error" });
+    // Wait past the 250ms grace window.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    // Polling fallback fired with the pre-open reason — and crucially
+    // no second WS socket was opened (the loop would be pointless).
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "forced-polling-pre-open" })
+    );
+    expect(sockets).toHaveLength(1);
+
+    await sync.stop();
+  });
+
   it("does NOT double-recover when a normal close follows the ws error", async () => {
     // Companion to the above: when the error IS followed by a close (the
     // well-behaved path), the close handler must clear the grace timer so

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -262,6 +262,12 @@ export class RelayFileSync {
   // by the matching `close` (or by `stop()`); fires forceReconnect when
   // the OS layer fails to deliver a close after the error.
   private errorRecoveryTimer?: ReturnType<typeof setTimeout>;
+  // Tracks whether this.socket has reached the OPEN state. Reset every
+  // time we attach to a fresh socket; flipped true in the `open` handler.
+  // The error watchdog checks this so that a pre-open failure (auth reject,
+  // proxy RST during handshake, etc.) routes to polling rather than an
+  // infinite reconnect loop against a server that won't accept the WS.
+  private currentSocketHasOpened = false;
   // Tracks the last time *any* WebSocket frame was received (event, pong, or
   // otherwise). The watchdog uses this to detect silent socket death.
   private lastFrameAt = 0;
@@ -469,11 +475,13 @@ export class RelayFileSync {
     }
 
     this.socket = socket;
+    this.currentSocketHasOpened = false;
 
     socket.addEventListener("open", (event) => {
       if (this.socket !== socket || this.stopped) {
         return;
       }
+      this.currentSocketHasOpened = true;
       this.reconnectAttempts = 0;
       // Reset frame/ping bookkeeping for the freshly opened socket so the
       // watchdog has a clean baseline. lastPingSentAt=0 disables the pong
@@ -527,10 +535,20 @@ export class RelayFileSync {
         if (this.stopped || this.socket !== socket) {
           return;
         }
+        // If the socket never reached OPEN, this is a handshake-stage
+        // failure (auth rejection on upgrade, proxy RST, server cold
+        // start). Reconnecting in a tight loop just retries the same
+        // failing handshake. Drop straight into polling instead — that
+        // path tolerates 401/403/timeout and surfaces the error to the
+        // caller without burning the loop.
+        const preOpen = !this.currentSocketHasOpened;
         debugLog("ws error with no successor close — forcing recovery", {
-          workspaceId: this.workspaceId
+          workspaceId: this.workspaceId,
+          preOpen
         });
-        this.forceReconnect(socket, "ws-error-no-close");
+        this.forceReconnect(socket, preOpen ? "ws-error-pre-open" : "ws-error-no-close", {
+          preferPolling: preOpen
+        });
       }, ERROR_TO_CLOSE_GRACE_MS);
     });
 
@@ -790,7 +808,16 @@ export class RelayFileSync {
   // no-ops via the `this.socket !== socket` guards) and trigger the standard
   // reconnect path. Catches errors from `close()` because some socket
   // implementations throw when closing an already-broken connection.
-  private forceReconnect(socket: RelayFileSyncSocket, reason: string): void {
+  //
+  // `options.preferPolling` lets the caller force the polling fallback even
+  // when reconnect is enabled. Used by the error watchdog when the failed
+  // socket never reached OPEN (handshake-stage failure) — retrying the WS
+  // upgrade in a loop won't help when the server is rejecting at the upgrade.
+  private forceReconnect(
+    socket: RelayFileSyncSocket,
+    reason: string,
+    options?: { preferPolling?: boolean },
+  ): void {
     this.clearPingTimer();
     this.clearErrorRecoveryTimer();
     if (this.socket === socket) {
@@ -805,8 +832,11 @@ export class RelayFileSync {
       this.setState("closed");
       return;
     }
-    if (!this.reconnect.enabled) {
-      this.startPolling("forced-reconnect-no-retry", reason);
+    if (!this.reconnect.enabled || options?.preferPolling) {
+      this.startPolling(
+        options?.preferPolling ? "forced-polling-pre-open" : "forced-reconnect-no-retry",
+        reason,
+      );
       return;
     }
     this.scheduleReconnect();

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -106,6 +106,11 @@ const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
 // (the events API is itself capped at ~1000 per page), small enough to keep
 // memory bounded across long-lived processes.
 const POLLING_DEDUPE_CACHE_LIMIT = 2048;
+// How long we wait after a WS `error` for the matching `close` to arrive
+// before forcing a recovery. Some implementations (notably Node's built-in
+// WebSocket on auth-rejected upgrades) emit `error` with no successor
+// `close`; without this watchdog the dispatcher stalls indefinitely.
+const ERROR_TO_CLOSE_GRACE_MS = 250;
 
 function warnPollingFallback(reason: string, cause?: unknown): void {
   // Always-on warning (NOT gated by RELAYFILE_SDK_DEBUG) because silent
@@ -253,6 +258,10 @@ export class RelayFileSync {
   private pollingPromise?: Promise<void>;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private pingTimer?: ReturnType<typeof setInterval>;
+  // See ERROR_TO_CLOSE_GRACE_MS: armed in the WS `error` handler, cleared
+  // by the matching `close` (or by `stop()`); fires forceReconnect when
+  // the OS layer fails to deliver a close after the error.
+  private errorRecoveryTimer?: ReturnType<typeof setTimeout>;
   // Tracks the last time *any* WebSocket frame was received (event, pong, or
   // otherwise). The watchdog uses this to detect silent socket death.
   private lastFrameAt = 0;
@@ -346,6 +355,7 @@ export class RelayFileSync {
     this.stopped = true;
     this.clearReconnectTimer();
     this.clearPingTimer();
+    this.clearErrorRecoveryTimer();
     const socket = this.socket;
     this.socket = undefined;
     if (socket) {
@@ -492,6 +502,36 @@ export class RelayFileSync {
       }
       debugLog("ws error", event);
       this.emit("error", normalizeError(event) as Error | Event);
+      // Per WHATWG, an `error` should be followed by a `close` and the
+      // close handler is the one that schedules reconnect / starts polling.
+      // In practice though, some WebSocket implementations (notably Node's
+      // built-in/undici WebSocket on auth-rejected upgrades, and some
+      // proxies that abruptly RST after the upgrade) deliver `error` with
+      // no successor `close`. The dispatcher would then sit silent forever
+      // — exactly the failure mode in the cortical-demo bug report (WS
+      // error fires, no close, no reconnect, no polling fallback).
+      //
+      // To recover, we arm a short grace timer here. If the close handler
+      // for THIS socket runs before it fires (the well-behaved path), it
+      // clears the timer. Otherwise the timer fires, sees the socket is
+      // still current, and forces the same recovery path the close handler
+      // would have taken (reconnect or polling). The grace window is
+      // intentionally short — by the time `error` has fired, the socket
+      // is already known-bad; we are only giving the OS layer a beat to
+      // deliver its close.
+      if (this.errorRecoveryTimer) {
+        return;
+      }
+      this.errorRecoveryTimer = setTimeout(() => {
+        this.errorRecoveryTimer = undefined;
+        if (this.stopped || this.socket !== socket) {
+          return;
+        }
+        debugLog("ws error with no successor close — forcing recovery", {
+          workspaceId: this.workspaceId
+        });
+        this.forceReconnect(socket, "ws-error-no-close");
+      }, ERROR_TO_CLOSE_GRACE_MS);
     });
 
     socket.addEventListener("close", (event) => {
@@ -512,6 +552,7 @@ export class RelayFileSync {
       }
       this.socket = undefined;
       this.clearPingTimer();
+      this.clearErrorRecoveryTimer();
       debugLog("ws close", { code: event?.code, reason: event?.reason, stopped: this.stopped });
       this.emit("close", event);
       if (this.stopped) {
@@ -751,6 +792,7 @@ export class RelayFileSync {
   // implementations throw when closing an already-broken connection.
   private forceReconnect(socket: RelayFileSyncSocket, reason: string): void {
     this.clearPingTimer();
+    this.clearErrorRecoveryTimer();
     if (this.socket === socket) {
       this.socket = undefined;
     }
@@ -835,6 +877,13 @@ export class RelayFileSync {
     if (this.pingTimer) {
       clearInterval(this.pingTimer);
       this.pingTimer = undefined;
+    }
+  }
+
+  private clearErrorRecoveryTimer(): void {
+    if (this.errorRecoveryTimer) {
+      clearTimeout(this.errorRecoveryTimer);
+      this.errorRecoveryTimer = undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Two related bugs in the `onWrite` flow surfaced against `@relayfile/sdk@0.6.12` while running the cortical-demo on Node 22.22.1. Both leave the dispatcher silently stalled (one WS error, then nothing) instead of streaming events.

### Bug A — auto-derive shadowed by stale `RELAYFILE_TOKEN` env

`onWrite.ts` resolved the WS token as `options.token ?? readEnv(\"RELAYFILE_TOKEN\") ?? undefined`. Any caller that joined a workspace via `WorkspaceHandle.mountEnv()` ends up with `RELAYFILE_TOKEN` set in their env to the JWT captured at join-time — and `mountEnv()` never refreshes it. So the env literal would silently shadow the auto-derive fix from PR #96, and ~1 hour after workspace-join the WS upgrade started failing with an auth error.

The fix: when the caller omits `options.token`, fall through to `undefined` and let `RelayFileSync` auto-derive on every (re)connect via `client.getToken()`. The default-client path (when `options.client` is omitted) still works because `getDefaultClient()` itself wires `RELAYFILE_TOKEN` into the client's `tokenProvider`.

The cortical-demo workaround — explicitly passing `token: () => workspace.client().tokenProvider()` — was working precisely because it bypassed the env shadow and let `getOrRefreshToken()` run on every connect. After this PR, that workaround is no longer required.

### Bug B — WS error with no successor close

Some WebSocket implementations (notably Node's built-in WebSocket on auth-rejected upgrades, and proxies that RST after the upgrade handshake) deliver `error` and never the matching `close`. The close handler was the only path that scheduled reconnect / started polling, so the dispatcher emitted one error and then sat silent forever — the exact symptom the cortical-demo reported.

The fix arms a short (250ms) grace timer in the WS `error` handler. If a `close` arrives in time (the well-behaved path), the close handler clears it. Otherwise the timer fires, sees the socket is still current, and forces the same recovery path the close handler would have taken (`forceReconnect` → `scheduleReconnect` or `startPolling` if reconnect is disabled). Polling fallback now also engages reliably under this failure mode, addressing the secondary symptom from the bug report.

### Relationship to PR #98

PR #98 (ErrorEvent polyfill) is also in `sync.ts` and is independent of these changes. The two can be rebased in either order — this PR does not touch `normalizeError`.

## Test plan

- [x] `npx vitest run` in `packages/sdk/typescript` — 112/112 pass (added 3 new tests: env-shadowing, error-no-close recovery, error-followed-by-close de-dupe)
- [x] `tsc` clean
- [ ] Re-run cortical-demo `scripts/orchestrator.ts` with the WS-token workaround removed (i.e. omit `token` from the `onWrite` options) and confirm live events stream after a Notion edit
- [ ] Confirm a forced auth failure (e.g. expired JWT) now logs the polling-fallback warn within ~250ms instead of stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)