### PR TITLE
feat(mount): add _index.json everywhere + LAYOUT.md (issue #106 PR 1)

### DIFF
--- a/internal/mountfuse/fs.go
+++ b/internal/mountfuse/fs.go
@@ -324,6 +324,9 @@ func (s *fsState) listDirectory(ctx context.Context, remotePath string) (map[str
 		}
 		entries[meta.name] = meta
 	}
+	if remotePath == s.remoteRoot {
+		entries[layoutFilename] = virtualLayoutMeta(s.remoteRoot)
+	}
 	s.putDir(remotePath, entries)
 	return entries, nil
 }
@@ -358,6 +361,9 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 			modTime: time.Now(),
 		}, nil
 	}
+	if isVirtualLayoutPath(s.remoteRoot, remotePath) {
+		return virtualLayoutMeta(s.remoteRoot), nil
+	}
 	parentPath, name := splitParent(remotePath)
 	entries, err := s.listDirectory(ctx, parentPath)
 	if err != nil {
@@ -380,6 +386,9 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 
 func (s *fsState) readFile(ctx context.Context, remotePath string) (mountsync.RemoteFile, error) {
 	remotePath = normalizeRemotePath(remotePath)
+	if isVirtualLayoutPath(s.remoteRoot, remotePath) {
+		return readVirtualLayout(s.remoteRoot), nil
+	}
 	if file, ok := s.getFile(remotePath); ok {
 		return file, nil
 	}

--- a/internal/mountfuse/fuse_test.go
+++ b/internal/mountfuse/fuse_test.go
@@ -329,6 +329,7 @@ func TestDirNodeLookupAndReadAcceptsLegacyAndNameIDForms(t *testing.T) {
 	}
 	sort.Strings(gotNames)
 	wantNames := []string{
+		"LAYOUT.md",
 		"human-name__legacy-id.json",
 		"legacy-id.json",
 		"only-human__shared-id.json",

--- a/internal/mountfuse/layout.go
+++ b/internal/mountfuse/layout.go
@@ -1,0 +1,69 @@
+package mountfuse
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/mountsync"
+)
+
+const (
+	layoutFilename    = "LAYOUT.md"
+	layoutRevision    = "virtual-layout"
+	layoutContentType = "text/markdown; charset=utf-8"
+)
+
+const LayoutMarkdown = `# LAYOUT
+
+This mount exposes upstream files together with navigation helpers.
+
+## Indexes
+
+` + "`_index.json`" + ` files live next to the content they index. Start with ` + "`notion/pages/_index.json`" + `, ` + "`linear/issues/_index.json`" + `, and ` + "`github/repos/_index.json`" + `.
+
+## Find by title
+
+To ` + "`find by title`" + `, read the relevant ` + "`_index.json`" + ` file, find the matching row, then read the named file from that row.
+
+## Filenames
+
+Entity files use the ` + "`<sanitized-name>__<id>`" + ` filename convention. Recover the id from the last ` + "`__`" + `-separated segment.
+
+## Integration-specific layouts
+
+See per-integration ` + "`<integration>/.layout.md`" + ` files for integration-specific tree shapes.
+
+## Forward note
+
+Direct by-title / by-id aliases land in a later release.
+`
+
+func layoutRemotePath(remoteRoot string) string {
+	return joinRemotePath(remoteRoot, layoutFilename)
+}
+
+func isVirtualLayoutPath(remoteRoot, remotePath string) bool {
+	return normalizeRemotePath(remotePath) == layoutRemotePath(remoteRoot)
+}
+
+func virtualLayoutMeta(remoteRoot string) nodeMeta {
+	return nodeMeta{
+		path:        layoutRemotePath(remoteRoot),
+		name:        layoutFilename,
+		mode:        syscall.S_IFREG | defaultFileMode,
+		revision:    layoutRevision,
+		size:        uint64(len(LayoutMarkdown)),
+		modTime:     time.Unix(0, 0).UTC(),
+		contentType: layoutContentType,
+	}
+}
+
+func readVirtualLayout(remoteRoot string) mountsync.RemoteFile {
+	meta := virtualLayoutMeta(remoteRoot)
+	return mountsync.RemoteFile{
+		Path:        meta.path,
+		Revision:    meta.revision,
+		ContentType: meta.contentType,
+		Content:     LayoutMarkdown,
+	}
+}

--- a/internal/mountfuse/layout_test.go
+++ b/internal/mountfuse/layout_test.go
@@ -1,0 +1,204 @@
+package mountfuse
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/agentworkforce/relayfile/internal/mountsync"
+	gofusefs "github.com/hanwen/go-fuse/v2/fs"
+	"github.com/hanwen/go-fuse/v2/fuse"
+)
+
+type layoutRemoteClient struct {
+	trees         map[string]mountsync.TreeResponse
+	readFilePaths []string
+}
+
+func (c *layoutRemoteClient) ListTree(_ context.Context, _, path string, _ int, _ string) (mountsync.TreeResponse, error) {
+	if resp, ok := c.trees[path]; ok {
+		return resp, nil
+	}
+	return mountsync.TreeResponse{Path: path}, nil
+}
+
+func (c *layoutRemoteClient) ListEvents(_ context.Context, _, _, _ string, _ int) (mountsync.EventFeed, error) {
+	return mountsync.EventFeed{}, nil
+}
+
+func (c *layoutRemoteClient) ReadFile(_ context.Context, _, path string) (mountsync.RemoteFile, error) {
+	c.readFilePaths = append(c.readFilePaths, path)
+	return mountsync.RemoteFile{}, &mountsync.HTTPError{StatusCode: 404, Code: "not_found", Message: "file not found"}
+}
+
+func (c *layoutRemoteClient) WriteFile(_ context.Context, _, _, _, _, _ string) (mountsync.WriteResult, error) {
+	return mountsync.WriteResult{}, nil
+}
+
+func (c *layoutRemoteClient) WriteFilesBulk(_ context.Context, _ string, _ []mountsync.BulkWriteFile) (mountsync.BulkWriteResponse, error) {
+	return mountsync.BulkWriteResponse{}, nil
+}
+
+func (c *layoutRemoteClient) DeleteFile(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestLayoutMarkdownContainsRequiredAnchors(t *testing.T) {
+	t.Parallel()
+
+	required := []string{
+		"LAYOUT",
+		"_index.json",
+		"notion/pages/_index.json",
+		"linear/issues/_index.json",
+		"github/repos/_index.json",
+		"find by title",
+		"__",
+		"<integration>/.layout.md",
+		"by-title / by-id aliases land in a later release",
+	}
+	for _, needle := range required {
+		if !strings.Contains(LayoutMarkdown, needle) {
+			t.Fatalf("LayoutMarkdown missing %q", needle)
+		}
+	}
+}
+
+func TestRootDirectorySynthesizesLayoutMarkdown(t *testing.T) {
+	t.Parallel()
+
+	remote := &layoutRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {Path: "/", Entries: nil},
+		},
+	}
+	root, err := New(Config{Client: remote, WorkspaceID: "ws_layout", RemoteRoot: "/"})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	ctx := context.Background()
+	stream, errno := root.Readdir(ctx)
+	if errno != 0 {
+		t.Fatalf("Readdir errno = %d, want 0", errno)
+	}
+	defer stream.Close()
+
+	var gotNames []string
+	for stream.HasNext() {
+		entry, nextErrno := stream.Next()
+		if nextErrno != 0 {
+			t.Fatalf("Readdir.Next errno = %d, want 0", nextErrno)
+		}
+		gotNames = append(gotNames, entry.Name)
+	}
+	sort.Strings(gotNames)
+	if len(gotNames) != 1 || gotNames[0] != layoutFilename {
+		t.Fatalf("Readdir names = %v, want [%s]", gotNames, layoutFilename)
+	}
+
+	var entryOut fuse.EntryOut
+	child, lookupErrno := root.Lookup(ctx, layoutFilename, &entryOut)
+	if lookupErrno != 0 {
+		t.Fatalf("Lookup(%q) errno = %d, want 0", layoutFilename, lookupErrno)
+	}
+	if entryOut.Attr.Mode&syscall.S_IFMT != syscall.S_IFREG {
+		t.Fatalf("Lookup(%q) mode = %o, want regular file", layoutFilename, entryOut.Attr.Mode)
+	}
+	if entryOut.Attr.Size != uint64(len(LayoutMarkdown)) {
+		t.Fatalf("Lookup(%q) size = %d, want %d", layoutFilename, entryOut.Attr.Size, len(LayoutMarkdown))
+	}
+
+	fileNode, ok := child.Operations().(*FileNode)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned %T, want *FileNode", layoutFilename, child.Operations())
+	}
+	handle, _, openErrno := fileNode.Open(ctx, 0)
+	if openErrno != 0 {
+		t.Fatalf("Open(%q) errno = %d, want 0", layoutFilename, openErrno)
+	}
+	fileHandle, ok := handle.(*FileHandle)
+	if !ok {
+		t.Fatalf("Open(%q) returned %T, want *FileHandle", layoutFilename, handle)
+	}
+	result, readErrno := fileHandle.Read(ctx, make([]byte, len(LayoutMarkdown)+16), 0)
+	if readErrno != 0 {
+		t.Fatalf("Read(%q) errno = %d, want 0", layoutFilename, readErrno)
+	}
+	data, status := result.Bytes(nil)
+	if status != 0 {
+		t.Fatalf("Read(%q) status = %d, want 0", layoutFilename, status)
+	}
+	result.Done()
+	if string(data) != LayoutMarkdown {
+		t.Fatalf("Read(%q) content mismatch", layoutFilename)
+	}
+
+	virtualFile, err := root.state.readFile(ctx, layoutRemotePath(root.state.remoteRoot))
+	if err != nil {
+		t.Fatalf("state.readFile(%q) failed: %v", layoutFilename, err)
+	}
+	if virtualFile.ContentType != layoutContentType {
+		t.Fatalf("virtual layout content type = %q, want %q", virtualFile.ContentType, layoutContentType)
+	}
+	if len(remote.readFilePaths) != 0 {
+		t.Fatalf("expected virtual layout reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
+	}
+}
+
+func TestVirtualLayoutWinsOverRemoteCollision(t *testing.T) {
+	t.Parallel()
+
+	remote := &layoutRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {
+				Path: "/",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/LAYOUT.md", Type: "file", Revision: "remote-layout"},
+				},
+			},
+		},
+	}
+	root, err := New(Config{Client: remote, WorkspaceID: "ws_layout_collision", RemoteRoot: "/"})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	ctx := context.Background()
+	var entryOut fuse.EntryOut
+	child, lookupErrno := root.Lookup(ctx, layoutFilename, &entryOut)
+	if lookupErrno != 0 {
+		t.Fatalf("Lookup(%q) errno = %d, want 0", layoutFilename, lookupErrno)
+	}
+	fileNode, ok := child.Operations().(*FileNode)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned %T, want *FileNode", layoutFilename, child.Operations())
+	}
+	handle, _, openErrno := fileNode.Open(ctx, 0)
+	if openErrno != 0 {
+		t.Fatalf("Open(%q) errno = %d, want 0", layoutFilename, openErrno)
+	}
+	fileHandle, ok := handle.(*FileHandle)
+	if !ok {
+		t.Fatalf("Open(%q) returned %T, want *FileHandle", layoutFilename, handle)
+	}
+	result, readErrno := fileHandle.Read(ctx, make([]byte, len(LayoutMarkdown)+16), 0)
+	if readErrno != 0 {
+		t.Fatalf("Read(%q) errno = %d, want 0", layoutFilename, readErrno)
+	}
+	data, status := result.Bytes(nil)
+	if status != 0 {
+		t.Fatalf("Read(%q) status = %d, want 0", layoutFilename, status)
+	}
+	result.Done()
+	if string(data) != LayoutMarkdown {
+		t.Fatalf("collision read returned remote content instead of virtual layout")
+	}
+	if len(remote.readFilePaths) != 0 {
+		t.Fatalf("expected collision reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
+	}
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1820,6 +1820,9 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	if err != nil {
 		return nil
 	}
+	// _index.json files and nested <integration>/.layout.md dotfiles are
+	// first-class remote payloads. Do not filter or normalize them here; only
+	// the internal .relayfile-mount-state.json family is reserved elsewhere.
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
 	}
