### PR TITLE
feat(mount): adopt <name>__<id> filename convention (issue #106 PR 0)

### DIFF
--- a/docs/LAYOUT.md
+++ b/docs/LAYOUT.md
@@ -1,0 +1,12 @@
+# Layout
+
+During the mount naming transition, every entity-named segment is `<sanitized-human-readable>__<id>`; IDs are the LAST `__`-separated segment. Consumers MUST continue to accept both the new-style filename and the legacy `<id>`-only basename while producers are being updated.
+
+For example:
+
+```text
+inbox/threads/Re_Welcome__01HXYZ.json
+inbox/threads/01HXYZ.json
+```
+
+The first path is the canonical human-readable form. The second path is the legacy fallback that remains readable during the transition.

--- a/internal/mountfuse/dir.go
+++ b/internal/mountfuse/dir.go
@@ -53,7 +53,7 @@ func (n *DirNode) Getattr(ctx context.Context, _ gofusefs.FileHandle, out *fuse.
 }
 
 func (n *DirNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*gofusefs.Inode, syscall.Errno) {
-	if child := n.GetChild(name); child != nil {
+	if child := n.lookupCachedChild(name); child != nil {
 		if existing, ok := child.Operations().(interface {
 			fillEntry(*fuse.EntryOut) syscall.Errno
 		}); ok {
@@ -67,7 +67,7 @@ func (n *DirNode) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (
 	if err != nil {
 		return nil, readErrno(err)
 	}
-	meta, ok := entries[name]
+	meta, _, ok := resolveDirectoryEntry(entries, name)
 	if !ok {
 		out.SetEntryTimeout(n.state.negativeTTL)
 		return nil, syscall.ENOENT
@@ -135,7 +135,7 @@ func (n *DirNode) Unlink(ctx context.Context, name string) syscall.Errno {
 	if err != nil {
 		return writeErrno(err)
 	}
-	meta, ok := entries[name]
+	meta, resolvedName, ok := resolveDirectoryEntry(entries, name)
 	if !ok {
 		return syscall.ENOENT
 	}
@@ -154,7 +154,11 @@ func (n *DirNode) Unlink(ctx context.Context, name string) syscall.Errno {
 		return writeErrno(err)
 	}
 	n.state.invalidate(meta.path)
-	n.RmChild(name)
+	if resolvedName == name || n.GetChild(name) == nil {
+		n.RmChild(resolvedName)
+		return 0
+	}
+	n.RmChild(resolvedName, name)
 	return 0
 }
 
@@ -166,4 +170,20 @@ func (n *DirNode) fillEntry(out *fuse.EntryOut) syscall.Errno {
 	}
 	meta.fillEntry(out, n.state)
 	return 0
+}
+
+func (n *DirNode) lookupCachedChild(name string) *gofusefs.Inode {
+	if child := n.GetChild(name); child != nil {
+		return child
+	}
+	children := n.Children()
+	names := make([]string, 0, len(children))
+	for childName := range children {
+		names = append(names, childName)
+	}
+	resolvedName, ok := resolveNameByID(names, name)
+	if !ok {
+		return nil
+	}
+	return n.GetChild(resolvedName)
 }

--- a/internal/mountfuse/fs.go
+++ b/internal/mountfuse/fs.go
@@ -328,6 +328,19 @@ func (s *fsState) listDirectory(ctx context.Context, remotePath string) (map[str
 	return entries, nil
 }
 
+func resolveDirectoryEntry(entries map[string]nodeMeta, requestedName string) (nodeMeta, string, bool) {
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	resolvedName, ok := resolveNameByID(names, requestedName)
+	if !ok {
+		return nodeMeta{}, "", false
+	}
+	meta, ok := entries[resolvedName]
+	return meta, resolvedName, ok
+}
+
 func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMeta, error) {
 	remotePath = normalizeRemotePath(remotePath)
 	if remotePath == s.remoteRoot {
@@ -343,12 +356,13 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 	if err != nil {
 		return nodeMeta{}, err
 	}
-	meta, ok := entries[name]
+	// Resolve legacy and new-style basenames through the shared nameid parser.
+	meta, _, ok := resolveDirectoryEntry(entries, name)
 	if !ok {
 		return nodeMeta{}, &mountsync.HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
 	}
 	if meta.isFile() && meta.size == 0 {
-		if file, err := s.readFile(ctx, remotePath); err == nil {
+		if file, err := s.readFile(ctx, meta.path); err == nil {
 			meta.size = uint64(len(file.Content))
 			meta.revision = file.Revision
 			meta.contentType = file.ContentType
@@ -450,6 +464,45 @@ func splitParent(remotePath string) (string, string) {
 		return "/", ""
 	}
 	return normalizeRemotePath(path.Dir(remotePath)), path.Base(remotePath)
+}
+
+// nameWithId rebuilds the canonical basename from an already-clean name/id pair; it does not slugify raw titles.
+func nameWithId(name, id string) string {
+	stem := strings.TrimSpace(id)
+	if strings.TrimSpace(name) != "" {
+		stem = strings.TrimSpace(name) + "__" + stem
+	}
+	if stem == "" {
+		return ""
+	}
+	return stem + ".json"
+}
+
+func resolveNameByID(names []string, requestedName string) (string, bool) {
+	requestedID := IDFromBasename(requestedName)
+	if requestedID == "" {
+		return "", false
+	}
+	bestName := ""
+	bestScore := -1
+	for _, candidate := range names {
+		candidateName, candidateID := ParseNameID(candidate)
+		if candidateID != requestedID {
+			continue
+		}
+		score := 0
+		if candidateName != "" && nameWithId(candidateName, candidateID) == candidate {
+			score = 1
+		}
+		if score > bestScore || (score == bestScore && (bestName == "" || candidate < bestName)) {
+			bestName = candidate
+			bestScore = score
+		}
+	}
+	if bestName == "" {
+		return "", false
+	}
+	return bestName, true
 }
 
 func joinRemotePath(parentPath, name string) string {

--- a/internal/mountfuse/fs.go
+++ b/internal/mountfuse/fs.go
@@ -333,12 +333,19 @@ func resolveDirectoryEntry(entries map[string]nodeMeta, requestedName string) (n
 	for name := range entries {
 		names = append(names, name)
 	}
-	resolvedName, ok := resolveNameByID(names, requestedName)
-	if !ok {
-		return nodeMeta{}, "", false
+	if resolvedName, ok := resolveNameByID(names, requestedName); ok {
+		if meta, found := entries[resolvedName]; found {
+			return meta, resolvedName, true
+		}
 	}
-	meta, ok := entries[resolvedName]
-	return meta, resolvedName, ok
+	// Direct exact-match fallback: covers basenames where the parsed ID is
+	// empty (e.g. "test__.json") and ID-based lookup cannot help. The
+	// ID-based lookup is preferred so that canonical (name__id) siblings win
+	// over legacy (id-only) basenames when both exist.
+	if meta, ok := entries[requestedName]; ok {
+		return meta, requestedName, true
+	}
+	return nodeMeta{}, "", false
 }
 
 func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMeta, error) {
@@ -491,8 +498,15 @@ func resolveNameByID(names []string, requestedName string) (string, bool) {
 			continue
 		}
 		score := 0
-		if candidateName != "" && nameWithId(candidateName, candidateID) == candidate {
-			score = 1
+		// Canonical preference: candidate must round-trip to itself when
+		// reconstructed from its parsed (name, id, extension). This works for
+		// any extension (including none, e.g. directories like
+		// "thread__01HXYZ" or files like "notes__abc.md").
+		if candidateName != "" {
+			ext := path.Ext(candidate)
+			if candidateName+"__"+candidateID+ext == candidate {
+				score = 1
+			}
 		}
 		if score > bestScore || (score == bestScore && (bestName == "" || candidate < bestName)) {
 			bestName = candidate

--- a/internal/mountfuse/fuse_test.go
+++ b/internal/mountfuse/fuse_test.go
@@ -2,10 +2,13 @@ package mountfuse
 
 import (
 	"context"
+	"sort"
 	"syscall"
 	"testing"
 
 	"github.com/agentworkforce/relayfile/internal/mountsync"
+	gofusefs "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
 )
 
 // fakeRemoteClient implements mountsync.RemoteClient for testing the
@@ -15,12 +18,19 @@ type fakeRemoteClient struct {
 	files map[string]mountsync.RemoteFile
 	trees map[string]mountsync.TreeResponse
 
+	deleteCalls []deleteCall
+
 	// Optional error injection — when non-nil the corresponding method
 	// returns this error instead of looking up data.
 	readFileErr  error
 	writeFileErr error
 	deleteErr    error
 	listTreeErr  error
+}
+
+type deleteCall struct {
+	path         string
+	baseRevision string
 }
 
 func (f *fakeRemoteClient) ListTree(_ context.Context, _, path string, _ int, _ string) (mountsync.TreeResponse, error) {
@@ -63,10 +73,11 @@ func (f *fakeRemoteClient) WriteFilesBulk(_ context.Context, _ string, _ []mount
 	return mountsync.BulkWriteResponse{}, nil
 }
 
-func (f *fakeRemoteClient) DeleteFile(_ context.Context, _, path, _ string) error {
+func (f *fakeRemoteClient) DeleteFile(_ context.Context, _, path, baseRevision string) error {
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
+	f.deleteCalls = append(f.deleteCalls, deleteCall{path: path, baseRevision: baseRevision})
 	return nil
 }
 
@@ -254,6 +265,269 @@ func TestMapError(t *testing.T) {
 			got := mapError(tt.err)
 			if got != tt.want {
 				t.Errorf("mapError(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDirNodeLookupAndReadAcceptsLegacyAndNameIDForms(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {
+				Path: "/",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/legacy-id.json", Type: "file", Revision: "r_legacy"},
+					{Path: "/human-name__legacy-id.json", Type: "file", Revision: "r_named"},
+					{Path: "/only-human__shared-id.json", Type: "file", Revision: "r_shared"},
+				},
+			},
+		},
+		files: map[string]mountsync.RemoteFile{
+			"/legacy-id.json": {
+				Path:        "/legacy-id.json",
+				Revision:    "r_legacy",
+				ContentType: "application/json",
+				Content:     `{"kind":"legacy"}`,
+			},
+			"/human-name__legacy-id.json": {
+				Path:        "/human-name__legacy-id.json",
+				Revision:    "r_named",
+				ContentType: "application/json",
+				Content:     `{"kind":"named"}`,
+			},
+			"/only-human__shared-id.json": {
+				Path:        "/only-human__shared-id.json",
+				Revision:    "r_shared",
+				ContentType: "application/json",
+				Content:     `{"kind":"shared"}`,
+			},
+		},
+	}
+
+	root, err := New(Config{Client: remote, WorkspaceID: "ws_nameid", RemoteRoot: "/"})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	ctx := context.Background()
+	stream, errno := root.Readdir(ctx)
+	if errno != 0 {
+		t.Fatalf("Readdir errno = %d, want 0", errno)
+	}
+	defer stream.Close()
+
+	var gotNames []string
+	for stream.HasNext() {
+		entry, nextErrno := stream.Next()
+		if nextErrno != 0 {
+			t.Fatalf("Readdir.Next errno = %d, want 0", nextErrno)
+		}
+		gotNames = append(gotNames, entry.Name)
+	}
+	sort.Strings(gotNames)
+	wantNames := []string{
+		"human-name__legacy-id.json",
+		"legacy-id.json",
+		"only-human__shared-id.json",
+	}
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("Readdir names = %v, want %v", gotNames, wantNames)
+	}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Fatalf("Readdir names = %v, want %v", gotNames, wantNames)
+		}
+	}
+
+	readByName := func(name string) string {
+		t.Helper()
+		var entryOut fuse.EntryOut
+		child, lookupErrno := root.Lookup(ctx, name, &entryOut)
+		if lookupErrno != 0 {
+			t.Fatalf("Lookup(%q) errno = %d, want 0", name, lookupErrno)
+		}
+		fileNode, ok := child.Operations().(*FileNode)
+		if !ok {
+			t.Fatalf("Lookup(%q) returned %T, want *FileNode", name, child.Operations())
+		}
+		handle, _, openErrno := fileNode.Open(ctx, 0)
+		if openErrno != 0 {
+			t.Fatalf("Open(%q) errno = %d, want 0", name, openErrno)
+		}
+		fileHandle, ok := handle.(*FileHandle)
+		if !ok {
+			t.Fatalf("Open(%q) returned %T, want *FileHandle", name, handle)
+		}
+		result, readErrno := fileHandle.Read(ctx, make([]byte, 1024), 0)
+		if readErrno != 0 {
+			t.Fatalf("Read(%q) errno = %d, want 0", name, readErrno)
+		}
+		data, status := result.Bytes(nil)
+		if status != 0 {
+			t.Fatalf("Read(%q) status = %d, want 0", name, status)
+		}
+		result.Done()
+		return string(data)
+	}
+
+	if got := readByName("legacy-id.json"); got != `{"kind":"named"}` {
+		t.Fatalf("read legacy alias with canonical sibling = %q, want %q", got, `{"kind":"named"}`)
+	}
+	if got := readByName("human-name__legacy-id.json"); got != `{"kind":"named"}` {
+		t.Fatalf("read named file = %q, want %q", got, `{"kind":"named"}`)
+	}
+
+	// Prime the child cache under the canonical new-style filename, then
+	// prove a legacy-style lookup still resolves through the same entity ID.
+	if got := readByName(nameWithId("only-human", "shared-id")); got != `{"kind":"shared"}` {
+		t.Fatalf("read canonical shared file = %q, want %q", got, `{"kind":"shared"}`)
+	}
+	if got := readByName("shared-id.json"); got != `{"kind":"shared"}` {
+		t.Fatalf("read legacy alias = %q, want %q", got, `{"kind":"shared"}`)
+	}
+
+	if legacyID := IDFromBasename("legacy-id.json"); legacyID != "legacy-id" {
+		t.Fatalf("IDFromBasename(legacy-id.json) = %q, want %q", legacyID, "legacy-id")
+	}
+	if namedID := IDFromBasename("human-name__legacy-id.json"); namedID != "legacy-id" {
+		t.Fatalf("IDFromBasename(human-name__legacy-id.json) = %q, want %q", namedID, "legacy-id")
+	}
+}
+
+func TestDirNodeLookupAcceptsNameIDDirectories(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {
+				Path: "/",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/thread__01HXYZ", Type: "directory"},
+				},
+			},
+			"/thread__01HXYZ": {
+				Path: "/thread__01HXYZ",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/thread__01HXYZ/note.json", Type: "file", Revision: "r_note"},
+				},
+			},
+		},
+		files: map[string]mountsync.RemoteFile{
+			"/thread__01HXYZ/note.json": {
+				Path:        "/thread__01HXYZ/note.json",
+				Revision:    "r_note",
+				ContentType: "application/json",
+				Content:     `{"note":"ok"}`,
+			},
+		},
+	}
+
+	root, err := New(Config{Client: remote, WorkspaceID: "ws_nameid_dirs", RemoteRoot: "/"})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	ctx := context.Background()
+	for _, name := range []string{"thread__01HXYZ", "01HXYZ"} {
+		t.Run(name, func(t *testing.T) {
+			var entryOut fuse.EntryOut
+			child, errno := root.Lookup(ctx, name, &entryOut)
+			if errno != 0 {
+				t.Fatalf("Lookup(%q) errno = %d, want 0", name, errno)
+			}
+			dirNode, ok := child.Operations().(*DirNode)
+			if !ok {
+				t.Fatalf("Lookup(%q) returned %T, want *DirNode", name, child.Operations())
+			}
+			var nestedOut fuse.EntryOut
+			nested, nestedErrno := dirNode.Lookup(ctx, "note.json", &nestedOut)
+			if nestedErrno != 0 {
+				t.Fatalf("Lookup(%q)/note.json errno = %d, want 0", name, nestedErrno)
+			}
+			if _, ok := nested.Operations().(*FileNode); !ok {
+				t.Fatalf("Lookup(%q)/note.json returned %T, want *FileNode", name, nested.Operations())
+			}
+		})
+	}
+}
+
+func TestDirNodeUnlinkAcceptsLegacyAndNameIDForms(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		deleteName  string
+		primeLookup string
+	}{
+		{
+			name:        "canonical unlink",
+			deleteName:  "only-human__shared-id.json",
+			primeLookup: "only-human__shared-id.json",
+		},
+		{
+			name:        "legacy alias unlink",
+			deleteName:  "shared-id.json",
+			primeLookup: "only-human__shared-id.json",
+		},
+		{
+			name:       "legacy alias unlink without cache prime",
+			deleteName: "shared-id.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := &fakeRemoteClient{
+				trees: map[string]mountsync.TreeResponse{
+					"/": {
+						Path: "/",
+						Entries: []mountsync.TreeEntry{
+							{Path: "/only-human__shared-id.json", Type: "file", Revision: "r_shared"},
+						},
+					},
+				},
+			}
+
+			root, err := New(Config{Client: remote, WorkspaceID: "ws_nameid_unlink", RemoteRoot: "/"})
+			if err != nil {
+				t.Fatalf("New() failed: %v", err)
+			}
+			_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+			ctx := context.Background()
+			if tt.primeLookup != "" {
+				var entryOut fuse.EntryOut
+				child, errno := root.Lookup(ctx, tt.primeLookup, &entryOut)
+				if errno != 0 {
+					t.Fatalf("Lookup(%q) errno = %d, want 0", tt.primeLookup, errno)
+				}
+				root.AddChild("only-human__shared-id.json", child, true)
+				if root.GetChild("only-human__shared-id.json") == nil {
+					t.Fatalf("expected canonical child cache to be populated before unlink")
+				}
+			} else if root.GetChild("only-human__shared-id.json") != nil {
+				t.Fatalf("expected canonical child cache to start empty without a prime lookup")
+			}
+
+			errno := root.Unlink(ctx, tt.deleteName)
+			if errno != 0 {
+				t.Fatalf("Unlink(%q) errno = %d, want 0", tt.deleteName, errno)
+			}
+			if len(remote.deleteCalls) != 1 {
+				t.Fatalf("DeleteFile calls = %d, want 1", len(remote.deleteCalls))
+			}
+			if remote.deleteCalls[0].path != "/only-human__shared-id.json" {
+				t.Fatalf("DeleteFile path = %q, want %q", remote.deleteCalls[0].path, "/only-human__shared-id.json")
+			}
+			if remote.deleteCalls[0].baseRevision != "r_shared" {
+				t.Fatalf("DeleteFile baseRevision = %q, want %q", remote.deleteCalls[0].baseRevision, "r_shared")
+			}
+			if root.GetChild("only-human__shared-id.json") != nil {
+				t.Fatalf("expected canonical child cache to be cleared after unlink")
 			}
 		})
 	}

--- a/internal/mountfuse/nameid.go
+++ b/internal/mountfuse/nameid.go
@@ -1,0 +1,33 @@
+package mountfuse
+
+import (
+	"path"
+	"strings"
+)
+
+// ID is the LAST `__`-separated segment.
+func ParseNameID(basename string) (name, id string) {
+	base := strings.TrimSpace(basename)
+	if base == "" || base == "/" || base == "." {
+		return "", ""
+	}
+	base = path.Base(base)
+	if base == "" || base == "/" || base == "." {
+		return "", ""
+	}
+	ext := path.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	if stem == "" {
+		return "", ""
+	}
+	idx := strings.LastIndex(stem, "__")
+	if idx < 0 {
+		return "", stem
+	}
+	return stem[:idx], stem[idx+2:]
+}
+
+func IDFromBasename(basename string) string {
+	_, id := ParseNameID(basename)
+	return id
+}

--- a/internal/mountfuse/nameid_test.go
+++ b/internal/mountfuse/nameid_test.go
@@ -1,0 +1,165 @@
+package mountfuse
+
+import "testing"
+
+func TestParseNameID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		basename      string
+		wantName      string
+		wantID        string
+		wantRoundTrip string
+	}{
+		{
+			name:          "new style",
+			basename:      "alpha__123e4567.json",
+			wantName:      "alpha",
+			wantID:        "123e4567",
+			wantRoundTrip: "alpha__123e4567.json",
+		},
+		{
+			name:     "legacy",
+			basename: "uuid.json",
+			wantName: "",
+			wantID:   "uuid",
+		},
+		{
+			name:     "no extension",
+			basename: "alpha__123e4567",
+			wantName: "alpha",
+			wantID:   "123e4567",
+		},
+		{
+			name:     "multi separator",
+			basename: "a__b__c.json",
+			wantName: "a__b",
+			wantID:   "c",
+		},
+		{
+			name:     "empty input",
+			basename: "",
+			wantName: "",
+			wantID:   "",
+		},
+		{
+			name:     "root path",
+			basename: "/",
+			wantName: "",
+			wantID:   "",
+		},
+		{
+			name:     "directory style basename",
+			basename: "thread__01HXYZ",
+			wantName: "thread",
+			wantID:   "01HXYZ",
+		},
+		{
+			name:     "dot only extension",
+			basename: ".json",
+			wantName: "",
+			wantID:   "",
+		},
+		{
+			name:     "empty name half",
+			basename: "__abc.json",
+			wantName: "",
+			wantID:   "abc",
+		},
+		{
+			name:     "slug with dot",
+			basename: "Re_Welcome.draft__01HXYZ.json",
+			wantName: "Re_Welcome.draft",
+			wantID:   "01HXYZ",
+		},
+		{
+			name:     "mixed case extension",
+			basename: "alpha__ABC.JSON",
+			wantName: "alpha",
+			wantID:   "ABC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotID := ParseNameID(tt.basename)
+			if gotName != tt.wantName || gotID != tt.wantID {
+				t.Fatalf("ParseNameID(%q) = (%q, %q), want (%q, %q)", tt.basename, gotName, gotID, tt.wantName, tt.wantID)
+			}
+			if got := IDFromBasename(tt.basename); got != tt.wantID {
+				t.Fatalf("IDFromBasename(%q) = %q, want %q", tt.basename, got, tt.wantID)
+			}
+			if tt.wantRoundTrip != "" {
+				if got := nameWithId(gotName, gotID); got != tt.wantRoundTrip {
+					t.Fatalf("nameWithId(%q, %q) = %q, want %q", gotName, gotID, got, tt.wantRoundTrip)
+				}
+			}
+		})
+	}
+}
+
+func TestNameIDSameIDAcrossNamingStyles(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"abc.json",
+		"slug__abc.json",
+		"a__b__abc.json",
+	}
+	for _, name := range names {
+		if got := IDFromBasename(name); got != "abc" {
+			t.Fatalf("IDFromBasename(%q) = %q, want %q", name, got, "abc")
+		}
+	}
+}
+
+func TestResolveNameByID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		names         []string
+		requestedName string
+		wantName      string
+		wantOK        bool
+	}{
+		{
+			name:          "legacy alias resolves canonical when only canonical exists",
+			names:         []string{"only-human__shared-id.json"},
+			requestedName: "shared-id.json",
+			wantName:      "only-human__shared-id.json",
+			wantOK:        true,
+		},
+		{
+			name:          "canonical sibling wins when legacy and canonical siblings coexist",
+			names:         []string{"legacy-id.json", "human-name__legacy-id.json"},
+			requestedName: "legacy-id.json",
+			wantName:      "human-name__legacy-id.json",
+			wantOK:        true,
+		},
+		{
+			name:          "canonical exact match is stable",
+			names:         []string{"legacy-id.json", "human-name__legacy-id.json"},
+			requestedName: "human-name__legacy-id.json",
+			wantName:      "human-name__legacy-id.json",
+			wantOK:        true,
+		},
+		{
+			name:          "missing id returns false",
+			names:         []string{"alpha__123.json"},
+			requestedName: "missing.json",
+			wantName:      "",
+			wantOK:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotOK := resolveNameByID(tt.names, tt.requestedName)
+			if gotName != tt.wantName || gotOK != tt.wantOK {
+				t.Fatalf("resolveNameByID(%v, %q) = (%q, %t), want (%q, %t)", tt.names, tt.requestedName, gotName, gotOK, tt.wantName, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/mountfuse/nameid_test.go
+++ b/internal/mountfuse/nameid_test.go
@@ -1,6 +1,9 @@
 package mountfuse
 
-import "testing"
+import (
+	"syscall"
+	"testing"
+)
 
 func TestParseNameID(t *testing.T) {
 	t.Parallel()
@@ -152,6 +155,27 @@ func TestResolveNameByID(t *testing.T) {
 			wantName:      "",
 			wantOK:        false,
 		},
+		{
+			name:          "directory canonical wins over legacy",
+			names:         []string{"01HXYZ", "thread__01HXYZ"},
+			requestedName: "01HXYZ",
+			wantName:      "thread__01HXYZ",
+			wantOK:        true,
+		},
+		{
+			name:          "non-json extension canonical wins over legacy",
+			names:         []string{"abc.md", "notes__abc.md"},
+			requestedName: "abc.md",
+			wantName:      "notes__abc.md",
+			wantOK:        true,
+		},
+		{
+			name:          "non-json canonical exact match",
+			names:         []string{"abc.md", "notes__abc.md"},
+			requestedName: "notes__abc.md",
+			wantName:      "notes__abc.md",
+			wantOK:        true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -161,5 +185,23 @@ func TestResolveNameByID(t *testing.T) {
 				t.Fatalf("resolveNameByID(%v, %q) = (%q, %t), want (%q, %t)", tt.names, tt.requestedName, gotName, gotOK, tt.wantName, tt.wantOK)
 			}
 		})
+	}
+}
+
+func TestResolveDirectoryEntryExactMatchFallback(t *testing.T) {
+	t.Parallel()
+
+	// Basenames where the parsed ID is empty (stem ends with "__") would
+	// otherwise be unreachable via ID-based lookup. The exact-match fallback
+	// ensures they remain accessible.
+	entries := map[string]nodeMeta{
+		"test__.json": {name: "test__.json", path: "/test__.json", mode: syscall.S_IFREG | 0o644},
+	}
+	meta, resolved, ok := resolveDirectoryEntry(entries, "test__.json")
+	if !ok {
+		t.Fatalf("resolveDirectoryEntry exact-match fallback failed: ok=false")
+	}
+	if resolved != "test__.json" || meta.name != "test__.json" {
+		t.Fatalf("resolveDirectoryEntry exact match = (%+v, %q), want test__.json", meta, resolved)
 	}
 }

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2678,6 +2678,10 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 }
 
 func localToRemotePath(localRoot, remoteRoot, localPath string) (string, error) {
+	// Wave 106 only makes mountfuse consumers tolerant of both `<id>.json`
+	// and `<name>__<id>.json` basenames. mountsync does not derive entity IDs
+	// from local basenames here; it mirrors the caller's relative path back to
+	// the remote root verbatim, so no name/id canonicalization is required.
 	rel, err := filepath.Rel(localRoot, localPath)
 	if err != nil {
 		return "", err

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2274,6 +2274,15 @@ func TestRemoteToLocalAndLocalToRemotePath(t *testing.T) {
 	if remotePath != "/notion/Folder/File.md" {
 		t.Fatalf("unexpected remote path mapping: %s", remotePath)
 	}
+
+	nameIDPath := filepath.Join(localRoot, "Folder", "Human Name__01HXYZ.json")
+	nameIDRemotePath, err := localToRemotePath(localRoot, "/notion", nameIDPath)
+	if err != nil {
+		t.Fatalf("localToRemotePath for name/id basename failed: %v", err)
+	}
+	if nameIDRemotePath != "/notion/Folder/Human Name__01HXYZ.json" {
+		t.Fatalf("unexpected name/id remote path mapping: %s", nameIDRemotePath)
+	}
 }
 
 func TestInferProviderFromRoot(t *testing.T) {


### PR DESCRIPTION
Foundational structural change for #106. Names every canonical
mount entity `<sanitized-human-readable>__<id>` so `ls` returns
useful filenames without the agent having to read each file.

Renames canonical mount records:
- linear/issues/<uuid>.json → linear/issues/AGE-8__<uuid>.json
- linear/users/<uuid>.json → linear/users/<display-name>__<uuid>.json
- linear/teams/<uuid>.json → linear/teams/<team-key>__<uuid>.json
- notion/pages/<uuid>.json → notion/pages/<sanitized-title>__<uuid>.json
- notion/databases/<uuid>/ → notion/databases/<sanitized-name>__<uuid>/
- github/repos/<owner>/<repo>/pulls/<num>/ →
  github/repos/<owner>/<repo>/pulls/<num>__<sanitized-title>/

The canonical id is always the LAST `__`-separated segment so
resolvers can split on `__` and take the tail. Human-readable parts
are sanitized and not constructible — agents must `ls` to discover
exact names.

Runs FIRST in the #106 sequence; PR 1/2/3 build on the new canonical
filenames. Mountfuse + mountsync stay tolerant of legacy
`<uuid>.json` names during the transition.

## Repo scope

This PR is the **relayfile** part of wave `wave0-naming`. The
companion PRs in the other repos are linked from issue #106.

## Test plan

- [x] `cd /Users/khaliqgant/Projects/AgentWorkforce/relayfile && go test ./internal/mountfuse/... ./internal/mountsync/...`
- [x] `cd /Users/khaliqgant/Projects/AgentWorkforce/relayfile && go vet ./...`
- [ ] Manual: re-run the cost benchmark referenced in #106 after all 3 PRs merge.

Generated by an overnight agent run. See
`/tmp/106-wave0-naming-status.md` on the host for triage notes.

Refs AgentWorkforce/relayfile#106
