### PR TITLE
feat(sdk): add agentInviteScoped() for true per-invite scope downscoping

### DIFF
--- a/packages/sdk/typescript/README.md
+++ b/packages/sdk/typescript/README.md
@@ -40,12 +40,17 @@ const mountEnv = workspace.mountEnv({
   remotePath: '/notion',
 })
 
-// Secret invite payload for a trusted co-worker agent
-const invite = workspace.agentInvite({
-  agentName: 'review-agent',
-  scopes: ['fs:read', 'relaycast:write'],
+// Secret invite payload for a trusted co-worker agent — same scopes as this
+// workspace's token (no per-invite downscoping).
+const invite = workspace.agentInvite({ agentName: 'review-agent' })
+
+// To grant a strictly narrower set of scopes, mint a fresh JWT via the cloud
+// API. The cloud rejects requests that exceed the calling token's grant.
+const scopedInvite = await workspace.agentInviteScoped({
+  agentName: 'notion-summarizer',
+  scopes: ['relayfile:fs:read:/notion/pages/*'],
 })
-// Never log invite — it contains credential material
+// Never log invites — they contain credential material
 ```
 
 For the full end-to-end journey, failure modes, and acceptance criteria see

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -31,6 +31,7 @@ export {
   WORKSPACE_INTEGRATION_PROVIDERS,
   type AgentWorkspaceInvite,
   type AgentWorkspaceInviteOptions,
+  type AgentWorkspaceScopedInviteOptions,
   type ConnectIntegrationOptions,
   type ConnectIntegrationResult,
   type CreateWorkspaceOptions,

--- a/packages/sdk/typescript/src/setup-types.ts
+++ b/packages/sdk/typescript/src/setup-types.ts
@@ -89,8 +89,26 @@ export type WorkspaceMountEnv = Record<string, string>
 
 export interface AgentWorkspaceInviteOptions {
   agentName?: string
-  scopes?: string[]
   relaycastBaseUrl?: string
+  includeRelayfileToken?: boolean
+}
+
+export interface AgentWorkspaceScopedInviteOptions {
+  /**
+   * Scopes to grant on the minted JWT. Must be a subset of the calling
+   * workspace token's grant; the cloud API rejects requests that exceed it.
+   * If omitted, falls back to the join-time scopes (effectively the same as
+   * the sync `agentInvite()`).
+   */
+  scopes?: string[]
+  agentName?: string
+  permissions?: WorkspacePermissions
+  relaycastBaseUrl?: string
+  /**
+   * Set false to omit `relayfileToken` from the returned invite — useful
+   * when the receiving agent already has a token and only needs the
+   * connection metadata.
+   */
   includeRelayfileToken?: boolean
 }
 

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -658,6 +658,13 @@ describe("RelayfileSetup", () => {
       agentName: "review-agent",
       scopes: ["relayfile:fs:read:/notion/pages/*"]
     })
+    // Authorization header carries the calling workspace JWT so the cloud
+    // can verify requestedScopes ⊆ caller's grant. Without this the cloud
+    // can't enforce subset semantics and a permissive endpoint would mint
+    // a silently-wide token.
+    expect(readRequestHeaders(fetchMock, 1).Authorization).toBe(
+      "Bearer rf_jwt_lead"
+    )
     expect(invite).toEqual({
       workspaceId: "ws_123",
       cloudApiUrl: "https://staging.agentrelay.com/cloud",
@@ -668,6 +675,30 @@ describe("RelayfileSetup", () => {
       scopes: ["relayfile:fs:read:/notion/pages/*"],
       relayfileToken: "rf_jwt_scoped"
     })
+  })
+
+  it("agentInviteScoped picks up a fresher relaycastBaseUrl from the join response", async () => {
+    queueFetch(
+      makeJoinResponse("rf_jwt_lead", {
+        relaycastBaseUrl: "https://relaycast.old.test"
+      }),
+      makeJoinResponse("rf_jwt_scoped", {
+        relaycastBaseUrl: "https://relaycast.new.test"
+      })
+    )
+
+    const setup = new RelayfileSetup()
+    const handle = await setup.joinWorkspace("ws_123", {
+      agentName: "lead-agent",
+      scopes: ["fs:read", "fs:write"]
+    })
+
+    const invite = await handle.agentInviteScoped({
+      agentName: "review-agent",
+      scopes: ["fs:read"]
+    })
+
+    expect(invite.relaycastBaseUrl).toBe("https://relaycast.new.test")
   })
 
   it("agentInviteScoped surfaces cloud-side scope rejection", async () => {

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -626,4 +626,92 @@ describe("RelayfileSetup", () => {
       "relaycast:write"
     ])
   })
+
+  it("agentInviteScoped mints a fresh JWT scoped to the requested subset", async () => {
+    const fetchMock = queueFetch(
+      makeJoinResponse("rf_jwt_lead", {
+        relaycastBaseUrl: "https://relaycast.staging.test"
+      }),
+      makeJoinResponse("rf_jwt_scoped", {
+        relaycastBaseUrl: "https://relaycast.staging.test"
+      })
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/cloud"
+    })
+    const handle = await setup.joinWorkspace("ws_123", {
+      agentName: "lead-agent",
+      scopes: ["fs:read", "fs:write", "relaycast:write"]
+    })
+
+    const invite = await handle.agentInviteScoped({
+      agentName: "review-agent",
+      scopes: ["relayfile:fs:read:/notion/pages/*"]
+    })
+
+    // Second fetch is the scoped join request.
+    expect(readRequestUrl(fetchMock, 1)).toBe(
+      "https://staging.agentrelay.com/cloud/api/v1/workspaces/ws_123/join"
+    )
+    expect(readRequestBody(fetchMock, 1)).toEqual({
+      agentName: "review-agent",
+      scopes: ["relayfile:fs:read:/notion/pages/*"]
+    })
+    expect(invite).toEqual({
+      workspaceId: "ws_123",
+      cloudApiUrl: "https://staging.agentrelay.com/cloud",
+      relayfileUrl: "https://relayfile.test",
+      relaycastApiKey: "rc_test",
+      relaycastBaseUrl: "https://relaycast.staging.test",
+      agentName: "review-agent",
+      scopes: ["relayfile:fs:read:/notion/pages/*"],
+      relayfileToken: "rf_jwt_scoped"
+    })
+  })
+
+  it("agentInviteScoped surfaces cloud-side scope rejection", async () => {
+    queueFetch(
+      makeJoinResponse("rf_jwt_lead"),
+      jsonResponse(
+        { error: "insufficient_scope", code: "insufficient_scope" },
+        { status: 403 }
+      )
+    )
+
+    const setup = new RelayfileSetup()
+    const handle = await setup.joinWorkspace("ws_123", {
+      agentName: "lead-agent",
+      scopes: ["fs:read"]
+    })
+
+    await expect(
+      handle.agentInviteScoped({
+        agentName: "review-agent",
+        scopes: ["fs:admin"]
+      })
+    ).rejects.toThrow()
+  })
+
+  it("agentInviteScoped omits relayfileToken when includeRelayfileToken is false", async () => {
+    queueFetch(
+      makeJoinResponse("rf_jwt_lead"),
+      makeJoinResponse("rf_jwt_scoped")
+    )
+
+    const setup = new RelayfileSetup()
+    const handle = await setup.joinWorkspace("ws_123", {
+      agentName: "lead-agent",
+      scopes: ["fs:read", "fs:write"]
+    })
+
+    const invite = await handle.agentInviteScoped({
+      agentName: "review-agent",
+      scopes: ["fs:read"],
+      includeRelayfileToken: false
+    })
+
+    expect("relayfileToken" in invite).toBe(false)
+    expect(invite.scopes).toEqual(["fs:read"])
+  })
 })

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -231,7 +231,8 @@ export class RelayfileSetup {
 
   async joinWorkspaceResponse(
     workspaceId: string,
-    options: NormalizedJoinWorkspaceOptions
+    options: NormalizedJoinWorkspaceOptions,
+    overrides: { tokenProvider?: AccessTokenProvider } = {}
   ): Promise<ValidatedJoinWorkspaceResponse> {
     return validateJoinWorkspaceResponse(
       await this.requestJson({
@@ -242,7 +243,8 @@ export class RelayfileSetup {
           agentName: options.agentName,
           scopes: [...options.scopes],
           permissions: clonePermissions(options.permissions)
-        })
+        }),
+        tokenProvider: overrides.tokenProvider
       })
     )
   }
@@ -577,9 +579,6 @@ export class WorkspaceHandle {
   async agentInviteScoped(
     options: AgentWorkspaceScopedInviteOptions = {}
   ): Promise<AgentWorkspaceInvite> {
-    const relaycastBaseUrl = this.resolveRelaycastBaseUrl(
-      options.relaycastBaseUrl
-    )
     const requestedScopes =
       options.scopes && options.scopes.length > 0
         ? [...options.scopes]
@@ -587,16 +586,28 @@ export class WorkspaceHandle {
     const agentName = options.agentName ?? this._joinOptions.agentName
     const permissions = options.permissions ?? this._joinOptions.permissions
 
-    // Mint a per-invite JWT with the requested scopes. The cloud API enforces
-    // that requested scopes ⊆ caller's grant; an over-broad request is
-    // rejected at this boundary, not surfaced as a silently-wide token.
+    // Authenticate the join with this handle's workspace JWT. Without it,
+    // the cloud cannot verify that requestedScopes ⊆ caller's grant, and
+    // anonymous (or permissive) endpoints would silently mint a wide token —
+    // exactly the failure this method is designed to prevent. The setup-
+    // level accessToken (used for createWorkspace/joinWorkspace at the
+    // workspace-bootstrap layer) is the wrong identity here; we want the
+    // workspace JWT itself to be the parent the cloud downscopes from.
     const joinResponse = await this._setup.joinWorkspaceResponse(
       this.workspaceId,
       {
         agentName,
         scopes: requestedScopes,
         permissions
-      }
+      },
+      { tokenProvider: async () => this.getOrRefreshToken() }
+    )
+
+    // Prefer a relaycastBaseUrl returned by the cloud over the cached one —
+    // the cloud is authoritative if it shipped a fresher value with the
+    // join response.
+    const relaycastBaseUrl = this.resolveRelaycastBaseUrl(
+      options.relaycastBaseUrl ?? joinResponse.relaycastBaseUrl
     )
 
     return compactObject({

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -22,6 +22,7 @@ import {
   WORKSPACE_INTEGRATION_PROVIDERS,
   type AgentWorkspaceInvite,
   type AgentWorkspaceInviteOptions,
+  type AgentWorkspaceScopedInviteOptions,
   type ConnectIntegrationOptions,
   type ConnectIntegrationResult,
   type CreateWorkspaceOptions,
@@ -527,6 +528,13 @@ export class WorkspaceHandle {
     })
   }
 
+  /**
+   * Build an invite that hands a peer agent the calling workspace's existing
+   * JWT and metadata. The invite carries the SAME token this handle holds,
+   * with the SAME scopes — there is no per-invite downscoping. Use
+   * {@link agentInviteScoped} when the receiver should have a strictly
+   * narrower set of scopes than this workspace.
+   */
   agentInvite(options: AgentWorkspaceInviteOptions = {}): AgentWorkspaceInvite {
     const relaycastBaseUrl = this.resolveRelaycastBaseUrl(
       options.relaycastBaseUrl
@@ -539,12 +547,71 @@ export class WorkspaceHandle {
       relaycastApiKey: this.info.relaycastApiKey,
       relaycastBaseUrl,
       agentName: options.agentName ?? this._joinOptions.agentName,
-      scopes:
-        options.scopes && options.scopes.length > 0
-          ? [...options.scopes]
-          : [...this._joinOptions.scopes],
+      scopes: [...this._joinOptions.scopes],
       relayfileToken:
         options.includeRelayfileToken === false ? undefined : this.getToken(),
+      createdAt: this.info.createdAt,
+      name: this.info.name
+    })
+  }
+
+  /**
+   * Mint a fresh, downscoped relayfile JWT for a peer agent and return an
+   * invite carrying that token. Round-trips through the cloud join endpoint
+   * (`POST /api/v1/workspaces/{id}/join`), which signs a new JWT whose
+   * `scopes` claim is the requested subset of this workspace's grant. The
+   * cloud API rejects requests that exceed the calling workspace's scopes.
+   *
+   * Prefer this over {@link agentInvite} whenever the receiver should not
+   * inherit the full workspace token's reach (e.g. one agent that only needs
+   * `relayfile:fs:read:/notion/pages/*`). The caller's token is unaffected;
+   * a separate JWT is issued for the invitee.
+   *
+   * @example
+   * const invite = await workspace.agentInviteScoped({
+   *   agentName: 'notion-summarizer',
+   *   scopes: ['relayfile:fs:read:/notion/pages/*'],
+   * })
+   * // invite.relayfileToken is a JWT with scopes=['relayfile:fs:read:/notion/pages/*']
+   */
+  async agentInviteScoped(
+    options: AgentWorkspaceScopedInviteOptions = {}
+  ): Promise<AgentWorkspaceInvite> {
+    const relaycastBaseUrl = this.resolveRelaycastBaseUrl(
+      options.relaycastBaseUrl
+    )
+    const requestedScopes =
+      options.scopes && options.scopes.length > 0
+        ? [...options.scopes]
+        : [...this._joinOptions.scopes]
+    const agentName = options.agentName ?? this._joinOptions.agentName
+    const permissions = options.permissions ?? this._joinOptions.permissions
+
+    // Mint a per-invite JWT with the requested scopes. The cloud API enforces
+    // that requested scopes ⊆ caller's grant; an over-broad request is
+    // rejected at this boundary, not surfaced as a silently-wide token.
+    const joinResponse = await this._setup.joinWorkspaceResponse(
+      this.workspaceId,
+      {
+        agentName,
+        scopes: requestedScopes,
+        permissions
+      }
+    )
+
+    return compactObject({
+      workspaceId: this.workspaceId,
+      cloudApiUrl: this._setup.getCloudApiUrl(),
+      relayfileUrl: joinResponse.relayfileUrl ?? this.info.relayfileUrl,
+      relaycastApiKey:
+        joinResponse.relaycastApiKey ?? this.info.relaycastApiKey,
+      relaycastBaseUrl,
+      agentName,
+      scopes: requestedScopes,
+      relayfileToken:
+        options.includeRelayfileToken === false
+          ? undefined
+          : joinResponse.token,
       createdAt: this.info.createdAt,
       name: this.info.name
     })


### PR DESCRIPTION
## Summary

- Remove `scopes` from `AgentWorkspaceInviteOptions`. The sync `agentInvite()` never honored it at the token layer.
- Add async `agentInviteScoped(options)` that round-trips through `POST /api/v1/workspaces/{id}/join` to mint a fresh JWT whose `scopes` claim is the requested subset.
- Tests cover URL/body, cloud-side rejection, and the `includeRelayfileToken=false` path.

## Why

Today's `agentInvite({ scopes })`:

```ts
agentInvite(options = {}) {
  return compactObject({
    ...
    scopes: options.scopes && options.scopes.length > 0
      ? [...options.scopes]
      : [...this._joinOptions.scopes],
    relayfileToken: options.includeRelayfileToken === false ? undefined : this.getToken(),
    ...
  });
}
```

`this.getToken()` is the calling workspace's full-grant JWT — regardless of what was passed in `scopes`. The `scopes` field in the returned invite was informational only. Anyone building "this agent should only see /notion/pages/*" on top of this was handing out a silently-wide token.

## API

```ts
// Same scopes as the calling workspace, no downscoping.
const peer = workspace.agentInvite({ agentName: 'review-agent' })

// Strictly narrower scopes. The cloud rejects requests that exceed the
// calling workspace's grant.
const summarizer = await workspace.agentInviteScoped({
  agentName: 'notion-summarizer',
  scopes: ['relayfile:fs:read:/notion/pages/*'],
})
```

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| `agentInvite()` (no scopes) | Returns this workspace's JWT, with `_joinOptions.scopes` echoed in `.scopes` | Same |
| `agentInvite({ scopes: [narrower] })` | Returns this workspace's JWT (silently wide), with the narrower scopes echoed in `.scopes` | TS error (option removed) |
| `agentInviteScoped({ scopes: [narrower] })` | n/a | Round-trip through cloud → fresh JWT with narrower scopes |
| `agentInviteScoped({ scopes: [wider] })` | n/a | Cloud rejects → SDK throws |

## Breaking change

`AgentWorkspaceInviteOptions.scopes` is removed. No active callers in this repo passed it (verified via grep across `packages/`, `docs/`, `scripts/`). Any external caller that did was getting silently-wrong behavior; switching them to `agentInviteScoped` is the correctness fix.

Recommend cutting this as a minor bump (`0.7.0`) given the type-level breakage and the deferred `relayfile@d6a9439` token-shadow fix that's also queued for release.

## Test plan

- [x] `npx vitest run src/setup.test.ts` — 23/23 green (3 new tests for `agentInviteScoped`: round-trip body/url, rejection, `includeRelayfileToken=false`)
- [x] `tsc --noEmit` clean
- [x] Verified no internal callers in this repo pass `scopes` to `agentInvite`
- [ ] After publish + integration with cortical-demo: verify a downscoped invite produces a JWT whose decoded payload has the expected `scopes` claim

## Companion to

- AgentWorkforce/relay#819 — relaycast-mcp probe-then-rotate root-cause fix
- AgentWorkforce/relay#820 — `applyWorkspaceEnv` workspace-id conflation fix
- AgentWorkforce/demos#1 — cortical-demo orchestrator drops the pre-mint workaround

## Out of scope

- Cutting `@relayfile/sdk > 0.6.12` to publish the stale-token-shadow fix (`d6a9439`) is a separate release task; this PR adds a feature on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)