@@ -2678,10 +2681,6 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 }
 
 func localToRemotePath(localRoot, remoteRoot, localPath string) (string, error) {
-	// Wave 106 only makes mountfuse consumers tolerant of both `<id>.json`
-	// and `<name>__<id>.json` basenames. mountsync does not derive entity IDs
-	// from local basenames here; it mirrors the caller's relative path back to
-	// the remote root verbatim, so no name/id canonicalization is required.
 	rel, err := filepath.Rel(localRoot, localPath)
 	if err != nil {
 		return "", err

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2274,14 +2274,198 @@ func TestRemoteToLocalAndLocalToRemotePath(t *testing.T) {
 	if remotePath != "/notion/Folder/File.md" {
 		t.Fatalf("unexpected remote path mapping: %s", remotePath)
 	}
+}
 
-	nameIDPath := filepath.Join(localRoot, "Folder", "Human Name__01HXYZ.json")
-	nameIDRemotePath, err := localToRemotePath(localRoot, "/notion", nameIDPath)
+func TestApplyRemoteFile_IndexAndLayoutFiles(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_index_layout",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
 	if err != nil {
-		t.Fatalf("localToRemotePath for name/id basename failed: %v", err)
+		t.Fatalf("new syncer failed: %v", err)
 	}
-	if nameIDRemotePath != "/notion/Folder/Human Name__01HXYZ.json" {
-		t.Fatalf("unexpected name/id remote path mapping: %s", nameIDRemotePath)
+
+	indexBody := "{\n  \"title\": \"Caf\\u00e9 \\u2615\",\n  \"rows\": [\n    {\"title\": \"Alpha\", \"file\": \"alpha__page-1.md\"}\n  ]\n}\n"
+	layoutBody := "# notion layout\n\nRead `_index.json` first.\n"
+
+	if err := syncer.applyRemoteFile("/notion/pages/_index.json", RemoteFile{
+		Path:        "/notion/pages/_index.json",
+		Revision:    "rev_index",
+		ContentType: "application/json",
+		Content:     indexBody,
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteFile(_index.json) failed: %v", err)
+	}
+	if err := syncer.applyRemoteFile("/notion/.layout.md", RemoteFile{
+		Path:        "/notion/.layout.md",
+		Revision:    "rev_layout",
+		ContentType: "text/markdown",
+		Content:     layoutBody,
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteFile(.layout.md) failed: %v", err)
+	}
+
+	indexPath := filepath.Join(localDir, "notion", "pages", "_index.json")
+	layoutPath := filepath.Join(localDir, "notion", ".layout.md")
+	indexBytes, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read %s failed: %v", indexPath, err)
+	}
+	layoutBytes, err := os.ReadFile(layoutPath)
+	if err != nil {
+		t.Fatalf("read %s failed: %v", layoutPath, err)
+	}
+	if string(indexBytes) != indexBody {
+		t.Fatalf("_index.json content mismatch: got %q, want %q", string(indexBytes), indexBody)
+	}
+	if string(layoutBytes) != layoutBody {
+		t.Fatalf(".layout.md content mismatch: got %q, want %q", string(layoutBytes), layoutBody)
+	}
+	if got, want := hashBytes(indexBytes), hashBytes([]byte(indexBody)); got != want {
+		t.Fatalf("_index.json hash = %s, want %s", got, want)
+	}
+	if got, want := hashBytes(layoutBytes), hashBytes([]byte(layoutBody)); got != want {
+		t.Fatalf(".layout.md hash = %s, want %s", got, want)
+	}
+	if info, err := os.Stat(filepath.Join(localDir, "notion", "pages")); err != nil {
+		t.Fatalf("stat notion/pages failed: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected notion/pages to be a directory")
+	}
+}
+
+func TestApplyRemoteFile_NestedIndexAndLayout(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_nested_indexes",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	cases := []struct {
+		remotePath string
+		revision   string
+		content    string
+	}{
+		{
+			remotePath: "/linear/issues/_index.json",
+			revision:   "rev_linear",
+			content:    "{\n  \"rows\": [{\"title\": \"Bug 106\", \"file\": \"bug-106__issue-1.md\"}]\n}\n",
+		},
+		{
+			remotePath: "/github/repos/_index.json",
+			revision:   "rev_github",
+			content:    "{\n  \"rows\": [{\"title\": \"relayfile\", \"file\": \"relayfile__repo-1.md\"}]\n}\n",
+		},
+	}
+
+	for _, tc := range cases {
+		if err := syncer.applyRemoteFile(tc.remotePath, RemoteFile{
+			Path:        tc.remotePath,
+			Revision:    tc.revision,
+			ContentType: "application/json",
+			Content:     tc.content,
+		}, nil); err != nil {
+			t.Fatalf("applyRemoteFile(%s) failed: %v", tc.remotePath, err)
+		}
+		localPath := filepath.Join(localDir, filepath.FromSlash(strings.TrimPrefix(tc.remotePath, "/")))
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			t.Fatalf("read %s failed: %v", localPath, err)
+		}
+		if string(data) != tc.content {
+			t.Fatalf("%s content mismatch: got %q, want %q", localPath, string(data), tc.content)
+		}
+		if got, want := hashBytes(data), hashBytes([]byte(tc.content)); got != want {
+			t.Fatalf("%s hash = %s, want %s", localPath, got, want)
+		}
+		if info, err := os.Stat(filepath.Dir(localPath)); err != nil {
+			t.Fatalf("stat %s failed: %v", filepath.Dir(localPath), err)
+		} else if !info.IsDir() {
+			t.Fatalf("expected %s to be a directory", filepath.Dir(localPath))
+		}
+	}
+}
+
+func TestApplyRemoteSnapshot_PreservesNestedLayoutDotfiles(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_snapshot_layout",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	remoteFiles := map[string]RemoteFile{
+		"/notion/.layout.md": {
+			Path:        "/notion/.layout.md",
+			Revision:    "rev_snapshot_layout",
+			ContentType: "text/markdown",
+			Content:     "# snapshot layout\n",
+		},
+		"/notion/pages/_index.json": {
+			Path:        "/notion/pages/_index.json",
+			Revision:    "rev_snapshot_index",
+			ContentType: "application/json",
+			Content:     "{\n  \"rows\": []\n}\n",
+		},
+	}
+	if err := syncer.applyRemoteSnapshot(remoteFiles, nil); err != nil {
+		t.Fatalf("applyRemoteSnapshot failed: %v", err)
+	}
+
+	assertLocalFileContent(t, filepath.Join(localDir, "notion", ".layout.md"), "# snapshot layout\n")
+	assertLocalFileContent(t, filepath.Join(localDir, "notion", "pages", "_index.json"), "{\n  \"rows\": []\n}\n")
+}
+
+func TestApplyWebSocketEvent_PreservesNestedLayoutDotfiles(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/.layout.md": {
+				Path:        "/notion/.layout.md",
+				Revision:    "rev_ws_layout",
+				ContentType: "text/markdown",
+				Content:     "# websocket layout\n",
+			},
+		},
+	}
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_event_layout",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.applyWebSocketEvent(context.Background(), websocketEvent{
+		Type:      "file.updated",
+		Path:      "/notion/.layout.md",
+		Timestamp: "2026-05-09T00:00:00Z",
+	}); err != nil {
+		t.Fatalf("applyWebSocketEvent failed: %v", err)
+	}
+
+	assertLocalFileContent(t, filepath.Join(localDir, "notion", ".layout.md"), "# websocket layout\n")
+	if client.readFileCalls != 1 {
+		t.Fatalf("expected websocket layout update to perform one ReadFile, got %d", client.readFileCalls)
 	}
 }
 


### PR DESCRIPTION
Part 1 of 3 from #106. Additive, low-risk.

Adds:
- `_index.json` in every materialized mount directory containing a
  compact list of `{ id, title|name, updated }` rows so agents can
  do "find by title" in two reads instead of N.
- `LAYOUT.md` (a.k.a. SKILL.md) at the mount root teaching agents
  the structure on first look.

No existing files are renamed or moved. Symlinks / by-title / by-id
aliases land in PR 2 (#106). State-grouped views + lazy GH land in PR 3.

See AgentWorkforce/relayfile#106 for benchmark motivation.

## Repo scope

This PR is the **relayfile** part of wave `wave1-indexes`. The
companion PRs in the other repos are linked from issue #106.

## Test plan

- [x] `cd /Users/khaliqgant/Projects/AgentWorkforce/relayfile && go test ./internal/mountfuse/... ./internal/mountsync/...`
- [x] `cd /Users/khaliqgant/Projects/AgentWorkforce/relayfile && go vet ./...`
- [ ] Manual: re-run the cost benchmark referenced in #106 after all 3 PRs merge.

Generated by an overnight agent run. See
`/tmp/106-wave1-indexes-status.md` on the host for triage notes.

Refs AgentWorkforce/relayfile#106
