### PR TITLE
feat(local-mount)!: async createMount yields the event loop during init

### DIFF
--- a/.trajectories/completed/2026-05/traj_v1un6n66y38i.json
+++ b/.trajectories/completed/2026-05/traj_v1un6n66y38i.json
@@ -1,0 +1,69 @@
+{
+  "id": "traj_v1un6n66y38i",
+  "version": 1,
+  "task": {
+    "title": "Async createMount — issue #104",
+    "source": {
+      "system": "plain",
+      "id": "AgentWorkforce/relayfile#104"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-08T17:27:24.218Z",
+  "completedAt": "2026-05-08T17:31:22.965Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-08T17:27:28.870Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_h5pix8dh1x3q",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-08T17:27:28.870Z",
+      "endedAt": "2026-05-08T17:31:22.965Z",
+      "events": [
+        {
+          "ts": 1778261248871,
+          "type": "decision",
+          "content": "Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside: Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside",
+          "raw": {
+            "question": "Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside",
+            "chosen": "Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside",
+            "alternatives": [],
+            "reasoning": "Issue lists this as the preferred option since the package is pre-1.0, only one known consumer (AgentWorkforce CLI), and avoids maintaining two near-identical entry points."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778261475320,
+          "type": "decision",
+          "content": "Yield via setImmediate at directory entry + every 64 entries within a directory: Yield via setImmediate at directory entry + every 64 entries within a directory",
+          "raw": {
+            "question": "Yield via setImmediate at directory entry + every 64 entries within a directory",
+            "chosen": "Yield via setImmediate at directory entry + every 64 entries within a directory",
+            "alternatives": [],
+            "reasoning": "Issue says one yield per directory is enough. Adding 1-per-64 inside the loop covers worst-case flat directories with thousands of files without measurable perf impact."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Made createMount async; walker yields the event loop between directory entries (and every 64 entries in flat dirs) so consumer setInterval keeps firing during init. Updated launch.ts, all mount/auto-sync/launch tests, and added an event-loop yield regression test. README and CHANGELOG updated.",
+    "approach": "Standard approach",
+    "confidence": 0.85
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/relayfile/.claude/worktrees/issue-104-async-create-mount",
+  "tags": [],
+  "_trace": {
+    "startRef": "5b427af9094b53eb728f9fab360f2efaf7b968a2",
+    "endRef": "5b427af9094b53eb728f9fab360f2efaf7b968a2"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_v1un6n66y38i.md
+++ b/.trajectories/completed/2026-05/traj_v1un6n66y38i.md
@@ -1,0 +1,37 @@
+# Trajectory: Async createMount — issue #104
+
+> **Status:** ✅ Completed
+> **Task:** AgentWorkforce/relayfile#104
+> **Confidence:** 85%
+> **Started:** May 8, 2026 at 01:27 PM
+> **Completed:** May 8, 2026 at 01:31 PM
+
+---
+
+## Summary
+
+Made createMount async; walker yields the event loop between directory entries (and every 64 entries in flat dirs) so consumer setInterval keeps firing during init. Updated launch.ts, all mount/auto-sync/launch tests, and added an event-loop yield regression test. README and CHANGELOG updated.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside
+- **Chose:** Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside
+- **Reasoning:** Issue lists this as the preferred option since the package is pre-1.0, only one known consumer (AgentWorkforce CLI), and avoids maintaining two near-identical entry points.
+
+### Yield via setImmediate at directory entry + every 64 entries within a directory
+- **Chose:** Yield via setImmediate at directory entry + every 64 entries within a directory
+- **Reasoning:** Issue says one yield per directory is enough. Adding 1-per-64 inside the loop covers worst-case flat directories with thousands of files without measurable perf impact.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside: Make createMount async (Promise<MountHandle>), not adding a new createMountAsync alongside
+- Yield via setImmediate at directory entry + every 64 entries within a directory: Yield via setImmediate at directory entry + every 64 entries within a directory

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-04T10:40:25.933Z",
+  "lastUpdated": "2026-05-08T17:31:23.172Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -159,6 +159,13 @@
       "startedAt": "2026-05-04T10:38:33.363Z",
       "completedAt": "2026-05-04T10:40:25.800Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_2nl6e3gqkvki.json"
+    },
+    "traj_v1un6n66y38i": {
+      "title": "Async createMount — issue #104",
+      "status": "completed",
+      "startedAt": "2026-05-08T17:27:24.218Z",
+      "completedAt": "2026-05-08T17:31:22.965Z",
+      "path": "/Users/will/Projects/relayfile/.claude/worktrees/issue-104-async-create-mount/.trajectories/completed/2026-05/traj_v1un6n66y38i.json"
     }
   }
 }

--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- **BREAKING:** `createMount` is now async and returns `Promise<MountHandle>`. The walker yields the event loop between directory entries during init, so a consumer's `setInterval` (e.g. an `ora` spinner) keeps firing while the mount is being built. Previously the synchronous walker froze the consumer's event loop for the entire init window, causing spinners to display a static frame. Callers must `await createMount(...)` — there is no `createMountSync`. `launchOnMount` already awaits it internally so its surface is unchanged. (#104)
 
 ## [0.6.14] - 2026-05-08
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -14,9 +14,11 @@ npm install @relayfile/local-mount
 
 ### `createMount(projectDir, mountDir, options)`
 
-Builds a mounted copy of `projectDir` at `mountDir` and returns a handle:
+Builds a mounted copy of `projectDir` at `mountDir` and resolves with a handle:
 
 ```ts
+const handle = await createMount(projectDir, mountDir, options);
+
 interface MountHandle {
   mountDir: string;
   syncBack(opts?: { signal?: AbortSignal }): Promise<number>;
@@ -24,6 +26,8 @@ interface MountHandle {
   cleanup(): void;
 }
 ```
+
+`createMount` returns `Promise<MountHandle>`. The walker yields the event loop between directory entries so consumer-side timers (e.g. an `ora` spinner driven by `setInterval`) keep firing while the mount is being built.
 
 Behavior:
 - Copies regular files into the mount

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -53,7 +53,7 @@ describe('startAutoSync', () => {
   it('propagates mount→project edits without waiting for final syncBack', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -75,7 +75,7 @@ describe('startAutoSync', () => {
   it('propagates project→mount external edits', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -97,7 +97,7 @@ describe('startAutoSync', () => {
   it('propagates mount→project deletes', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -117,7 +117,7 @@ describe('startAutoSync', () => {
   it('propagates project→mount deletes', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -137,7 +137,7 @@ describe('startAutoSync', () => {
   it('respects readonly patterns: mount-side edits do not sync back', async () => {
     write(path.join(projectDir, 'locked.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['locked.txt'],
       excludeDirs: [],
@@ -165,7 +165,7 @@ describe('startAutoSync', () => {
   it('readonly: project-side edits flow into the mount', async () => {
     write(path.join(projectDir, 'locked.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['locked.txt'],
       excludeDirs: [],
@@ -187,7 +187,7 @@ describe('startAutoSync', () => {
   it('mount-wins: concurrent edits on both sides resolve to mount content', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -218,7 +218,7 @@ describe('startAutoSync', () => {
   it('ignored paths are never synced in either direction', async () => {
     write(path.join(projectDir, 'keep.txt'), 'keep');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: ['secrets/'],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -248,7 +248,7 @@ describe('startAutoSync', () => {
     // path happens to include a segment of the same name must still sync.
     write(path.join(projectDir, 'docs/cache'), 'this is a file, not a dir');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: ['cache/'],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -270,7 +270,7 @@ describe('startAutoSync', () => {
   it('periodic full scan catches changes even if watcher events are missed', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -294,7 +294,7 @@ describe('startAutoSync', () => {
   it('stop({ signal }) skips the draining reconcile when already aborted, but still closes watchers', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -323,7 +323,7 @@ describe('startAutoSync', () => {
   it('includeGit: project-side .git edits flow into the mount', async () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref: refs/heads/main\n');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -351,7 +351,7 @@ describe('startAutoSync', () => {
   it('includeGit: mount-side .git edits do NOT flow back to the project', async () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref: refs/heads/main\n');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -383,7 +383,7 @@ describe('startAutoSync', () => {
   });
 
   it('does not sync the _MOUNT_README.md or marker files', async () => {
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],

--- a/packages/local-mount/src/launch.test.ts
+++ b/packages/local-mount/src/launch.test.ts
@@ -88,7 +88,7 @@ describe('launchOnMount', () => {
     let cleanedUp = false;
     let stopCalled = false;
 
-    const createSpy = vi.spyOn(mountModule, 'createMount').mockReturnValue({
+    const createSpy = vi.spyOn(mountModule, 'createMount').mockResolvedValue({
       mountDir,
       startAutoSync: () => ({
         stop: async () => {

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -67,7 +67,7 @@ export interface LaunchOnMountResult {
  * exit code.
  */
 export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchOnMountResult> {
-  const handle: MountHandle = createMount(opts.projectDir, opts.mountDir, {
+  const handle: MountHandle = await createMount(opts.projectDir, opts.mountDir, {
     ignoredPatterns: opts.ignoredPatterns ?? [],
     readonlyPatterns: opts.readonlyPatterns ?? [],
     excludeDirs: opts.excludeDirs ?? [],

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -72,15 +72,7 @@ export interface LaunchOnMountResult {
  * exit code.
  */
 export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchOnMountResult> {
-  const handle: MountHandle = await createMount(opts.projectDir, opts.mountDir, {
-    ignoredPatterns: opts.ignoredPatterns ?? [],
-    readonlyPatterns: opts.readonlyPatterns ?? [],
-    excludeDirs: opts.excludeDirs ?? [],
-    agentName: opts.agentName,
-    includeGit: opts.includeGit,
-    includeDefaultExcludeDirs: opts.includeDefaultExcludeDirs,
-  });
-
+  let handle: MountHandle | undefined;
   let syncedCount = 0;
   let finalized = false;
   let autoSync: AutoSyncHandle | undefined;
@@ -95,17 +87,27 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
         autoSyncChanges = autoSync.totalChanges();
         autoSync = undefined;
       }
+      if (!handle) return;
       const finalSynced = await handle.syncBack({ signal: opts.shutdownSignal });
       syncedCount = autoSyncChanges + finalSynced;
       if (opts.onAfterSync) {
         await opts.onAfterSync(syncedCount);
       }
     } finally {
-      handle.cleanup();
+      handle?.cleanup();
     }
   };
 
   try {
+    handle = await createMount(opts.projectDir, opts.mountDir, {
+      ignoredPatterns: opts.ignoredPatterns ?? [],
+      readonlyPatterns: opts.readonlyPatterns ?? [],
+      excludeDirs: opts.excludeDirs ?? [],
+      agentName: opts.agentName,
+      includeGit: opts.includeGit,
+      includeDefaultExcludeDirs: opts.includeDefaultExcludeDirs,
+    });
+
     if (opts.onBeforeLaunch) {
       await opts.onBeforeLaunch(handle.mountDir);
     }
@@ -120,9 +122,10 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
       ...(opts.env ?? {}),
     };
 
+    const mountCwd = handle.mountDir;
     const exitCode = await new Promise<number>((resolve, reject) => {
       const child = spawn(opts.cli, opts.args, {
-        cwd: handle.mountDir,
+        cwd: mountCwd,
         stdio: 'inherit',
         env: envVars,
       });

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -37,13 +37,13 @@ describe('createMount', () => {
     try { rmSync(path.dirname(mountDir), { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
-  it('happy path: copies non-ignored files, chmods readonly to 0o444, skips ignored', () => {
+  it('happy path: copies non-ignored files, chmods readonly to 0o444, skips ignored', async () => {
     write(path.join(projectDir, 'src/code.ts'), 'code');
     write(path.join(projectDir, 'secrets/api-key.txt'), 'shhh');
     write(path.join(projectDir, 'docs/guide.md'), 'guide');
     write(path.join(projectDir, 'config.ro'), 'frozen');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: ['secrets/'],
       readonlyPatterns: ['*.ro', 'docs/**'],
       excludeDirs: [],
@@ -68,24 +68,24 @@ describe('createMount', () => {
     handle.cleanup();
   });
 
-  it('refuses mountDir === projectDir', () => {
-    expect(() =>
+  it('refuses mountDir === projectDir', async () => {
+    await expect(
       createMount(projectDir, projectDir, {
         ignoredPatterns: [],
         readonlyPatterns: [],
         excludeDirs: [],
       })
-    ).toThrow(/mountDir must be different from projectDir/);
+    ).rejects.toThrow(/mountDir must be different from projectDir/);
   });
 
-  it('excludes .git, node_modules, and .npm-cache by default, but NOT .relay', () => {
+  it('excludes .git, node_modules, and .npm-cache by default, but NOT .relay', async () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref');
     write(path.join(projectDir, 'node_modules/dep/index.js'), '1');
     write(path.join(projectDir, '.npm-cache/_cacache/content-v2/sha512/aa/bb/blob'), 'cached');
     write(path.join(projectDir, '.relay/state.json'), '{}');
     write(path.join(projectDir, 'keep.txt'), 'yes');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -101,12 +101,12 @@ describe('createMount', () => {
     handle.cleanup();
   });
 
-  it('includeGit: copies .git into the mount and leaves it writable', () => {
+  it('includeGit: copies .git into the mount and leaves it writable', async () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref: refs/heads/main\n');
     write(path.join(projectDir, '.git/refs/heads/main'), 'deadbeef\n');
     write(path.join(projectDir, 'src/code.ts'), 'code');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -129,7 +129,7 @@ describe('createMount', () => {
     write(path.join(projectDir, '.git/HEAD'), 'ref: refs/heads/main\n');
     write(path.join(projectDir, 'src/code.ts'), 'code');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -158,7 +158,7 @@ describe('createMount', () => {
     write(path.join(projectDir, 'writable.txt'), 'original');
     write(path.join(projectDir, 'readonly.txt'), 'original-ro');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: ['readonly.txt'],
       excludeDirs: [],
@@ -193,7 +193,7 @@ describe('createMount', () => {
   it('syncBack: returns immediately when already aborted', async () => {
     write(path.join(projectDir, 'writable.txt'), 'original');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -217,7 +217,7 @@ describe('createMount', () => {
     write(path.join(projectDir, 'b.txt'), 'b0');
     write(path.join(projectDir, 'c.txt'), 'c0');
 
-    const handle = createMount(projectDir, mountDir, {
+    const handle = await createMount(projectDir, mountDir, {
       ignoredPatterns: [],
       readonlyPatterns: [],
       excludeDirs: [],
@@ -242,6 +242,39 @@ describe('createMount', () => {
     ];
     expect(values.filter((value) => value.endsWith('1'))).toHaveLength(synced);
 
+    handle.cleanup();
+  });
+
+  // Regression for #104: a synchronous walker froze the consumer's event loop
+  // for the entire init window, so things like an `ora` spinner driven by
+  // setInterval would not animate. Drive a setInterval counter while
+  // createMount runs over a synthetic many-file tree and assert it advanced.
+  it('yields the event loop during init so consumer setInterval can fire', async () => {
+    const dirs = 50;
+    const filesPerDir = 100;
+    for (let d = 0; d < dirs; d += 1) {
+      for (let f = 0; f < filesPerDir; f += 1) {
+        write(path.join(projectDir, `d${d}`, `f${f}.txt`), 'x');
+      }
+    }
+
+    let ticks = 0;
+    const timer = setInterval(() => {
+      ticks += 1;
+    }, 5);
+
+    let handle;
+    try {
+      handle = await createMount(projectDir, mountDir, {
+        ignoredPatterns: [],
+        readonlyPatterns: [],
+        excludeDirs: [],
+      });
+    } finally {
+      clearInterval(timer);
+    }
+
+    expect(ticks).toBeGreaterThanOrEqual(2);
     handle.cleanup();
   });
 });

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -63,11 +63,11 @@ const MOUNT_MARKER_FILENAME = '.relayfile-local-mount';
 const MOUNT_MARKER_CONTENT =
   'This directory is managed by @relayfile/local-mount. Do not place unrelated files here; the directory will be deleted when the mount is torn down.\n';
 
-export function createMount(
+export async function createMount(
   projectDir: string,
   mountDir: string,
   options: MountOptions
-): MountHandle {
+): Promise<MountHandle> {
   const resolvedProjectDir = realpathSync(projectDir);
   const resolvedMountDir = path.resolve(mountDir);
   const readonlyPatterns = [...options.readonlyPatterns];
@@ -108,7 +108,7 @@ export function createMount(
   const realMountDir = realpathSync(resolvedMountDir);
   writeFileSync(path.join(realMountDir, MOUNT_MARKER_FILENAME), MOUNT_MARKER_CONTENT, 'utf8');
 
-  walkProjectTree(
+  await walkProjectTree(
     resolvedProjectDir,
     resolvedProjectDir,
     realMountDir,
@@ -222,17 +222,29 @@ function assertMountDirSafeToRemove(mountDir: string, projectDir: string): void 
   }
 }
 
-function walkProjectTree(
+// Yield often enough that a consumer's setInterval (e.g. an `ora` spinner) can
+// tick during init even on flat directories with thousands of entries. The
+// goal is not throughput; it is keeping the parent event loop unblocked.
+const WALK_YIELD_EVERY = 64;
+
+async function walkProjectTree(
   projectDir: string,
   currentDir: string,
   mountDir: string,
   excludeSet: Set<string>,
   readonlyMatcher: Ignore,
   ignoredMatcher: Ignore
-): void {
+): Promise<void> {
+  await yieldToEventLoop();
   const entries = readdirSync(currentDir, { withFileTypes: true });
 
+  let processed = 0;
   for (const entry of entries) {
+    if (processed > 0 && processed % WALK_YIELD_EVERY === 0) {
+      await yieldToEventLoop();
+    }
+    processed += 1;
+
     const absolutePath = path.join(currentDir, entry.name);
     const relativePath = normalizeRelativePosix(path.relative(projectDir, absolutePath));
 
@@ -258,7 +270,7 @@ function walkProjectTree(
       if (!ensureDirectoryWithinRoot(mountDir, mountPath)) {
         continue;
       }
-      walkProjectTree(projectDir, absolutePath, mountDir, excludeSet, readonlyMatcher, ignoredMatcher);
+      await walkProjectTree(projectDir, absolutePath, mountDir, excludeSet, readonlyMatcher, ignoredMatcher);
       continue;
     }
 
@@ -273,6 +285,10 @@ function walkProjectTree(
 
     copyMountedFile(projectDir, mountDir, absolutePath, mountPath, relativePath, readonlyMatcher);
   }
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 function copySymlinkedFile(


### PR DESCRIPTION
## Summary

- Closes #104. `createMount` is now `async` and returns `Promise<MountHandle>`. The walker yields the event loop between directory entries (and every 64 entries inside a single directory) so a consumer's `setInterval` — e.g. an `ora` spinner — keeps firing while the mount is being built.
- Previously `walkProjectTree` recursed with `readdirSync` + `copyFileSync` and never yielded, so consumers saw a static spinner frame for the entire init window.
- This is the event-loop story only; #102 still owns init *throughput* (hardlinks, parallel copy, fewer syscalls). Per #104, that issue would close this for free if it lands first; this PR is the smaller standalone fix.

## Breaking change

Callers must `await createMount(...)`. There is no `createMountSync`. The package is pre-1.0; the only known external consumer is the AgentWorkforce CLI, which already invokes the function from an async context. `launchOnMount` awaits internally, so its surface is unchanged.

## Implementation note

Yields use ``await new Promise<void>((resolve) => setImmediate(resolve))`` — the same pattern already used inside `syncBack` for abort-cooperative scans. One yield at each recursion entry plus one every 64 file entries within a single directory keeps both deeply-nested and very-flat trees responsive without measurable perf cost (the issue calls one-yield-per-directory ""enough"").

## Test plan

- [x] `npm test` in `packages/local-mount` — 31 passed (4 files).
- [x] `npm run typecheck` in `packages/local-mount` — clean.
- [x] New regression test `createMount > yields the event loop during init so consumer setInterval can fire` drives a 5ms `setInterval` counter while `createMount` processes 5000 files across 50 directories and asserts the counter advanced ≥ 2 ticks. A sync walker would leave it at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)