### PR TITLE
Speed up local mount initialization

### DIFF
--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -113,36 +113,43 @@ Conflict and delete rules:
 ## Default Excludes
 
 By default, mounts skip directories and files that are usually large generated output
-or local caches:
+or local caches. These names match at any path depth:
 
 ```txt
 .git
 node_modules
 .npm-cache
-target
-.next
-dist
-build
-out
 __pycache__
 .pytest_cache
 .mypy_cache
 .ruff_cache
-.venv
-venv
-env
 .gradle
-coverage
 .nyc_output
 .turbo
 .cache
 .DS_Store
 ```
 
+These more generic names match only at the project root so source paths such as
+`src/build/` or `packages/env/` are still mounted:
+
+```txt
+target
+.next
+dist
+build
+out
+.venv
+venv
+env
+coverage
+```
+
 Pass `includeDefaultExcludeDirs: false` to opt out of the broad build/cache list.
 For safety, `.git` stays excluded unless you also pass `includeGit: true`.
-`excludeDirs` still appends additional names or root-relative prefixes to whichever
-default set is active.
+`excludeDirs` still appends to whichever default set is active; bare caller entries
+retain the historical any-depth behavior, while path-style entries are root-relative
+prefixes.
 
 ## Including `.git`
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -26,17 +26,12 @@ interface MountHandle {
 ```
 
 Behavior:
-- Copies writable regular files into the mount
+- Copies regular files into the mount
 - Applies ignore rules from `ignoredPatterns`
-- Hardlinks read-only matches when possible, falling back to a copied `0o444` file on cross-device or permission failures
+- Marks read-only matches as mode `0o444`
 - Excludes `.git`, `node_modules`, `.npm-cache`, and common build/cache output directories by default. Pass `includeGit: true` to opt the project's `.git` directory back in (see [Including `.git`](#including-git))
 - Writes `_MOUNT_README.md` and `.relayfile-local-mount` into the mount
 - Skips syncing `_MOUNT_README.md`, `.relayfile-local-mount`, ignored files, read-only files, and symlinks back to the source project
-
-Read-only patterns are a sync policy, not a security boundary. When a read-only file
-is hardlinked into the mount, the mount path and project path share an inode; normal
-writes to either path affect the same file. The mount does not `chmod` hardlinked
-read-only files because that would also change the project file's mode.
 
 ### `readAgentDotfiles(projectDir, options?)`
 
@@ -112,7 +107,7 @@ Conflict and delete rules:
 - only one side changed → propagate that change
 - one side deleted and the other unchanged since last sync → propagate the delete
 - one side deleted and the other changed since last sync → recreate the missing file from the changed side
-- readonly paths are ignored by sync-back; project-side edits still flow into the mount (through the shared hardlink when linked, or by overwriting and re-chmodding a copied fallback)
+- readonly paths never flow mount→project; project-side edits still flow into the mount (the mount copy is re-chmodded `0o444`)
 - `_MOUNT_README.md`, `.relayfile-local-mount`, ignored paths, and excluded directories never cross
 
 ## Default Excludes
@@ -189,9 +184,8 @@ coverage/
 
 ### `.agentreadonly`
 
-Files matching these patterns are hardlinked into the mount when the filesystem
-allows it, or copied into the mount as `0o444` when hardlinking is not available.
-They are skipped by sync-back.
+Files matching these patterns are copied into the mount, but made read-only.
+Changes to those files are not synced back.
 
 Example:
 
@@ -275,29 +269,23 @@ The implementation is intentionally conservative about `mountDir`:
 
 These checks help prevent accidental deletion of unrelated directories during mount recreation and cleanup.
 
-## Why not symlink everything?
+## Why copy instead of symlink?
 
-The mount is built by copying writable files and hardlinking read-only files when
-possible, rather than symlinking the source tree. Symlinks would break several of
-the package's guarantees:
+The mount is built by copying files rather than symlinking them. Symlinks would break several of the package's guarantees:
 
-1. **Writable files need containment.** A copy gives you a checkpoint: if the agent destroys files or writes garbage, the source is untouched until `syncBack()` filters and copies back.
-2. **The auto-sync conflict model assumes distinct writable files.** Rules like "both sides changed → mount wins" and "one side deleted → propagate" only make sense if the normal writable mount and source paths are separate bytes.
+1. **`.agentreadonly` can't be enforced.** Read-only is implemented by `chmod 0o444` on the mount copy. `chmod` follows symlinks, so applying it to a symlink would mark the *source* file read-only, flipping the project's permissions instead of restricting the agent's view.
+2. **The auto-sync conflict model assumes two distinct files.** Rules like "both sides changed → mount wins", "one side deleted → propagate", and "readonly paths never flow mount→project but project-side edits still flow into the mount" only make sense if mount and source are separate bytes. Through a symlink they're the same inode — there's no mount-side copy to re-chmod `0o444` after a project-side edit.
 3. **Editor save-via-rename breaks symlinks anyway.** Most editors save by writing a temp file and renaming it over the target, which replaces the symlink with a regular file and severs the link. A "live view" via symlinks isn't reliable in practice.
-4. **`.agentignore` hiding works fine with symlinks** (just don't link), but writable sync semantics still need copies.
+4. **Containment.** A copy gives you a checkpoint: if the agent destroys files or writes garbage, the source is untouched until `syncBack()` filters and copies back. With symlinks, every keystroke is live on the project.
+5. **`.agentignore` hiding works fine with symlinks** (just don't link), but the readonly and conflict semantics still need copies — so a hybrid would be more complex than just copying everything.
 
-Read-only hardlinks are the narrow exception: they avoid byte-copying files that
-the mount should not sync back. The implementation never `chmod`s those hardlinks,
-because mode bits are inode metadata and changing them would mutate the source
-file's permissions.
-
-Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; they are materialized as regular mount entries using the same copy-or-hardlink rules. Symlinks the agent creates inside the mount are skipped on sync-back.
+Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; the resolved bytes are copied. Symlinks the agent creates inside the mount are skipped on sync-back.
 
 ## Notes
 
 - Requires Node.js 18+
-- The current implementation materializes files into the mount rather than creating filesystem-level FUSE mounts
-- Source symlinks are only materialized when they resolve to regular files inside the source project
+- The current implementation copies files into the mount rather than creating filesystem-level FUSE mounts
+- Source symlinks are only copied when they resolve to regular files inside the source project
 
 ## License
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -26,12 +26,17 @@ interface MountHandle {
 ```
 
 Behavior:
-- Copies regular files into the mount
+- Copies writable regular files into the mount
 - Applies ignore rules from `ignoredPatterns`
-- Marks read-only matches as mode `0o444`
-- Excludes `.git`, `node_modules`, and `.npm-cache` by default. Pass `includeGit: true` to opt the project's `.git` directory back in (see [Including `.git`](#including-git))
+- Hardlinks read-only matches when possible, falling back to a copied `0o444` file on cross-device or permission failures
+- Excludes `.git`, `node_modules`, `.npm-cache`, and common build/cache output directories by default. Pass `includeGit: true` to opt the project's `.git` directory back in (see [Including `.git`](#including-git))
 - Writes `_MOUNT_README.md` and `.relayfile-local-mount` into the mount
 - Skips syncing `_MOUNT_README.md`, `.relayfile-local-mount`, ignored files, read-only files, and symlinks back to the source project
+
+Read-only patterns are a sync policy, not a security boundary. When a read-only file
+is hardlinked into the mount, the mount path and project path share an inode; normal
+writes to either path affect the same file. The mount does not `chmod` hardlinked
+read-only files because that would also change the project file's mode.
 
 ### `readAgentDotfiles(projectDir, options?)`
 
@@ -107,8 +112,42 @@ Conflict and delete rules:
 - only one side changed → propagate that change
 - one side deleted and the other unchanged since last sync → propagate the delete
 - one side deleted and the other changed since last sync → recreate the missing file from the changed side
-- readonly paths never flow mount→project; project-side edits still flow into the mount (the mount copy is re-chmodded `0o444`)
+- readonly paths are ignored by sync-back; project-side edits still flow into the mount (through the shared hardlink when linked, or by overwriting and re-chmodding a copied fallback)
 - `_MOUNT_README.md`, `.relayfile-local-mount`, ignored paths, and excluded directories never cross
+
+## Default Excludes
+
+By default, mounts skip directories and files that are usually large generated output
+or local caches:
+
+```txt
+.git
+node_modules
+.npm-cache
+target
+.next
+dist
+build
+out
+__pycache__
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+venv
+env
+.gradle
+coverage
+.nyc_output
+.turbo
+.cache
+.DS_Store
+```
+
+Pass `includeDefaultExcludeDirs: false` to opt out of the broad build/cache list.
+For safety, `.git` stays excluded unless you also pass `includeGit: true`.
+`excludeDirs` still appends additional names or root-relative prefixes to whichever
+default set is active.
 
 ## Including `.git`
 
@@ -150,8 +189,9 @@ coverage/
 
 ### `.agentreadonly`
 
-Files matching these patterns are copied into the mount, but made read-only.
-Changes to those files are not synced back.
+Files matching these patterns are hardlinked into the mount when the filesystem
+allows it, or copied into the mount as `0o444` when hardlinking is not available.
+They are skipped by sync-back.
 
 Example:
 
@@ -192,7 +232,7 @@ const result = await launchOnMount({
   mountDir,
   ignoredPatterns,
   readonlyPatterns,
-  excludeDirs: ['dist'],
+  excludeDirs: ['vendor-cache'],
   agentName: 'reviewer',
   onBeforeLaunch: async (dir) => {
     // Add extra instructions or scratch files inside the mount if needed.
@@ -235,23 +275,29 @@ The implementation is intentionally conservative about `mountDir`:
 
 These checks help prevent accidental deletion of unrelated directories during mount recreation and cleanup.
 
-## Why copy instead of symlink?
+## Why not symlink everything?
 
-The mount is built by copying files rather than symlinking them. Symlinks would break several of the package's guarantees:
+The mount is built by copying writable files and hardlinking read-only files when
+possible, rather than symlinking the source tree. Symlinks would break several of
+the package's guarantees:
 
-1. **`.agentreadonly` can't be enforced.** Read-only is implemented by `chmod 0o444` on the mount copy. `chmod` follows symlinks, so applying it to a symlink would mark the *source* file read-only, flipping the project's permissions instead of restricting the agent's view.
-2. **The auto-sync conflict model assumes two distinct files.** Rules like "both sides changed → mount wins", "one side deleted → propagate", and "readonly paths never flow mount→project but project-side edits still flow into the mount" only make sense if mount and source are separate bytes. Through a symlink they're the same inode — there's no mount-side copy to re-chmod `0o444` after a project-side edit.
+1. **Writable files need containment.** A copy gives you a checkpoint: if the agent destroys files or writes garbage, the source is untouched until `syncBack()` filters and copies back.
+2. **The auto-sync conflict model assumes distinct writable files.** Rules like "both sides changed → mount wins" and "one side deleted → propagate" only make sense if the normal writable mount and source paths are separate bytes.
 3. **Editor save-via-rename breaks symlinks anyway.** Most editors save by writing a temp file and renaming it over the target, which replaces the symlink with a regular file and severs the link. A "live view" via symlinks isn't reliable in practice.
-4. **Containment.** A copy gives you a checkpoint: if the agent destroys files or writes garbage, the source is untouched until `syncBack()` filters and copies back. With symlinks, every keystroke is live on the project.
-5. **`.agentignore` hiding works fine with symlinks** (just don't link), but the readonly and conflict semantics still need copies — so a hybrid would be more complex than just copying everything.
+4. **`.agentignore` hiding works fine with symlinks** (just don't link), but writable sync semantics still need copies.
 
-Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; the resolved bytes are copied. Symlinks the agent creates inside the mount are skipped on sync-back.
+Read-only hardlinks are the narrow exception: they avoid byte-copying files that
+the mount should not sync back. The implementation never `chmod`s those hardlinks,
+because mode bits are inode metadata and changing them would mutate the source
+file's permissions.
+
+Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; they are materialized as regular mount entries using the same copy-or-hardlink rules. Symlinks the agent creates inside the mount are skipped on sync-back.
 
 ## Notes
 
 - Requires Node.js 18+
-- The current implementation copies files into the mount rather than creating filesystem-level FUSE mounts
-- Source symlinks are only copied when they resolve to regular files inside the source project
+- The current implementation materializes files into the mount rather than creating filesystem-level FUSE mounts
+- Source symlinks are only materialized when they resolve to regular files inside the source project
 
 ## License
 

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -145,10 +146,9 @@ describe('startAutoSync', () => {
     const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
     await auto.ready();
     try {
-      // Replace the readonly hardlink with a mount-local file so the test can
-      // exercise no-sync-back filtering without mutating the source via the link.
+      // Bypass the 0o444 permission for the test.
       const mountFile = path.join(handle.mountDir, 'locked.txt');
-      rmSync(mountFile, { force: true });
+      chmodSync(mountFile, 0o644);
       writeFileSync(mountFile, 'tampered', 'utf8');
 
       // Give autosync time to notice and choose not to propagate.

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -146,9 +145,10 @@ describe('startAutoSync', () => {
     const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
     await auto.ready();
     try {
-      // Bypass the 0o444 permission for the test.
+      // Replace the readonly hardlink with a mount-local file so the test can
+      // exercise no-sync-back filtering without mutating the source via the link.
       const mountFile = path.join(handle.mountDir, 'locked.txt');
-      chmodSync(mountFile, 0o644);
+      rmSync(mountFile, { force: true });
       writeFileSync(mountFile, 'tampered', 'utf8');
 
       // Give autosync time to notice and choose not to propagate.

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -19,14 +19,17 @@ export interface AutoSyncContext {
   realProjectDir: string;
   isExcluded: (relPosix: string) => boolean;
   /**
-   * The exact set of normalized directory names/prefixes that drive
-   * `isExcluded` (i.e., {@link MountOptions.excludeDirs} merged with the
-   * library defaults). Used purely to hint `@parcel/watcher` which subtrees
-   * to skip subscribing to. The in-handler `isSyncCandidate` filter remains
-   * authoritative; this is just a perf hint that keeps the watcher from
-   * recursing into heavy trees like `node_modules` or `.npm-cache`.
+   * Normalized directory names that drive any-depth `isExcluded` matches.
+   * Used purely to hint `@parcel/watcher` which subtrees to skip subscribing
+   * to. The in-handler `isSyncCandidate` filter remains authoritative.
    */
-  excludedNames: readonly string[];
+  excludedAnyDepthNames: readonly string[];
+  /**
+   * Root-anchored excluded names/prefixes such as `build` or `packages/cache`.
+   * These are matched only from the watch root to avoid hiding legitimate
+   * nested source directories like `src/build`.
+   */
+  excludedRootPrefixes: readonly string[];
   /**
    * Directory-only ignore patterns (ending in `/`) must only match when the
    * path is a directory. Callers that know the path's type pass `isDirectory`;
@@ -244,22 +247,21 @@ function buildIgnoreGlobs(ctx: AutoSyncContext, watchRoot: string): string[] {
   // `isExcludedPath`'s semantics, so a watcher-suppressed event never differs
   // from what the in-handler filter would have rejected.
   //
-  //   - Bare directory names (e.g. `node_modules`) match at any depth, so
-  //     emit `**/<name>` plus `**/<name>/**`. picomatch turns both into
-  //     depth-agnostic regexes that catch the dir and its descendants.
-  //   - Path-style entries (e.g. `build/cache`) are root-anchored prefixes
+  //   - Any-depth names (e.g. `node_modules`) emit `**/<name>` plus
+  //     `**/<name>/**`. picomatch turns both into depth-agnostic regexes
+  //     that catch the dir and its descendants.
+  //   - Root prefixes (e.g. `build` or `build/cache`) are root-anchored
   //     in `isExcludedPath` — they only match `<root>/build/cache`, NOT
   //     `<root>/src/build/cache`. Emit absolute patterns rooted at the
   //     watch dir so the watcher hides the same set: a literal absolute
   //     path (which the wrapper routes to ignorePaths) plus an anchored
   //     descendant glob.
   const globs: string[] = [];
-  for (const name of ctx.excludedNames) {
-    if (name.includes('/')) {
-      globs.push(`${watchRoot}/${name}`, `${watchRoot}/${name}/**`);
-    } else {
-      globs.push(`**/${name}`, `**/${name}/**`);
-    }
+  for (const name of ctx.excludedAnyDepthNames) {
+    globs.push(`**/${name}`, `**/${name}/**`);
+  }
+  for (const prefix of ctx.excludedRootPrefixes) {
+    globs.push(`${watchRoot}/${prefix}`, `${watchRoot}/${prefix}/**`);
   }
   return globs;
 }

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -354,10 +354,9 @@ function reconcile(
  *   • Otherwise → propagate the delete.
  *
  * `readonly` and `noSyncBack` both forbid mount→project. The split exists so
- * copied fallback readonly entries (e.g. `.agentreadonly` matches) can still be
- * chmodded 0o444, while noSyncBack entries (e.g. `.git/**` with
- * `includeGit: true`) stay writable in the mount so tools can mutate them
- * locally.
+ * the chmod 0o444 only fires for true readonly entries (e.g. `.agentreadonly`
+ * matches), while noSyncBack entries (e.g. `.git/**` when `includeGit: true`)
+ * stay writable in the mount so tools can mutate them locally.
  */
 function syncOneFile(
   relPosix: string,
@@ -486,7 +485,7 @@ function doProjectToMount(
     updateState(state, relPosix, target, projectAbs);
     return false;
   }
-  // A copied fallback readonly file can have mode 0o444, which blocks
+  // The mount copy of a readonly file has mode 0o444, which blocks
   // copyFileSync from overwriting it. Temporarily restore write permission.
   if (existsSync(target)) {
     try { chmodSync(target, 0o644); } catch { /* best effort */ }

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -354,9 +354,10 @@ function reconcile(
  *   • Otherwise → propagate the delete.
  *
  * `readonly` and `noSyncBack` both forbid mount→project. The split exists so
- * the chmod 0o444 only fires for true readonly entries (e.g. `.agentreadonly`
- * matches), while noSyncBack entries (e.g. `.git/**` when `includeGit: true`)
- * stay writable in the mount so tools can mutate them locally.
+ * copied fallback readonly entries (e.g. `.agentreadonly` matches) can still be
+ * chmodded 0o444, while noSyncBack entries (e.g. `.git/**` with
+ * `includeGit: true`) stay writable in the mount so tools can mutate them
+ * locally.
  */
 function syncOneFile(
   relPosix: string,
@@ -485,7 +486,7 @@ function doProjectToMount(
     updateState(state, relPosix, target, projectAbs);
     return false;
   }
-  // The mount copy of a readonly file has mode 0o444, which blocks
+  // A copied fallback readonly file can have mode 0o444, which blocks
   // copyFileSync from overwriting it. Temporarily restore write permission.
   if (existsSync(target)) {
     try { chmodSync(target, 0o644); } catch { /* best effort */ }
@@ -653,4 +654,3 @@ function walk(
     }
   }
 }
-

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -13,10 +13,15 @@ export interface LaunchOnMountOptions {
   args: string[];
   /** Glob-style ignore patterns (files excluded entirely from the mount). */
   ignoredPatterns?: string[];
-  /** Glob-style readonly patterns (files copied with mode 0o444). */
+  /** Glob-style readonly patterns (files hardlinked when possible and skipped on sync-back). */
   readonlyPatterns?: string[];
   /** Extra directory names to exclude from the mount on top of defaults. */
   excludeDirs?: string[];
+  /**
+   * Include the built-in cache/build exclusion list. Defaults to true. `.git`
+   * remains excluded unless `includeGit` is true.
+   */
+  includeDefaultExcludeDirs?: boolean;
   /**
    * Include the project's `.git` directory inside the mount with one-way
    * project→mount sync. Defaults to false. See {@link MountOptions.includeGit}
@@ -73,6 +78,7 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
     excludeDirs: opts.excludeDirs ?? [],
     agentName: opts.agentName,
     includeGit: opts.includeGit,
+    includeDefaultExcludeDirs: opts.includeDefaultExcludeDirs,
   });
 
   let syncedCount = 0;

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -13,7 +13,7 @@ export interface LaunchOnMountOptions {
   args: string[];
   /** Glob-style ignore patterns (files excluded entirely from the mount). */
   ignoredPatterns?: string[];
-  /** Glob-style readonly patterns (files hardlinked when possible and skipped on sync-back). */
+  /** Glob-style readonly patterns (files copied with mode 0o444). */
   readonlyPatterns?: string[];
   /** Extra directory names to exclude from the mount on top of defaults. */
   excludeDirs?: string[];

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -36,7 +37,7 @@ describe('createMount', () => {
     try { rmSync(path.dirname(mountDir), { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
-  it('happy path: copies non-ignored files, hardlinks readonly files when possible, skips ignored', () => {
+  it('happy path: copies non-ignored files, chmods readonly to 0o444, skips ignored', () => {
     write(path.join(projectDir, 'src/code.ts'), 'code');
     write(path.join(projectDir, 'secrets/api-key.txt'), 'shhh');
     write(path.join(projectDir, 'docs/guide.md'), 'guide');
@@ -54,15 +55,14 @@ describe('createMount', () => {
     expect(existsSync(path.join(handle.mountDir, 'secrets/api-key.txt'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, 'secrets'))).toBe(false);
 
-    const sourceRo = statSync(path.join(projectDir, 'config.ro'));
-    const mountRo = statSync(path.join(handle.mountDir, 'config.ro'));
-    expect(mountRo.dev).toBe(sourceRo.dev);
-    expect(mountRo.ino).toBe(sourceRo.ino);
+    const roPath = path.join(handle.mountDir, 'config.ro');
+    const roMode = statSync(roPath).mode & 0o777;
+    expect(roMode).toBe(0o444);
+    expect(() => writeFileSync(roPath, 'should fail', 'utf8')).toThrow();
+    expect(readFileSync(path.join(projectDir, 'config.ro'), 'utf8')).toBe('frozen');
 
-    const sourceGuide = statSync(path.join(projectDir, 'docs/guide.md'));
-    const mountGuide = statSync(path.join(handle.mountDir, 'docs/guide.md'));
-    expect(mountGuide.dev).toBe(sourceGuide.dev);
-    expect(mountGuide.ino).toBe(sourceGuide.ino);
+    const guideMode = statSync(path.join(handle.mountDir, 'docs/guide.md')).mode & 0o777;
+    expect(guideMode).toBe(0o444);
 
     // Writable file retains something other than 0o444
     const writableMode = statSync(path.join(handle.mountDir, 'src/code.ts')).mode & 0o777;
@@ -226,10 +226,10 @@ describe('createMount', () => {
 
     // Modify writable file in mount
     writeFileSync(path.join(handle.mountDir, 'writable.txt'), 'changed', 'utf8');
-    // Replace the readonly hardlink with a mount-local file so the test can
-    // exercise syncBack filtering without mutating the source via the link.
+    // Modify "readonly" file directly (bypass chmod for test purposes)
+    // by writing it with write permissions first.
     const roPath = path.join(handle.mountDir, 'readonly.txt');
-    rmSync(roPath, { force: true });
+    chmodSync(roPath, 0o644);
     writeFileSync(roPath, 'tampered', 'utf8');
 
     // Add a net-new writable file in the mount

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -263,6 +263,35 @@ describe('createMount', () => {
     handle.cleanup();
   });
 
+  it('syncBack: skips files under default excluded paths', async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'original');
+
+    const handle = createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    write(path.join(handle.mountDir, 'src/code.ts'), 'changed');
+    write(path.join(handle.mountDir, 'dist/generated.js'), 'dist');
+    write(path.join(handle.mountDir, 'build/generated.js'), 'build');
+    write(path.join(handle.mountDir, 'node_modules/dep/index.js'), 'dep');
+    write(path.join(handle.mountDir, 'packages/web/node_modules/dep/index.js'), 'nested dep');
+    write(path.join(handle.mountDir, 'src/build/helper.ts'), 'source build');
+
+    const synced = await handle.syncBack();
+
+    expect(synced).toBe(2);
+    expect(readFileSync(path.join(projectDir, 'src/code.ts'), 'utf8')).toBe('changed');
+    expect(readFileSync(path.join(projectDir, 'src/build/helper.ts'), 'utf8')).toBe('source build');
+    expect(existsSync(path.join(projectDir, 'dist'))).toBe(false);
+    expect(existsSync(path.join(projectDir, 'build'))).toBe(false);
+    expect(existsSync(path.join(projectDir, 'node_modules'))).toBe(false);
+    expect(existsSync(path.join(projectDir, 'packages/web/node_modules'))).toBe(false);
+
+    handle.cleanup();
+  });
+
   it('syncBack: returns immediately when already aborted', async () => {
     write(path.join(projectDir, 'writable.txt'), 'original');
 

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -37,7 +36,7 @@ describe('createMount', () => {
     try { rmSync(path.dirname(mountDir), { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
-  it('happy path: copies non-ignored files, chmods readonly to 0o444, skips ignored', () => {
+  it('happy path: copies non-ignored files, hardlinks readonly files when possible, skips ignored', () => {
     write(path.join(projectDir, 'src/code.ts'), 'code');
     write(path.join(projectDir, 'secrets/api-key.txt'), 'shhh');
     write(path.join(projectDir, 'docs/guide.md'), 'guide');
@@ -55,11 +54,15 @@ describe('createMount', () => {
     expect(existsSync(path.join(handle.mountDir, 'secrets/api-key.txt'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, 'secrets'))).toBe(false);
 
-    const roMode = statSync(path.join(handle.mountDir, 'config.ro')).mode & 0o777;
-    expect(roMode).toBe(0o444);
+    const sourceRo = statSync(path.join(projectDir, 'config.ro'));
+    const mountRo = statSync(path.join(handle.mountDir, 'config.ro'));
+    expect(mountRo.dev).toBe(sourceRo.dev);
+    expect(mountRo.ino).toBe(sourceRo.ino);
 
-    const guideMode = statSync(path.join(handle.mountDir, 'docs/guide.md')).mode & 0o777;
-    expect(guideMode).toBe(0o444);
+    const sourceGuide = statSync(path.join(projectDir, 'docs/guide.md'));
+    const mountGuide = statSync(path.join(handle.mountDir, 'docs/guide.md'));
+    expect(mountGuide.dev).toBe(sourceGuide.dev);
+    expect(mountGuide.ino).toBe(sourceGuide.ino);
 
     // Writable file retains something other than 0o444
     const writableMode = statSync(path.join(handle.mountDir, 'src/code.ts')).mode & 0o777;
@@ -78,10 +81,28 @@ describe('createMount', () => {
     ).toThrow(/mountDir must be different from projectDir/);
   });
 
-  it('excludes .git, node_modules, and .npm-cache by default, but NOT .relay', () => {
+  it('excludes common cache and build output paths by default, but NOT .relay', () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref');
     write(path.join(projectDir, 'node_modules/dep/index.js'), '1');
     write(path.join(projectDir, '.npm-cache/_cacache/content-v2/sha512/aa/bb/blob'), 'cached');
+    write(path.join(projectDir, 'target/debug/app'), 'rust');
+    write(path.join(projectDir, '.next/cache/entry'), 'next');
+    write(path.join(projectDir, 'dist/bundle.js'), 'dist');
+    write(path.join(projectDir, 'build/output.js'), 'build');
+    write(path.join(projectDir, 'out/page.html'), 'out');
+    write(path.join(projectDir, '__pycache__/module.pyc'), 'python');
+    write(path.join(projectDir, '.pytest_cache/v/cache/nodeids'), 'pytest');
+    write(path.join(projectDir, '.mypy_cache/meta.json'), 'mypy');
+    write(path.join(projectDir, '.ruff_cache/CACHEDIR.TAG'), 'ruff');
+    write(path.join(projectDir, '.venv/bin/python'), 'venv');
+    write(path.join(projectDir, 'venv/bin/python'), 'venv');
+    write(path.join(projectDir, 'env/bin/python'), 'venv');
+    write(path.join(projectDir, '.gradle/caches/modules-2/files'), 'gradle');
+    write(path.join(projectDir, 'coverage/lcov.info'), 'coverage');
+    write(path.join(projectDir, '.nyc_output/out.json'), 'nyc');
+    write(path.join(projectDir, '.turbo/cache'), 'turbo');
+    write(path.join(projectDir, '.cache/tool/state'), 'cache');
+    write(path.join(projectDir, '.DS_Store'), 'metadata');
     write(path.join(projectDir, '.relay/state.json'), '{}');
     write(path.join(projectDir, 'keep.txt'), 'yes');
 
@@ -95,8 +116,47 @@ describe('createMount', () => {
     expect(existsSync(path.join(handle.mountDir, '.git'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, 'node_modules'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, '.npm-cache'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'target'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.next'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'dist'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'build'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'out'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '__pycache__'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.pytest_cache'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.mypy_cache'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.ruff_cache'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.venv'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'venv'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'env'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.gradle'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'coverage'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.nyc_output'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.turbo'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.cache'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, '.DS_Store'))).toBe(false);
     // Regression: .relay must NOT be excluded by default anymore.
     expect(existsSync(path.join(handle.mountDir, '.relay/state.json'))).toBe(true);
+
+    handle.cleanup();
+  });
+
+  it('can opt out of broad default excludes while keeping .git excluded by default', () => {
+    write(path.join(projectDir, '.git/HEAD'), 'ref');
+    write(path.join(projectDir, 'node_modules/dep/index.js'), '1');
+    write(path.join(projectDir, 'dist/bundle.js'), 'dist');
+    write(path.join(projectDir, '.cache/tool/state'), 'cache');
+
+    const handle = createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      includeDefaultExcludeDirs: false,
+    });
+
+    expect(existsSync(path.join(handle.mountDir, '.git'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'node_modules/dep/index.js'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'dist/bundle.js'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, '.cache/tool/state'))).toBe(true);
 
     handle.cleanup();
   });
@@ -166,10 +226,10 @@ describe('createMount', () => {
 
     // Modify writable file in mount
     writeFileSync(path.join(handle.mountDir, 'writable.txt'), 'changed', 'utf8');
-    // Modify "readonly" file directly (bypass chmod for test purposes)
-    // by writing it with write permissions first
+    // Replace the readonly hardlink with a mount-local file so the test can
+    // exercise syncBack filtering without mutating the source via the link.
     const roPath = path.join(handle.mountDir, 'readonly.txt');
-    chmodSync(roPath, 0o644);
+    rmSync(roPath, { force: true });
     writeFileSync(roPath, 'tampered', 'utf8');
 
     // Add a net-new writable file in the mount

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -84,6 +84,7 @@ describe('createMount', () => {
   it('excludes common cache and build output paths by default, but NOT .relay', () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref');
     write(path.join(projectDir, 'node_modules/dep/index.js'), '1');
+    write(path.join(projectDir, 'packages/web/node_modules/dep/index.js'), 'nested dep');
     write(path.join(projectDir, '.npm-cache/_cacache/content-v2/sha512/aa/bb/blob'), 'cached');
     write(path.join(projectDir, 'target/debug/app'), 'rust');
     write(path.join(projectDir, '.next/cache/entry'), 'next');
@@ -104,6 +105,11 @@ describe('createMount', () => {
     write(path.join(projectDir, '.cache/tool/state'), 'cache');
     write(path.join(projectDir, '.DS_Store'), 'metadata');
     write(path.join(projectDir, '.relay/state.json'), '{}');
+    write(path.join(projectDir, 'src/build/helper.ts'), 'nested build source');
+    write(path.join(projectDir, 'packages/env/config.ts'), 'nested env source');
+    write(path.join(projectDir, 'lib/out/formatter.ts'), 'nested out source');
+    write(path.join(projectDir, 'src/target/arm64.rs'), 'nested target source');
+    write(path.join(projectDir, 'test/coverage/reporter.ts'), 'nested coverage source');
     write(path.join(projectDir, 'keep.txt'), 'yes');
 
     const handle = createMount(projectDir, mountDir, {
@@ -115,6 +121,7 @@ describe('createMount', () => {
     expect(existsSync(path.join(handle.mountDir, 'keep.txt'))).toBe(true);
     expect(existsSync(path.join(handle.mountDir, '.git'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, 'node_modules'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'packages/web/node_modules'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, '.npm-cache'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, 'target'))).toBe(false);
     expect(existsSync(path.join(handle.mountDir, '.next'))).toBe(false);
@@ -136,6 +143,12 @@ describe('createMount', () => {
     expect(existsSync(path.join(handle.mountDir, '.DS_Store'))).toBe(false);
     // Regression: .relay must NOT be excluded by default anymore.
     expect(existsSync(path.join(handle.mountDir, '.relay/state.json'))).toBe(true);
+    // Generic build/cache names are root-level defaults, not any-depth matches.
+    expect(existsSync(path.join(handle.mountDir, 'src/build/helper.ts'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'packages/env/config.ts'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'lib/out/formatter.ts'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'src/target/arm64.rs'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'test/coverage/reporter.ts'))).toBe(true);
 
     handle.cleanup();
   });

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -192,7 +192,8 @@ export function createMount(
           realProjectDir,
           readonlyMatcher,
           ignoredMatcher,
-          noSyncBackMatcher
+          noSyncBackMatcher,
+          (relPosix) => isExcludedPath(relPosix, excludeRules)
         );
         synced += syncedForFile;
 
@@ -515,14 +516,16 @@ function syncMountedFileBack(
   projectDir: string,
   readonlyMatcher: Ignore,
   ignoredMatcher: Ignore,
-  noSyncBackMatcher: Ignore
+  noSyncBackMatcher: Ignore,
+  isExcluded: (relPosix: string) => boolean
 ): number {
   const relative = resolveSyncRelativePath(
     sourceFile,
     mountDir,
     readonlyMatcher,
     ignoredMatcher,
-    noSyncBackMatcher
+    noSyncBackMatcher,
+    isExcluded
   );
   if (!relative) return 0;
 
@@ -542,7 +545,8 @@ function resolveSyncRelativePath(
   mountDir: string,
   readonlyMatcher: Ignore,
   ignoredMatcher: Ignore,
-  noSyncBackMatcher: Ignore
+  noSyncBackMatcher: Ignore,
+  isExcluded: (relPosix: string) => boolean
 ): string | null {
   const relative = path.relative(mountDir, sourceFile);
   if (relative === '' || relative.startsWith('..')) return null;
@@ -550,6 +554,7 @@ function resolveSyncRelativePath(
   if (relativePosix === MOUNT_README_FILENAME) return null;
   if (relativePosix === MOUNT_MARKER_FILENAME) return null;
   if (
+    isExcluded(relativePosix) ||
     isPathMatched(relative, readonlyMatcher) ||
     isPathMatched(relative, ignoredMatcher) ||
     isPathMatched(relative, noSyncBackMatcher)

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -63,28 +63,36 @@ export interface MountHandle {
   cleanup(): void;
 }
 
-const DEFAULT_EXCLUDED_DIRS = [
+interface ExcludeRules {
+  anyDepthNames: Set<string>;
+  rootPrefixes: Set<string>;
+}
+
+const DEFAULT_ANY_DEPTH_EXCLUDES = [
   '.git',
   'node_modules',
   '.npm-cache',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.ruff_cache',
+  '.gradle',
+  '.nyc_output',
+  '.turbo',
+  '.cache',
+  '.DS_Store',
+];
+
+const DEFAULT_ROOT_EXCLUDES = [
   'target',
   '.next',
   'dist',
   'build',
   'out',
-  '__pycache__',
-  '.pytest_cache',
-  '.mypy_cache',
-  '.ruff_cache',
   '.venv',
   'venv',
   'env',
-  '.gradle',
   'coverage',
-  '.nyc_output',
-  '.turbo',
-  '.cache',
-  '.DS_Store',
 ];
 const MOUNT_README_FILENAME = '_MOUNT_README.md';
 const MOUNT_MARKER_FILENAME = '.relayfile-local-mount';
@@ -104,21 +112,11 @@ export function createMount(
   const readonlyMatcher = createPathMatcher(readonlyPatterns);
   const ignoredMatcher = createPathMatcher(ignoredPatterns);
   const includeDefaultExcludeDirs = options.includeDefaultExcludeDirs !== false;
-  // `.git` is in DEFAULT_EXCLUDED_DIRS so the mount stays small and git
+  // `.git` is in the default any-depth excludes so the mount stays small and git
   // operations don't accidentally cross-mutate the host repo. When the caller
   // opts in via `includeGit`, drop it from the defaults and instead route it
   // through the noSyncBack matcher below so it stays one-way.
-  const defaultExcludes = includeDefaultExcludeDirs
-    ? DEFAULT_EXCLUDED_DIRS
-    : ['.git'];
-  const activeDefaultExcludes = includeGit
-    ? defaultExcludes.filter((d) => d !== '.git')
-    : defaultExcludes;
-  const excludeSet = new Set(
-    [...activeDefaultExcludes, ...options.excludeDirs]
-      .map((entry) => normalizeRelativePosix(entry).replace(/^\/+|\/+$/g, ''))
-      .filter(Boolean)
-  );
+  const excludeRules = createExcludeRules(options.excludeDirs, includeGit, includeDefaultExcludeDirs);
   const noSyncBackPatterns = includeGit ? ['.git', '.git/**'] : [];
   const noSyncBackMatcher = createPathMatcher(noSyncBackPatterns);
 
@@ -145,7 +143,7 @@ export function createMount(
     resolvedProjectDir,
     realMountDir,
     realMountDir,
-    excludeSet,
+    excludeRules,
     readonlyMatcher,
     ignoredMatcher
   );
@@ -164,8 +162,9 @@ export function createMount(
   const autoSyncContext: AutoSyncContext = {
     realMountDir,
     realProjectDir: resolvedProjectDir,
-    isExcluded: (relPosix) => isExcludedPath(relPosix, excludeSet),
-    excludedNames: [...excludeSet],
+    isExcluded: (relPosix) => isExcludedPath(relPosix, excludeRules),
+    excludedAnyDepthNames: [...excludeRules.anyDepthNames],
+    excludedRootPrefixes: [...excludeRules.rootPrefixes],
     isIgnored: (relPosix, isDir) => isPathMatched(relPosix, ignoredMatcher, isDir),
     isReadonly: (relPosix) => isPathMatched(relPosix, readonlyMatcher),
     isNoSyncBack: (relPosix) => isPathMatched(relPosix, noSyncBackMatcher),
@@ -260,7 +259,7 @@ function walkProjectTree(
   currentDir: string,
   mountDir: string,
   currentMountDir: string,
-  excludeSet: Set<string>,
+  excludeRules: ExcludeRules,
   readonlyMatcher: Ignore,
   ignoredMatcher: Ignore
 ): void {
@@ -278,7 +277,7 @@ function walkProjectTree(
       continue;
     }
 
-    if (isExcludedPath(relativePath, excludeSet)) {
+    if (isExcludedPath(relativePath, excludeRules)) {
       continue;
     }
 
@@ -298,7 +297,7 @@ function walkProjectTree(
         absolutePath,
         mountDir,
         safeMountDir,
-        excludeSet,
+        excludeRules,
         readonlyMatcher,
         ignoredMatcher
       );
@@ -312,8 +311,7 @@ function walkProjectTree(
         absolutePath,
         mountPath,
         relativePath,
-        readonlyMatcher,
-        true
+        readonlyMatcher
       );
       continue;
     }
@@ -328,9 +326,7 @@ function walkProjectTree(
       absolutePath,
       mountPath,
       relativePath,
-      readonlyMatcher,
-      undefined,
-      true
+      readonlyMatcher
     );
   }
 }
@@ -341,8 +337,7 @@ function copySymlinkedFile(
   sourcePath: string,
   mountPath: string,
   relativePath: string,
-  readonlyMatcher: Ignore,
-  targetDirectoryReady = false
+  readonlyMatcher: Ignore
 ): void {
   let realSource: string;
   let resolvedStat: Stats;
@@ -364,8 +359,7 @@ function copySymlinkedFile(
     mountPath,
     relativePath,
     readonlyMatcher,
-    resolvedStat.mode,
-    targetDirectoryReady
+    resolvedStat.mode
   );
 }
 
@@ -376,10 +370,9 @@ function copyMountedFile(
   mountPath: string,
   relativePath: string,
   readonlyMatcher: Ignore,
-  sourceMode?: number,
-  targetDirectoryReady = false
+  sourceMode?: number
 ): void {
-  const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath, { targetDirectoryReady });
+  const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath);
   if (!safeMountPath) {
     return;
   }
@@ -445,6 +438,51 @@ function createPathMatcher(patterns: string[]): Ignore {
   return ignore().add(
     patterns.map((pattern) => pattern.trim()).filter((pattern) => pattern !== '' && !pattern.startsWith('#'))
   );
+}
+
+function createExcludeRules(
+  excludeDirs: string[],
+  includeGit: boolean,
+  includeDefaultExcludeDirs: boolean
+): ExcludeRules {
+  const anyDepthNames = new Set<string>();
+  const rootPrefixes = new Set<string>();
+
+  if (includeDefaultExcludeDirs) {
+    addExcludeEntries(anyDepthNames, rootPrefixes, DEFAULT_ANY_DEPTH_EXCLUDES, 'any-depth');
+    addExcludeEntries(anyDepthNames, rootPrefixes, DEFAULT_ROOT_EXCLUDES, 'root-prefix');
+  } else if (!includeGit) {
+    addExcludeEntries(anyDepthNames, rootPrefixes, ['.git'], 'any-depth');
+  }
+
+  if (includeGit) {
+    anyDepthNames.delete('.git');
+  }
+
+  // Preserve caller-supplied excludeDirs semantics: bare names match at any
+  // depth, while path-style entries are root-anchored prefixes.
+  addExcludeEntries(anyDepthNames, rootPrefixes, excludeDirs, 'legacy');
+
+  return { anyDepthNames, rootPrefixes };
+}
+
+function addExcludeEntries(
+  anyDepthNames: Set<string>,
+  rootPrefixes: Set<string>,
+  entries: string[],
+  mode: 'any-depth' | 'root-prefix' | 'legacy'
+): void {
+  for (const entry of entries) {
+    const normalized = normalizeRelativePosix(entry).replace(/^\/+|\/+$/g, '');
+    if (!normalized) {
+      continue;
+    }
+    if (mode === 'root-prefix' || (mode === 'legacy' && normalized.includes('/'))) {
+      rootPrefixes.add(normalized);
+    } else {
+      anyDepthNames.add(normalized);
+    }
+  }
 }
 
 function isPathMatched(relPath: string, matcher: Ignore, isDirectory = false): boolean {
@@ -549,13 +587,13 @@ function resolveVerifiedSyncTarget(projectDir: string, relativePath: string): st
   }
 }
 
-function isExcludedPath(relativePath: string, excludeSet: Set<string>): boolean {
+function isExcludedPath(relativePath: string, excludeRules: ExcludeRules): boolean {
   const normalized = normalizeRelativePosix(relativePath).replace(/^\/+|\/+$/g, '');
   if (!normalized) return false;
   const segments = normalized.split('/');
   return segments.some((segment, index) => {
     const prefix = segments.slice(0, index + 1).join('/');
-    return excludeSet.has(segment) || excludeSet.has(prefix);
+    return excludeRules.anyDepthNames.has(segment) || excludeRules.rootPrefixes.has(prefix);
   });
 }
 
@@ -565,23 +603,12 @@ function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
   return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
 }
 
-function resolveSafeCopyTarget(
-  rootPath: string,
-  candidatePath: string,
-  opts: { targetDirectoryReady?: boolean } = {}
-): string | null {
+function resolveSafeCopyTarget(rootPath: string, candidatePath: string): string | null {
   if (!isPathWithinRoot(candidatePath, rootPath)) {
     return null;
   }
 
   const parentPath = path.dirname(candidatePath);
-  if (opts.targetDirectoryReady) {
-    if (!isPathWithinRoot(parentPath, rootPath)) {
-      return null;
-    }
-    return path.join(parentPath, path.basename(candidatePath));
-  }
-
   const realParent = ensureDirectoryWithinRoot(rootPath, parentPath);
   if (!realParent) {
     return null;

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -2,7 +2,6 @@ import {
   chmodSync,
   copyFileSync,
   existsSync,
-  linkSync,
   lstatSync,
   mkdirSync,
   readdirSync,
@@ -390,14 +389,9 @@ function copyMountedFile(
     return;
   }
 
-  const readonly = isPathMatched(relativePath, readonlyMatcher);
-  if (readonly && hardlinkMountedFile(safeSourcePath, safeMountPath)) {
-    return;
-  }
-
   copyFileSync(safeSourcePath, safeMountPath);
 
-  if (readonly) {
+  if (isPathMatched(relativePath, readonlyMatcher)) {
     chmodSync(safeMountPath, 0o444);
     return;
   }
@@ -596,19 +590,6 @@ function resolveSafeCopyTarget(
   return path.join(realParent, path.basename(candidatePath));
 }
 
-function hardlinkMountedFile(sourcePath: string, targetPath: string): boolean {
-  try {
-    linkSync(sourcePath, targetPath);
-    return true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === 'EXDEV' || code === 'EPERM') {
-      return false;
-    }
-    throw err;
-  }
-}
-
 function resolveVerifiedFilePath(rootPath: string, candidatePath: string): string | null {
   try {
     const realCandidate = realpathSync(candidatePath);
@@ -648,7 +629,7 @@ function buildMountReadme(
 This workspace is a mounted mirror of the project directory.
 File access is controlled by project-local .agentignore and .agentreadonly.
 
-## Read-only files (sync-back disabled)
+## Read-only files (cannot be modified)
 ${readonlyList}
 
 ## Hidden files (not available in this workspace)
@@ -657,8 +638,8 @@ ${ignoredList}
 ## Writable files
 All other files can be read and modified freely.
 
+If you get "permission denied", the file is read-only.
 Changes to read-only files are not synced back to the source project.
-When these files are hardlinked, writes to the mount path affect the same inode as the project path.
 Edits or permission changes to read-only files inside this mount may be discarded or overwritten when the mount is recreated.
 ${agentLine}`;
 }

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   copyFileSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   readdirSync,
@@ -43,6 +44,12 @@ export interface MountOptions {
    *   are discarded with the mount on cleanup. Push to a remote to keep them.
    */
   includeGit?: boolean;
+  /**
+   * Include the built-in list of large cache/build output directories in
+   * the mount exclusion set. Default: true. The `.git` directory remains
+   * excluded unless `includeGit` is true, even when this is false.
+   */
+  includeDefaultExcludeDirs?: boolean;
 }
 
 export interface MountHandle {
@@ -57,7 +64,29 @@ export interface MountHandle {
   cleanup(): void;
 }
 
-const DEFAULT_EXCLUDED_DIRS = ['.git', 'node_modules', '.npm-cache'];
+const DEFAULT_EXCLUDED_DIRS = [
+  '.git',
+  'node_modules',
+  '.npm-cache',
+  'target',
+  '.next',
+  'dist',
+  'build',
+  'out',
+  '__pycache__',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.ruff_cache',
+  '.venv',
+  'venv',
+  'env',
+  '.gradle',
+  'coverage',
+  '.nyc_output',
+  '.turbo',
+  '.cache',
+  '.DS_Store',
+];
 const MOUNT_README_FILENAME = '_MOUNT_README.md';
 const MOUNT_MARKER_FILENAME = '.relayfile-local-mount';
 const MOUNT_MARKER_CONTENT =
@@ -75,15 +104,19 @@ export function createMount(
   const includeGit = options.includeGit === true;
   const readonlyMatcher = createPathMatcher(readonlyPatterns);
   const ignoredMatcher = createPathMatcher(ignoredPatterns);
+  const includeDefaultExcludeDirs = options.includeDefaultExcludeDirs !== false;
   // `.git` is in DEFAULT_EXCLUDED_DIRS so the mount stays small and git
   // operations don't accidentally cross-mutate the host repo. When the caller
   // opts in via `includeGit`, drop it from the defaults and instead route it
   // through the noSyncBack matcher below so it stays one-way.
-  const defaultExcludes = includeGit
-    ? DEFAULT_EXCLUDED_DIRS.filter((d) => d !== '.git')
-    : DEFAULT_EXCLUDED_DIRS;
+  const defaultExcludes = includeDefaultExcludeDirs
+    ? DEFAULT_EXCLUDED_DIRS
+    : ['.git'];
+  const activeDefaultExcludes = includeGit
+    ? defaultExcludes.filter((d) => d !== '.git')
+    : defaultExcludes;
   const excludeSet = new Set(
-    [...defaultExcludes, ...options.excludeDirs]
+    [...activeDefaultExcludes, ...options.excludeDirs]
       .map((entry) => normalizeRelativePosix(entry).replace(/^\/+|\/+$/g, ''))
       .filter(Boolean)
   );
@@ -111,6 +144,7 @@ export function createMount(
   walkProjectTree(
     resolvedProjectDir,
     resolvedProjectDir,
+    realMountDir,
     realMountDir,
     excludeSet,
     readonlyMatcher,
@@ -226,6 +260,7 @@ function walkProjectTree(
   projectDir: string,
   currentDir: string,
   mountDir: string,
+  currentMountDir: string,
   excludeSet: Set<string>,
   readonlyMatcher: Ignore,
   ignoredMatcher: Ignore
@@ -252,18 +287,35 @@ function walkProjectTree(
       continue;
     }
 
-    const mountPath = path.join(mountDir, relativePath);
+    const mountPath = path.join(currentMountDir, entry.name);
 
     if (entry.isDirectory()) {
-      if (!ensureDirectoryWithinRoot(mountDir, mountPath)) {
+      const safeMountDir = ensureDirectoryWithinRoot(mountDir, mountPath);
+      if (!safeMountDir) {
         continue;
       }
-      walkProjectTree(projectDir, absolutePath, mountDir, excludeSet, readonlyMatcher, ignoredMatcher);
+      walkProjectTree(
+        projectDir,
+        absolutePath,
+        mountDir,
+        safeMountDir,
+        excludeSet,
+        readonlyMatcher,
+        ignoredMatcher
+      );
       continue;
     }
 
     if (entry.isSymbolicLink()) {
-      copySymlinkedFile(projectDir, mountDir, absolutePath, mountPath, relativePath, readonlyMatcher);
+      copySymlinkedFile(
+        projectDir,
+        mountDir,
+        absolutePath,
+        mountPath,
+        relativePath,
+        readonlyMatcher,
+        true
+      );
       continue;
     }
 
@@ -271,7 +323,16 @@ function walkProjectTree(
       continue;
     }
 
-    copyMountedFile(projectDir, mountDir, absolutePath, mountPath, relativePath, readonlyMatcher);
+    copyMountedFile(
+      projectDir,
+      mountDir,
+      absolutePath,
+      mountPath,
+      relativePath,
+      readonlyMatcher,
+      undefined,
+      true
+    );
   }
 }
 
@@ -281,7 +342,8 @@ function copySymlinkedFile(
   sourcePath: string,
   mountPath: string,
   relativePath: string,
-  readonlyMatcher: Ignore
+  readonlyMatcher: Ignore,
+  targetDirectoryReady = false
 ): void {
   let realSource: string;
   let resolvedStat: Stats;
@@ -303,7 +365,8 @@ function copySymlinkedFile(
     mountPath,
     relativePath,
     readonlyMatcher,
-    resolvedStat.mode
+    resolvedStat.mode,
+    targetDirectoryReady
   );
 }
 
@@ -314,9 +377,10 @@ function copyMountedFile(
   mountPath: string,
   relativePath: string,
   readonlyMatcher: Ignore,
-  sourceMode?: number
+  sourceMode?: number,
+  targetDirectoryReady = false
 ): void {
-  const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath);
+  const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath, { targetDirectoryReady });
   if (!safeMountPath) {
     return;
   }
@@ -326,9 +390,14 @@ function copyMountedFile(
     return;
   }
 
+  const readonly = isPathMatched(relativePath, readonlyMatcher);
+  if (readonly && hardlinkMountedFile(safeSourcePath, safeMountPath)) {
+    return;
+  }
+
   copyFileSync(safeSourcePath, safeMountPath);
 
-  if (isPathMatched(relativePath, readonlyMatcher)) {
+  if (readonly) {
     chmodSync(safeMountPath, 0o444);
     return;
   }
@@ -341,17 +410,17 @@ function ensureDirectory(pathValue: string): void {
   mkdirSync(pathValue, { recursive: true });
 }
 
-function ensureDirectoryWithinRoot(rootPath: string, dirPath: string): boolean {
+function ensureDirectoryWithinRoot(rootPath: string, dirPath: string): string | null {
   if (!isPathWithinRoot(dirPath, rootPath)) {
-    return false;
+    return null;
   }
 
   try {
     ensureDirectory(dirPath);
     const realDir = realpathSync(dirPath);
-    return isPathWithinRoot(realDir, rootPath);
+    return isPathWithinRoot(realDir, rootPath) ? realDir : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -502,25 +571,41 @@ function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
   return resolvedCandidate === resolvedRoot || resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
 }
 
-function resolveSafeCopyTarget(rootPath: string, candidatePath: string): string | null {
+function resolveSafeCopyTarget(
+  rootPath: string,
+  candidatePath: string,
+  opts: { targetDirectoryReady?: boolean } = {}
+): string | null {
   if (!isPathWithinRoot(candidatePath, rootPath)) {
     return null;
   }
 
   const parentPath = path.dirname(candidatePath);
-  if (!ensureDirectoryWithinRoot(rootPath, parentPath)) {
+  if (opts.targetDirectoryReady) {
+    if (!isPathWithinRoot(parentPath, rootPath)) {
+      return null;
+    }
+    return path.join(parentPath, path.basename(candidatePath));
+  }
+
+  const realParent = ensureDirectoryWithinRoot(rootPath, parentPath);
+  if (!realParent) {
     return null;
   }
 
-  try {
-    const realParent = realpathSync(parentPath);
-    if (!isPathWithinRoot(realParent, rootPath)) {
-      return null;
-    }
+  return path.join(realParent, path.basename(candidatePath));
+}
 
-    return path.join(realParent, path.basename(candidatePath));
-  } catch {
-    return null;
+function hardlinkMountedFile(sourcePath: string, targetPath: string): boolean {
+  try {
+    linkSync(sourcePath, targetPath);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EXDEV' || code === 'EPERM') {
+      return false;
+    }
+    throw err;
   }
 }
 
@@ -563,7 +648,7 @@ function buildMountReadme(
 This workspace is a mounted mirror of the project directory.
 File access is controlled by project-local .agentignore and .agentreadonly.
 
-## Read-only files (cannot be modified)
+## Read-only files (sync-back disabled)
 ${readonlyList}
 
 ## Hidden files (not available in this workspace)
@@ -572,8 +657,8 @@ ${ignoredList}
 ## Writable files
 All other files can be read and modified freely.
 
-If you get "permission denied", the file is read-only.
 Changes to read-only files are not synced back to the source project.
+When these files are hardlinked, writes to the mount path affect the same inode as the project path.
 Edits or permission changes to read-only files inside this mount may be discarded or overwritten when the mount is recreated.
 ${agentLine}`;
 }


### PR DESCRIPTION
## Summary

- trim redundant destination safety work by returning the verified real parent from `ensureDirectoryWithinRoot`
- expand default excludes for common build/cache/venv output and add `includeDefaultExcludeDirs: false` for callers that need those paths
- split default excludes so generic names like `build`, `env`, and `coverage` only match at the project root
- apply the same default-exclude filtering during manual `syncBack()`
- keep `.agentreadonly` files as copied `0o444` files so direct mount writes still fail instead of mutating source files
- document the expanded default exclude list

Refs #102.

## Verification

- `npm run test --workspace=packages/local-mount` (passed outside sandbox; sandboxed run cannot start macOS FSEvents)
- one earlier full-suite run hit the existing abort timing flake in `syncBack: returns a partial count when aborted mid-walk`; rerun passed unchanged
- `npm run typecheck` (after `npm run build --workspace=packages/core` in the fresh worktree)
- `npm run build --workspace=packages/local-mount`

No HTTP server changes, so `scripts/check-contract-surface.sh` was not needed.
