### PR TITLE
improve sync durability and add storage bridge specs

### DIFF
--- a/.trajectories/completed/2026-05/traj_xeov1ooxflbx.json
+++ b/.trajectories/completed/2026-05/traj_xeov1ooxflbx.json
@@ -1,0 +1,121 @@
+{
+  "id": "traj_xeov1ooxflbx",
+  "version": 1,
+  "task": {
+    "title": "Define relayfile pricing strategy: tiers, platform plans, and rationale"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-09T08:55:49.452Z",
+  "completedAt": "2026-05-09T08:57:52.662Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-09T08:55:57.001Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_dyhwk2vq6s3h",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-09T08:55:57.001Z",
+      "endedAt": "2026-05-09T08:57:52.662Z",
+      "events": [
+        {
+          "ts": 1778316957004,
+          "type": "decision",
+          "content": "Charge on events (webhook ingestions + file writes), not seats or agent connections: Charge on events (webhook ingestions + file writes), not seats or agent connections",
+          "raw": {
+            "question": "Charge on events (webhook ingestions + file writes), not seats or agent connections",
+            "chosen": "Charge on events (webhook ingestions + file writes), not seats or agent connections",
+            "alternatives": [],
+            "reasoning": "Seats don't map to AI agents (agents aren't humans, aren't persistent). Per-agent pricing is hard to count — agents are ephemeral. Events are the best proxy for coordination work done and scale proportionally with value delivered. Fan-out to agent WebSocket connections is explicitly excluded from event counting: broadcasting one file change to 20 agents is one event, not 20, because penalizing multi-agent usage would undermine the core value proposition."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778316965041,
+          "type": "decision",
+          "content": "Starter at $79/month (not $49): Starter at $79/month (not $49)",
+          "raw": {
+            "question": "Starter at $79/month (not $49)",
+            "chosen": "Starter at $79/month (not $49)",
+            "alternatives": [],
+            "reasoning": "Composio Starter is $29/month for 200K tool calls — pure routing, no coordination. Relayfile provides a qualitatively different layer (real-time fan-out, forks, persistent workspace) that justifies a premium. $49 was the initial estimate but doesn't cover Nango Starter infrastructure costs (~$20-30/month for 8 integrations) at meaningful margin. $79 leaves ~40% gross margin while positioning clearly above tool-call commoditization."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778316973142,
+          "type": "decision",
+          "content": "Growth at $499/month (bumped from $299): Growth at $499/month (bumped from $299)",
+          "raw": {
+            "question": "Growth at $499/month (bumped from $299)",
+            "chosen": "Growth at $499/month (bumped from $299)",
+            "alternatives": [],
+            "reasoning": "The Nango cost problem: at $299/month you cannot cover a Nango Growth plan ($500/month) for a customer using all integrations. Nango Growth costs ~$150-200/month as a fraction of usage for a Growth-tier customer. $499 covers that at ~60% gross margin. $499 also matches Nango's own Growth price ($500) which is a useful anchor — relayfile costs the same as Nango but adds the coordination layer Nango doesn't have. Composio Professional is $229; relayfile at $499 is clearly premium but justified by the multi-agent coordination, real-time fan-out, forks, and ACLs that Composio doesn't provide."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778316982546,
+          "type": "decision",
+          "content": "Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder: Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder",
+          "raw": {
+            "question": "Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder",
+            "chosen": "Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder",
+            "alternatives": [],
+            "reasoning": "Customers arriving via Nango, Composio, or Pipedream have already paid for adjacent infrastructure. Charging them full Growth ($499) on top of their existing spend creates sticker shock that kills conversion. Platform plans are priced to complement what the customer already pays: Nango plan assumes customer's Nango subscription handles provider OAuth and sync — relayfile only adds coordination and fan-out, so infrastructure costs are lower, justifying $299. Composio plan anchors to Composio Pro ($229) — 'Composio gives agents hands, relayfile gives them shared memory' — combined spend ~$428 for a full multi-agent stack. Pipedream plan targets cost-sensitive developers; $149 is the floor covering event infrastructure. These plans also serve as distribution: listed on each platform's marketplace they generate leads from customers who are already agent-infrastructure buyers."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778316993303,
+          "type": "decision",
+          "content": "Position relayfile as coordination layer, not storage/sync/routing competitor: Position relayfile as coordination layer, not storage/sync/routing competitor",
+          "raw": {
+            "question": "Position relayfile as coordination layer, not storage/sync/routing competitor",
+            "chosen": "Position relayfile as coordination layer, not storage/sync/routing competitor",
+            "alternatives": [],
+            "reasoning": "Mirage is open-source and free — competing on storage/sync would require underpricing or matching free, which is unsustainable. Composio has driven tool-call routing to near-zero ($0.15-0.30/1K calls). The defensible position is the coordination layer: multi-agent concurrent writes with conflict detection (If-Match), forks for proposals, real-time WebSocket fan-out, ACLs per agent, and semantic metadata with cross-provider queries. None of MCP, Mirage, Nango, Composio, or Pipedream provide this. The pricing must reflect this positioning: we're not a better S3 or a smarter webhook router, we're the shared workspace where humans and agents work together on the same records at the same time. Integration value-add is highest for multi-writer collaboration tools (Linear, Jira, GitHub, Notion) — not storage backends — because that's where the coordination problem is hardest and relayfile's value is clearest."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778317065784,
+          "type": "reflection",
+          "content": "Pricing strategy fully defined across standard tiers and platform plans. Key insight: the Nango cost problem forced Growth from $299 to $499, which accidentally improved competitive positioning (now matches Nango Growth price while adding the coordination layer). Platform plans solve distribution AND conversion — priced to complement existing spend rather than compete with it.",
+          "raw": {
+            "focalPoints": [
+              "margin",
+              "positioning",
+              "distribution"
+            ],
+            "confidence": 0.85
+          },
+          "significance": "high",
+          "tags": [
+            "focal:margin",
+            "focal:positioning",
+            "focal:distribution",
+            "confidence:0.85"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Defined relayfile pricing: Free/$0, Starter/$79, Growth/$499, Enterprise/custom standard tiers; plus Nango/$299, Composio/$199, Pipedream/$149 platform plans. Billing unit is events (not seats/agents). Fan-out is free. Rationale for every number grounded in competitor pricing (Nango $500, Composio $229/$29) and Nango infrastructure cost model.",
+    "approach": "Standard approach",
+    "confidence": 0.85
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/home/user/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "e5da17142445608ee08ed5f4419c2d1069e9983a",
+    "endRef": "e5da17142445608ee08ed5f4419c2d1069e9983a"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_xeov1ooxflbx.md
+++ b/.trajectories/completed/2026-05/traj_xeov1ooxflbx.md
@@ -1,0 +1,52 @@
+# Trajectory: Define relayfile pricing strategy: tiers, platform plans, and rationale
+
+> **Status:** ✅ Completed
+> **Confidence:** 85%
+> **Started:** May 9, 2026 at 08:55 AM
+> **Completed:** May 9, 2026 at 08:57 AM
+
+---
+
+## Summary
+
+Defined relayfile pricing: Free/$0, Starter/$79, Growth/$499, Enterprise/custom standard tiers; plus Nango/$299, Composio/$199, Pipedream/$149 platform plans. Billing unit is events (not seats/agents). Fan-out is free. Rationale for every number grounded in competitor pricing (Nango $500, Composio $229/$29) and Nango infrastructure cost model.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Charge on events (webhook ingestions + file writes), not seats or agent connections
+- **Chose:** Charge on events (webhook ingestions + file writes), not seats or agent connections
+- **Reasoning:** Seats don't map to AI agents (agents aren't humans, aren't persistent). Per-agent pricing is hard to count — agents are ephemeral. Events are the best proxy for coordination work done and scale proportionally with value delivered. Fan-out to agent WebSocket connections is explicitly excluded from event counting: broadcasting one file change to 20 agents is one event, not 20, because penalizing multi-agent usage would undermine the core value proposition.
+
+### Starter at $79/month (not $49)
+- **Chose:** Starter at $79/month (not $49)
+- **Reasoning:** Composio Starter is $29/month for 200K tool calls — pure routing, no coordination. Relayfile provides a qualitatively different layer (real-time fan-out, forks, persistent workspace) that justifies a premium. $49 was the initial estimate but doesn't cover Nango Starter infrastructure costs (~$20-30/month for 8 integrations) at meaningful margin. $79 leaves ~40% gross margin while positioning clearly above tool-call commoditization.
+
+### Growth at $499/month (bumped from $299)
+- **Chose:** Growth at $499/month (bumped from $299)
+- **Reasoning:** The Nango cost problem: at $299/month you cannot cover a Nango Growth plan ($500/month) for a customer using all integrations. Nango Growth costs ~$150-200/month as a fraction of usage for a Growth-tier customer. $499 covers that at ~60% gross margin. $499 also matches Nango's own Growth price ($500) which is a useful anchor — relayfile costs the same as Nango but adds the coordination layer Nango doesn't have. Composio Professional is $229; relayfile at $499 is clearly premium but justified by the multi-agent coordination, real-time fan-out, forks, and ACLs that Composio doesn't provide.
+
+### Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder
+- **Chose:** Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder
+- **Reasoning:** Customers arriving via Nango, Composio, or Pipedream have already paid for adjacent infrastructure. Charging them full Growth ($499) on top of their existing spend creates sticker shock that kills conversion. Platform plans are priced to complement what the customer already pays: Nango plan assumes customer's Nango subscription handles provider OAuth and sync — relayfile only adds coordination and fan-out, so infrastructure costs are lower, justifying $299. Composio plan anchors to Composio Pro ($229) — 'Composio gives agents hands, relayfile gives them shared memory' — combined spend ~$428 for a full multi-agent stack. Pipedream plan targets cost-sensitive developers; $149 is the floor covering event infrastructure. These plans also serve as distribution: listed on each platform's marketplace they generate leads from customers who are already agent-infrastructure buyers.
+
+### Position relayfile as coordination layer, not storage/sync/routing competitor
+- **Chose:** Position relayfile as coordination layer, not storage/sync/routing competitor
+- **Reasoning:** Mirage is open-source and free — competing on storage/sync would require underpricing or matching free, which is unsustainable. Composio has driven tool-call routing to near-zero ($0.15-0.30/1K calls). The defensible position is the coordination layer: multi-agent concurrent writes with conflict detection (If-Match), forks for proposals, real-time WebSocket fan-out, ACLs per agent, and semantic metadata with cross-provider queries. None of MCP, Mirage, Nango, Composio, or Pipedream provide this. The pricing must reflect this positioning: we're not a better S3 or a smarter webhook router, we're the shared workspace where humans and agents work together on the same records at the same time. Integration value-add is highest for multi-writer collaboration tools (Linear, Jira, GitHub, Notion) — not storage backends — because that's where the coordination problem is hardest and relayfile's value is clearest.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Charge on events (webhook ingestions + file writes), not seats or agent connections: Charge on events (webhook ingestions + file writes), not seats or agent connections
+- Starter at $79/month (not $49): Starter at $79/month (not $49)
+- Growth at $499/month (bumped from $299): Growth at $499/month (bumped from $299)
+- Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder: Create platform plans (Nango $299, Composio $199, Pipedream $149) rather than a single pricing ladder
+- Position relayfile as coordination layer, not storage/sync/routing competitor: Position relayfile as coordination layer, not storage/sync/routing competitor
+- Pricing strategy fully defined across standard tiers and platform plans. Key insight: the Nango cost problem forced Growth from $299 to $499, which accidentally improved competitive positioning (now matches Nango Growth price while adding the coordination layer). Platform plans solve distribution AND conversion — priced to complement existing spend rather than compete with it.

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-08T17:31:23.172Z",
+  "lastUpdated": "2026-05-09T08:57:52.757Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -166,6 +166,13 @@
       "startedAt": "2026-05-08T17:27:24.218Z",
       "completedAt": "2026-05-08T17:31:22.965Z",
       "path": "/Users/will/Projects/relayfile/.claude/worktrees/issue-104-async-create-mount/.trajectories/completed/2026-05/traj_v1un6n66y38i.json"
+    },
+    "traj_xeov1ooxflbx": {
+      "title": "Define relayfile pricing strategy: tiers, platform plans, and rationale",
+      "status": "completed",
+      "startedAt": "2026-05-09T08:55:49.452Z",
+      "completedAt": "2026-05-09T08:57:52.662Z",
+      "path": "/home/user/relayfile/.trajectories/completed/2026-05/traj_xeov1ooxflbx.json"
     }
   }
 }

--- a/docs/guides/proactive-agents.md
+++ b/docs/guides/proactive-agents.md
@@ -1,0 +1,202 @@
+# Making Agents Proactive
+
+Most agents are reactive — they respond when called. A proactive agent knows when something changed in the outside world and acts without being triggered manually.
+
+Getting there without relayfile requires significant infrastructure. Here is the concrete comparison.
+
+---
+
+## Without Relayfile
+
+To make an agent proactive against a single provider (Linear), you need:
+
+### 1. A public webhook endpoint
+
+```typescript
+import express from 'express';
+import crypto from 'crypto';
+import { timingSafeEqual } from 'crypto';
+
+const app = express();
+
+// Must consume raw body before JSON parsing for signature verification
+app.post('/webhooks/linear', express.raw({ type: '*/*' }), async (req, res) => {
+
+  // 2. Verify Linear's HMAC-SHA256 signature
+  const signature = req.headers['x-linear-signature'] as string;
+  const expected = crypto
+    .createHmac('sha256', process.env.LINEAR_WEBHOOK_SECRET!)
+    .update(req.body)
+    .digest('hex');
+
+  if (!timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+    return res.status(401).send('Unauthorized');
+  }
+
+  // 3. Must respond within 2 seconds or Linear retries for 2 hours
+  res.status(200).send('OK');
+
+  // 4. Hand off to queue immediately — do not process inline
+  await queue.add('linear-event', {
+    body: req.body.toString(),
+    receivedAt: Date.now(),
+  });
+});
+```
+
+### 2. Queue infrastructure and a worker
+
+```typescript
+// Requires Redis or SQS running somewhere
+import Queue from 'bull';
+const queue = new Queue('linear-event', process.env.REDIS_URL!);
+
+queue.process(async (job) => {
+  const payload = JSON.parse(job.data.body);
+
+  // 5. Deduplicate — Linear sends duplicates under load
+  const dedupKey = `seen:${payload.webhookId}`;
+  const already = await redis.get(dedupKey);
+  if (already) return;
+  await redis.set(dedupKey, '1', 'EX', 86400);
+
+  // 6. Filter to relevant event types
+  if (payload.type !== 'Issue') return;
+
+  // 7. Fetch current state — webhook payload is often partial
+  const issue = await linearClient.issue(payload.data.id);
+
+  // 8. Load agent context for this workspace
+  const context = await db.query(
+    'SELECT * FROM agent_contexts WHERE team_id = $1',
+    [issue.team.id]
+  );
+
+  // 9. Trigger agent
+  await agent.handle({ issue, context: context.rows[0] });
+});
+```
+
+### 3. Register the webhook with Linear
+
+```typescript
+// Run once per environment — and again whenever your URL changes
+await linearClient.createWebhook({
+  url: 'https://your-domain.com/webhooks/linear',
+  teamId: process.env.LINEAR_TEAM_ID!,
+  resourceTypes: ['Issue', 'Comment', 'Project'],
+});
+```
+
+### That is one provider.
+
+Now add GitHub, Jira, and Slack. Each requires its own endpoint, its own signature format, its own retry behavior, its own payload schema, and its own registration step:
+
+| Provider | Signature header | Algorithm | Retry window | Partial payload? |
+|---|---|---|---|---|
+| Linear | `X-Linear-Signature` | HMAC-SHA256 | 2 hours | Yes |
+| GitHub | `X-Hub-Signature-256` | HMAC-SHA256 | 3 attempts | No |
+| Jira | `X-Hub-Signature` | HMAC-SHA256 (admin) or none | No retry | Yes |
+| Slack | `X-Slack-Signature` | HMAC-SHA256 + timestamp | 3 retries | No |
+| Notion | None (IP allowlist only) | — | No retry | Yes |
+
+Four endpoints. Four verification implementations. Four registration flows. Four payload parsers. Ongoing maintenance when providers change schemas.
+
+**Estimated build time: 4–8 weeks for production-ready multi-provider coverage.**
+
+You now own this infrastructure. You are responsible for queue health, dead-letter monitoring, webhook re-registration when your URL changes, and debugging silent failures when a provider changes its schema.
+
+---
+
+## With Relayfile
+
+Relayfile handles endpoint registration, signature verification, deduplication, ordering, normalization, and state persistence. The agent sees none of it.
+
+### Setup: connect your providers once
+
+```typescript
+// In your relayfile workspace config — done once, not per-agent
+{
+  "workspace": "acme/ops",
+  "providers": ["linear", "github", "jira", "slack"]
+}
+```
+
+### Agent code: three lines
+
+```typescript
+import { RelayFileSync } from '@relayfile/sdk';
+
+const sync = new RelayFileSync({
+  workspace: 'acme/ops',
+  token: process.env.RELAYFILE_TOKEN,
+});
+
+sync.on('change', async (file) => {
+  await agent.handle(file);
+});
+```
+
+The agent receives a normalized file update — not a raw webhook payload. The affected file path, the previous state, and the current state are already resolved. The agent does not know which provider originated the event and does not need to.
+
+### What a change event looks like
+
+```typescript
+// file received by the agent
+{
+  path: '/linear/issues/ENG-412.json',
+  event: 'updated',
+  previous: { status: 'in_review', assignee: 'alice' },
+  current:  { status: 'blocked',   assignee: 'alice', blockedReason: 'waiting on design' },
+  occurredAt: '2026-05-10T14:32:01Z',
+  source: 'linear.issue.updated',
+}
+```
+
+The agent reads what changed and decides what to do. Everything else is handled.
+
+### Handling multiple providers
+
+```typescript
+sync.on('change', async (file) => {
+  if (file.path.startsWith('/linear/issues/')) {
+    await handleLinearIssue(file);
+  } else if (file.path.startsWith('/github/pulls/')) {
+    await handleGithubPR(file);
+  } else if (file.path.startsWith('/slack/messages/')) {
+    await handleSlackMessage(file);
+  }
+});
+```
+
+No new infrastructure per provider. No new verification logic. No new registration steps.
+
+---
+
+## Side-by-Side
+
+| | Without relayfile | With relayfile |
+|---|---|---|
+| Public endpoint required | Yes — you host and maintain it | No |
+| Signature verification | Per provider, per algorithm | None |
+| Queue infrastructure | Yes — Redis or SQS | None |
+| Deduplication logic | Yes — per provider | None |
+| Payload parsing | Per provider, per event type | Normalized file diff |
+| Webhook registration | Per provider, per environment | Workspace config |
+| Re-registration on URL change | Manual | N/A |
+| State between agent runs | You build it | Built in |
+| New provider | 1–2 weeks per provider | Config change |
+| Time to first proactive agent | 4–8 weeks | < 1 day |
+
+---
+
+## What "Proactive" Actually Enables
+
+A reactive agent waits. A proactive agent acts when the moment is right.
+
+- **Support agent** closes a ticket the moment the customer replies, not the next time it is scheduled to check.
+- **Coding agent** pauses mid-task when it detects the ticket scope changed, rather than finishing work that is now invalid.
+- **Sales agent** enriches a contact record the moment a new deal is created, while the rep is still on the intake call.
+- **Incident agent** starts a runbook the moment PagerDuty fires, not 60 seconds later when the next polling cycle runs.
+
+The difference between reactive and proactive is the difference between an assistant that needs to be asked and one that already handled it.

--- a/docs/guides/proactive-agents.md
+++ b/docs/guides/proactive-agents.md
@@ -112,6 +112,14 @@ You now own this infrastructure. You are responsible for queue health, dead-lett
 
 Relayfile handles endpoint registration, signature verification, deduplication, ordering, normalization, and state persistence. The agent sees none of it.
 
+More broadly, **relaycron, relaycast, and relayfile are all ways an agent can become proactive**:
+
+- **relaycron** wakes the agent up on time
+- **relayfile** wakes the agent up when the world changes
+- **relaycast** wakes the agent up when someone or something has something to say
+
+That is the core loop. A proactive cloud agent does not just run on a schedule. It can wake up because time passed, data changed, or a message arrived.
+
 ### Setup: connect your providers once
 
 ```typescript
@@ -136,6 +144,8 @@ sync.on('change', async (file) => {
   await agent.handle(file);
 });
 ```
+
+The same agent can also be woken up by relaycron ticks or relaycast messages. Relayfile is one part of the proactive runtime, not the only trigger.
 
 The agent receives a normalized file update — not a raw webhook payload. The affected file path, the previous state, and the current state are already resolved. The agent does not know which provider originated the event and does not need to.
 
@@ -200,3 +210,11 @@ A reactive agent waits. A proactive agent acts when the moment is right.
 - **Incident agent** starts a runbook the moment PagerDuty fires, not 60 seconds later when the next polling cycle runs.
 
 The difference between reactive and proactive is the difference between an assistant that needs to be asked and one that already handled it.
+
+In practice, that usually means combining three triggers:
+
+- **relaycron** for scheduled wakeups
+- **relayfile** for change-driven wakeups
+- **relaycast** for message-driven wakeups
+
+Together they give developers a very small mental model for proactive agents: give the agent a workspace, a clock, and an inbox.

--- a/docs/integration-priority.md
+++ b/docs/integration-priority.md
@@ -1,0 +1,167 @@
+# Integration Priority
+
+Which integrations to build and in what order, based on where relayfile's value-add is highest.
+
+---
+
+## The Prioritization Framework
+
+Relayfile's core value is not being a better notification bridge or a smarter cache. It is the **shared workspace where humans and agents work on the same things at the same time**. That means value is highest where:
+
+1. **Multiple writers** — humans and agents both mutate the same records concurrently
+2. **Living state** — records evolve continuously, not just at ingestion time
+3. **Cross-record relationships** — the graph of connections between records matters to agents
+4. **Consequential writeback** — an agent writing back has real business impact, so conflict detection and ACLs are not optional
+5. **Webhook support** — the system can push changes rather than requiring polling
+
+Where all five are true, relayfile is genuinely irreplaceable. Where none are true, MCP or Mirage compete just as well.
+
+This framework produces four tiers:
+
+| Tier | Characteristics | Relayfile value |
+|---|---|---|
+| **1 — Collaboration** | Multi-writer, living state, rich relations | Irreplaceable |
+| **2 — Action** | Human+agent writes, consequential, ACL-sensitive | Very high |
+| **3 — Awareness** | Real-time read, cross-record, some writes | High |
+| **4 — Data** | Mostly read, append-only, low concurrency | Moderate |
+
+---
+
+## Tier 1: Collaboration (Highest Value)
+
+These are the systems where humans and agents are actively reading and writing the same records at the same time. Conflict detection, forks, ACLs, and real-time fan-out are all load-bearing here. MCP and Mirage offer nothing comparable.
+
+### Already Built
+
+| Adapter | Why it's Tier 1 | Status |
+|---|---|---|
+| **Linear** | Issues live-edited by humans while agents triage, comment, and update status simultaneously. Relations between issues, projects, and cycles are rich. | ✓ Built |
+| **Jira** | Enterprise issue tracking with complex workflows, assignees, comments, and linked issues. Agent writes to status and comments are consequential. | ✓ Built |
+| **GitHub** | PRs, issues, and code review are the canonical multi-writer collaboration surface. Agents commenting, reviewing, and updating issues alongside humans. | ✓ Built |
+| **GitLab** | Same as GitHub for GitLab-native teams. | ✓ Built |
+| **Notion** | Collaborative knowledge base with nested pages, databases, and relations. Humans edit pages while agents synthesize, summarize, and link records. | ✓ Built |
+| **Asana** | Task and project management with assignees, dependencies, and timelines. Agent and human updates to task status and comments. | ✓ Built |
+| **ClickUp** | Broad task management with docs, whiteboards, and automations. Heavy multi-writer usage. | ✓ Built |
+
+### Missing — Build Next
+
+| Integration | Why it belongs here | Priority |
+|---|---|---|
+| **Confluence** | The dominant enterprise knowledge base. Pages are collaboratively authored by humans; agents need to read, synthesize, and update them alongside human editors. Relations between Confluence pages and Jira issues are critical — already have Jira, Confluence completes the Atlassian pair. Webhooks available. | **#1** |
+| **Google Docs / Sheets** | Where the majority of collaborative knowledge work happens outside dedicated tools. Docs are living documents edited by multiple humans in real-time; agents that can see edits as they happen and write back are qualitatively more useful than any poll-based integration. Drive Watch API provides real-time push. | **#2** |
+| **SharePoint / OneDrive** | Enterprise equivalent of Google Docs for Microsoft 365 organizations. Document libraries are the primary collaboration surface for large enterprises. Graph subscriptions give real-time push. Completing the Microsoft stack (already have Teams). | **#3** |
+| **Monday.com** | Fast-growing project management platform with 225k+ organizations. Item boards have rich field types, automations, and cross-board relations. Webhooks available. | **#4** |
+| **Coda** | Collaborative doc-database hybrid popular with product and ops teams. Tables with cross-doc relations and automations. Webhooks available. | **#5** |
+| **Figma** | Design collaboration platform where comments, component links, and file versions are the coordination surface. Agents reviewing designs, creating comment threads, and extracting specs alongside designers. Webhook support for file changes and comments. | **#6** |
+| **Miro** | Collaborative whiteboard used heavily in planning and retros. Board items, sticky notes, and connections have relational structure. REST API with webhooks. | **#7** |
+
+---
+
+## Tier 2: Action (Very High Value)
+
+These systems have consequential agent writes — updating a CRM record, resolving a support ticket, escalating an incident. Conflict detection and ACLs matter because getting it wrong has real business impact. Cross-record relations (contact → deal → company) are rich.
+
+### Already Built
+
+| Adapter | Why it's Tier 2 | Status |
+|---|---|---|
+| **Salesforce** | CRM records (leads, contacts, opportunities, accounts) are the most consequential writes an agent can make. Relations between objects are deep. | ✓ Built |
+| **HubSpot** | Marketing and sales CRM with contacts, deals, companies, and activities. Agent writes to deal stage and contact properties are high-impact. | ✓ Built |
+| **Pipedrive** | Sales-focused CRM with deal pipeline. Common for SMB sales teams. | ✓ Built |
+| **Zendesk** | Customer support tickets with comments, assignees, and status transitions. Agent responses and status updates are public-facing and consequential. | ✓ Built |
+| **Intercom** | Customer messaging platform. Agent-drafted responses to customer conversations require ACL enforcement and conflict detection (two agents shouldn't both reply). | ✓ Built |
+
+### Missing — Build Next
+
+| Integration | Why it belongs here | Priority |
+|---|---|---|
+| **Freshdesk** | Second-largest helpdesk platform after Zendesk. Many organizations run Freshdesk specifically; a Zendesk adapter doesn't help them. Webhooks available. | **#1** |
+| **ServiceNow** | Dominant enterprise ITSM platform. Incident, change, and problem records are high-stakes; agent writes must be conflict-safe. REST API with table-level webhooks. | **#2** |
+| **PagerDuty** | Incident management. Agents acknowledging, escalating, and resolving incidents alongside on-call humans is a canonical multi-writer scenario. Webhooks available. | **#3** |
+| **Freshsales** | CRM from Freshworks ecosystem. Common companion to Freshdesk in SMB. | **#4** |
+| **Trello** | Simpler card-based project management with large user base. Cards, lists, and attachments. Webhooks available. | **#5** |
+
+---
+
+## Tier 3: Awareness (High Value)
+
+These systems are primarily real-time communication channels. Agents read and react to messages and events; writeback happens (sending messages, posting updates) but concurrency conflicts are softer than Tier 1/2.
+
+### Already Built
+
+| Adapter | Why it's Tier 3 | Status |
+|---|---|---|
+| **Slack** | The primary human communication channel. Agents reading channels and threads in real-time and posting responses. Cross-record relations to Linear, GitHub, Jira (via link unfurls and integrations) are valuable. | ✓ Built |
+| **Microsoft Teams** | Enterprise equivalent of Slack. Heavy in Microsoft 365 organizations (same stack as SharePoint/OneDrive). | ✓ Built |
+
+### Missing — Build Next
+
+| Integration | Why it belongs here | Priority |
+|---|---|---|
+| **Discord** | Primary communication platform for developer communities, open-source projects, and web3 teams. Bot webhooks give real-time message delivery. Growing for internal team use. | **#1** |
+| **Gmail** | Email remains the primary communication channel for B2B workflows. Agents reading threads and drafting replies with real-time push via Gmail Watch API + Pub/Sub. | **#2** |
+| **Outlook / Exchange** | Enterprise email for Microsoft 365 organizations. Graph API subscriptions for real-time push. Completes the Microsoft stack. | **#3** |
+| **Telegram** | Real-time bot webhooks (< 1s). Valuable for teams that use Telegram as a workflow channel, particularly in crypto, fintech, and international organizations. | **#4** |
+
+---
+
+## Tier 4: Data (Moderate Value)
+
+These systems are primarily read-heavy. Agents ingest data, run analysis, and occasionally write back. The concurrency problem is soft; MCP competes reasonably well here. Relayfile adds value through the semantic layer (cross-provider queries, relations to Tier 1/2 records) and scheduled freshness, but is not irreplaceable.
+
+### Already Built
+
+| Adapter | Why it's Tier 4 | Status |
+|---|---|---|
+| **Airtable** | Database/spreadsheet hybrid. Read-heavy for most agent workflows; occasional writes. Nango already has this. | ✓ Built |
+| **Shopify** | E-commerce platform. Order and product data read-heavy; writeback limited by Shopify's API (orders largely read-only). | ✓ Built |
+| **Stripe** | Payment data. Primarily read for analytics and reconciliation; some consequential writes (refunds, subscription updates). | ✓ Built |
+| **Mixpanel** | Analytics event data. Read-only for agents. Value is in cross-referencing with CRM (Salesforce contacts) via relations. | ✓ Built |
+| **Segment** | Customer data platform. Write-heavy from products into Segment; agents mostly read user traits and events. | ✓ Built |
+| **Mailgun** | Email delivery service. Transactional; agents read delivery status and bounces. Low concurrency. | ✓ Built |
+| **SendGrid** | Same as Mailgun. | ✓ Built |
+| **Calendly** | Scheduling. Agents reading availability and booking data. Low write-back, low concurrency. | ✓ Built |
+
+### Missing — Lower Priority
+
+| Integration | Notes | Priority |
+|---|---|---|
+| **Snowflake** | Cloud data warehouse. Read-heavy; agents query data but rarely write back. Value mainly through cross-provider relations (user IDs linking to Salesforce contacts). | Low |
+| **BigQuery** | Same as Snowflake for GCP teams. | Low |
+| **Twilio** | SMS/voice. Transactional; no real concurrency problem. | Low |
+| **Typeform** | Form responses. Append-only, read by agents. | Low |
+| **Webflow** | CMS. Content read-heavy; some writeback (publishing pages). | Low |
+
+---
+
+## Summary: What to Build Next
+
+Mapping against the existing 24 adapters, the highest-value gaps in order:
+
+| # | Integration | Tier | Gap it fills |
+|---|---|---|---|
+| 1 | **Confluence** | 1 — Collaboration | Completes Atlassian stack; Jira alone is half the picture |
+| 2 | **Google Docs / Drive** | 1 — Collaboration | Largest collaborative document surface in the world |
+| 3 | **SharePoint / OneDrive** | 1 — Collaboration | Enterprise document collaboration for Microsoft orgs |
+| 4 | **Freshdesk** | 2 — Action | Covers the half of support teams not on Zendesk |
+| 5 | **Gmail** | 3 — Awareness | Primary B2B communication channel; real-time push available |
+| 6 | **ServiceNow** | 2 — Action | Enterprise ITSM; high-stakes writes need conflict safety |
+| 7 | **PagerDuty** | 2 — Action | Incident management; canonical multi-writer scenario |
+| 8 | **Monday.com** | 1 — Collaboration | 225k+ organizations; rich project structure |
+| 9 | **Discord** | 3 — Awareness | Developer communities and modern team communication |
+| 10 | **Figma** | 1 — Collaboration | Design collaboration; comments and specs alongside designers |
+| 11 | **Outlook** | 3 — Awareness | Completes Microsoft 365 stack |
+| 12 | **Coda** | 1 — Collaboration | Collaborative doc-database popular in product/ops teams |
+| 13 | **Trello** | 2 — Action | Large user base; simple but widely deployed |
+| 14 | **Miro** | 1 — Collaboration | Planning and retro workflows |
+
+---
+
+## What Not to Build Yet
+
+- **Pure storage backends** (S3, GCS, R2, SFTP) — covered in `storage-bridge-spec.md`; valuable infrastructure but not where the coordination value is
+- **Analytics-only tools** (Looker, Metabase, Amplitude) — read-only for agents; MCP handles this fine
+- **Pure notification/transactional tools** (Twilio, Plaid, Braintree) — low concurrency, low relation depth; MCP or direct SDK is sufficient
+- **Self-hosted databases** (Postgres, MySQL, MongoDB) — covered in `storage-bridge-spec.md`; useful but not the coordination differentiation story
+
+These are worth doing eventually for completeness, but building them before Confluence, Google Docs, or Freshdesk would be optimizing for breadth over depth at the wrong moment.

--- a/docs/market-framing.md
+++ b/docs/market-framing.md
@@ -4,7 +4,27 @@
 
 "Multi-agent coordination layer" is the right description of what relayfile is, but it is the wrong pitch for today's market. Most teams are not running multiple peer agents writing to shared state. Pitching coordination for a pattern they don't yet have creates a timing mismatch — the product sounds like infrastructure for a future they haven't hit yet.
 
-The market that exists today is larger and more immediate, and relayfile serves it directly.
+The market that exists today is larger and more immediate. The academic research validates the architecture. The competitive landscape has clear gaps. And the enterprise opportunity is underserved by a small incumbent that relayfile can displace.
+
+---
+
+## Academic Validation
+
+Before the market framing, the architecture: a 2024 paper from Tsinghua, Huawei, and collaborators — *"Proactive Agent: Shifting LLM Agents from Reactive Responses to Active Assistance"* (arXiv:2410.12361) — empirically validates relayfile's core design choices across a benchmark of 6,790 training events and 233 real-world test cases.
+
+**What the paper proves:**
+
+1. **Push architecture, not polling, is the correct model for proactive agents.** The paper formalizes proactive agents as event stream consumers. An agent that polls cannot be proactive by definition — it is always acting on state that is N seconds old.
+
+2. **Persistent state per session is non-negotiable.** The paper proves mathematically that a stateless agent cannot infer intent. It has no basis for knowing what the user is building toward. Durable, queryable memory per session is a hard requirement, not an optimization.
+
+3. **Shared environmental state is the coordination primitive.** The paper's "Environment Gym" — a shared workspace that both agents and the simulated user read and write — is structurally identical to relayfile's VFS. Coordination happens through shared state, not direct message passing.
+
+4. **The hardest problem is calibrated restraint.** Without domain-specific fine-tuning, models "tend to provide as much assistance as possible, instead of necessary assistance." False alarms destroy user trust faster than missed detections. Even GPT-4o only achieves 64.60% F1 on proactive task prediction — the problem is hard at the frontier. This maps to relayfile's event normalization layer: not every webhook should fire the agent.
+
+5. **Multi-candidate fan-out dramatically outperforms single proposals.** Proposing three candidate tasks (Pred@3) and letting users filter improved GPT-4o from 64.60% to 77.72% F1. This is relayfile's fan-out model validated: broadcast to multiple agents, let the right one handle it.
+
+The paper's core quote: *"Currently, most existing LLM-based agents predominantly work in the reactive paradigm: they require explicit human instructions to initiate task completion and remain dormant in terms of providing services until prompted by user instructions."* That is the problem relayfile sells against.
 
 ---
 
@@ -12,7 +32,7 @@ The market that exists today is larger and more immediate, and relayfile serves 
 
 **Make your agent proactive with a few lines of code.**
 
-Today most agents are reactive — they respond when called. Relayfile makes them proactive: the agent knows when something changed in the outside world and acts without being polled or triggered manually. A Jira ticket moves to blocked, the agent is notified. A PR is merged, the agent updates its working state. A customer sends a message, the agent picks it up in real time.
+Today most cloud agents are reactive — they respond when called. Relayfile makes them proactive: the agent knows when something changed in the outside world and acts without being polled or manually triggered. A Jira ticket moves to blocked, the agent is notified. A PR is merged, the agent updates its working state. A customer sends a message, the agent picks it up in real time.
 
 That shift — from reactive to proactive — is one SDK call:
 
@@ -51,11 +71,13 @@ Every team shipping cloud agent products runs into the same class of failures. T
 
 Cloud agents have no filesystem. Between runs, between retries, between handoffs to a different instance, state must be stored somewhere. The default solution is a database table or a blob in S3. Neither supports real-time reads, concurrent writes, or conflict detection. Every team builds an ad hoc version of a shared workspace and none of them generalize.
 
+MindStudio, a popular agent-building platform, documents this gap directly in their blog: they recommend using Jira or Linear tickets as the shared state layer for multi-agent systems. That is a workaround, not a solution — and it is relayfile's market.
+
 ### Problem 2 — Stale reads
 
 The agent reads a record from an external system, spends time reasoning or executing multi-step tasks, and by the time it writes back the record has changed. The agent never knew. It overwrites the new state with a response based on the old one.
 
-This is the TOCTOU problem (time-of-check to time-of-use), endemic to every polling-based architecture. A 30-second polling interval means every agent action is based on state that is at least 30 seconds old. For cloud agents running long tasks, the drift can be minutes.
+This is the TOCTOU problem (time-of-check to time-of-use), endemic to every polling-based architecture. A 30-second polling interval means every agent action is based on state that is at least 30 seconds old. For cloud agents running long tasks, the drift can be minutes. The arXiv paper proves this is not solvable with better polling — the architecture must change to push.
 
 ### Problem 3 — Silent concurrent writes
 
@@ -71,7 +93,7 @@ The cloud agent starts a multi-step task. Halfway through, the context changes: 
 
 Every team building a cloud agent product builds the same pipeline from scratch: receive webhook, verify the signature (different format per provider), deduplicate, order, retry on failure, dead-letter, persist state, deliver to the agent. Then repeat for every provider.
 
-This is undifferentiated infrastructure. Every Tier 1 ICP below has already built a version of this and is maintaining it instead of building their actual product.
+This is undifferentiated infrastructure. Every Tier 1 ICP below has already built a version of this and is maintaining it instead of building their actual product. See `docs/guides/proactive-agents.md` for the concrete before/after.
 
 ### Problem 6 — State loss between agent sessions
 
@@ -79,43 +101,81 @@ A cloud agent run ends. The next run starts — scheduled, retried, or handed to
 
 ---
 
-## Why This Is Unserved
+## The Competitive Landscape
 
-| Layer | Existing tools | What they do | What they miss |
-|---|---|---|---|
-| Tool execution | Composio, Merge, Executor | Call the API on demand | No state between calls |
-| Data ingestion | Nango, Paragon Managed Sync | Get data in on a schedule | Polling latency; no conflict model |
-| **Persistent agent workspace** | **Nobody** | — | **Real-time currency; conflict detection; state across runs** |
+### What exists today and where it falls short
 
-Composio and Merge solve execution. Nango and Paragon solve ingestion. Nobody has standardized the layer where the cloud agent holds its working state between runs, knows in real time when something changed underneath it, and detects conflicts before acting on outdated information.
+**MindStudio** ($20/mo, 150K+ agents deployed): No-code visual workflow builder. 1,000+ integrations, 200+ models. Their proactive agent pattern is a "heartbeat" — polling every N minutes, wake, query APIs, reason, act. Their webhook trigger uses URL obscurity with no signature verification. They do not have a persistent shared workspace. Their own blog posts document the gap: they recommend file-based memory, shared SQLite, and issue trackers as state layers — all workarounds for the missing coordination layer. MindStudio is a natural distribution channel for relayfile, not a competitor.
 
----
+**Tonkean** (~$10K+/mo, F500 customers including Google, Workday, OpenAI): Enterprise G&A orchestration for procurement, legal, finance, and HR. The most technically sophisticated incumbent. Their patented async state engine handles durable workflow state with pause/resume on external events. Their context graph captures human decisions and cross-run lineage. Their proactive agents use webhook triggers and scheduled monitoring. This is real, well-designed infrastructure — for enterprise internal operations teams.
 
-## The Pitch
+Tonkean's moat is depth in G&A workflows. Their vulnerability is narrowness: they are an internal ops tool, not infrastructure for companies building agent products. They do not expose an SDK. They do not support companies shipping agents to their own customers. They raised $83M total with a $50M Series B in 2021 — four years ago, with no publicized Series C. They are a mid-sized company in a category that is about to get much larger.
 
-**Not:** "Relayfile is a coordination layer for multi-agent workflows."
+**Lindy, Relevance AI, Dust, n8n agents**: AI automation platforms that patch the state problem with workarounds (conversation memory, per-agent variables, ad hoc databases). None have a proper coordination layer. All are building for the same ICP as relayfile and all are paying the infrastructure tax.
 
-**Not:** "Relayfile is for developers building with AI agents." (Too broad — includes local dev use cases where it adds no value.)
+**Composio, Merge, Nango, Paragon**: Tool execution and data ingestion layers. They solve how agents call APIs and how data gets in. None of them solve the coordination layer — what the agent holds between reads and writes.
 
-**Yes:** "Make your agent proactive with a few lines of code." — and underneath that: a persistent cloud workspace, real-time event delivery, conflict-safe writes, and state that survives between runs, with none of the webhook infrastructure built by you.
+### The gap
 
-Multi-agent coordination is what customers grow into. The entry is simpler: the agent needs a workspace that exists between runs and knows when the world changed.
-
----
-
-## ICPs Today
-
-The right filter: **companies shipping cloud agents as a product**, where the agent runs in the vendor's infrastructure and has no local filesystem. Not developers using agents as tools on their own machines.
+| Layer | Existing tools | Gap |
+|---|---|---|
+| Tool execution | Composio, Merge, Executor | No state between calls |
+| Data ingestion | Nango, Paragon | Polling latency; no conflict model |
+| Workflow building | MindStudio, Lindy, Relevance AI | Ad hoc state workarounds |
+| Enterprise G&A ops | Tonkean | Only internal ops, not agent product companies; narrow vertical; stale funding |
+| **Persistent agent workspace** | **Nobody at the infrastructure layer** | **Real-time push, conflict detection, state across runs, for any use case** |
 
 ---
 
-### Tier 1 — AI Automation Platforms
+## The Enterprise Opportunity
 
-Cloud agents that take actions in users' SaaS tools on their behalf. The highest-density ICP: every company here is building the same coordination infrastructure from scratch, in their cloud, for every customer.
+Tonkean proves the enterprise pays for sophisticated agent state management. Their customers are paying $10K+/month for durable workflow state, context graphs, and proactive orchestration. The market is real.
+
+Tonkean's weaknesses are relayfile's opening:
+
+**Vertical lock-in.** Tonkean is purpose-built for G&A (procurement, legal, finance). An enterprise engineering team, IT ops team, or AI product team cannot use Tonkean for their use case. Relayfile is horizontal — the same coordination layer works for any agent workflow in any function.
+
+**Closed ecosystem.** Tonkean does not expose an SDK. You cannot embed Tonkean's state engine into your own product. Companies building internal AI agents or shipping AI features to their customers cannot use Tonkean as infrastructure — they must build on top of their workflow builder or not use it at all. Relayfile is infrastructure-first: the SDK is the product.
+
+**Funding gap.** The last publicized Tonkean round was a $50M Series B in 2021. The Cinch acquisition (December 2025) signals they needed inorganic growth. A well-capitalized, horizontally-positioned competitor with a developer-first go-to-market can move faster.
+
+**No agent product company story.** Tonkean targets procurement teams at large enterprises. Relayfile targets the companies those enterprises are buying AI products from — and the enterprises themselves building internal AI agents. These are different buyers with different needs, and Tonkean cannot serve both.
+
+### Enterprise go-to-market
+
+The enterprise play is not head-to-head with Tonkean on G&A workflow orchestration. It is the adjacent and larger opportunity: enterprises building internal AI agents across engineering, IT, customer success, and operations — and enterprises that are AI product companies themselves (Salesforce, SAP, ServiceNow building AI features for their customers).
+
+**Entry points:**
+
+1. **Engineering and DevOps teams at enterprises** — internal agents for code review automation, incident response, deployment coordination. Relayfile's integrations with GitHub, Linear, Jira, and PagerDuty are strongest here. The buyer is the VP of Engineering or Platform team, not procurement.
+
+2. **Enterprise AI product teams** — the team at Salesforce building Einstein, at SAP building Joule, at Zendesk building Fin. They need the coordination layer for the AI features they're shipping to their customers. Relayfile is infrastructure for their product, not a workflow tool for their ops.
+
+3. **System integrators** — Accenture, Deloitte, KPMG building AI solutions for enterprise clients. They need reusable coordination infrastructure they can embed in every engagement. Relayfile as a partner platform accelerates their delivery.
+
+**Enterprise requirements relayfile already has:**
+- On-premise and self-hosted deployment (Enterprise plan)
+- SSO / SAML
+- Audit logs
+- ACLs (workspace-level and file-level via relayauth)
+- 99.9% SLA
+- Dedicated support
+
+**What the enterprise pitch looks like:**
+
+*"Every enterprise building internal AI agents is writing the same infrastructure from scratch — webhook pipelines, state stores, conflict handling. Relayfile is that infrastructure, deployable on-premise, with the audit logs and access controls your security team requires. We are what Tonkean's state engine would be if it were an SDK you could embed anywhere, not a workflow builder you have to use."*
+
+---
+
+## ICPs
+
+### Tier 1 — AI Automation Platforms (Primary, Near-Term)
+
+Cloud agents that take actions in users' SaaS tools on their behalf. Every company here is building the same coordination infrastructure from scratch, in their cloud, for every customer.
 
 **Lindy, Relevance AI, Dust, n8n (agent mode), Zapier AI Actions, Make.com AI, Relay.app, Bardeen, Gumloop**
 
-The problem: The agent runs in the vendor's cloud. It needs a workspace scoped to each customer, a real-time feed of what's happening in that customer's tools, and persistent state across runs. Today they build polling loops, database flags, and custom webhook handlers. Relayfile replaces all of it.
+The agent runs in the vendor's cloud. It needs a workspace scoped to each customer, a real-time feed of what's changing in that customer's tools, and persistent state across runs. Today they build polling loops, database flags, and custom webhook handlers. Relayfile replaces all of it.
 
 ---
 
@@ -125,41 +185,63 @@ Cloud-hosted agents that work software tickets end-to-end without a human in the
 
 **Cognition (Devin), Factory, SWE-agent deployments, GitHub Copilot Workspace (cloud mode)**
 
-The problem: The agent runs in a cloud sandbox. It needs to know if the ticket scope changed mid-task, if a human pushed a conflicting change to the same branch, or if another agent instance was assigned to the same issue. There is no local filesystem — the working state must live somewhere durable between steps.
+The agent runs in a cloud sandbox with no local filesystem. Working state must live somewhere durable between steps. The agent needs to know if ticket scope changed mid-task, if a human pushed a conflicting commit, or if another instance was assigned to the same issue.
 
-Note: Cursor and Windsurf are primarily local developer tools and are not the ICP. Cloud-hosted, fully-autonomous agents are.
+Note: Cursor and Windsurf are primarily local developer tools and are not this ICP. Cloud-hosted autonomous agents are.
 
 ---
 
 ### Tier 1 — AI Customer Support Platforms
 
-Cloud agents that handle customer cases autonomously, often in parallel with human support agents working the same queue.
+Cloud agents handling customer cases autonomously, in parallel with human agents on the same queue.
 
 **Intercom (Fin), Zendesk AI, Salesforce Service Cloud AI, Freshdesk (Freddy), Kustomer AI, Forethought, Thankful**
 
-The problem: The AI agent runs in the vendor's cloud and drafts a resolution. A human support agent opens the same case 15 seconds later. Neither knows the other is active. One resolution goes out. The customer receives two responses, or the human's work is silently overwritten.
-
-These companies handle this today with queue locking and manual review — neither scales with AI volume.
+The AI agent runs in the vendor's cloud and drafts a resolution. A human support agent opens the same case 15 seconds later. Neither knows the other is active. Queue locking and manual review are the current solutions — neither scales with AI volume.
 
 ---
 
 ### Tier 1 — AI Sales and CRM Automation
 
-Cloud agents that enrich, update, and act on CRM records while humans are in active sales motions against the same data.
+Cloud agents enriching, updating, and acting on CRM records while humans are in active sales motions.
 
 **Clay, Amplemarket, Apollo.io AI, Outreach AI, HubSpot AI workflows, Salesforce Einstein agents**
 
-The problem: The enrichment agent runs in the vendor's cloud and updates contact fields. The sales rep opens the same contact during a live call and is looking at pre-enrichment data. Or the rep updates the deal stage while the agent is mid-write and one update is silently dropped.
+The enrichment agent runs in the vendor's cloud and updates contact fields. The sales rep opens the same contact during a live call and is looking at pre-enrichment data. Or the rep updates the deal stage while the agent is mid-write and one update is silently dropped.
 
 ---
 
 ### Tier 1 — AI DevOps and Incident Response
 
-Cloud agents that triage and take remediation actions during incidents, running concurrently with on-call engineers.
+Cloud agents triaging and taking remediation actions during incidents, running concurrently with on-call engineers.
 
 **PagerDuty AI, Incident.io AI, Rootly AI, Grafana Incident AI, FireHydrant, Cortex**
 
-The problem: The agent fires at 2am and starts running runbooks in the vendor's cloud. The on-call engineer wakes up and starts investigating independently. By the time they sync, the agent has taken actions the engineer didn't know about, and the engineer has updated the incident timeline with observations the agent didn't see.
+The agent fires at 2am and starts running runbooks. The on-call engineer wakes up and starts investigating independently. By the time they sync, the agent has taken actions the engineer didn't know about, and the engineer has updated the timeline with observations the agent didn't see.
+
+---
+
+### Tier 2 — Enterprise Internal AI Agents (Enterprise Play — Tonkean Territory)
+
+Large enterprises building internal AI agents across engineering, IT, finance, HR, and operations. This is the market Tonkean currently serves for G&A workflows — but Tonkean cannot serve engineering, IT, or product teams, and cannot be embedded in enterprise-built AI products.
+
+**F500 engineering teams, enterprise platform teams, AI centers of excellence**
+
+The agent runs in the enterprise's own infrastructure. It needs a coordination layer that works with their existing tools (Jira, ServiceNow, GitHub, Salesforce), can be deployed on-premise, passes their security review (SOC 2, HIPAA, FedRAMP as applicable), and exposes the audit trail their compliance team requires.
+
+Tonkean serves procurement teams in this segment. Relayfile serves engineering, IT, and AI product teams — and is embeddable as SDK infrastructure rather than requiring adoption of a new workflow builder.
+
+**The pitch:** *"Tonkean's state engine for your use case, deployed on your infrastructure, as an SDK you can embed anywhere."*
+
+---
+
+### Tier 2 — AI-Embedded SaaS Products (Enterprise Product Companies)
+
+Large SaaS companies building AI features where AI and humans write to the same records.
+
+**Salesforce (Einstein), SAP (Joule), ServiceNow AI, HubSpot AI, Zendesk AI, Atlassian Intelligence**
+
+These companies are shipping AI agents that operate on the same records as their customers' human users. Their AI features need conflict detection, real-time awareness, and state persistence — infrastructure that their current platforms don't provide. Relayfile is the coordination layer they embed in their product.
 
 ---
 
@@ -169,59 +251,53 @@ Cloud-hosted AI features inside work management tools that triage, assign, and u
 
 **Linear AI, Jira AI (Atlassian Intelligence), Asana AI, Monday.com AI, Notion AI**
 
-The problem: The AI triage feature runs as a background cloud process touching the same backlog a team lead is manually processing. At scale — hundreds of issues per hour — the backlog becomes incoherent because neither writer knows what the other changed.
+The AI triage feature runs as a background cloud process touching the same backlog a team lead is manually processing. At scale — hundreds of issues per hour — the backlog becomes incoherent because neither writer knows what the other changed.
 
 ---
 
 ### Tier 2 — AI Code Review and PR Automation
 
-Cloud agents that review pull requests based on a snapshot of the PR at trigger time.
+Cloud agents reviewing pull requests based on a snapshot of the PR at trigger time.
 
 **CodeRabbit, Greptile, Graphite, Trunk, Sourcegraph Cody (review mode)**
 
-The problem: The review agent runs in the vendor's cloud against the PR as it existed when triggered. The author pushes a new commit mid-review. The review comments are now based on stale code. The agent has no way to know the code changed without being fully re-triggered.
+The review agent runs against the PR as it existed when triggered. The author pushes a new commit mid-review. The review comments are now based on stale code. The agent has no way to know the code changed without being fully re-triggered.
 
 ---
 
 ### Tier 2 — Healthcare AI
 
-Cloud agents that read and write to patient records alongside clinicians, where a stale or conflicted write is a compliance failure.
+Cloud agents reading and writing to patient records alongside clinicians.
 
 **Ambience Healthcare, Nabla, Abridge, Nuance (DAX), Suki, Notable Health**
 
-The problem: The AI agent runs in the vendor's HIPAA-compliant cloud and pre-fills structured EHR fields while the clinician is simultaneously reviewing and dictating. An undetected conflict is not just a product bug — it is an auditable regulatory failure.
+An undetected conflict between the AI's write and the clinician's write is not just a product bug — it is an auditable regulatory failure. These companies need conflict detection that is provable, logged, and compliant.
 
 ---
 
 ### Tier 2 — AI-Powered E-Commerce Operations
 
-Cloud agents that manage pricing and inventory while human merchandisers are working the same catalog.
+Cloud agents managing pricing and inventory while human merchandisers are working the same catalog.
 
 **Shopify AI automation, Feedonomics, Linnworks AI, Akeneo AI**
 
-The problem: The AI pricing agent runs on a schedule in the vendor's cloud. The merchandiser is manually adjusting the same SKUs. One set of changes wins silently. The merchandiser's intentional strategy is overwritten, or the agent's campaign goes live at the wrong price.
+The AI pricing agent runs on a schedule and applies discount rules. The merchandiser is manually adjusting the same SKUs. One set of changes wins silently.
 
 ---
 
-### Tier 2 — AI DevOps and Incident Response *(see Tier 1)*
-
 ### Tier 3 — AI Research and Analysis Platforms
-
-Cloud agents that synthesize information across sources into shared outputs.
 
 **Perplexity (enterprise), Elicit, Brightwave, Hebbia**
 
-The problem: Multiple research sessions on overlapping topics each build their own view of source material in the vendor's cloud, with no shared representation of what has been found or what contradicts another session's findings.
+Multiple research sessions on overlapping topics with no shared representation of findings, contradictions, or in-progress work.
 
 ---
 
 ### Tier 3 — AI Content Operations
 
-Cloud-hosted AI that generates and revises content concurrently with human editors.
-
 **Jasper, Copy.ai, Writer**
 
-The problem: Multiple contributors and AI drafts converge on the same content asset with no conflict detection when a human edit and an AI revision both modify the same section.
+Multiple contributors and AI drafts converging on the same asset with no conflict detection.
 
 ---
 
@@ -229,7 +305,9 @@ The problem: Multiple contributors and AI drafts converge on the same content as
 
 Every company in Tier 1 has already built a version of this infrastructure. It took 4–12 weeks of engineering. It handles their specific topology and breaks when they add a new integration, change their agent framework, or scale to more concurrent runs.
 
-This is undifferentiated infrastructure: expensive to build, expensive to maintain, not a competitive advantage, and blocking higher-value work. Relayfile is what every company on this list should be buying instead of building.
+Tonkean proves the enterprise pays $10K+/month for a pre-built version of this. MindStudio's blog content proves the SMB pays in engineering time for workarounds. The arXiv paper proves the architecture (push events + persistent shared state) is the correct solution.
+
+Relayfile is what every company on this list should be buying instead of building — at a price point calibrated to their scale, deployable on their infrastructure, embeddable in their product.
 
 ---
 
@@ -237,8 +315,8 @@ This is undifferentiated infrastructure: expensive to build, expensive to mainta
 
 Teams do not buy relayfile for multi-agent coordination on day one. The natural progression:
 
-1. **Entry:** "Make my cloud agent proactive." Real-time event delivery, no polling, agent knows when the world changed.
-2. **Expansion:** "Give my agent persistent state across runs." Workspace survives between sessions, picks up where it left off.
-3. **Platform:** "Coordinate multiple agents and humans on the same shared records without conflicts." The full coordination layer.
+1. **Entry:** "Make my cloud agent proactive." Real-time event delivery, no polling, agent knows when the world changed. Single agent, immediate value.
+2. **Expansion:** "Give my agent persistent state across runs." Workspace survives between sessions, picks up where it left off. Multiple runs, coherent behavior.
+3. **Platform:** "Coordinate multiple agents and humans on the same shared records without conflicts." The full coordination layer. The Tonkean-level problem, solved at the infrastructure level for any use case.
 
-The entry pitch is unambiguous and solvable today. The platform pitch is where relayfile's full value is captured as agentic architectures mature.
+The entry pitch is unambiguous and solvable today. The enterprise pitch is the Tonkean displacement play for teams that cannot or will not adopt a G&A-specific workflow builder. The platform pitch is where relayfile's full value is captured as agentic architectures mature across every industry.

--- a/docs/market-framing.md
+++ b/docs/market-framing.md
@@ -8,35 +8,74 @@ The market that exists today is larger and more immediate, and relayfile serves 
 
 ---
 
+## The Developer Pitch
+
+**Make your agent proactive with a few lines of code.**
+
+Today most agents are reactive — they respond when called. Relayfile makes them proactive: the agent knows when something changed in the outside world and acts without being polled or triggered manually. A Jira ticket moves to blocked, the agent is notified. A PR is merged, the agent updates its working state. A customer sends a message, the agent picks it up in real time.
+
+That shift — from reactive to proactive — is one SDK call:
+
+```typescript
+const sync = new RelayFileSync({ workspace: 'acme/support' });
+sync.on('change', (file) => agent.handle(file));
+```
+
+No webhook endpoints. No signature verification. No polling loops. The agent just listens.
+
+---
+
+## The Critical Distinction: Local Agent vs. Cloud Agent
+
+This is the question investors ask, and it has a sharp answer.
+
+**A local developer using an agent** (Cursor, Claude Code, Windsurf) is at a keyboard. Their files live on their machine. If something changes, they see it. The agent is a co-pilot — one human, one machine, one session. Local files work. Mirage works. Relayfile adds infrastructure complexity for a problem that barely exists at this scale.
+
+**A cloud agent running in production** is a different category entirely. The agent is the product — it runs in the vendor's cloud infrastructure, not on a user's laptop. It has no filesystem. It has no persistent state between runs. It has no built-in way to receive webhooks. When a run finishes and the next one starts, the agent wakes up with amnesia unless someone built the state layer.
+
+Lindy deploys an agent for a customer. That agent runs in Lindy's infrastructure. It needs to know what is on the customer's Linear board right now. It needs to receive a webhook when a ticket changes while it is mid-task. It needs to persist its working state so the next run continues where the last one stopped. It cannot conflict with the human who also has Linear open.
+
+There is no local filesystem. There is no fast-enough polling. There is no built-in state persistence. Every company shipping cloud agents is building this infrastructure from scratch.
+
+**Relayfile is for companies shipping cloud agents as a product — not for developers using agents as tools.**
+
+This is the investor answer. It is also the correct ICP filter.
+
+---
+
 ## The Core Problem
 
-Every team shipping AI automation runs into the same class of failures. The names differ. The root cause is always the same: **the agent's view of the world is wrong by the time it acts.**
+Every team shipping cloud agent products runs into the same class of failures. The names differ. The root cause is always the same: **the agent's view of the world is wrong by the time it acts.**
 
-### Problem 1 — Stale reads
+### Problem 1 — No persistent workspace
 
-The agent reads a record, spends time reasoning or executing, and by the time it writes back the record has changed. The agent never knew. It overwrites the new state with a response based on the old one.
+Cloud agents have no filesystem. Between runs, between retries, between handoffs to a different instance, state must be stored somewhere. The default solution is a database table or a blob in S3. Neither supports real-time reads, concurrent writes, or conflict detection. Every team builds an ad hoc version of a shared workspace and none of them generalize.
 
-This is the TOCTOU problem (time-of-check to time-of-use), and it is endemic to every polling-based agent architecture. A 30-second polling interval means every agent action is based on state that is at least 30 seconds old — often much more.
+### Problem 2 — Stale reads
 
-### Problem 2 — Silent concurrent writes
+The agent reads a record from an external system, spends time reasoning or executing multi-step tasks, and by the time it writes back the record has changed. The agent never knew. It overwrites the new state with a response based on the old one.
 
-A human and an AI agent both update the same record within seconds of each other. One wins. Neither knows the other acted. The human assumes their change is in effect. The agent assumes its change is in effect. Both are sometimes wrong.
+This is the TOCTOU problem (time-of-check to time-of-use), endemic to every polling-based architecture. A 30-second polling interval means every agent action is based on state that is at least 30 seconds old. For cloud agents running long tasks, the drift can be minutes.
+
+### Problem 3 — Silent concurrent writes
+
+A human and a cloud agent both update the same record within seconds of each other. One wins. Neither knows the other acted. The human assumes their change is in effect. The agent assumes its change is in effect. Both are sometimes wrong.
 
 There is no standard mechanism in Salesforce, Linear, Jira, or Notion to detect this at the application layer. Teams discover it in postmortems when a customer complains that their case was closed while they were still waiting for a response.
 
-### Problem 3 — No awareness during long-running tasks
+### Problem 4 — No awareness during long-running tasks
 
-The agent starts a multi-step task. Halfway through, the context changes: the human cancels the request, a higher-priority item arrives, the underlying data is updated by another process. The agent has no channel to receive that signal. It finishes the task on a premise that is no longer true.
-
-### Problem 4 — State loss between sessions
-
-An agent session ends. A new session begins — scheduled run, retry, handoff to a different agent — with no memory of what the previous session observed or changed. Teams paper over this with text files in prompts, database rows, or manually constructed context strings. All of it is ad hoc. None of it is reliable under concurrent access.
+The cloud agent starts a multi-step task. Halfway through, the context changes: the human cancels the request, a higher-priority item arrives, the underlying data is updated. The agent has no channel to receive that signal. It finishes the task on a premise that is no longer true.
 
 ### Problem 5 — Webhook infrastructure rebuilt for every product
 
-Every team building an agent product builds the same pipeline: receive webhook from Slack/GitHub/Jira/Linear, deduplicate, order, retry on failure, dead-letter on repeated failure, persist current state somewhere. Then build a second pipeline to deliver changes to the agent. Then a third to handle conflict resolution.
+Every team building a cloud agent product builds the same pipeline from scratch: receive webhook, verify the signature (different format per provider), deduplicate, order, retry on failure, dead-letter, persist state, deliver to the agent. Then repeat for every provider.
 
-This is not differentiated work. It is undifferentiated infrastructure that every company is building from scratch because no standard exists.
+This is undifferentiated infrastructure. Every Tier 1 ICP below has already built a version of this and is maintaining it instead of building their actual product.
+
+### Problem 6 — State loss between agent sessions
+
+A cloud agent run ends. The next run starts — scheduled, retried, or handed to a different instance — with no memory of what the previous run observed or changed. Teams paper over this with prompt injection, database flags, or manually constructed context strings. None of it is reliable under concurrent access or at scale.
 
 ---
 
@@ -44,11 +83,11 @@ This is not differentiated work. It is undifferentiated infrastructure that ever
 
 | Layer | Existing tools | What they do | What they miss |
 |---|---|---|---|
-| Tool execution | Composio, Merge, Executor | Call the API | No state between calls |
+| Tool execution | Composio, Merge, Executor | Call the API on demand | No state between calls |
 | Data ingestion | Nango, Paragon Managed Sync | Get data in on a schedule | Polling latency; no conflict model |
-| **State between reads and writes** | **Nobody** | — | **Real-time currency; conflict detection; agent awareness** |
+| **Persistent agent workspace** | **Nobody** | — | **Real-time currency; conflict detection; state across runs** |
 
-Composio and Merge solve execution. Nango and Paragon solve ingestion. Nobody has standardized the layer where the agent holds state between reads and writes, knows in real time when something changed underneath it, and detects conflicts before acting on outdated information.
+Composio and Merge solve execution. Nango and Paragon solve ingestion. Nobody has standardized the layer where the cloud agent holds its working state between runs, knows in real time when something changed underneath it, and detects conflicts before acting on outdated information.
 
 ---
 
@@ -56,178 +95,150 @@ Composio and Merge solve execution. Nango and Paragon solve ingestion. Nobody ha
 
 **Not:** "Relayfile is a coordination layer for multi-agent workflows."
 
-**Yes:** "Relayfile is the real-time shared workspace that keeps your agent's view of the world current — without polling."
+**Not:** "Relayfile is for developers building with AI agents." (Too broad — includes local dev use cases where it adds no value.)
 
-One agent. One human. The agent always knows when something changed, before it acts on stale state. That is the wedge. Multi-agent coordination is what customers grow into, not what they buy on day one.
+**Yes:** "Make your agent proactive with a few lines of code." — and underneath that: a persistent cloud workspace, real-time event delivery, conflict-safe writes, and state that survives between runs, with none of the webhook infrastructure built by you.
+
+Multi-agent coordination is what customers grow into. The entry is simpler: the agent needs a workspace that exists between runs and knows when the world changed.
 
 ---
 
 ## ICPs Today
 
-### Tier 1 — AI Automation Platforms
-
-Companies building agents that take actions in their users' SaaS tools on their behalf. This is the highest-density ICP: every company in this category is building the same coordination infrastructure from scratch.
-
-**Lindy, Relevance AI, Dust, n8n (agent mode), Zapier AI Actions, Make.com AI, Relay.app, Bardeen, Gumloop**
-
-The problem: An agent is mid-task on a user's Linear board or Salesforce pipeline. The user makes a change. The agent has no way to know. It completes the task on a premise that no longer holds. The fix today is polling every N seconds — slow, expensive, and still racy.
-
-These companies are all solving this. Their solutions are all one-offs. Relayfile is the infrastructure they should be buying.
+The right filter: **companies shipping cloud agents as a product**, where the agent runs in the vendor's infrastructure and has no local filesystem. Not developers using agents as tools on their own machines.
 
 ---
 
-### Tier 1 — AI Coding Tools
+### Tier 1 — AI Automation Platforms
 
-Companies where AI agents take actions on codebases — often in parallel with human developers or other AI sessions.
+Cloud agents that take actions in users' SaaS tools on their behalf. The highest-density ICP: every company here is building the same coordination infrastructure from scratch, in their cloud, for every customer.
 
-**Cursor, Windsurf, Cognition (Devin), GitHub Copilot Workspace, Replit Agent, Sourcegraph Cody, Factory**
+**Lindy, Relevance AI, Dust, n8n (agent mode), Zapier AI Actions, Make.com AI, Relay.app, Bardeen, Gumloop**
 
-The problem: A developer has two Cursor sessions open on the same repo. Or Devin is working a ticket while the developer is also making changes. There is no shared representation of what changed and when. Conflicts are discovered at commit time or not at all. Agent sessions have no memory of what prior sessions did — every run starts from scratch.
+The problem: The agent runs in the vendor's cloud. It needs a workspace scoped to each customer, a real-time feed of what's happening in that customer's tools, and persistent state across runs. Today they build polling loops, database flags, and custom webhook handlers. Relayfile replaces all of it.
 
-The coordination need here is acute. These are fast-moving codebases with multiple writers. The cost of a stale-read conflict is a broken build or a reverted commit.
+---
+
+### Tier 1 — Autonomous Coding Agents
+
+Cloud-hosted agents that work software tickets end-to-end without a human in the loop during execution.
+
+**Cognition (Devin), Factory, SWE-agent deployments, GitHub Copilot Workspace (cloud mode)**
+
+The problem: The agent runs in a cloud sandbox. It needs to know if the ticket scope changed mid-task, if a human pushed a conflicting change to the same branch, or if another agent instance was assigned to the same issue. There is no local filesystem — the working state must live somewhere durable between steps.
+
+Note: Cursor and Windsurf are primarily local developer tools and are not the ICP. Cloud-hosted, fully-autonomous agents are.
 
 ---
 
 ### Tier 1 — AI Customer Support Platforms
 
-Companies where AI and human agents work the same support queue concurrently.
+Cloud agents that handle customer cases autonomously, often in parallel with human support agents working the same queue.
 
 **Intercom (Fin), Zendesk AI, Salesforce Service Cloud AI, Freshdesk (Freddy), Kustomer AI, Forethought, Thankful**
 
-The problem: An AI agent drafts a resolution to a ticket. A human support agent picks up the same ticket 15 seconds later and starts typing a different response. Neither knows the other is active. One response goes out. The customer receives two, or the human overwrites the AI response that was already marked as sent.
+The problem: The AI agent runs in the vendor's cloud and drafts a resolution. A human support agent opens the same case 15 seconds later. Neither knows the other is active. One resolution goes out. The customer receives two responses, or the human's work is silently overwritten.
 
-This is a real operational failure that these companies handle today with locking, queuing, or manual review — none of which scale with AI volume.
+These companies handle this today with queue locking and manual review — neither scales with AI volume.
 
 ---
 
-### Tier 1 — AI Sales and CRM Tools
+### Tier 1 — AI Sales and CRM Automation
 
-Companies where AI enriches, updates, or acts on CRM records while humans are in active sales motions.
+Cloud agents that enrich, update, and act on CRM records while humans are in active sales motions against the same data.
 
-**HubSpot AI, Salesforce Einstein, Clay, Apollo.io AI, Outreach AI, Gong, Chorus, Amplemarket**
+**Clay, Amplemarket, Apollo.io AI, Outreach AI, HubSpot AI workflows, Salesforce Einstein agents**
 
-The problem: A sales rep is on a live call. Clay's AI is simultaneously enriching the contact record with new data and updating fields. The rep's view of the contact is now wrong — they're looking at what the record said before the enrichment ran. Or worse: the rep updates the deal stage while the AI is mid-write, and one of the updates is silently dropped.
+The problem: The enrichment agent runs in the vendor's cloud and updates contact fields. The sales rep opens the same contact during a live call and is looking at pre-enrichment data. Or the rep updates the deal stage while the agent is mid-write and one update is silently dropped.
 
-CRM is high-stakes. A lost update to a deal stage or a wrong contact field costs real pipeline. These companies need the AI's writes to be aware of the human's activity.
+---
+
+### Tier 1 — AI DevOps and Incident Response
+
+Cloud agents that triage and take remediation actions during incidents, running concurrently with on-call engineers.
+
+**PagerDuty AI, Incident.io AI, Rootly AI, Grafana Incident AI, FireHydrant, Cortex**
+
+The problem: The agent fires at 2am and starts running runbooks in the vendor's cloud. The on-call engineer wakes up and starts investigating independently. By the time they sync, the agent has taken actions the engineer didn't know about, and the engineer has updated the incident timeline with observations the agent didn't see.
 
 ---
 
 ### Tier 2 — AI-Embedded Project Management
 
-Teams building AI features inside work management tools, or building on top of them with agents.
+Cloud-hosted AI features inside work management tools that triage, assign, and update issues concurrently with human team activity.
 
-**Linear AI, Jira AI (Atlassian Intelligence), Asana AI, Monday.com AI, Notion AI, Height**
+**Linear AI, Jira AI (Atlassian Intelligence), Asana AI, Monday.com AI, Notion AI**
 
-The problem: An AI triage agent is processing the backlog — labeling issues, assigning owners, setting priorities. A team lead is doing the same thing manually in the same queue. They are concurrently touching the same set of issues. The AI's changes overwrite the human's, or the human's overwrite the AI's. Neither party has visibility into what the other changed.
-
-At scale — hundreds of issues processed per hour — this produces a backlog that neither the human nor the AI recognizes as accurate.
+The problem: The AI triage feature runs as a background cloud process touching the same backlog a team lead is manually processing. At scale — hundreds of issues per hour — the backlog becomes incoherent because neither writer knows what the other changed.
 
 ---
 
 ### Tier 2 — AI Code Review and PR Automation
 
-Companies building AI agents that review pull requests, often alongside human reviewers and other AI tools.
+Cloud agents that review pull requests based on a snapshot of the PR at trigger time.
 
-**CodeRabbit, Greptile, Graphite, Trunk, Bloop, GitHub Copilot (review mode)**
+**CodeRabbit, Greptile, Graphite, Trunk, Sourcegraph Cody (review mode)**
 
-The problem: Three things happen to a PR in the same 60-second window: a human reviewer leaves a comment, the author pushes a new commit, and the AI reviewer posts its analysis. The AI's analysis was based on the pre-push state. The human reviewer's comment thread is now stale. The author doesn't know which review comments are still valid.
-
-These companies handle this today with re-trigger logic — re-run the AI review on every new commit. That is expensive and doesn't solve the staleness problem for comments already posted.
-
----
-
-### Tier 2 — AI Document and Knowledge Platforms
-
-Companies where AI and humans are concurrently editing, summarizing, or restructuring the same documents.
-
-**Notion AI, Coda AI, Confluence AI (Atlassian), Google Workspace AI, Quip AI, Guru, Tettra**
-
-The problem: A human is editing a wiki page. The AI is simultaneously re-summarizing it based on a recent meeting transcript. The human saves. The AI saves. One overwrites the other. The user sees their edits disappear, or the AI's summary is based on a version of the doc that no longer exists.
-
-Document platforms have optimistic locking at the session level but not across the human/AI boundary — the AI writes through a service account that has no awareness of active human sessions.
-
----
-
-### Tier 2 — AI DevOps and Incident Response
-
-Companies where AI agents triage, diagnose, or act on incidents while on-call engineers are simultaneously investigating.
-
-**PagerDuty AI, Incident.io AI, Rootly AI, Grafana Incident AI, FireHydrant, Cortex**
-
-The problem: An incident fires at 2am. The AI agent starts diagnosing — pulling logs, running runbooks, updating the incident timeline. The on-call engineer wakes up and starts investigating independently. By the time they sync, the AI has taken actions the engineer didn't know about, and the engineer has updated the timeline with observations the AI didn't incorporate.
-
-In incident response, a stale or conflicted state is directly dangerous. These companies need the AI's actions and the human's actions to be visible to each other in real time.
+The problem: The review agent runs in the vendor's cloud against the PR as it existed when triggered. The author pushes a new commit mid-review. The review comments are now based on stale code. The agent has no way to know the code changed without being fully re-triggered.
 
 ---
 
 ### Tier 2 — Healthcare AI
 
-Companies building clinical AI that reads and writes to patient records alongside clinicians.
+Cloud agents that read and write to patient records alongside clinicians, where a stale or conflicted write is a compliance failure.
 
 **Ambience Healthcare, Nabla, Abridge, Nuance (DAX), Suki, Notable Health**
 
-The problem: A clinician is reviewing a patient chart and dictating notes. The AI is simultaneously generating a clinical summary and pre-filling structured fields. Both are writing to the EHR. If they conflict, clinical data integrity is compromised. In regulated environments, an undetected overwrite is a compliance failure.
-
-The stakes here are higher than in any other category. These companies need conflict detection that is auditable and provable, not just best-effort.
+The problem: The AI agent runs in the vendor's HIPAA-compliant cloud and pre-fills structured EHR fields while the clinician is simultaneously reviewing and dictating. An undetected conflict is not just a product bug — it is an auditable regulatory failure.
 
 ---
 
 ### Tier 2 — AI-Powered E-Commerce Operations
 
-Companies where AI manages inventory, pricing, and product listings while human merchandisers are actively working.
+Cloud agents that manage pricing and inventory while human merchandisers are working the same catalog.
 
-**Shopify (Sidekick and AI features), BigCommerce AI, Feedonomics, Linnworks AI, Akeneo AI**
+**Shopify AI automation, Feedonomics, Linnworks AI, Akeneo AI**
 
-The problem: A merchandiser is repricing a product category. The AI pricing agent is simultaneously running a discount campaign on the same SKUs. One set of changes wins. The merchandiser's intentional pricing strategy is silently overwritten, or the AI's campaign goes live at the wrong price.
-
----
-
-### Tier 3 — AI Research and Analysis Tools
-
-Companies where AI agents synthesize information into shared outputs that multiple users or agents contribute to.
-
-**Perplexity (enterprise), Elicit, Consensus, Brightwave, Hebbia**
-
-The problem: Multiple analysts are using AI to research the same topic. Each AI session builds a separate view of the source material. There is no shared representation of what has been found, what is still being investigated, and what contradictions exist. Teams end up with duplicate work and conflicting conclusions.
+The problem: The AI pricing agent runs on a schedule in the vendor's cloud. The merchandiser is manually adjusting the same SKUs. One set of changes wins silently. The merchandiser's intentional strategy is overwritten, or the agent's campaign goes live at the wrong price.
 
 ---
 
-### Tier 3 — AI Content Creation Platforms
+### Tier 2 — AI DevOps and Incident Response *(see Tier 1)*
 
-Companies where multiple AI drafts of the same content exist alongside human editing.
+### Tier 3 — AI Research and Analysis Platforms
 
-**Jasper, Copy.ai, Writer, Wordtune, Lex**
+Cloud agents that synthesize information across sources into shared outputs.
 
-The problem: A content team has three people and an AI generating variations of the same landing page copy. All four are writing simultaneously. The "current version" is undefined. There is no conflict detection when two people accept different AI suggestions for the same paragraph.
+**Perplexity (enterprise), Elicit, Brightwave, Hebbia**
+
+The problem: Multiple research sessions on overlapping topics each build their own view of source material in the vendor's cloud, with no shared representation of what has been found or what contradicts another session's findings.
 
 ---
 
-### Tier 3 — Financial Services AI
+### Tier 3 — AI Content Operations
 
-Companies where AI analyzes portfolios, flags compliance issues, or generates trade recommendations while human advisors are active on the same accounts.
+Cloud-hosted AI that generates and revises content concurrently with human editors.
 
-**Betterment, Wealthfront AI features, Addepar AI, Riskalyze AI, Compliance.ai**
+**Jasper, Copy.ai, Writer**
 
-The problem: The AI flags a compliance issue on an account and initiates a review workflow. The advisor closes the issue manually based on a client call. The AI's workflow continues against a resolved issue. Duplicate notifications go to the client.
+The problem: Multiple contributors and AI drafts converge on the same content asset with no conflict detection when a human edit and an AI revision both modify the same section.
 
 ---
 
 ## The Build-vs-Buy Argument
 
-Every company in Tier 1 has already built a version of this infrastructure. It took 4–12 weeks of engineering. It handles their specific topology (their SaaS tools, their agent architecture, their polling intervals) and nothing else. It breaks when they add a new integration or change their agent framework.
+Every company in Tier 1 has already built a version of this infrastructure. It took 4–12 weeks of engineering. It handles their specific topology and breaks when they add a new integration, change their agent framework, or scale to more concurrent runs.
 
-This is classic undifferentiated infrastructure: expensive to build, expensive to maintain, not a competitive advantage, and blocking higher-value work.
-
-Relayfile is the standard infrastructure layer that every company on this list should be buying instead of building.
+This is undifferentiated infrastructure: expensive to build, expensive to maintain, not a competitive advantage, and blocking higher-value work. Relayfile is what every company on this list should be buying instead of building.
 
 ---
 
 ## Progression Path
 
-Teams do not buy relayfile for multi-agent coordination on day one. They buy it to stop building polling loops. The natural progression:
+Teams do not buy relayfile for multi-agent coordination on day one. The natural progression:
 
-1. **Entry:** "Keep my agent's view of the world current without polling." Single agent, real-time awareness, no stale reads.
-2. **Expansion:** "Let multiple agents share state without conflicts." Two or three agents on the same workspace.
-3. **Platform:** "Coordinate arbitrary numbers of agents, humans, and automated processes on the same shared records." The full coordination layer.
+1. **Entry:** "Make my cloud agent proactive." Real-time event delivery, no polling, agent knows when the world changed.
+2. **Expansion:** "Give my agent persistent state across runs." Workspace survives between sessions, picks up where it left off.
+3. **Platform:** "Coordinate multiple agents and humans on the same shared records without conflicts." The full coordination layer.
 
 The entry pitch is unambiguous and solvable today. The platform pitch is where relayfile's full value is captured as agentic architectures mature.

--- a/docs/market-framing.md
+++ b/docs/market-framing.md
@@ -8,34 +8,47 @@ The market that exists today is larger and more immediate, and relayfile serves 
 
 ---
 
-## The Real Market Today
+## The Core Problem
 
-### Human + AI on the Same Records
+Every team shipping AI automation runs into the same class of failures. The names differ. The root cause is always the same: **the agent's view of the world is wrong by the time it acts.**
 
-Every company shipping AI features is hitting this problem right now:
+### Problem 1 — Stale reads
 
-- A human updates a Linear ticket. The AI agent that was working on it doesn't know, and submits a PR that conflicts with what the human decided.
-- A sales rep is on a call. HubSpot's AI rewrites the contact record mid-conversation.
-- A human merges a PR. Copilot's agent was mid-review and now its suggestions are stale.
-- A support agent picks up a ticket. The AI already drafted a response based on state that changed 30 seconds ago.
+The agent reads a record, spends time reasoning or executing, and by the time it writes back the record has changed. The agent never knew. It overwrites the new state with a response based on the old one.
 
-This is not a future problem. It is happening at every B2B SaaS company that has shipped AI features — which is now most of them.
+This is the TOCTOU problem (time-of-check to time-of-use), and it is endemic to every polling-based agent architecture. A 30-second polling interval means every agent action is based on state that is at least 30 seconds old — often much more.
 
-The solutions in use today are all bad: polling loops with arbitrary intervals, database flags that drift, accepting stale reads, letting last-write-win and cleaning up conflicts manually. None of it is coordinated. None of it is real-time.
+### Problem 2 — Silent concurrent writes
 
-### AI Automation Companies
+A human and an AI agent both update the same record within seconds of each other. One wins. Neither knows the other acted. The human assumes their change is in effect. The agent assumes its change is in effect. Both are sometimes wrong.
 
-The more concentrated ICP: companies building agents that take actions in their users' SaaS tools on their behalf.
+There is no standard mechanism in Salesforce, Linear, Jira, or Notion to detect this at the application layer. Teams discover it in postmortems when a customer complains that their case was closed while they were still waiting for a response.
 
-Lindy, Relevance AI, Dust, n8n's agent features, Zapier AI Actions, Make.com agents — these companies are all solving the same infrastructure problem from scratch:
+### Problem 3 — No awareness during long-running tasks
 
-- How do I know if a human changed something while my agent was running?
-- How do I prevent two agent runs from conflicting on the same user record?
-- How does the agent maintain a coherent view of state across a long-running task without polling every 10 seconds?
+The agent starts a multi-step task. Halfway through, the context changes: the human cancels the request, a higher-priority item arrives, the underlying data is updated by another process. The agent has no channel to receive that signal. It finishes the task on a premise that is no longer true.
 
-Every one of these companies has built an ad hoc version of the same thing: a polling loop, a database flag, a custom webhook handler, a job queue. None of it generalizes. None of it handles concurrent writes gracefully. None of it fans out to the agent in real time when the underlying data changes.
+### Problem 4 — State loss between sessions
 
-This is the market. It is large, it is today, and it is genuinely unserved.
+An agent session ends. A new session begins — scheduled run, retry, handoff to a different agent — with no memory of what the previous session observed or changed. Teams paper over this with text files in prompts, database rows, or manually constructed context strings. All of it is ad hoc. None of it is reliable under concurrent access.
+
+### Problem 5 — Webhook infrastructure rebuilt for every product
+
+Every team building an agent product builds the same pipeline: receive webhook from Slack/GitHub/Jira/Linear, deduplicate, order, retry on failure, dead-letter on repeated failure, persist current state somewhere. Then build a second pipeline to deliver changes to the agent. Then a third to handle conflict resolution.
+
+This is not differentiated work. It is undifferentiated infrastructure that every company is building from scratch because no standard exists.
+
+---
+
+## Why This Is Unserved
+
+| Layer | Existing tools | What they do | What they miss |
+|---|---|---|---|
+| Tool execution | Composio, Merge, Executor | Call the API | No state between calls |
+| Data ingestion | Nango, Paragon Managed Sync | Get data in on a schedule | Polling latency; no conflict model |
+| **State between reads and writes** | **Nobody** | — | **Real-time currency; conflict detection; agent awareness** |
+
+Composio and Merge solve execution. Nango and Paragon solve ingestion. Nobody has standardized the layer where the agent holds state between reads and writes, knows in real time when something changed underneath it, and detects conflicts before acting on outdated information.
 
 ---
 
@@ -45,38 +58,176 @@ This is the market. It is large, it is today, and it is genuinely unserved.
 
 **Yes:** "Relayfile is the real-time shared workspace that keeps your agent's view of the world current — without polling."
 
-One agent. One human. The agent always knows when something changed, before it acts on stale state.
-
-That is the wedge. Multi-agent coordination is what customers grow into, not what they buy on day one.
+One agent. One human. The agent always knows when something changed, before it acts on stale state. That is the wedge. Multi-agent coordination is what customers grow into, not what they buy on day one.
 
 ---
 
-## Why This Market Is Unserved
+## ICPs Today
 
-| Layer | Existing tools | Gap |
-|---|---|---|
-| Tool execution | Composio, Merge, Executor | Call the API |
-| Data ingestion | Nango, Paragon Managed Sync | Get the data in |
-| **State between reads and writes** | **Nobody** | **Keep the agent's view current; detect when it goes stale** |
+### Tier 1 — AI Automation Platforms
 
-Composio and Merge solve the execution problem. Nango and Paragon solve the ingestion problem. Nobody has standardized the layer where the agent *holds* state between reads and writes, knows in real time when something changed, and detects conflicts before acting on outdated information.
+Companies building agents that take actions in their users' SaaS tools on their behalf. This is the highest-density ICP: every company in this category is building the same coordination infrastructure from scratch.
 
-That is relayfile's position. It is not adjacent to these tools — it sits on top of all of them.
+**Lindy, Relevance AI, Dust, n8n (agent mode), Zapier AI Actions, Make.com AI, Relay.app, Bardeen, Gumloop**
 
----
+The problem: An agent is mid-task on a user's Linear board or Salesforce pipeline. The user makes a change. The agent has no way to know. It completes the task on a premise that no longer holds. The fix today is polling every N seconds — slow, expensive, and still racy.
 
-## ICP Today
-
-**Primary:** AI automation companies (teams building agents that act in users' SaaS tools). They are reinventing this infrastructure for every product they ship.
-
-**Secondary:** B2B SaaS companies embedding AI features where AI and humans write to the same records (Notion, Linear, Intercom, HubSpot, Salesforce — and every vertical SaaS doing the same).
-
-**Growing into:** Teams running parallel agents on shared workspaces — the multi-agent pattern that will become the norm as agentic architectures mature.
+These companies are all solving this. Their solutions are all one-offs. Relayfile is the infrastructure they should be buying.
 
 ---
 
-## Why Now
+### Tier 1 — AI Coding Tools
 
-The number of teams shipping autonomous AI actions (not just AI suggestions) is accelerating. Every AI automation company that reaches production hits the coordination wall within months. The infrastructure they build to get past it is expensive, brittle, and not their core product. Relayfile is what they should be buying instead.
+Companies where AI agents take actions on codebases — often in parallel with human developers or other AI sessions.
 
-The framing shifts from "coordination layer" (a solution looking for a problem) to "no more stale agent state" (a problem every AI automation team is already paying to solve, badly).
+**Cursor, Windsurf, Cognition (Devin), GitHub Copilot Workspace, Replit Agent, Sourcegraph Cody, Factory**
+
+The problem: A developer has two Cursor sessions open on the same repo. Or Devin is working a ticket while the developer is also making changes. There is no shared representation of what changed and when. Conflicts are discovered at commit time or not at all. Agent sessions have no memory of what prior sessions did — every run starts from scratch.
+
+The coordination need here is acute. These are fast-moving codebases with multiple writers. The cost of a stale-read conflict is a broken build or a reverted commit.
+
+---
+
+### Tier 1 — AI Customer Support Platforms
+
+Companies where AI and human agents work the same support queue concurrently.
+
+**Intercom (Fin), Zendesk AI, Salesforce Service Cloud AI, Freshdesk (Freddy), Kustomer AI, Forethought, Thankful**
+
+The problem: An AI agent drafts a resolution to a ticket. A human support agent picks up the same ticket 15 seconds later and starts typing a different response. Neither knows the other is active. One response goes out. The customer receives two, or the human overwrites the AI response that was already marked as sent.
+
+This is a real operational failure that these companies handle today with locking, queuing, or manual review — none of which scale with AI volume.
+
+---
+
+### Tier 1 — AI Sales and CRM Tools
+
+Companies where AI enriches, updates, or acts on CRM records while humans are in active sales motions.
+
+**HubSpot AI, Salesforce Einstein, Clay, Apollo.io AI, Outreach AI, Gong, Chorus, Amplemarket**
+
+The problem: A sales rep is on a live call. Clay's AI is simultaneously enriching the contact record with new data and updating fields. The rep's view of the contact is now wrong — they're looking at what the record said before the enrichment ran. Or worse: the rep updates the deal stage while the AI is mid-write, and one of the updates is silently dropped.
+
+CRM is high-stakes. A lost update to a deal stage or a wrong contact field costs real pipeline. These companies need the AI's writes to be aware of the human's activity.
+
+---
+
+### Tier 2 — AI-Embedded Project Management
+
+Teams building AI features inside work management tools, or building on top of them with agents.
+
+**Linear AI, Jira AI (Atlassian Intelligence), Asana AI, Monday.com AI, Notion AI, Height**
+
+The problem: An AI triage agent is processing the backlog — labeling issues, assigning owners, setting priorities. A team lead is doing the same thing manually in the same queue. They are concurrently touching the same set of issues. The AI's changes overwrite the human's, or the human's overwrite the AI's. Neither party has visibility into what the other changed.
+
+At scale — hundreds of issues processed per hour — this produces a backlog that neither the human nor the AI recognizes as accurate.
+
+---
+
+### Tier 2 — AI Code Review and PR Automation
+
+Companies building AI agents that review pull requests, often alongside human reviewers and other AI tools.
+
+**CodeRabbit, Greptile, Graphite, Trunk, Bloop, GitHub Copilot (review mode)**
+
+The problem: Three things happen to a PR in the same 60-second window: a human reviewer leaves a comment, the author pushes a new commit, and the AI reviewer posts its analysis. The AI's analysis was based on the pre-push state. The human reviewer's comment thread is now stale. The author doesn't know which review comments are still valid.
+
+These companies handle this today with re-trigger logic — re-run the AI review on every new commit. That is expensive and doesn't solve the staleness problem for comments already posted.
+
+---
+
+### Tier 2 — AI Document and Knowledge Platforms
+
+Companies where AI and humans are concurrently editing, summarizing, or restructuring the same documents.
+
+**Notion AI, Coda AI, Confluence AI (Atlassian), Google Workspace AI, Quip AI, Guru, Tettra**
+
+The problem: A human is editing a wiki page. The AI is simultaneously re-summarizing it based on a recent meeting transcript. The human saves. The AI saves. One overwrites the other. The user sees their edits disappear, or the AI's summary is based on a version of the doc that no longer exists.
+
+Document platforms have optimistic locking at the session level but not across the human/AI boundary — the AI writes through a service account that has no awareness of active human sessions.
+
+---
+
+### Tier 2 — AI DevOps and Incident Response
+
+Companies where AI agents triage, diagnose, or act on incidents while on-call engineers are simultaneously investigating.
+
+**PagerDuty AI, Incident.io AI, Rootly AI, Grafana Incident AI, FireHydrant, Cortex**
+
+The problem: An incident fires at 2am. The AI agent starts diagnosing — pulling logs, running runbooks, updating the incident timeline. The on-call engineer wakes up and starts investigating independently. By the time they sync, the AI has taken actions the engineer didn't know about, and the engineer has updated the timeline with observations the AI didn't incorporate.
+
+In incident response, a stale or conflicted state is directly dangerous. These companies need the AI's actions and the human's actions to be visible to each other in real time.
+
+---
+
+### Tier 2 — Healthcare AI
+
+Companies building clinical AI that reads and writes to patient records alongside clinicians.
+
+**Ambience Healthcare, Nabla, Abridge, Nuance (DAX), Suki, Notable Health**
+
+The problem: A clinician is reviewing a patient chart and dictating notes. The AI is simultaneously generating a clinical summary and pre-filling structured fields. Both are writing to the EHR. If they conflict, clinical data integrity is compromised. In regulated environments, an undetected overwrite is a compliance failure.
+
+The stakes here are higher than in any other category. These companies need conflict detection that is auditable and provable, not just best-effort.
+
+---
+
+### Tier 2 — AI-Powered E-Commerce Operations
+
+Companies where AI manages inventory, pricing, and product listings while human merchandisers are actively working.
+
+**Shopify (Sidekick and AI features), BigCommerce AI, Feedonomics, Linnworks AI, Akeneo AI**
+
+The problem: A merchandiser is repricing a product category. The AI pricing agent is simultaneously running a discount campaign on the same SKUs. One set of changes wins. The merchandiser's intentional pricing strategy is silently overwritten, or the AI's campaign goes live at the wrong price.
+
+---
+
+### Tier 3 — AI Research and Analysis Tools
+
+Companies where AI agents synthesize information into shared outputs that multiple users or agents contribute to.
+
+**Perplexity (enterprise), Elicit, Consensus, Brightwave, Hebbia**
+
+The problem: Multiple analysts are using AI to research the same topic. Each AI session builds a separate view of the source material. There is no shared representation of what has been found, what is still being investigated, and what contradictions exist. Teams end up with duplicate work and conflicting conclusions.
+
+---
+
+### Tier 3 — AI Content Creation Platforms
+
+Companies where multiple AI drafts of the same content exist alongside human editing.
+
+**Jasper, Copy.ai, Writer, Wordtune, Lex**
+
+The problem: A content team has three people and an AI generating variations of the same landing page copy. All four are writing simultaneously. The "current version" is undefined. There is no conflict detection when two people accept different AI suggestions for the same paragraph.
+
+---
+
+### Tier 3 — Financial Services AI
+
+Companies where AI analyzes portfolios, flags compliance issues, or generates trade recommendations while human advisors are active on the same accounts.
+
+**Betterment, Wealthfront AI features, Addepar AI, Riskalyze AI, Compliance.ai**
+
+The problem: The AI flags a compliance issue on an account and initiates a review workflow. The advisor closes the issue manually based on a client call. The AI's workflow continues against a resolved issue. Duplicate notifications go to the client.
+
+---
+
+## The Build-vs-Buy Argument
+
+Every company in Tier 1 has already built a version of this infrastructure. It took 4–12 weeks of engineering. It handles their specific topology (their SaaS tools, their agent architecture, their polling intervals) and nothing else. It breaks when they add a new integration or change their agent framework.
+
+This is classic undifferentiated infrastructure: expensive to build, expensive to maintain, not a competitive advantage, and blocking higher-value work.
+
+Relayfile is the standard infrastructure layer that every company on this list should be buying instead of building.
+
+---
+
+## Progression Path
+
+Teams do not buy relayfile for multi-agent coordination on day one. They buy it to stop building polling loops. The natural progression:
+
+1. **Entry:** "Keep my agent's view of the world current without polling." Single agent, real-time awareness, no stale reads.
+2. **Expansion:** "Let multiple agents share state without conflicts." Two or three agents on the same workspace.
+3. **Platform:** "Coordinate arbitrary numbers of agents, humans, and automated processes on the same shared records." The full coordination layer.
+
+The entry pitch is unambiguous and solvable today. The platform pitch is where relayfile's full value is captured as agentic architectures mature.

--- a/docs/market-framing.md
+++ b/docs/market-framing.md
@@ -1,0 +1,82 @@
+# Relayfile Market Framing
+
+## The Framing Problem
+
+"Multi-agent coordination layer" is the right description of what relayfile is, but it is the wrong pitch for today's market. Most teams are not running multiple peer agents writing to shared state. Pitching coordination for a pattern they don't yet have creates a timing mismatch — the product sounds like infrastructure for a future they haven't hit yet.
+
+The market that exists today is larger and more immediate, and relayfile serves it directly.
+
+---
+
+## The Real Market Today
+
+### Human + AI on the Same Records
+
+Every company shipping AI features is hitting this problem right now:
+
+- A human updates a Linear ticket. The AI agent that was working on it doesn't know, and submits a PR that conflicts with what the human decided.
+- A sales rep is on a call. HubSpot's AI rewrites the contact record mid-conversation.
+- A human merges a PR. Copilot's agent was mid-review and now its suggestions are stale.
+- A support agent picks up a ticket. The AI already drafted a response based on state that changed 30 seconds ago.
+
+This is not a future problem. It is happening at every B2B SaaS company that has shipped AI features — which is now most of them.
+
+The solutions in use today are all bad: polling loops with arbitrary intervals, database flags that drift, accepting stale reads, letting last-write-win and cleaning up conflicts manually. None of it is coordinated. None of it is real-time.
+
+### AI Automation Companies
+
+The more concentrated ICP: companies building agents that take actions in their users' SaaS tools on their behalf.
+
+Lindy, Relevance AI, Dust, n8n's agent features, Zapier AI Actions, Make.com agents — these companies are all solving the same infrastructure problem from scratch:
+
+- How do I know if a human changed something while my agent was running?
+- How do I prevent two agent runs from conflicting on the same user record?
+- How does the agent maintain a coherent view of state across a long-running task without polling every 10 seconds?
+
+Every one of these companies has built an ad hoc version of the same thing: a polling loop, a database flag, a custom webhook handler, a job queue. None of it generalizes. None of it handles concurrent writes gracefully. None of it fans out to the agent in real time when the underlying data changes.
+
+This is the market. It is large, it is today, and it is genuinely unserved.
+
+---
+
+## The Pitch
+
+**Not:** "Relayfile is a coordination layer for multi-agent workflows."
+
+**Yes:** "Relayfile is the real-time shared workspace that keeps your agent's view of the world current — without polling."
+
+One agent. One human. The agent always knows when something changed, before it acts on stale state.
+
+That is the wedge. Multi-agent coordination is what customers grow into, not what they buy on day one.
+
+---
+
+## Why This Market Is Unserved
+
+| Layer | Existing tools | Gap |
+|---|---|---|
+| Tool execution | Composio, Merge, Executor | Call the API |
+| Data ingestion | Nango, Paragon Managed Sync | Get the data in |
+| **State between reads and writes** | **Nobody** | **Keep the agent's view current; detect when it goes stale** |
+
+Composio and Merge solve the execution problem. Nango and Paragon solve the ingestion problem. Nobody has standardized the layer where the agent *holds* state between reads and writes, knows in real time when something changed, and detects conflicts before acting on outdated information.
+
+That is relayfile's position. It is not adjacent to these tools — it sits on top of all of them.
+
+---
+
+## ICP Today
+
+**Primary:** AI automation companies (teams building agents that act in users' SaaS tools). They are reinventing this infrastructure for every product they ship.
+
+**Secondary:** B2B SaaS companies embedding AI features where AI and humans write to the same records (Notion, Linear, Intercom, HubSpot, Salesforce — and every vertical SaaS doing the same).
+
+**Growing into:** Teams running parallel agents on shared workspaces — the multi-agent pattern that will become the norm as agentic architectures mature.
+
+---
+
+## Why Now
+
+The number of teams shipping autonomous AI actions (not just AI suggestions) is accelerating. Every AI automation company that reaches production hits the coordination wall within months. The infrastructure they build to get past it is expensive, brittle, and not their core product. Relayfile is what they should be buying instead.
+
+The framing shifts from "coordination layer" (a solution looking for a problem) to "no more stale agent state" (a problem every AI automation team is already paying to solve, badly).

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -9,6 +9,8 @@ That distinction drives every pricing decision:
 - **Mirage** is open-source and free. Competing on storage or caching is unsustainable.
 - **Composio** has driven tool-call routing to near-zero ($0.15–$0.30/1K calls). Competing on routing price is a race to the bottom.
 - **Nango** charges $500/month for sync infrastructure. Relayfile sits on top of Nango and charges the same amount for a qualitatively different layer.
+- **Merge Agent Handler** charges $1,000/month for enterprise MCP tool execution with per-user OAuth and PII/PHI scanning. It is stateless — no persistent workspace, no agent-to-agent coordination.
+- **Paragon** handles multi-tenant data ingestion, tool calling, and workflow automation for AI product companies. It explicitly does not coordinate agents or manage shared state.
 - **MCP** is a free protocol. Relayfile's value is what happens after the tool call: persistent shared state, conflict detection, and real-time awareness.
 
 The integrations where relayfile's value is highest are multi-writer collaboration tools — Linear, Jira, GitHub, Notion — where humans and agents are concurrently editing the same records. Storage backends (S3, GCS, R2) have softer concurrency problems and are lower priority.
@@ -115,7 +117,7 @@ At Enterprise scale the build-it-yourself cost (3–6 weeks engineering, $24K–
 
 ## Platform Plans
 
-Customers arriving via Nango, Composio, or Pipedream have already paid for adjacent infrastructure. Charging them the full Growth rate ($499) on top of their existing spend creates sticker shock that kills conversion. Platform plans are priced to complement what the customer already pays, serve as distribution via each platform's marketplace, and reflect lower infrastructure costs where the customer's existing subscription handles part of the stack.
+Customers arriving via Nango, Composio, Merge, Paragon, Executor, or Pipedream have already paid for adjacent infrastructure. Charging them the full Growth rate ($499) on top of their existing spend creates sticker shock that kills conversion. Platform plans are priced to complement what the customer already pays, serve as distribution via each platform's marketplace, and reflect lower infrastructure costs where the customer's existing subscription handles part of the stack.
 
 ---
 
@@ -164,6 +166,58 @@ Composio handles tool execution and agent-to-API calls. Relayfile provides the p
 **Pitch:** "Composio gives your agents hands. Relayfile gives them shared memory."
 
 **Distribution:** Composio marketplace, Composio integration directory.
+
+---
+
+### Merge Plan — $349/month
+
+For AI product teams using Merge Agent Handler who need persistent multi-agent state alongside tool execution.
+
+Merge Agent Handler provides production-grade MCP access to 150+ pre-built connectors with per-user OAuth, inline PII/PHI scanning (Presidio), and full audit logs. What it doesn't provide: persistent agent state, multi-agent coordination, or real-time fan-out between agents. Relayfile fills that gap — the shared workspace agents read from and write to between Merge tool calls, with conflict detection and real-time awareness across concurrent agents.
+
+Merge also forwards inbound third-party webhooks (Slack events, Jira webhooks, GitHub events) as unified `inbound_webhook.received` events. Relayfile ingests these directly, giving the agent's working set a live view of third-party state without a separate Nango subscription.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 5 |
+| Integrations | Bring-your-own Merge (all connectors in the customer's Agent Handler Tool Pack) |
+| Events/month | 2M |
+| Overage | $0.20/1K events |
+| Forks + ACLs | ✓ |
+| Audit logs | ✓ |
+| Support | Priority |
+
+**Rationale:** Merge Agent Handler Pro is $1,000/month. Teams already committed to $1K/month for tool execution are enterprise buyers who will find $349 proportional. Relayfile's infrastructure costs are low on this plan because Merge handles all provider OAuth and API calls; relayfile only processes forwarded webhook events and manages coordination state. ~72% gross margin. Combined spend of $1,349/month for full tool-execution + coordination is coherent for an enterprise agent team.
+
+**Pitch:** "Merge Agent Handler gives your agents production-grade tools. Relayfile gives them the shared memory to coordinate across calls."
+
+**Distribution:** Merge partner directory, Merge Discord, enterprise referrals.
+
+---
+
+### Paragon Plan — $299/month
+
+For AI product companies using Paragon who need a coordination layer on top of Paragon's sync and action infrastructure.
+
+Paragon handles multi-tenant data ingestion (Managed Sync with normalized schemas and RBAC permissions graph), real-time tool calling (ActionKit + MCP), and async workflow orchestration. What Paragon explicitly does not provide: persistent shared agent state, multi-agent conflict detection, or real-time fan-out to connected agents. Relayfile provides the coordination workspace above Paragon's integration layer — where agents read each other's writes, resolve conflicts, and maintain a coherent shared view across concurrent operations.
+
+Paragon's Permissions API (a RBAC graph tracking which users can access which synced objects) maps directly to relayfile ACLs: Paragon defines who owns what data, relayfile enforces those boundaries on the shared workspace.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 5 |
+| Integrations | Bring-your-own Paragon (Managed Sync sources + ActionKit connectors the customer already has) |
+| Events/month | 3M |
+| Overage | $0.15/1K events |
+| Forks + ACLs | ✓ |
+| Audit logs | ✓ |
+| Support | Priority |
+
+**Rationale:** Paragon targets B2B SaaS and AI product companies with significant infrastructure commitments — pricing is opaque but typical spend is $500–2K/month. $299 anchors relayfile as a mid-weight complement, similar to the Nango Plan. Event limit is higher (3M) because Paragon's Managed Sync generates substantial ingestion volume from background sync across many connected tenants. Relayfile's infrastructure costs are lower because Paragon handles provider API rate limiting and schema normalization. ~68% gross margin.
+
+**Pitch:** "Paragon ingests and acts on your users' data. Relayfile is the coordination layer where your agents work on it together."
+
+**Distribution:** Paragon partner ecosystem, Paragon marketplace.
 
 ---
 
@@ -226,6 +280,8 @@ Pipedream handles event-driven workflow automation. Relayfile provides the share
 | Growth | 5M | $0.15 |
 | Nango Plan | 3M | $0.15 |
 | Composio Plan | 1M | $0.20 |
+| Merge Plan | 2M | $0.20 |
+| Paragon Plan | 3M | $0.15 |
 | Executor Plan | 500K | $0.25 |
 | Pipedream Plan | 500K | $0.25 |
 | Enterprise | Negotiated | Negotiated |
@@ -243,6 +299,8 @@ Overage rates decrease with plan tier — higher-paying customers get cheaper ov
 | Growth | $499 | ~$150–200 | ~60–70% |
 | Nango Plan | $299 | ~$50–80 (relayfile infra only; customer pays Nango) | ~70–75% |
 | Composio Plan | $199 | ~$40–60 | ~70% |
+| Merge Plan | $349 | ~$50–80 (Merge handles provider layer; relayfile processes forwarded events) | ~72% |
+| Paragon Plan | $299 | ~$60–95 (Paragon handles ingestion; relayfile processes coordination events) | ~68% |
 | Executor Plan | $149 | ~$25–35 (no Nango layer; customer has no background sync) | ~77% |
 | Pipedream Plan | $149 | ~$30–40 | ~75% |
 | Enterprise | custom | negotiated | 75%+ |
@@ -253,16 +311,20 @@ Platform plans have higher gross margins than standard plans because the custome
 
 ## Competitive Anchoring
 
-| | Executor | Composio Pro | Nango Growth | Relayfile Growth |
-|---|---|---|---|---|
-| Price | Free (MIT) | $229/month | $500/month | $499/month |
-| Purpose | BYO-spec tool execution runtime | Managed tool call catalog | OAuth + scheduled sync infrastructure | Coordination layer + real-time workspace |
-| Pre-built integration catalog | ✗ | ✓ (250+) | ✓ (250+) | — |
-| Background sync / webhook ingestion | ✗ | ✗ | ✓ | ✓ (via Nango) |
-| Persistent shared workspace | ✗ | ✗ | ✗ | ✓ |
-| Multi-agent conflict detection | ✗ | ✗ | ✗ | ✓ |
-| Real-time WebSocket fan-out | ✗ | ✗ | ✗ | ✓ |
-| Forks + ACLs | ✗ | ✗ | ✗ | ✓ |
-| Semantic metadata + relations | ✗ | ✗ | ✗ | ✓ |
+| | Executor | Composio Pro | Merge Agent Handler Pro | Paragon | Nango Growth | Relayfile Growth |
+|---|---|---|---|---|---|---|
+| Price | Free (MIT) | $229/month | $1,000/month | Custom (~$500–2K/month) | $500/month | $499/month |
+| Purpose | BYO-spec tool execution | Managed tool call catalog | Enterprise MCP + per-user OAuth | Multi-tenant sync + actions + workflows | OAuth + scheduled sync | Coordination layer + real-time workspace |
+| Pre-built integration catalog | ✗ | ✓ (250+) | ✓ (150+) | ✓ (130+) | ✓ (250+) | — |
+| Background sync / webhook ingestion | ✗ | ✗ | Inbound webhook forwarding | ✓ (Managed Sync) | ✓ | ✓ (via Nango) |
+| Per-user OAuth + credential management | BYO | ✓ | ✓ | ✓ | ✓ | — |
+| Inline PII/PHI scanning | ✗ | ✗ | ✓ (Presidio) | ✗ | ✗ | — |
+| RBAC permissions graph | ✗ | ✗ | ✗ | ✓ | ✗ | ✓ (ACLs) |
+| Persistent shared workspace | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Multi-agent conflict detection | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Real-time WebSocket fan-out | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Forks + semantic metadata | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 
-Executor is the open-source alternative to Composio for teams that want to own their tool execution stack. It has no persistence layer at all — making the relayfile gap larger, not smaller, than with Composio users. Relayfile Growth ($499) costs roughly the same as Nango Growth ($500) but delivers the coordination layer none of the others have. For a team already using Nango, the Nango Plan ($299) is the right entry point. For Executor or Composio teams, the respective platform plans are the conversion path.
+Every platform in this table solves the integration access problem (how do agents get data and execute actions). None of them solve the coordination problem (how do agents share state, detect conflicts, and stay in sync with each other in real time). That is the gap relayfile fills.
+
+Relayfile Growth ($499) costs roughly the same as Nango Growth ($500) but delivers the coordination layer none of the others have. For teams already using one of these platforms, the corresponding platform plan is the right entry point — priced to complement existing spend rather than replace it.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,11 +1,32 @@
 # Relayfile Pricing
 
-## Principles
+## Positioning
 
-- Charge on **events** (webhook ingestions + file state changes) — the best proxy for coordination work done
-- Integrations are capped per tier to reflect real Nango infrastructure costs underneath
-- Platform plans (Nango, Composio, Pipedream) serve customers who arrive via those ecosystems with pricing tuned to each
-- Free tier is real enough to prototype with; not real enough to run in production
+Relayfile is not a better S3, a smarter webhook router, or a cheaper Nango. It is the **coordination layer** — the shared workspace where humans and agents read and write the same records at the same time, with conflict detection, real-time fan-out, forks, ACLs, and semantic metadata.
+
+That distinction drives every pricing decision:
+
+- **Mirage** is open-source and free. Competing on storage or caching is unsustainable.
+- **Composio** has driven tool-call routing to near-zero ($0.15–$0.30/1K calls). Competing on routing price is a race to the bottom.
+- **Nango** charges $500/month for sync infrastructure. Relayfile sits on top of Nango and charges the same amount for a qualitatively different layer.
+- **MCP** is a free protocol. Relayfile's value is what happens after the tool call: persistent shared state, conflict detection, and real-time awareness.
+
+The integrations where relayfile's value is highest are multi-writer collaboration tools — Linear, Jira, GitHub, Notion — where humans and agents are concurrently editing the same records. Storage backends (S3, GCS, R2) have softer concurrency problems and are lower priority.
+
+---
+
+## Billing Unit: Events
+
+**One event = one webhook ingested from a provider, or one file write via the API.**
+
+This is the right unit because:
+- Seats don't map to AI agents — agents aren't humans, aren't persistent, and can't be counted like people
+- Per-agent pricing is hard to enforce — agents are ephemeral processes that start and stop
+- Events scale proportionally with coordination work done and grow with the value relayfile delivers
+
+**Fan-out is always free.** Broadcasting one file change to 20 connected agents counts as one event, not 20. Charging for fan-out would penalize multi-agent usage — exactly the use case relayfile is built for.
+
+Bulk writes count as one event per file written. Fork commits count as one event per file in the fork.
 
 ---
 
@@ -26,6 +47,8 @@ For prototyping and individual developers evaluating the platform.
 | ACLs | ✗ |
 | Support | Community |
 
+The free tier is real enough to prototype with but not to run in production. Its purpose is conversion, not revenue.
+
 ---
 
 ### Starter — $79/month
@@ -44,13 +67,13 @@ For small teams shipping their first agent product.
 | ACLs | ✗ |
 | Support | Email |
 
-**Why $79:** Positioned above Composio Starter ($29) — we're not a tool call router, we're a coordination layer. Margins work at this price covering Nango Starter costs for 8 integrations.
+**Rationale:** Composio Starter is $29/month for 200K tool calls — pure routing with no coordination layer. Relayfile provides real-time fan-out, forks, and a persistent workspace that justifies a clear premium. $49 was considered but doesn't cover Nango Starter infrastructure costs (~$20–30/month for 8 integrations) at meaningful margin. $79 yields ~40% gross margin and positions relayfile above tool-call commoditization without being out of reach for a small team.
 
 ---
 
 ### Growth — $499/month
 
-For teams running agent products in production with real workloads.
+For teams running agent products in production.
 
 | Resource | Limit |
 |---|---|
@@ -65,7 +88,7 @@ For teams running agent products in production with real workloads.
 | Audit logs | ✓ |
 | Support | Priority (Slack) |
 
-**Why $499:** Covers Nango Growth costs (~$200/month for the integration infrastructure) at reasonable margin. Below Nango's own Growth plan ($500) only because relayfile is the coordination layer on top, not a replacement for Nango. Matches what a Composio Professional ($229) + Nango Starter ($50) customer would pay combined — and relayfile gives them both in one.
+**Rationale:** The Nango cost problem forced this number up from the initial $299 estimate. A Growth-tier customer using all integrations incurs ~$150–200/month in Nango infrastructure costs underneath. At $299 the margin is negative. At $499 it's ~60% gross margin — viable for a production service with support obligations. $499 also anchors neatly against Nango's own Growth plan ($500): relayfile costs the same as Nango but adds the entire coordination layer Nango doesn't have. Composio Professional is $229; relayfile at $499 is clearly premium but justified by multi-agent coordination, real-time fan-out, forks, and ACLs that Composio doesn't provide.
 
 ---
 
@@ -83,14 +106,16 @@ For organizations with compliance requirements, large workloads, or deployment c
 | Forks + ACLs + Audit logs | ✓ |
 | SSO / SAML | ✓ |
 | On-premise deployment | ✓ |
-| SLA | 99.9% uptime |
+| SLA | 99.9% uptime guarantee |
 | Support | Dedicated |
+
+At Enterprise scale the build-it-yourself cost (3–6 weeks engineering, $24K–$48K loaded cost plus ongoing maintenance) makes self-hosting economically irrational for most organizations. The SLA and on-premise option are the unlock for regulated industries.
 
 ---
 
 ## Platform Plans
 
-For customers who arrive via Nango, Composio, or Pipedream ecosystems. These plans are listed in each platform's marketplace or integration directory and priced to complement what the customer is already paying.
+Customers arriving via Nango, Composio, or Pipedream have already paid for adjacent infrastructure. Charging them the full Growth rate ($499) on top of their existing spend creates sticker shock that kills conversion. Platform plans are priced to complement what the customer already pays, serve as distribution via each platform's marketplace, and reflect lower infrastructure costs where the customer's existing subscription handles part of the stack.
 
 ---
 
@@ -98,7 +123,7 @@ For customers who arrive via Nango, Composio, or Pipedream ecosystems. These pla
 
 For teams already running Nango who need the coordination layer on top.
 
-Nango handles OAuth, token refresh, and scheduled sync. Relayfile connects to the customer's existing Nango instance and provides the real-time workspace, multi-agent coordination, and semantic layer on top. The customer keeps their Nango subscription separately.
+Nango handles OAuth, token refresh, and scheduled sync. Relayfile connects to the customer's existing Nango instance and adds the real-time workspace, multi-agent coordination, and semantic layer on top. The customer keeps their Nango subscription; relayfile only processes events and manages state.
 
 | Resource | Limit |
 |---|---|
@@ -110,11 +135,11 @@ Nango handles OAuth, token refresh, and scheduled sync. Relayfile connects to th
 | Audit logs | ✓ |
 | Support | Priority |
 
-**Positioning:** "You're already paying Nango for the sync layer. Relayfile makes that data usable by agents in real-time with no extra integration work." The customer's Nango connection count and sync quota come from their own Nango plan; relayfile only adds the coordination and fan-out layer.
+**Rationale:** The customer is already paying Nango $50–$500/month. Another $499 on top makes the combined bill $549–$999, which is a hard sell. At $299 the combined spend is $349–$799 — reasonable for a production agent team. Relayfile's infrastructure costs are genuinely lower here because Nango handles all provider API calls; relayfile only processes the resulting events and manages workspace state. ~65% gross margin at this price.
 
-**Listed on:** Nango integration directory, Nango partner page.
+**Pitch:** "You're already paying Nango for the sync layer. Relayfile makes that data usable by agents in real-time with no extra integration work."
 
-**Why $299 not $499:** The customer is already paying Nango ($50–$500/month). Asking for another $499 on top would make the total cost prohibitive. At $299 the combined spend is $349–$799, which is reasonable for a production agent team. Relayfile's infrastructure costs are lower here because Nango handles all the provider API calls; relayfile only processes events and manages state.
+**Distribution:** Nango integration directory, Nango partner page.
 
 ---
 
@@ -122,7 +147,7 @@ Nango handles OAuth, token refresh, and scheduled sync. Relayfile connects to th
 
 For teams using Composio for tool calls who need persistent shared state between agents.
 
-Composio handles tool execution and agent-to-API calls. Relayfile provides the persistent workspace that agents read from and write to between tool calls — the shared memory layer that makes multi-agent workflows coherent over time.
+Composio handles tool execution and agent-to-API calls. Relayfile provides the persistent workspace that agents read from and write to between tool calls — the shared memory that makes multi-agent workflows coherent over time.
 
 | Resource | Limit |
 |---|---|
@@ -131,22 +156,22 @@ Composio handles tool execution and agent-to-API calls. Relayfile provides the p
 | Events/month | 1M |
 | Overage | $0.20/1K events |
 | Forks | ✓ |
-| ACLs | ✗ (Growth add-on) |
+| ACLs | ✗ (upgrade to Growth) |
 | Support | Email |
 
-**Positioning:** "Composio gives your agents hands. Relayfile gives them shared memory." A Composio Professional customer ($229/month) adding relayfile at $199/month pays $428/month total for a complete multi-agent stack: tool execution + persistent coordination workspace.
+**Rationale:** Composio Professional is $229/month. Anchoring relayfile at $199 positions both as roughly equal weight in the stack, which reflects the actual split in responsibilities: Composio executes, relayfile remembers. Combined spend of ~$428/month for a full multi-agent stack — tool execution plus persistent coordination workspace — is a coherent value story for a team that's hit the coordination wall.
 
-**Listed on:** Composio marketplace, Composio integration directory.
+**Pitch:** "Composio gives your agents hands. Relayfile gives them shared memory."
 
-**Why $199:** Composio's own Pro plan is $229. Customers comparing total spend will anchor to that. At $199 relayfile feels like roughly equal weight in the stack, which reflects the actual split in responsibilities.
+**Distribution:** Composio marketplace, Composio integration directory.
 
 ---
 
 ### Pipedream Plan — $149/month
 
-For teams using Pipedream workflows who need a shared state layer between workflow steps and between agents running in parallel.
+For teams using Pipedream workflows who need a shared state layer between parallel workflows and agents.
 
-Pipedream handles event-driven workflow automation. Relayfile provides the shared workspace that multiple Pipedream workflows (and the agents they spawn) read from and write to — solving the coordination problem when parallel workflows need consistent shared state.
+Pipedream handles event-driven workflow automation. Relayfile provides the shared workspace that multiple parallel Pipedream workflows read from and write to consistently — solving the coordination problem when workflows running in parallel need coherent shared state.
 
 | Resource | Limit |
 |---|---|
@@ -158,19 +183,19 @@ Pipedream handles event-driven workflow automation. Relayfile provides the share
 | ACLs | ✗ |
 | Support | Email |
 
-**Positioning:** "Pipedream orchestrates your workflows. Relayfile is the shared filesystem they all read and write consistently." Pipedream's own paid plans start around $29–$49/month; relayfile at $149 is a meaningful add-on but justified for teams hitting the coordination wall with parallel workflows.
+**Rationale:** Pipedream's customer base skews toward developers and automation engineers who are cost-sensitive. Pipedream's own paid plans start around $29–$49/month; a $499 relayfile add-on would be a non-starter. $149 is the floor at which relayfile's infrastructure costs are covered for the event volume included. Combined spend of ~$200/month is accessible for a developer running production workflows.
 
-**Listed on:** Pipedream marketplace, Pipedream integration directory.
+**Pitch:** "Pipedream orchestrates your workflows. Relayfile is the shared filesystem they all read and write consistently."
 
-**Why $149:** Pipedream's customer base skews toward developers and automation engineers who are cost-sensitive. $149 is the floor at which relayfile's infrastructure costs are covered for the event volume included. A Pipedream paid customer adding relayfile spends ~$200/month combined — reasonable for a production workflow infrastructure.
+**Distribution:** Pipedream marketplace, Pipedream integration directory.
 
 ---
 
 ## Overage Rates Summary
 
-| Plan | Included events | Overage per 1K |
+| Plan | Included events/month | Overage per 1K events |
 |---|---|---|
-| Free | 25K | Not available — upgrade required |
+| Free | 25K | Upgrade required |
 | Starter | 500K | $0.25 |
 | Growth | 5M | $0.15 |
 | Nango Plan | 3M | $0.15 |
@@ -178,18 +203,23 @@ Pipedream handles event-driven workflow automation. Relayfile provides the share
 | Pipedream Plan | 500K | $0.25 |
 | Enterprise | Negotiated | Negotiated |
 
+Overage rates decrease with plan tier — higher-paying customers get cheaper overages as a volume reward and to avoid penalizing successful deployments.
+
 ---
 
-## What Counts as an Event
+## Gross Margin Model
 
-One event = one of the following:
+| Plan | Price | Est. Nango/infra cost | Est. gross margin |
+|---|---|---|---|
+| Free | $0 | ~$0 (within Nango free limits) | — |
+| Starter | $79 | ~$20–30 | ~60% |
+| Growth | $499 | ~$150–200 | ~60–70% |
+| Nango Plan | $299 | ~$50–80 (relayfile infra only; customer pays Nango) | ~70–75% |
+| Composio Plan | $199 | ~$40–60 | ~70% |
+| Pipedream Plan | $149 | ~$30–40 | ~75% |
+| Enterprise | custom | negotiated | 75%+ |
 
-- A webhook received from a provider (Linear issue updated, Slack message posted, etc.)
-- A file write via the REST API (`PUT /fs/file`)
-- A bulk write operation counts as one event per file written
-- A fork commit counts as one event per file in the fork
-
-WebSocket fan-out to agents does **not** count as events — broadcasting one file change to 20 agents is still one event. Charging for fan-out would penalize multi-agent usage, which is the core value proposition.
+Platform plans have higher gross margins than standard plans because the customer's existing platform subscription covers the expensive provider API layer. Relayfile only runs the coordination infrastructure.
 
 ---
 
@@ -198,11 +228,11 @@ WebSocket fan-out to agents does **not** count as events — broadcasting one fi
 | | Composio Pro | Nango Growth | Relayfile Growth |
 |---|---|---|---|
 | Price | $229/month | $500/month | $499/month |
-| What you get | Tool call routing | OAuth + sync infrastructure | Coordination layer + real-time workspace |
-| Multi-agent coordination | ✗ | ✗ | ✓ |
-| Real-time fan-out | ✗ | ✗ | ✓ |
+| Purpose | Tool call routing | OAuth + sync infrastructure | Coordination layer + real-time workspace |
+| Multi-agent conflict detection | ✗ | ✗ | ✓ |
+| Real-time WebSocket fan-out | ✗ | ✗ | ✓ |
 | Forks + ACLs | ✗ | ✗ | ✓ |
 | Semantic metadata + relations | ✗ | ✗ | ✓ |
-| Builds on Nango | — | Is Nango | Optional |
+| Persistent shared workspace | ✗ | ✗ | ✓ |
 
-Relayfile Growth at $499 costs roughly the same as Nango Growth ($500) but delivers the coordination layer they don't have. For a team already using Nango, the Nango Plan at $299 is the right entry point.
+Relayfile Growth ($499) costs roughly the same as Nango Growth ($500) but delivers the coordination layer neither Nango nor Composio have. For a team already using Nango, the Nango Plan ($299) is the right entry point — they keep Nango for what it's good at and add relayfile for what they're missing.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -1,0 +1,208 @@
+# Relayfile Pricing
+
+## Principles
+
+- Charge on **events** (webhook ingestions + file state changes) — the best proxy for coordination work done
+- Integrations are capped per tier to reflect real Nango infrastructure costs underneath
+- Platform plans (Nango, Composio, Pipedream) serve customers who arrive via those ecosystems with pricing tuned to each
+- Free tier is real enough to prototype with; not real enough to run in production
+
+---
+
+## Standard Plans
+
+### Free — $0/month
+
+For prototyping and individual developers evaluating the platform.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 1 |
+| Integrations | 3 |
+| Events/month | 25K |
+| Concurrent agent connections | 5 |
+| Event history | 24 hours |
+| Forks | ✗ |
+| ACLs | ✗ |
+| Support | Community |
+
+---
+
+### Starter — $79/month
+
+For small teams shipping their first agent product.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 2 |
+| Integrations | 8 |
+| Events/month | 500K |
+| Overage | $0.25/1K events |
+| Concurrent agent connections | Unlimited |
+| Event history | 7 days |
+| Forks | ✓ |
+| ACLs | ✗ |
+| Support | Email |
+
+**Why $79:** Positioned above Composio Starter ($29) — we're not a tool call router, we're a coordination layer. Margins work at this price covering Nango Starter costs for 8 integrations.
+
+---
+
+### Growth — $499/month
+
+For teams running agent products in production with real workloads.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 10 |
+| Integrations | All (24+) |
+| Events/month | 5M |
+| Overage | $0.15/1K events |
+| Concurrent agent connections | Unlimited |
+| Event history | 30 days |
+| Forks | ✓ |
+| ACLs | ✓ |
+| Audit logs | ✓ |
+| Support | Priority (Slack) |
+
+**Why $499:** Covers Nango Growth costs (~$200/month for the integration infrastructure) at reasonable margin. Below Nango's own Growth plan ($500) only because relayfile is the coordination layer on top, not a replacement for Nango. Matches what a Composio Professional ($229) + Nango Starter ($50) customer would pay combined — and relayfile gives them both in one.
+
+---
+
+### Enterprise — Custom
+
+For organizations with compliance requirements, large workloads, or deployment constraints.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | Unlimited |
+| Integrations | Unlimited |
+| Events/month | Negotiated |
+| Concurrent agent connections | Unlimited |
+| Event history | Custom retention |
+| Forks + ACLs + Audit logs | ✓ |
+| SSO / SAML | ✓ |
+| On-premise deployment | ✓ |
+| SLA | 99.9% uptime |
+| Support | Dedicated |
+
+---
+
+## Platform Plans
+
+For customers who arrive via Nango, Composio, or Pipedream ecosystems. These plans are listed in each platform's marketplace or integration directory and priced to complement what the customer is already paying.
+
+---
+
+### Nango Plan — $299/month
+
+For teams already running Nango who need the coordination layer on top.
+
+Nango handles OAuth, token refresh, and scheduled sync. Relayfile connects to the customer's existing Nango instance and provides the real-time workspace, multi-agent coordination, and semantic layer on top. The customer keeps their Nango subscription separately.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 5 |
+| Integrations | Bring-your-own Nango (all connections the customer already has) |
+| Events/month | 3M |
+| Overage | $0.15/1K events |
+| Forks + ACLs | ✓ |
+| Audit logs | ✓ |
+| Support | Priority |
+
+**Positioning:** "You're already paying Nango for the sync layer. Relayfile makes that data usable by agents in real-time with no extra integration work." The customer's Nango connection count and sync quota come from their own Nango plan; relayfile only adds the coordination and fan-out layer.
+
+**Listed on:** Nango integration directory, Nango partner page.
+
+**Why $299 not $499:** The customer is already paying Nango ($50–$500/month). Asking for another $499 on top would make the total cost prohibitive. At $299 the combined spend is $349–$799, which is reasonable for a production agent team. Relayfile's infrastructure costs are lower here because Nango handles all the provider API calls; relayfile only processes events and manages state.
+
+---
+
+### Composio Plan — $199/month
+
+For teams using Composio for tool calls who need persistent shared state between agents.
+
+Composio handles tool execution and agent-to-API calls. Relayfile provides the persistent workspace that agents read from and write to between tool calls — the shared memory layer that makes multi-agent workflows coherent over time.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 3 |
+| Integrations | 10 (Composio handles the tool call layer) |
+| Events/month | 1M |
+| Overage | $0.20/1K events |
+| Forks | ✓ |
+| ACLs | ✗ (Growth add-on) |
+| Support | Email |
+
+**Positioning:** "Composio gives your agents hands. Relayfile gives them shared memory." A Composio Professional customer ($229/month) adding relayfile at $199/month pays $428/month total for a complete multi-agent stack: tool execution + persistent coordination workspace.
+
+**Listed on:** Composio marketplace, Composio integration directory.
+
+**Why $199:** Composio's own Pro plan is $229. Customers comparing total spend will anchor to that. At $199 relayfile feels like roughly equal weight in the stack, which reflects the actual split in responsibilities.
+
+---
+
+### Pipedream Plan — $149/month
+
+For teams using Pipedream workflows who need a shared state layer between workflow steps and between agents running in parallel.
+
+Pipedream handles event-driven workflow automation. Relayfile provides the shared workspace that multiple Pipedream workflows (and the agents they spawn) read from and write to — solving the coordination problem when parallel workflows need consistent shared state.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 2 |
+| Integrations | 6 (Pipedream handles event triggers and HTTP actions) |
+| Events/month | 500K |
+| Overage | $0.25/1K events |
+| Forks | ✓ |
+| ACLs | ✗ |
+| Support | Email |
+
+**Positioning:** "Pipedream orchestrates your workflows. Relayfile is the shared filesystem they all read and write consistently." Pipedream's own paid plans start around $29–$49/month; relayfile at $149 is a meaningful add-on but justified for teams hitting the coordination wall with parallel workflows.
+
+**Listed on:** Pipedream marketplace, Pipedream integration directory.
+
+**Why $149:** Pipedream's customer base skews toward developers and automation engineers who are cost-sensitive. $149 is the floor at which relayfile's infrastructure costs are covered for the event volume included. A Pipedream paid customer adding relayfile spends ~$200/month combined — reasonable for a production workflow infrastructure.
+
+---
+
+## Overage Rates Summary
+
+| Plan | Included events | Overage per 1K |
+|---|---|---|
+| Free | 25K | Not available — upgrade required |
+| Starter | 500K | $0.25 |
+| Growth | 5M | $0.15 |
+| Nango Plan | 3M | $0.15 |
+| Composio Plan | 1M | $0.20 |
+| Pipedream Plan | 500K | $0.25 |
+| Enterprise | Negotiated | Negotiated |
+
+---
+
+## What Counts as an Event
+
+One event = one of the following:
+
+- A webhook received from a provider (Linear issue updated, Slack message posted, etc.)
+- A file write via the REST API (`PUT /fs/file`)
+- A bulk write operation counts as one event per file written
+- A fork commit counts as one event per file in the fork
+
+WebSocket fan-out to agents does **not** count as events — broadcasting one file change to 20 agents is still one event. Charging for fan-out would penalize multi-agent usage, which is the core value proposition.
+
+---
+
+## Competitive Anchoring
+
+| | Composio Pro | Nango Growth | Relayfile Growth |
+|---|---|---|---|
+| Price | $229/month | $500/month | $499/month |
+| What you get | Tool call routing | OAuth + sync infrastructure | Coordination layer + real-time workspace |
+| Multi-agent coordination | ✗ | ✗ | ✓ |
+| Real-time fan-out | ✗ | ✗ | ✓ |
+| Forks + ACLs | ✗ | ✗ | ✓ |
+| Semantic metadata + relations | ✗ | ✗ | ✓ |
+| Builds on Nango | — | Is Nango | Optional |
+
+Relayfile Growth at $499 costs roughly the same as Nango Growth ($500) but delivers the coordination layer they don't have. For a team already using Nango, the Nango Plan at $299 is the right entry point.

--- a/docs/pricing.md
+++ b/docs/pricing.md
@@ -167,6 +167,32 @@ Composio handles tool execution and agent-to-API calls. Relayfile provides the p
 
 ---
 
+### Executor Plan — $149/month
+
+For teams using Executor (open-source, bring-your-own-spec tool runtime) who need persistent shared state between agents.
+
+Executor handles tool execution, credential management, and on-demand API calls across OpenAPI, GraphQL, MCP, and Google Discovery sources. It does not do background sync, webhook ingestion, or data materialization — it's purely on-demand. Relayfile provides the persistent workspace agents read from and write to between tool calls, and the real-time fan-out that makes multi-agent state coherent over time.
+
+| Resource | Limit |
+|---|---|
+| Workspaces | 2 |
+| Integrations | 6 (Executor handles tool execution; relayfile handles state) |
+| Events/month | 500K |
+| Overage | $0.25/1K events |
+| Forks | ✓ |
+| ACLs | ✗ |
+| Support | Email |
+
+**Rationale:** Executor is MIT-licensed and free — there is no Executor bill to anchor against. The plan is priced at $149 rather than $199 because Executor's purely on-demand model generates lower event volumes than Composio: no background webhook ingestion, no scheduled sync, only file writes triggered by explicit tool calls. The relayfile value prop is actually stronger here than with Composio users: Executor teams are building everything from scratch with no pre-built catalog, no materialized state, no persistence infrastructure whatsoever. Relayfile fills that entire gap. Combined spend is ~$149/month — accessible for a developer who chose open-source tooling precisely to control costs.
+
+**Pitch:** "Executor gives your agents hands. Relayfile gives them shared memory."
+
+**Key distinction from Composio Plan:** Composio provides a managed catalog of 250+ pre-built integrations with its own persistence layer. Executor teams configure every integration themselves from raw specs. They need relayfile more — not less — because they have no other state infrastructure.
+
+**Distribution:** Executor Discord, Executor GitHub README, open-source community.
+
+---
+
 ### Pipedream Plan — $149/month
 
 For teams using Pipedream workflows who need a shared state layer between parallel workflows and agents.
@@ -200,6 +226,7 @@ Pipedream handles event-driven workflow automation. Relayfile provides the share
 | Growth | 5M | $0.15 |
 | Nango Plan | 3M | $0.15 |
 | Composio Plan | 1M | $0.20 |
+| Executor Plan | 500K | $0.25 |
 | Pipedream Plan | 500K | $0.25 |
 | Enterprise | Negotiated | Negotiated |
 
@@ -216,6 +243,7 @@ Overage rates decrease with plan tier — higher-paying customers get cheaper ov
 | Growth | $499 | ~$150–200 | ~60–70% |
 | Nango Plan | $299 | ~$50–80 (relayfile infra only; customer pays Nango) | ~70–75% |
 | Composio Plan | $199 | ~$40–60 | ~70% |
+| Executor Plan | $149 | ~$25–35 (no Nango layer; customer has no background sync) | ~77% |
 | Pipedream Plan | $149 | ~$30–40 | ~75% |
 | Enterprise | custom | negotiated | 75%+ |
 
@@ -225,14 +253,16 @@ Platform plans have higher gross margins than standard plans because the custome
 
 ## Competitive Anchoring
 
-| | Composio Pro | Nango Growth | Relayfile Growth |
-|---|---|---|---|
-| Price | $229/month | $500/month | $499/month |
-| Purpose | Tool call routing | OAuth + sync infrastructure | Coordination layer + real-time workspace |
-| Multi-agent conflict detection | ✗ | ✗ | ✓ |
-| Real-time WebSocket fan-out | ✗ | ✗ | ✓ |
-| Forks + ACLs | ✗ | ✗ | ✓ |
-| Semantic metadata + relations | ✗ | ✗ | ✓ |
-| Persistent shared workspace | ✗ | ✗ | ✓ |
+| | Executor | Composio Pro | Nango Growth | Relayfile Growth |
+|---|---|---|---|---|
+| Price | Free (MIT) | $229/month | $500/month | $499/month |
+| Purpose | BYO-spec tool execution runtime | Managed tool call catalog | OAuth + scheduled sync infrastructure | Coordination layer + real-time workspace |
+| Pre-built integration catalog | ✗ | ✓ (250+) | ✓ (250+) | — |
+| Background sync / webhook ingestion | ✗ | ✗ | ✓ | ✓ (via Nango) |
+| Persistent shared workspace | ✗ | ✗ | ✗ | ✓ |
+| Multi-agent conflict detection | ✗ | ✗ | ✗ | ✓ |
+| Real-time WebSocket fan-out | ✗ | ✗ | ✗ | ✓ |
+| Forks + ACLs | ✗ | ✗ | ✗ | ✓ |
+| Semantic metadata + relations | ✗ | ✗ | ✗ | ✓ |
 
-Relayfile Growth ($499) costs roughly the same as Nango Growth ($500) but delivers the coordination layer neither Nango nor Composio have. For a team already using Nango, the Nango Plan ($299) is the right entry point — they keep Nango for what it's good at and add relayfile for what they're missing.
+Executor is the open-source alternative to Composio for teams that want to own their tool execution stack. It has no persistence layer at all — making the relayfile gap larger, not smaller, than with Composio users. Relayfile Growth ($499) costs roughly the same as Nango Growth ($500) but delivers the coordination layer none of the others have. For a team already using Nango, the Nango Plan ($299) is the right entry point. For Executor or Composio teams, the respective platform plans are the conversion path.

--- a/docs/storage-bridge-priority.md
+++ b/docs/storage-bridge-priority.md
@@ -27,7 +27,7 @@ These systems natively deliver HTTP webhook callbacks when files change. Integra
 
 Google Drive's Watch API allows subscribing to change notifications on any file, folder, or the entire drive. When a file is created, edited, moved, or deleted, Drive sends an HTTP POST to a registered callback URL. The notification includes the resource ID and a change token; the adapter then calls the Drive Changes API to fetch the delta.
 
-```
+```text
 User edits file in Google Drive
   │  (2–10s)
   ▼
@@ -66,7 +66,7 @@ Microsoft Graph subscriptions notify on changes to SharePoint document libraries
 
 SharePoint and OneDrive share the same Graph API surface — the same adapter handles both. SharePoint sites expose document libraries as drives; OneDrive is a personal drive. Both use the same subscription model.
 
-```
+```text
 User uploads file to SharePoint document library
   │
   ▼
@@ -98,7 +98,7 @@ SharePoint is the dominant enterprise document store. Organizations running Micr
 
 Dropbox webhooks notify when any change occurs in a connected account. The notification is intentionally minimal — it signals that something changed, without specifying what. The adapter then calls `/files/list_folder/continue` with a stored cursor to retrieve the actual delta. This two-step design is Dropbox's intentional architecture.
 
-```
+```text
 File added/modified/deleted in Dropbox
   │
   ▼
@@ -132,7 +132,7 @@ Gmail's Watch API routes change notifications through a Google Cloud Pub/Sub top
 
 Emails are surfaced in the relayfile workspace as files: each thread becomes a `.json` file at `/gmail/{account}/threads/{threadId}.json` containing the full thread with messages, labels, and attachments.
 
-```
+```text
 Email received or label changed
   │
   ▼
@@ -217,16 +217,16 @@ Already covered by the Nango SaaS bridge. Slack files are not a primary use case
 
 ## Priority Tier 3: Scheduled Sync Only (Lower Value-Add)
 
-These systems have no native push mechanism. Integration provides eventual consistency via Nango scheduled sync but not real-time awareness. Less differentiated from MCP or Mirage.
+These systems either have no native push mechanism or are listed here only for their fallback mode. Integration provides eventual consistency via Nango scheduled sync but not real-time awareness. Less differentiated from MCP or Mirage.
 
 | System | Best available | Typical lag |
 |---|---|---|
-| AWS S3 | SQS events (requires setup) or Nango poll | 1–5 min (Nango) |
+| AWS S3 | Tier 1 with SQS Event Notifications; Nango poll is fallback only | <10s with SQS; 1–5 min fallback |
 | SFTP | Poll | 5–60 min |
 | FTP | Poll | 5–60 min |
 | Local filesystem | inotify bridge | < 1s (but agent is local) |
 
-S3 moves to Tier 1 when SQS Event Notifications are configured — the poll fallback is Tier 3.
+S3 with SQS Event Notifications is Tier 1; polling via Nango or other pollers is a Tier 3 fallback.
 
 ---
 
@@ -236,13 +236,15 @@ S3 moves to Tier 1 when SQS Event Notifications are configured — the poll fall
 
 Drive and GCS share the Google OAuth model and the Cloud Pub/Sub infrastructure, making them natural to ship together.
 
-**Deliverables:**
+**MVP deliverables:**
 - Google Drive Watch API subscription manager (create, renew, delete)
 - Drive Changes API delta fetcher
-- GCS Pub/Sub notification bridge (from `storage-bridge-spec.md` Phase 1)
-- Storage adapter worker with Google Cloud Pub/Sub backend
+- GCS Pub/Sub notification bridge (from `storage-bridge-spec.md` Phase 2)
+
+**Deferred follow-up:**
+- Full Storage adapter worker with Google Cloud Pub/Sub backend
 - File path conventions for `/drive/{accountId}/{path}` and `/gcs/{bucket}/{key}`
-- Writeback for Drive (create, update, delete)
+- Drive writeback (create, update, delete)
 - Nango scheduled sync fallback for both
 
 **Why first:** Largest addressable market, shared infrastructure, Google OAuth already in Nango.
@@ -458,7 +460,7 @@ Systems **not** in Nango's catalog (S3, R2, Postgres, Redis, MongoDB, Supabase S
 
 | Metric | After Sprint 1 | After Sprint 2 | After Sprint 3 | After Sprint 5 |
 |---|---|---|---|---|
-| Total addressable users | ~3B (Google Workspace) | +1.5B (Microsoft 365) | +700M (Dropbox + Gmail) | +MongoDB + R2 developers |
+| Total addressable users | Approx. ~3B (Google Workspace) | Approx. +1.5B (Microsoft 365) | Illustrative +700M (Dropbox + Gmail) | +MongoDB + R2 developers |
 | Real-time integrations | 2 (Drive, GCS) | 5 (+SharePoint, OneDrive, Azure) | 7 (+Dropbox, Gmail) | 10 (+MongoDB, R2, Supabase) |
 | Scheduled fallback integrations | 2 | 5 | 7 | 13 (Nango catalog) |
 | Enterprise coverage | Google-stack | Full cloud | + Dropbox-heavy orgs | + MongoDB/CF developers |

--- a/docs/storage-bridge-priority.md
+++ b/docs/storage-bridge-priority.md
@@ -1,0 +1,298 @@
+# Storage Bridge Priority: Real-Time Notification Systems
+
+Which storage systems to integrate first, and why real-time push notifications are our biggest value differentiator.
+
+---
+
+## The Core Argument
+
+MCP gives agents tool calls. Mirage gives agents a cached read layer. Neither gives agents **continuous awareness** — the ability to know a file changed without asking.
+
+That awareness is relayfile's strongest differentiator, and it is only possible where the storage system can push change notifications. Systems that support push notifications are therefore our highest-value integrations. A file in Google Drive that updates the moment a collaborator edits it is qualitatively different from a file that might be stale by up to 10 minutes.
+
+This document ranks storage systems by their notification capability and implementation priority.
+
+---
+
+## Priority Tier 1: Native HTTP Push (Highest Value)
+
+These systems natively deliver HTTP webhook callbacks when files change. Integration produces true real-time awareness — changes reach the relayfile workspace within seconds.
+
+### Google Drive
+
+**Notification mechanism:** Drive Push Notifications (Watch API)  
+**Latency:** 2–10 seconds  
+**Coverage:** Individual files and folder trees  
+**Renewal:** Watch channels expire after max 1 week; adapter auto-renews
+
+Google Drive's Watch API allows subscribing to change notifications on any file, folder, or the entire drive. When a file is created, edited, moved, or deleted, Drive sends an HTTP POST to a registered callback URL. The notification includes the resource ID and a change token; the adapter then calls the Drive Changes API to fetch the delta.
+
+```
+User edits file in Google Drive
+  │  (2–10s)
+  ▼
+Drive POST /relayfile-adapter/drive/callback
+  │  { resourceId, changeToken }
+  ▼
+Adapter fetches changes: drive.changes.list(changeToken)
+  │
+  ▼
+StorageBridgeEvent published
+  │
+  ▼
+Relayfile workspace updated
+  │  (< 15s total)
+  ▼
+Agent sees change via WebSocket
+```
+
+**Why this is our #1 priority:**  
+Google Drive is where the majority of collaborative knowledge work happens. Agents that can see document changes in near-real-time can respond to human edits, draft follow-ups, or trigger downstream workflows without polling. No other integration delivers this cleanly for Drive today.
+
+**Scopes required:** `drive.readonly` for ingest, `drive` for writeback  
+**Nango integration:** Yes — Nango handles OAuth and can run scheduled syncs as fallback  
+**Writeback support:** Yes — Drive API supports file create, update, and delete
+
+---
+
+### SharePoint / OneDrive
+
+**Notification mechanism:** Microsoft Graph Subscriptions (webhooks)  
+**Latency:** 5–30 seconds  
+**Coverage:** Lists (document libraries), drives, and individual items  
+**Renewal:** Subscriptions expire after max 29 days; adapter auto-renews
+
+Microsoft Graph subscriptions notify on changes to SharePoint document libraries and OneDrive files. The notification payload is minimal (resource URL only); the adapter calls the Graph Delta API to fetch what changed since the last delta token.
+
+SharePoint and OneDrive share the same Graph API surface — the same adapter handles both. SharePoint sites expose document libraries as drives; OneDrive is a personal drive. Both use the same subscription model.
+
+```
+User uploads file to SharePoint document library
+  │
+  ▼
+Graph sends notification to adapter webhook endpoint
+  │  { subscriptionId, clientState, changeType, resource }
+  ▼
+Adapter: GET /v1.0/drives/{driveId}/root/delta?token={deltaToken}
+  │
+  ▼
+StorageBridgeEvent(s) published for each changed item
+```
+
+**Why this is #2:**  
+SharePoint is the dominant enterprise document store. Organizations running Microsoft 365 have their critical files here. Real-time awareness of SharePoint changes enables agents to act on document approval workflows, policy updates, and shared project files without polling.
+
+**Scopes required:** `Files.Read.All` for ingest, `Files.ReadWrite.All` for writeback  
+**Nango integration:** Yes — Nango has Microsoft Graph OAuth  
+**Writeback support:** Yes — Drive API supports full file CRUD  
+**Note:** Subscription validation requires a synchronous 200 response with the `validationToken` on initial handshake.
+
+---
+
+### Dropbox
+
+**Notification mechanism:** Dropbox Webhooks  
+**Latency:** 5–30 seconds  
+**Coverage:** Account-level (all changes in a connected account)  
+**Renewal:** Webhooks do not expire; registered once
+
+Dropbox webhooks notify when any change occurs in a connected account. The notification is intentionally minimal — it signals that something changed, without specifying what. The adapter then calls `/files/list_folder/continue` with a stored cursor to retrieve the actual delta. This two-step design is Dropbox's intentional architecture.
+
+```
+File added/modified/deleted in Dropbox
+  │
+  ▼
+Dropbox POST /adapter/dropbox/callback
+  │  { list_folder: { accounts: ["dbid:abc"] } }
+  ▼
+Adapter: POST /2/files/list_folder/continue { cursor }
+  │  returns list of changed entries
+  ▼
+StorageBridgeEvent published for each changed entry
+```
+
+**Why this is #3:**  
+Dropbox remains widely used for file sharing across organizations, particularly with external collaborators. The two-step notification+poll model is straightforward to implement and the cursor-based delta is reliable.
+
+**Scopes required:** `files.metadata.read` + `files.content.read`  
+**Nango integration:** Yes  
+**Writeback support:** Yes — Dropbox API supports upload and delete  
+**Note:** Webhook endpoint must respond to GET challenge for verification before receiving events.
+
+---
+
+### Gmail
+
+**Notification mechanism:** Gmail Push Notifications via Google Cloud Pub/Sub  
+**Latency:** 5–30 seconds  
+**Coverage:** Full mailbox, label-filtered, or specific threads  
+**Renewal:** Watch subscriptions expire after 7 days; adapter auto-renews
+
+Gmail's Watch API routes change notifications through a Google Cloud Pub/Sub topic. When new mail arrives or labels change, Gmail publishes a notification to the Pub/Sub topic. The adapter subscribes to the topic and calls the Gmail History API to fetch the actual changes since the last `historyId`.
+
+Emails are surfaced in the relayfile workspace as files: each thread becomes a `.json` file at `/gmail/{account}/threads/{threadId}.json` containing the full thread with messages, labels, and attachments.
+
+```
+Email received or label changed
+  │
+  ▼
+Gmail publishes to Cloud Pub/Sub topic
+  │
+  ▼
+Adapter receives Pub/Sub message
+  │  { emailAddress, historyId }
+  ▼
+Adapter: gmail.users.history.list(startHistoryId)
+  │  returns added/deleted messages and label changes
+  ▼
+StorageBridgeEvent published per changed thread
+```
+
+**Why Gmail:**  
+Email is a primary communication channel for business decisions, contracts, and approvals. Agents that can read email in real-time can draft responses, extract action items, and trigger workflows without human copy-paste. Gmail's Pub/Sub mechanism makes this genuinely real-time.
+
+**Scopes required:** `gmail.readonly` for ingest (labels + metadata + content)  
+**Nango integration:** Yes — Google OAuth via Nango  
+**Writeback support:** Yes — send drafts, apply labels, archive  
+**Note:** Requires a Google Cloud Pub/Sub topic in the agent's GCP project with Gmail service account granted publisher access.
+
+---
+
+### Google Cloud Storage (GCS)
+
+**Notification mechanism:** Native GCS Pub/Sub Notifications  
+**Latency:** 2–10 seconds  
+**Coverage:** Object-level (create, update, delete, metadata change)  
+**Renewal:** Notifications do not expire; configured once per bucket
+
+Already specified in `storage-bridge-spec.md`. Included here for completeness in the priority ranking.
+
+**Why high priority:** GCS is the default storage for GCP workloads. Data pipelines, ML training sets, and analytics exports live here. Real-time awareness means agents can trigger downstream processing the moment new data lands.
+
+---
+
+### Azure Blob Storage
+
+**Notification mechanism:** Azure Event Grid  
+**Latency:** 5–30 seconds  
+**Coverage:** Container-level or storage account-level, blob created and deleted  
+**Renewal:** Event subscriptions do not expire
+
+Already specified in `storage-bridge-spec.md`. Included here for completeness.
+
+**Why high priority:** Azure Blob is the dominant cloud storage in enterprise Microsoft environments — the same organizations using SharePoint and OneDrive. Pairing Azure Blob with SharePoint/OneDrive adapters gives full Microsoft 365 coverage.
+
+---
+
+## Priority Tier 2: Webhook Support, More Complex Setup
+
+These systems support webhooks but require more setup, have limitations, or are less universally used.
+
+### Box
+
+**Notification mechanism:** Box Webhooks (v2)  
+**Latency:** 5–60 seconds  
+**Coverage:** File and folder level; specific events (UPLOAD, COPY, DELETE, etc.)  
+**Renewal:** Webhooks do not expire
+
+Box supports granular webhook subscriptions per file or folder with specific event type filtering. Notification payloads include the triggering event type, the affected resource, and a timestamp. No second fetch needed for basic metadata — content still requires a separate download.
+
+**Priority:** Medium. Box is common in regulated industries (legal, healthcare, finance) but less universal than Drive or SharePoint.
+
+### Notion
+
+**Notification mechanism:** Notion Webhooks (beta as of 2026)  
+**Coverage:** Database and page-level changes
+
+Already handled by the Nango SaaS bridge (`nango-bridge-design.md`). Notion's webhook support is maturing; the Nango bridge covers it via scheduled sync today with real-time via webhooks as the endpoint stabilizes.
+
+### Slack (Files)
+
+**Notification mechanism:** Slack Events API  
+**Coverage:** File shared, file deleted events
+
+Already covered by the Nango SaaS bridge. Slack files are not a primary use case for storage bridge — they're better handled as part of the broader Slack message/channel integration.
+
+---
+
+## Priority Tier 3: Scheduled Sync Only (Lower Value-Add)
+
+These systems have no native push mechanism. Integration provides eventual consistency via Nango scheduled sync but not real-time awareness. Less differentiated from MCP or Mirage.
+
+| System | Best available | Typical lag |
+|---|---|---|
+| AWS S3 | SQS events (requires setup) or Nango poll | 1–5 min (Nango) |
+| SFTP | Poll | 5–60 min |
+| FTP | Poll | 5–60 min |
+| Local filesystem | inotify bridge | < 1s (but agent is local) |
+
+S3 moves to Tier 1 when SQS Event Notifications are configured — the poll fallback is Tier 3.
+
+---
+
+## Implementation Roadmap
+
+### Sprint 1 — Google Drive + GCS (4 weeks)
+
+Drive and GCS share the Google OAuth model and the Cloud Pub/Sub infrastructure, making them natural to ship together.
+
+**Deliverables:**
+- Google Drive Watch API subscription manager (create, renew, delete)
+- Drive Changes API delta fetcher
+- GCS Pub/Sub notification bridge (from `storage-bridge-spec.md` Phase 1)
+- Storage adapter worker with Google Cloud Pub/Sub backend
+- File path conventions for `/drive/{accountId}/{path}` and `/gcs/{bucket}/{key}`
+- Writeback for Drive (create, update, delete)
+- Nango scheduled sync fallback for both
+
+**Why first:** Largest addressable market, shared infrastructure, Google OAuth already in Nango.
+
+---
+
+### Sprint 2 — SharePoint + OneDrive + Azure Blob (4 weeks)
+
+Microsoft Graph subscriptions cover SharePoint and OneDrive with the same adapter. Azure Blob Event Grid is the natural companion for Microsoft-stack deployments.
+
+**Deliverables:**
+- Microsoft Graph subscription manager (create, renew, delete)
+- Drive Delta API poller for SharePoint document libraries and OneDrive
+- Azure Event Grid bridge (from `storage-bridge-spec.md`)
+- File path conventions for `/sharepoint/{siteId}/{driveId}/{path}` and `/onedrive/{accountId}/{path}`
+- Writeback for SharePoint and OneDrive
+- Nango fallback for all three
+
+**Why second:** Full Microsoft 365 coverage in one sprint. Enterprises with SharePoint almost certainly also use OneDrive and Azure.
+
+---
+
+### Sprint 3 — Dropbox + Gmail (3 weeks)
+
+**Deliverables:**
+- Dropbox webhook receiver + cursor-based delta fetcher
+- Gmail Watch API subscription manager + History API delta fetcher
+- Cloud Pub/Sub subscription for Gmail notifications
+- File path conventions for `/dropbox/{accountId}/{path}` and `/gmail/{account}/threads/{id}.json`
+- Writeback for Dropbox (upload, delete) and Gmail (draft, label, archive)
+
+---
+
+### Sprint 4 — S3 real-time + Box (3 weeks)
+
+**Deliverables:**
+- S3 SQS bridge (from `storage-bridge-spec.md` Phase 1)
+- Box webhook receiver + content fetcher
+- Nango fallback for S3 (already usable before this sprint)
+
+---
+
+## Why This Ordering Wins
+
+| Metric | After Sprint 1 | After Sprint 2 | After Sprint 3 |
+|---|---|---|---|
+| Total addressable users | ~3B (Google Workspace) | +1.5B (Microsoft 365) | +700M (Dropbox + Gmail personal) |
+| Real-time integrations | 2 (Drive, GCS) | 5 (+SharePoint, OneDrive, Azure) | 7 (+Dropbox, Gmail) |
+| Enterprise coverage | Google-stack | Full cloud (Google + Microsoft) | + Dropbox-heavy orgs |
+| Differentiation vs MCP | Clear (real-time Drive) | Strong (full M365 real-time) | Very strong |
+| Differentiation vs Mirage | Clear (push not pull) | Strong | Very strong |
+
+The case for relayfile over MCP or Mirage becomes undeniable once we have Google Drive and SharePoint on push notifications — those are the two file systems where collaborative editing makes real-time awareness genuinely valuable rather than just technically interesting.

--- a/docs/storage-bridge-priority.md
+++ b/docs/storage-bridge-priority.md
@@ -285,14 +285,184 @@ Microsoft Graph subscriptions cover SharePoint and OneDrive with the same adapte
 
 ---
 
+## Additional Systems: Supabase, Telegram, R2, MongoDB, Convex, Hugging Face
+
+### Supabase Storage
+
+**Notification mechanism:** HTTP webhook (pg-boss queue, Postgres-backed)  
+**Latency:** ~4s timeout per delivery; 30s max queue lifetime  
+**Coverage:** `object-created`, `object-removed`, `object-updated`, `bucket-created`, `bucket-deleted`, plus fine-grained S3-style events (Put, Copy, Move, Delete)  
+**Status:** Implemented in Supabase Storage codebase; self-hosted via env vars. Cloud availability unclear — not prominently documented as of 2026.
+
+Supabase Storage has a complete webhook delivery system internally, including per-event filtering, Bearer token auth on the callback, and Postgres-backed retry via pg-boss. For self-hosted Supabase deployments this is Tier 1. For cloud-hosted Supabase the feature appears to be in soft beta.
+
+Supabase Realtime covers **database changes only** — not storage file events.
+
+**Priority:** Tier 1 for self-hosted Supabase deployments (developer-heavy audience); Tier 2 for cloud until the feature is generally available.  
+**Nango support:** No Supabase integration in Nango's current catalog. Scheduled fallback requires custom Nango integration or direct S3-compatible API polling.  
+**Writeback support:** Yes — Supabase Storage is S3-compatible.
+
+---
+
+### MongoDB Atlas
+
+**Notification mechanism:** Atlas Database Triggers → Atlas Function → HTTP POST  
+**Latency:** Near-real-time (change stream based); up to 10,000 concurrent trigger executions  
+**Coverage:** Insert, Update, Delete, Replace on any collection; collection-level operations (Create, Drop, Rename)  
+**Alternative:** Atlas Triggers can forward directly to AWS EventBridge without writing Function code
+
+MongoDB Atlas Triggers watch a change stream and invoke an Atlas Function on each matched event. The Function runs serverless JavaScript/TypeScript and can `fetch()` any external HTTP endpoint, making it a genuine push mechanism to relayfile's ingest endpoint. At-least-once delivery.
+
+This is the cleanest real-time bridge for MongoDB without running self-hosted infrastructure. Self-hosted MongoDB requires a change stream listener process (similar to the Postgres LISTEN/NOTIFY bridge in `storage-bridge-spec.md`).
+
+Documents are serialized as JSON files: `/mongodb/{cluster}/{database}/{collection}/{_id}.json`.
+
+**Priority:** Tier 1 for Atlas users; Tier 2 for self-hosted MongoDB.  
+**Nango support:** No MongoDB integration in Nango's current catalog. Scheduled fallback requires custom integration.  
+**Writeback support:** Yes — Atlas Data API or driver-based upsert.
+
+---
+
+### Cloudflare R2
+
+**Notification mechanism:** R2 Event Notifications → Cloudflare Queues → Worker (push) or HTTP pull  
+**Latency:** No published SLA; queue throughput 5,000 msg/sec per queue  
+**Coverage:** `object-create` (PutObject, CopyObject, CompleteMultipartUpload), `object-delete` (DeleteObject, LifecycleDeletion)  
+**Filtering:** Up to 100 rules per bucket with prefix/suffix filters
+
+R2 does not push HTTP webhooks to arbitrary external URLs directly. Events flow into a Cloudflare Queue. To get events out:
+
+- **Path A (recommended):** A Cloudflare Worker acts as the queue consumer and calls the relayfile ingest endpoint via `fetch()`. Latency is low; runs inside Cloudflare's network.
+- **Path B:** The relayfile adapter polls the Queues HTTP pull consumer API. Simple but adds 1–5s of polling latency.
+
+Path A makes R2 effectively Tier 1 for teams already on Cloudflare. The Worker is ~20 lines and can be deployed alongside an existing R2 setup.
+
+**Priority:** Tier 1 with a Cloudflare Worker bridge; Tier 2 with HTTP pull polling.  
+**Nango support:** No R2 integration in Nango's current catalog.  
+**Writeback support:** Yes — R2 is S3-compatible.
+
+---
+
+### Telegram
+
+**Notification mechanism:** Bot API `setWebhook` — HTTP POST per update  
+**Latency:** < 1 second  
+**Coverage:** Every message, file, photo, document, or sticker sent to the bot
+
+Telegram's Bot API delivers every update (message, file, inline query, callback) to a registered HTTPS webhook endpoint in real-time. Files sent to a Telegram bot appear as `document`, `photo`, `video`, or `audio` objects with a `file_id`; the adapter calls `getFile` to obtain a download URL and fetches the content.
+
+The use case differs from traditional storage: Telegram is a **delivery channel**, not a storage backend. But for agent workflows where humans share files via Telegram (contracts, reports, images), making those files instantly available in the relayfile workspace unlocks a class of agent that can respond to document uploads in near-real-time.
+
+Files are surfaced at `/telegram/{botUsername}/chats/{chatId}/{messageId}/{fileName}`.
+
+**Priority:** Tier 1 technically; niche use case. Prioritize after the primary storage systems. High value for teams already using Telegram as a workflow tool.  
+**Nango support:** No Telegram integration in Nango's current catalog.  
+**Writeback support:** Yes — bot can send messages and files back to the chat.
+
+---
+
+### Redis
+
+Already specified in `storage-bridge-spec.md` as a Tier 2 system. Keyspace notifications are internal Redis pub/sub — not HTTP push to external endpoints. A bridge process subscribes and forwards to the pub/sub topic. No Nango integration available; scheduled fallback would require custom polling.
+
+---
+
+### Convex
+
+**Notification mechanism:** No native outbound webhook. User-built via `ctx.scheduler` + Action + `fetch()`  
+**Latency:** Depends on scheduler queue depth; no SLA  
+**File storage:** No event or notification API
+
+Convex's real-time model is client-subscription-based (WebSocket). There is no platform-level outbound webhook when data or files change. The closest approximation is: add a database Trigger (community library `convex-helpers`) that schedules a Convex Action, which then calls `fetch()` to POST to the relayfile ingest endpoint. This requires Convex users to write this integration themselves.
+
+Convex file storage has no events at all — files must be polled via `storage.getUrl()`.
+
+**Priority:** Tier 3. Convex's audience is growing but the integration requires user-authored code on the Convex side, making it unsuitable as a first-class bridge. Revisit when Convex ships native outbound webhooks.  
+**Nango support:** No Convex integration in Nango's current catalog.
+
+---
+
+### Hugging Face Storage Buckets
+
+**Notification mechanism:** None  
+**Latency:** Manual sync only  
+**Coverage:** N/A
+
+Hugging Face Buckets are S3-like mutable object storage for ML artifacts (checkpoints, optimizer states, data shards). As of 2026 there are no native event notifications, webhooks, or push mechanisms. Changes are detected only via the `hf` CLI or Python SDK `sync_bucket()` on demand.
+
+**Priority:** Tier 3. Can be polled on a schedule using the HF Hub API (`list_repo_tree` with `recursive=True`). Value for ML-heavy agent workflows that process training artifacts, but no real-time differentiation.  
+**Nango support:** No Hugging Face integration in Nango's current catalog. Would require a custom integration.  
+**Writeback support:** Yes — HF Hub API and `hf_hub_upload`.
+
+---
+
+## Nango Integration Catalog
+
+Nango's `flows.yaml` (121 integrations as of 2026) includes the following storage and file-related systems that get scheduled sync fallback for free when using the Nango bridge path from `nango-bridge-design.md`:
+
+| Integration | Type | Nango slug | Notes |
+|---|---|---|---|
+| Google Drive | Cloud storage | `google-drive` | Also has real-time Watch API (Sprint 1) |
+| OneDrive | Cloud storage | `one-drive` | Also has Graph subscriptions (Sprint 2) |
+| SharePoint Online | Enterprise docs | `sharepoint-online` | Also has Graph subscriptions (Sprint 2) |
+| Dropbox | Cloud storage | `dropbox` | Also has webhooks (Sprint 3) |
+| Box | Enterprise storage | `box` | Also has webhooks (Sprint 4) |
+| Notion | Docs/database | `notion` | Covered by nango-bridge-design.md |
+| Confluence | Documentation | `confluence` | Page-level sync via REST API |
+| Google Docs | Documents | `google-docs` | Individual doc sync |
+| Google Sheets | Spreadsheets | `google-sheet` | Sheet sync as structured JSON |
+| Smartsheet | Spreadsheets | `smartsheet` | Sheet and row sync |
+| Nextcloud | Self-hosted files | `next-cloud-ocs` | WebDAV-compatible; OCS API |
+| Airtable | Database/grid | `airtable` | Record-level sync |
+| Databricks Workspace | ML platform | `databricks-workspace` | Notebook and artifact sync |
+
+**What this means in practice:** Any system in this table gets a working scheduled sync integration immediately via the existing Nango bridge path. The storage bridge spec adds real-time push on top for systems that support it. The combination — Nango scheduled fallback + real-time bridge when available — gives us defense in depth: agents always have access to reasonably fresh data even during bridge outages.
+
+Systems **not** in Nango's catalog (S3, R2, Postgres, Redis, MongoDB, Supabase Storage, Convex, Hugging Face) require either a custom Nango integration or a direct bridge per `storage-bridge-spec.md`.
+
+---
+
+## Updated Full Priority Table
+
+| System | Push notifications | Nango scheduled fallback | Priority | Sprint |
+|---|---|---|---|---|
+| Google Drive | ✓ Watch API (< 10s) | ✓ | **Highest** | 1 |
+| GCS | ✓ Pub/Sub (< 10s) | — | **Highest** | 1 |
+| SharePoint / OneDrive | ✓ Graph subscriptions (< 30s) | ✓ | **Highest** | 2 |
+| Azure Blob | ✓ Event Grid (< 30s) | — | **Highest** | 2 |
+| Dropbox | ✓ Webhooks (< 30s) | ✓ | High | 3 |
+| Gmail | ✓ Pub/Sub (< 30s) | — | High | 3 |
+| MongoDB Atlas | ✓ Atlas Triggers (near real-time) | — | High | 5 |
+| Cloudflare R2 | ✓ via CF Worker (< 5s) | — | High | 5 |
+| Supabase Storage | ✓ self-hosted; ○ cloud beta | — | Medium | 5 |
+| Box | ✓ Webhooks (< 60s) | ✓ | Medium | 4 |
+| Telegram | ✓ Bot webhooks (< 1s) | — | Medium (niche) | 6 |
+| Confluence | — | ✓ | Medium | Nango only |
+| Google Docs / Sheets | — | ✓ | Medium | Nango only |
+| Smartsheet | — | ✓ | Medium | Nango only |
+| Nextcloud | — | ✓ | Medium | Nango only |
+| Airtable | — | ✓ | Medium | Nango only |
+| AWS S3 | ✓ SQS events (requires setup) | — | Medium | 4 |
+| Postgres | ✓ LISTEN/NOTIFY or Debezium | — | Medium | spec Phase 2 |
+| Redis | ○ Keyspace notifs (internal) | — | Lower | spec Phase 3 |
+| Databricks Workspace | — | ✓ | Lower | Nango only |
+| Hugging Face Buckets | — | — | Lower | Custom poll |
+| Convex | — (user-built only) | — | Lower | Defer |
+| SFTP / FTP | — | — | Lowest | Poll only |
+
+✓ = native push to external HTTP endpoint  ○ = push but with caveats  — = not available
+
+---
+
 ## Why This Ordering Wins
 
-| Metric | After Sprint 1 | After Sprint 2 | After Sprint 3 |
-|---|---|---|---|
-| Total addressable users | ~3B (Google Workspace) | +1.5B (Microsoft 365) | +700M (Dropbox + Gmail personal) |
-| Real-time integrations | 2 (Drive, GCS) | 5 (+SharePoint, OneDrive, Azure) | 7 (+Dropbox, Gmail) |
-| Enterprise coverage | Google-stack | Full cloud (Google + Microsoft) | + Dropbox-heavy orgs |
-| Differentiation vs MCP | Clear (real-time Drive) | Strong (full M365 real-time) | Very strong |
-| Differentiation vs Mirage | Clear (push not pull) | Strong | Very strong |
+| Metric | After Sprint 1 | After Sprint 2 | After Sprint 3 | After Sprint 5 |
+|---|---|---|---|---|
+| Total addressable users | ~3B (Google Workspace) | +1.5B (Microsoft 365) | +700M (Dropbox + Gmail) | +MongoDB + R2 developers |
+| Real-time integrations | 2 (Drive, GCS) | 5 (+SharePoint, OneDrive, Azure) | 7 (+Dropbox, Gmail) | 10 (+MongoDB, R2, Supabase) |
+| Scheduled fallback integrations | 2 | 5 | 7 | 13 (Nango catalog) |
+| Enterprise coverage | Google-stack | Full cloud | + Dropbox-heavy orgs | + MongoDB/CF developers |
+| Differentiation vs MCP | Clear | Strong | Very strong | Decisive |
+| Differentiation vs Mirage | Clear (push not pull) | Strong | Very strong | Decisive |
 
-The case for relayfile over MCP or Mirage becomes undeniable once we have Google Drive and SharePoint on push notifications — those are the two file systems where collaborative editing makes real-time awareness genuinely valuable rather than just technically interesting.
+The case for relayfile over MCP or Mirage becomes undeniable once we have Google Drive and SharePoint on push notifications — those are the two file systems where collaborative editing makes real-time awareness genuinely valuable rather than just technically interesting. Nango's existing catalog means every integration in that table gets scheduled sync for free, giving us breadth while we build depth on real-time bridges.

--- a/docs/storage-bridge-spec.md
+++ b/docs/storage-bridge-spec.md
@@ -83,6 +83,8 @@ Different backends support different freshness levels. Operators choose a tier p
 
 The spec covers real-time and near-real-time tiers. Pull-only is the existing behavior with no storage bridge.
 
+Redis is an exception to the Nango-backed tiers: it is real-time-only via keyspace notifications unless operators provide a custom polling script. There is no built-in Nango fallback for Redis.
+
 ---
 
 ## Common Event Envelope
@@ -188,7 +190,7 @@ S3 natively emits object-level events (create, delete, restore) to SNS/SQS/Lambd
 
 #### Setup
 
-```
+```text
 S3 Bucket
   └── Event Notifications
         ├── ObjectCreated:* → SQS queue: relayfile-s3-{bucket}-events
@@ -286,22 +288,27 @@ CREATE OR REPLACE FUNCTION relayfile_notify_change()
 RETURNS trigger AS $$
 DECLARE
   payload json;
+  row_json json;
+  pk_column text := TG_ARGV[0];
 BEGIN
+  row_json := row_to_json(COALESCE(NEW, OLD));
   payload := json_build_object(
     'schema', TG_TABLE_SCHEMA,
     'table',  TG_TABLE_NAME,
     'op',     TG_OP,           -- INSERT, UPDATE, DELETE
-    'pk',     row_to_json(NEW).id  -- assumes id column; configurable
+    'pk',     row_json ->> pk_column
   );
   PERFORM pg_notify('relayfile_changes', payload::text);
-  RETURN NEW;
+  RETURN COALESCE(NEW, OLD);
 END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER relayfile_orders_change
 AFTER INSERT OR UPDATE OR DELETE ON orders
-FOR EACH ROW EXECUTE FUNCTION relayfile_notify_change();
+FOR EACH ROW EXECUTE FUNCTION relayfile_notify_change('id');
 ```
+
+Production trigger generation must pass the actual primary key column for each watched table, and composite primary keys should encode a stable JSON object rather than assuming a column named `id`.
 
 The bridge process connects to Postgres, executes `LISTEN relayfile_changes`, and processes notifications:
 
@@ -330,16 +337,31 @@ async function runPostgresListenBridge(config: PostgresBridgeConfig): Promise<vo
         "postgres.pk": String(payload.pk),
         "postgres.op": payload.op,
         "postgres.database": config.database,
+        "postgres.row_json": JSON.stringify(row ?? null),
       },
       workspaceId: config.workspaceId,
     };
     await publishToPubSub(event, config.pubSubTopic);
   });
 
-  // Reconnect on connection loss
-  client.on("error", async () => {
-    await sleep(5000);
-    runPostgresListenBridge(config); // restart
+  // Reconnect on connection loss with bounded exponential backoff.
+  client.on("error", async (error) => {
+    for (let attempt = 1; attempt <= config.maxReconnectAttempts; attempt += 1) {
+      const delayMs = Math.min(
+        config.maxReconnectDelayMs,
+        config.initialReconnectDelayMs * 2 ** (attempt - 1)
+      );
+      console.warn("Postgres LISTEN bridge reconnecting", { attempt, delayMs, error });
+      await sleep(delayMs);
+      try {
+        await client.end().catch(() => undefined);
+        await runPostgresListenBridge(config);
+        return;
+      } catch (restartError) {
+        error = restartError;
+      }
+    }
+    throw new Error(`Postgres LISTEN bridge failed after ${config.maxReconnectAttempts} reconnect attempts`);
   });
 }
 ```
@@ -412,7 +434,7 @@ Redis keyspace notifications emit events for key-level operations (`SET`, `DEL`,
 
 #### Redis configuration
 
-```
+```ini
 # redis.conf
 notify-keyspace-events KEA
 # K = keyspace events (channel: __keyspace@{db}__:{key})
@@ -493,6 +515,7 @@ async function runRedisBridge(config: RedisBridgeConfig): Promise<void> {
         "redis.key": key,
         "redis.operation": operation,
         "redis.host": config.host,
+        "redis.value": value == null ? "null" : value.toString(),
       },
       workspaceId: config.workspaceId,
     };
@@ -654,7 +677,7 @@ function mapAzureBlobEvent(event: EventGridEvent, workspaceId: string): StorageB
 
 For backends where real-time event bridges are not deployed, Nango's scheduled sync provides a near-real-time alternative. The flow:
 
-```
+```text
 Nango sync runs on schedule
   │  detects added/updated/deleted objects since last cursor
   ▼
@@ -704,27 +727,33 @@ Nango delivers this payload to the configured webhook endpoint when a sync run c
 ### Nango webhook → StorageBridgeEvent mapping
 
 ```typescript
+/**
+ * Accepts Nango records whose canonical resource id may be exposed as
+ * `key`, `id`, or `record_id`, depending on the provider sync model.
+ */
 function mapNangoSyncRecord(
   record: NangoSyncRecord,
   meta: NangoSyncWebhook,
   workspaceId: string
 ): StorageBridgeEvent {
+  const recordId = record.key || record.id || record.record_id;
+  const normalizedRecord = { ...record, key: recordId };
   const action = record._nango_metadata.action;
   const changeType: StorageBridgeEvent["changeType"] =
     action === "ADDED" ? "created" :
     action === "DELETED" ? "deleted" : "updated";
 
   // Source-specific path computation based on providerConfigKey
-  const relayfilePath = computeRelayfilePath(meta.providerConfigKey, record);
+  const relayfilePath = computeRelayfilePath(meta.providerConfigKey, normalizedRecord);
 
   return {
-    eventId: `nango-${meta.connectionId}-${meta.syncName}-${record.key ?? record.id}-${meta.queryTimeStamp}`,
+    eventId: `nango-${meta.connectionId}-${meta.syncName}-${recordId}-${meta.queryTimeStamp}`,
     occurredAt: record.lastModified ?? meta.queryTimeStamp,
     detectedAt: new Date().toISOString(),
     source: mapNangoProviderToSource(meta.providerConfigKey),
     changeType,
     relayfilePath,
-    resourceId: computeResourceId(meta.providerConfigKey, record),
+    resourceId: computeResourceId(meta.providerConfigKey, normalizedRecord),
     sizeBytes: record.size ?? null,
     fingerprint: record.etag ?? null,
     metadata: {
@@ -885,7 +914,7 @@ The pub/sub topic is the decoupling point between per-system bridges and the sto
 
 ### Topic naming convention
 
-```
+```text
 relayfile.storage.events.{workspace_id}
 ```
 
@@ -934,7 +963,7 @@ All storage bridge files carry standard `semantics.properties` in the relayfile 
 
 Agents can query across all storage bridge files with:
 
-```
+```http
 GET /v1/workspaces/{id}/fs/query?property=storage.source:s3
 GET /v1/workspaces/{id}/fs/query?property=s3.bucket:my-bucket
 ```
@@ -980,12 +1009,23 @@ async function writebackToPostgres(item: WritebackItem, config: PostgresWritebac
 
   const row = JSON.parse(Buffer.from(item.content, "base64").toString());
   const pkColumn = tableConfig.pk_columns[0]; // simplified; composite PK needs expansion
+  const quoteIdent = (ident: string) => {
+    if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(ident)) {
+      throw new Error(`Unsafe SQL identifier: ${ident}`);
+    }
+    return `"${ident.replace(/"/g, '""')}"`;
+  };
+  const schemaIdent = quoteIdent(schema);
+  const tableIdent = quoteIdent(table);
+  const pkIdent = quoteIdent(pkColumn);
+  const assignments = Object.keys(row)
+    .filter((key) => key !== pkColumn)
+    .map((key) => `${quoteIdent(key)} = EXCLUDED.${quoteIdent(key)}`)
+    .join(", ");
 
   await config.client.query(
-    `INSERT INTO ${schema}.${table} SELECT * FROM json_populate_record(null::${schema}.${table}, $1)
-     ON CONFLICT (${pkColumn}) DO UPDATE SET ${
-       Object.keys(row).filter(k => k !== pkColumn).map(k => `${k} = EXCLUDED.${k}`).join(", ")
-     }`,
+    `INSERT INTO ${schemaIdent}.${tableIdent} SELECT * FROM json_populate_record(null::${schemaIdent}.${tableIdent}, $1)
+     ON CONFLICT (${pkIdent}) DO UPDATE SET ${assignments}`,
     [JSON.stringify(row)]
   );
 }
@@ -1044,7 +1084,7 @@ Writeback is optional per source and requires explicit `writeback_enabled: true`
 
 Messages that fail after max retry attempts are routed to a dead-letter topic:
 
-```
+```text
 relayfile.storage.deadletter.{workspace_id}
 ```
 
@@ -1244,7 +1284,7 @@ Delivers value for the most common use case immediately with minimal operational
 
 ## Open Questions
 
-1. **Content size limit in pub/sub**: Should the pub/sub envelope always omit content (fetched by adapter), or include it for objects under a threshold (e.g., 256 KB) to avoid a second round-trip? Tradeoff: lower latency vs. higher pub/sub message costs.
+1. **Content size limit in pub/sub**: The pub/sub envelope must default to omitting content and letting the adapter fetch it on delivery. Operators may opt into embedding small payloads by setting a per-source `pubsub_content_threshold` (default `0`, with `256KB` as the recommended upper bound until measured otherwise). Before raising the threshold for high-volume sources, document a cost model that compares message cost, egress, and latency saved for representative event volumes.
 
 2. **Postgres schema changes**: What happens when a watched table gains or loses a column between sync runs? The adapter should detect schema drift and re-serialize rows with the new shape. Needs a schema registry or a "fetch current schema on startup" step.
 

--- a/docs/storage-bridge-spec.md
+++ b/docs/storage-bridge-spec.md
@@ -1,0 +1,1259 @@
+# Storage Bridge Spec
+
+Real-time change notifications from infrastructure storage backends into Relayfile workspaces.
+
+> **Status (2026-05-09):** Specification. No implementation yet. Companion to `nango-bridge-design.md`, which covers SaaS providers (Zendesk, Shopify, Linear, etc.). This document covers infrastructure storage — S3, Postgres, Redis, GCS, Azure Blob — which cannot be integrated via Nango's OAuth+webhook model.
+
+---
+
+## Problem
+
+Relayfile's event model assumes providers push changes via HTTP webhooks. This works well for SaaS tools that have webhook infrastructure. Infrastructure storage systems do not:
+
+| System | Native push mechanism | Usable for relayfile? |
+|---|---|---|
+| AWS S3 | S3 Event Notifications → SNS/SQS | Yes, with a bridge |
+| Postgres | `LISTEN/NOTIFY`, logical replication | Yes, with a bridge |
+| Redis | Keyspace notifications (internal pub/sub) | Yes, with a bridge |
+| GCS | Pub/Sub notifications | Yes, with a bridge |
+| Azure Blob | Event Grid | Yes, with a bridge |
+| SSH/SFTP | Nothing | Poll only |
+| Local filesystem | inotify/FSEvents | Yes, with a bridge |
+
+Without bridges, agents accessing these systems must either poll (slow, wasteful) or use mirage's pull-on-demand cache (up to 10 min stale). The storage bridge closes this gap, making relayfile's push-driven consistency model available across the full source universe.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     Storage Systems                                 │
+│  S3  │  Postgres  │  Redis  │  GCS  │  Azure Blob  │  SFTP         │
+└──┬───┴─────┬──────┴────┬────┴───┬───┴──────┬───────┴──┬────────────┘
+   │         │           │        │           │          │
+   │ S3      │ LISTEN/   │ Key-   │ Pub/Sub   │ Event    │ Poll
+   │ Events  │ NOTIFY or │ space  │ notifs    │ Grid     │ (scheduled)
+   │ → SQS   │ Debezium  │ notifs │           │          │
+   │         │           │        │           │          │
+   ▼         ▼           ▼        ▼           ▼          ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Per-System Bridge Processes                      │
+│  Translate native events into a common StorageBridgeEvent envelope  │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                    common event envelope
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                         Pub/Sub Topic                               │
+│         (Google Cloud Pub/Sub, AWS SNS/SQS, or NATS)               │
+│   relayfile.storage.events.{workspace_id}                           │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Storage Adapter Worker                           │
+│  Subscribes to pub/sub, translates to relayfile webhook envelopes,  │
+│  calls POST /v1/workspaces/{id}/webhooks/ingest                     │
+└────────────────────────────┬────────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                          Relayfile                                  │
+│   Envelope queue → workspace file store → WebSocket fan-out         │
+│   Agents see changes within seconds via existing event model        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Nango's scheduled sync fits into this picture as a **secondary path** for systems where real-time bridge events are not configured. Nango polls on a schedule, detects changes, and fires a sync-complete webhook that flows through the same storage adapter worker.
+
+---
+
+## Latency Tiers
+
+Different backends support different freshness levels. Operators choose a tier per source when configuring a workspace.
+
+| Tier | Mechanism | Typical latency | Cost |
+|---|---|---|---|
+| **Real-time** | Native event notifications → pub/sub | < 5s | Higher infra complexity |
+| **Near-real-time** | Nango sync on short schedule (1–5 min) | 1–5 min | Low, uses existing Nango |
+| **Scheduled** | Nango sync on longer schedule (15–60 min) | 15–60 min | Lowest |
+| **Pull-only** | No bridge; agents query directly | On-demand | No bridge needed |
+
+The spec covers real-time and near-real-time tiers. Pull-only is the existing behavior with no storage bridge.
+
+---
+
+## Common Event Envelope
+
+All per-system bridges emit the same `StorageBridgeEvent` before publishing to the pub/sub topic. This decouples the bridge implementations from the adapter.
+
+```typescript
+interface StorageBridgeEvent {
+  // Unique ID for deduplication. Bridge generates if source doesn't provide one.
+  eventId: string;
+
+  // ISO 8601 timestamp of when the change occurred at the source.
+  occurredAt: string;
+
+  // ISO 8601 timestamp of when the bridge detected the change.
+  detectedAt: string;
+
+  // Which storage system emitted this event.
+  source: "s3" | "postgres" | "redis" | "gcs" | "azure_blob" | "sftp" | "local_fs";
+
+  // Change type.
+  changeType: "created" | "updated" | "deleted";
+
+  // The logical path this event maps to in the relayfile workspace.
+  // Bridge computes this from the source-specific resource identifier.
+  // Example: "s3://my-bucket/reports/q1.csv" → "/s3/my-bucket/reports/q1.csv"
+  relayfilePath: string;
+
+  // Raw resource identifier from the source system.
+  resourceId: string;
+
+  // Byte size of the object. Null for deletes or when unknown.
+  sizeBytes: number | null;
+
+  // Content fingerprint (ETag, content hash, or LSN). Used for deduplication
+  // and to detect whether content actually changed vs. metadata-only updates.
+  fingerprint: string | null;
+
+  // Source-specific metadata passed through to relayfile semantics.properties.
+  metadata: Record<string, string>;
+
+  // Workspace this event is destined for.
+  workspaceId: string;
+}
+```
+
+### Example: S3 object created
+
+```json
+{
+  "eventId": "s3-evt-us-east-1-my-bucket-reports-q1-csv-1746787200",
+  "occurredAt": "2026-05-09T10:00:00Z",
+  "detectedAt": "2026-05-09T10:00:02Z",
+  "source": "s3",
+  "changeType": "created",
+  "relayfilePath": "/s3/my-bucket/reports/q1.csv",
+  "resourceId": "s3://my-bucket/reports/q1.csv",
+  "sizeBytes": 204800,
+  "fingerprint": "d41d8cd98f00b204e9800998ecf8427e",
+  "metadata": {
+    "s3.bucket": "my-bucket",
+    "s3.key": "reports/q1.csv",
+    "s3.region": "us-east-1",
+    "s3.storage_class": "STANDARD",
+    "s3.version_id": "BCs11abcd"
+  },
+  "workspaceId": "ws_acme"
+}
+```
+
+---
+
+## File Path Conventions
+
+Storage bridges map source-specific resource identifiers to relayfile paths. Rules:
+
+- Top-level directory is the source system name: `/s3/`, `/postgres/`, `/redis/`, `/gcs/`, `/azure/`
+- Next segment identifies the resource container (bucket, database+table, keyspace, etc.)
+- Remaining segments mirror the source hierarchy
+- Files always carry an extension reflecting content type (`.csv`, `.json`, `.parquet`, `.txt`)
+- Postgres rows and Redis hashes are serialized as `.json`
+
+| Source | Resource | Path pattern | Example |
+|---|---|---|---|
+| S3 | Object | `/s3/{bucket}/{key}` | `/s3/my-bucket/reports/q1.csv` |
+| Postgres | Row | `/postgres/{db}/{schema}/{table}/{pk}.json` | `/postgres/prod/public/orders/48291.json` |
+| Redis | String key | `/redis/{db}/{key}` | `/redis/0/session:user:42` |
+| Redis | Hash | `/redis/{db}/{key}.json` | `/redis/0/user:42.json` |
+| Redis | Sorted set member | `/redis/{db}/{key}/{member}` | `/redis/0/leaderboard/alice` |
+| GCS | Object | `/gcs/{bucket}/{name}` | `/gcs/data-lake/exports/2026-05-09.parquet` |
+| Azure Blob | Blob | `/azure/{account}/{container}/{name}` | `/azure/mystg/raw/ingest/file.json` |
+| SFTP | File | `/sftp/{host}/{path}` | `/sftp/ftp.vendor.com/exports/data.csv` |
+
+---
+
+## Per-System Bridge Specifications
+
+### S3
+
+**Real-time path:** S3 Event Notifications → SQS → bridge process
+
+S3 natively emits object-level events (create, delete, restore) to SNS/SQS/Lambda on object operations. No additional infrastructure is needed on the storage side — the bucket is configured once.
+
+#### Setup
+
+```
+S3 Bucket
+  └── Event Notifications
+        ├── ObjectCreated:* → SQS queue: relayfile-s3-{bucket}-events
+        ├── ObjectRemoved:* → SQS queue: relayfile-s3-{bucket}-events
+        └── ObjectRestore:* → SQS queue: relayfile-s3-{bucket}-events
+```
+
+SQS queue policy allows S3 to publish. Bridge process polls the SQS queue (long polling, 20s wait) and translates each S3 event record into a `StorageBridgeEvent`.
+
+#### S3 Event → StorageBridgeEvent mapping
+
+```typescript
+function mapS3Event(record: S3EventRecord, workspaceId: string): StorageBridgeEvent {
+  const changeType =
+    record.eventName.startsWith("ObjectCreated") ? "created" :
+    record.eventName.startsWith("ObjectRemoved") ? "deleted" : "updated";
+
+  return {
+    eventId: record.responseElements?.["x-amz-request-id"] ?? uuid(),
+    occurredAt: record.eventTime,
+    detectedAt: new Date().toISOString(),
+    source: "s3",
+    changeType,
+    relayfilePath: `/s3/${record.s3.bucket.name}/${record.s3.object.key}`,
+    resourceId: `s3://${record.s3.bucket.name}/${record.s3.object.key}`,
+    sizeBytes: record.s3.object.size ?? null,
+    fingerprint: record.s3.object.eTag ?? null,
+    metadata: {
+      "s3.bucket": record.s3.bucket.name,
+      "s3.key": record.s3.object.key,
+      "s3.region": record.awsRegion,
+      "s3.version_id": record.s3.object.versionId ?? "",
+      "s3.event_name": record.eventName,
+    },
+    workspaceId,
+  };
+}
+```
+
+#### SQS bridge worker
+
+```typescript
+async function runS3Bridge(config: S3BridgeConfig): Promise<void> {
+  const sqs = new SQSClient({ region: config.region });
+  while (true) {
+    const result = await sqs.send(new ReceiveMessageCommand({
+      QueueUrl: config.queueUrl,
+      MaxNumberOfMessages: 10,
+      WaitTimeSeconds: 20,
+    }));
+    for (const message of result.Messages ?? []) {
+      const body = JSON.parse(message.Body!);
+      const s3Event: S3Event = JSON.parse(body.Message ?? body); // unwrap SNS if needed
+      for (const record of s3Event.Records ?? []) {
+        const event = mapS3Event(record, config.workspaceId);
+        await publishToPubSub(event, config.pubSubTopic);
+      }
+      await sqs.send(new DeleteMessageCommand({
+        QueueUrl: config.queueUrl,
+        ReceiptHandle: message.ReceiptHandle!,
+      }));
+    }
+  }
+}
+```
+
+#### Nango fallback path
+
+For S3 buckets where Event Notifications cannot be configured (third-party buckets, cross-account scenarios), Nango runs a scheduled sync using the S3 ListObjectsV2 API with a stored cursor (last-modified timestamp). Nango fires a sync-complete webhook with added/updated/deleted object lists. Latency: 1–5 min depending on sync interval.
+
+#### Deduplication
+
+S3 Event Notifications are at-least-once. The bridge uses the SQS message deduplication ID (for FIFO queues) or the `x-amz-request-id` from the event record as the `eventId`. The relayfile ingest endpoint deduplicates by `deliveryId`.
+
+---
+
+### Postgres
+
+**Real-time path:** `LISTEN/NOTIFY` bridge or Debezium (logical replication)
+
+Two options depending on operational context:
+
+**Option A: `LISTEN/NOTIFY` (lightweight)**
+Works for row-level changes where the application already fires triggers or the team is willing to add them. Low operational overhead, no extra infrastructure.
+
+**Option B: Debezium (robust)**
+Uses Postgres logical replication to capture every write without application-level triggers. Requires `wal_level = logical` in Postgres config. More operationally complex but captures all changes including bulk imports and migrations.
+
+#### Option A: LISTEN/NOTIFY bridge
+
+A Postgres trigger on each watched table fires `NOTIFY` with a JSON payload:
+
+```sql
+CREATE OR REPLACE FUNCTION relayfile_notify_change()
+RETURNS trigger AS $$
+DECLARE
+  payload json;
+BEGIN
+  payload := json_build_object(
+    'schema', TG_TABLE_SCHEMA,
+    'table',  TG_TABLE_NAME,
+    'op',     TG_OP,           -- INSERT, UPDATE, DELETE
+    'pk',     row_to_json(NEW).id  -- assumes id column; configurable
+  );
+  PERFORM pg_notify('relayfile_changes', payload::text);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER relayfile_orders_change
+AFTER INSERT OR UPDATE OR DELETE ON orders
+FOR EACH ROW EXECUTE FUNCTION relayfile_notify_change();
+```
+
+The bridge process connects to Postgres, executes `LISTEN relayfile_changes`, and processes notifications:
+
+```typescript
+async function runPostgresListenBridge(config: PostgresBridgeConfig): Promise<void> {
+  const client = new pg.Client(config.connectionString);
+  await client.connect();
+  await client.query("LISTEN relayfile_changes");
+
+  client.on("notification", async (msg) => {
+    const payload = JSON.parse(msg.payload!);
+    const row = await fetchRow(client, payload.schema, payload.table, payload.pk);
+    const event: StorageBridgeEvent = {
+      eventId: `pg-${payload.schema}-${payload.table}-${payload.pk}-${Date.now()}`,
+      occurredAt: new Date().toISOString(),
+      detectedAt: new Date().toISOString(),
+      source: "postgres",
+      changeType: payload.op === "INSERT" ? "created" : payload.op === "DELETE" ? "deleted" : "updated",
+      relayfilePath: `/postgres/${config.database}/${payload.schema}/${payload.table}/${payload.pk}.json`,
+      resourceId: `postgres://${config.database}/${payload.schema}/${payload.table}/${payload.pk}`,
+      sizeBytes: null,
+      fingerprint: null,
+      metadata: {
+        "postgres.schema": payload.schema,
+        "postgres.table": payload.table,
+        "postgres.pk": String(payload.pk),
+        "postgres.op": payload.op,
+        "postgres.database": config.database,
+      },
+      workspaceId: config.workspaceId,
+    };
+    await publishToPubSub(event, config.pubSubTopic);
+  });
+
+  // Reconnect on connection loss
+  client.on("error", async () => {
+    await sleep(5000);
+    runPostgresListenBridge(config); // restart
+  });
+}
+```
+
+#### Option B: Debezium (logical replication)
+
+Debezium connects as a Postgres replication slot and streams WAL events to Kafka or Pub/Sub directly. A thin adapter subscribes to the Debezium output topic and translates to `StorageBridgeEvent`.
+
+Debezium connector config:
+
+```json
+{
+  "name": "relayfile-postgres-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres.internal",
+    "database.port": "5432",
+    "database.user": "relayfile_replication",
+    "database.password": "${POSTGRES_REPLICATION_PASSWORD}",
+    "database.dbname": "prod",
+    "database.server.name": "prod",
+    "table.include.list": "public.orders,public.customers,public.products",
+    "plugin.name": "pgoutput",
+    "slot.name": "relayfile_slot",
+    "publication.name": "relayfile_pub",
+    "topic.prefix": "relayfile.postgres.prod"
+  }
+}
+```
+
+Postgres setup:
+
+```sql
+-- Requires superuser or replication role
+CREATE PUBLICATION relayfile_pub FOR TABLE orders, customers, products;
+-- Debezium creates the slot automatically on first connect
+```
+
+#### Primary key handling
+
+Postgres tables may have composite primary keys or non-integer PKs. The bridge config specifies the PK column(s) per table:
+
+```yaml
+tables:
+  - schema: public
+    table: orders
+    pk_columns: [id]
+  - schema: public
+    table: order_items
+    pk_columns: [order_id, line_item_id]  # composite → joined with "-"
+```
+
+For composite PKs, the relayfile path uses a joined key: `/postgres/prod/public/order_items/5001-3.json`.
+
+#### Content serialization
+
+Rows are serialized as JSON. Sensitive columns can be excluded per table in the bridge config. Arrays and JSONB columns are inlined. Large text/blob columns over 1 MB are truncated and a `_truncated: true` flag is added to the JSON.
+
+#### Nango fallback path
+
+Nango can poll Postgres via a SQL query with a `WHERE updated_at > $last_synced_at` cursor. This requires an `updated_at` column on each watched table. Suitable for tables without trigger support or when Debezium cannot be deployed. Latency: per Nango sync interval.
+
+---
+
+### Redis
+
+**Real-time path:** Keyspace notifications → bridge process → pub/sub
+
+Redis keyspace notifications emit events for key-level operations (`SET`, `DEL`, `EXPIRE`, `HSET`, etc.) over Redis pub/sub channels. A bridge process subscribes, fetches the current value of changed keys, and emits `StorageBridgeEvent`.
+
+#### Redis configuration
+
+```
+# redis.conf
+notify-keyspace-events KEA
+# K = keyspace events (channel: __keyspace@{db}__:{key})
+# E = keyevent events  (channel: __keyevent@{db}__:{op})
+# A = all commands (alias for g$lzxetd)
+```
+
+Only enable the specific event types needed to reduce noise:
+- `Kg$` — generic commands (SET, DEL, EXPIRE, RENAME)
+- `Kh` — hash commands (HSET, HDEL)
+- `Kz` — sorted set commands (ZADD, ZREM)
+
+#### Bridge process
+
+```typescript
+async function runRedisBridge(config: RedisBridgeConfig): Promise<void> {
+  const subscriber = new Redis(config.connectionString);
+  const reader = new Redis(config.connectionString);
+
+  // Subscribe to keyevent notifications for specified databases and key patterns
+  for (const db of config.databases) {
+    await subscriber.psubscribe(`__keyevent@${db}__:*`);
+  }
+
+  subscriber.on("pmessage", async (_pattern, channel, operation) => {
+    // channel: __keyevent@0__:set  → extract db and op
+    const dbMatch = channel.match(/__keyevent@(\d+)__:/);
+    if (!dbMatch) return;
+    const db = dbMatch[1];
+
+    // keyevent channels don't carry the key — need a second channel or scan
+    // Use __keyspace@{db}__:{key} pattern instead for key-level granularity
+  });
+
+  // Prefer keyspace channel which carries the key name
+  for (const db of config.databases) {
+    await subscriber.psubscribe(`__keyspace@${db}__:*`);
+  }
+
+  subscriber.on("pmessage", async (_pattern, channel, operation) => {
+    const match = channel.match(/__keyspace@(\d+)__:(.+)/);
+    if (!match) return;
+    const [, db, key] = match;
+
+    if (!config.keyPatterns.some(p => minimatch(key, p))) return;
+
+    const changeType: StorageBridgeEvent["changeType"] =
+      operation === "del" || operation === "expired" ? "deleted" : "updated";
+
+    let value: string | null = null;
+    let sizeBytes: number | null = null;
+
+    if (changeType !== "deleted") {
+      const type = await reader.type(key);
+      if (type === "string") {
+        value = await reader.get(key);
+      } else if (type === "hash") {
+        value = JSON.stringify(await reader.hgetall(key));
+      } else if (type === "zset") {
+        value = JSON.stringify(await reader.zrangebyscore(key, "-inf", "+inf", "WITHSCORES"));
+      }
+      sizeBytes = value ? Buffer.byteLength(value, "utf8") : null;
+    }
+
+    const extension = (await reader.type(key)) === "hash" ? ".json" : "";
+    const event: StorageBridgeEvent = {
+      eventId: `redis-${db}-${key}-${operation}-${Date.now()}`,
+      occurredAt: new Date().toISOString(),
+      detectedAt: new Date().toISOString(),
+      source: "redis",
+      changeType,
+      relayfilePath: `/redis/${db}/${key}${extension}`,
+      resourceId: `redis://${config.host}/${db}/${key}`,
+      sizeBytes,
+      fingerprint: value ? sha256(value) : null,
+      metadata: {
+        "redis.db": db,
+        "redis.key": key,
+        "redis.operation": operation,
+        "redis.host": config.host,
+      },
+      workspaceId: config.workspaceId,
+    };
+    await publishToPubSub(event, config.pubSubTopic);
+  });
+}
+```
+
+#### Limitations
+
+- Keyspace notifications are best-effort — Redis may drop them under memory pressure if `maxmemory-policy` evicts keys before the notification is processed.
+- Large values (> 1 MB) are truncated in the serialized file.
+- Redis cluster mode: each shard must be subscribed to independently.
+- No Nango fallback for Redis — Nango does not have a Redis integration. Schedule-tier support would require a custom poll script.
+
+---
+
+### GCS (Google Cloud Storage)
+
+**Real-time path:** GCS Pub/Sub notifications → bridge process
+
+GCS supports native Pub/Sub notifications triggered on object create, delete, metadata update, and archive events. This is the cleanest integration of all the storage backends.
+
+#### Setup
+
+```bash
+# Create notification on bucket
+gcloud storage buckets notifications create \
+  gs://my-bucket \
+  --topic=projects/my-project/topics/relayfile-gcs-events \
+  --event-types=OBJECT_FINALIZE,OBJECT_DELETE,OBJECT_METADATA_UPDATE \
+  --payload-format=JSON_API_V1
+
+# Grant GCS permission to publish to topic
+gcloud pubsub topics add-iam-policy-binding relayfile-gcs-events \
+  --member=serviceAccount:service-{PROJECT_NUMBER}@gs-project-accounts.iam.gserviceaccount.com \
+  --role=roles/pubsub.publisher
+```
+
+#### GCS message → StorageBridgeEvent mapping
+
+```typescript
+function mapGCSMessage(msg: GCSPubSubMessage, workspaceId: string): StorageBridgeEvent {
+  const attrs = msg.attributes;
+  const changeType: StorageBridgeEvent["changeType"] =
+    attrs.eventType === "OBJECT_FINALIZE" ? (attrs.overwroteGeneration ? "updated" : "created") :
+    attrs.eventType === "OBJECT_DELETE" ? "deleted" : "updated";
+
+  const payload = JSON.parse(Buffer.from(msg.data, "base64").toString());
+
+  return {
+    eventId: `gcs-${attrs.bucketId}-${attrs.objectId}-${attrs.eventTime}`,
+    occurredAt: attrs.eventTime,
+    detectedAt: new Date().toISOString(),
+    source: "gcs",
+    changeType,
+    relayfilePath: `/gcs/${attrs.bucketId}/${attrs.objectId}`,
+    resourceId: `gcs://${attrs.bucketId}/${attrs.objectId}`,
+    sizeBytes: payload.size ? parseInt(payload.size) : null,
+    fingerprint: payload.md5Hash ?? payload.etag ?? null,
+    metadata: {
+      "gcs.bucket": attrs.bucketId,
+      "gcs.object": attrs.objectId,
+      "gcs.generation": attrs.objectGeneration ?? "",
+      "gcs.content_type": payload.contentType ?? "",
+      "gcs.storage_class": payload.storageClass ?? "",
+    },
+    workspaceId,
+  };
+}
+```
+
+#### Bridge worker
+
+```typescript
+async function runGCSBridge(config: GCSBridgeConfig): Promise<void> {
+  const pubsub = new PubSub({ projectId: config.projectId });
+  const subscription = pubsub.subscription(config.subscriptionName);
+
+  subscription.on("message", async (message) => {
+    try {
+      const event = mapGCSMessage(message as GCSPubSubMessage, config.workspaceId);
+      await publishToPubSub(event, config.pubSubTopic);
+      message.ack();
+    } catch (err) {
+      console.error("GCS bridge error", err);
+      message.nack(); // redelivery
+    }
+  });
+
+  subscription.on("error", (err) => {
+    console.error("GCS subscription error", err);
+    // PubSub client auto-reconnects
+  });
+}
+```
+
+GCS Pub/Sub delivery is at-least-once with a 7-day retention window. The bridge acks after successfully publishing to the relay pub/sub topic; nacks on failure trigger redelivery.
+
+---
+
+### Azure Blob Storage
+
+**Real-time path:** Azure Event Grid → Event Hub or webhook → bridge process
+
+Azure Blob emits events via Event Grid for blob created, deleted, and renamed operations. Event Grid routes to an Event Hub (for high-volume), a webhook endpoint, or a storage queue.
+
+#### Setup
+
+```bash
+# Register Event Grid resource provider
+az provider register --namespace Microsoft.EventGrid
+
+# Create Event Grid subscription on storage account
+az eventgrid event-subscription create \
+  --name relayfile-blob-events \
+  --source-resource-id /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{account} \
+  --endpoint-type eventhub \
+  --endpoint /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.EventHub/namespaces/{ns}/eventhubs/relayfile-blob-events \
+  --included-event-types Microsoft.Storage.BlobCreated Microsoft.Storage.BlobDeleted
+```
+
+#### Azure Event Grid → StorageBridgeEvent mapping
+
+```typescript
+function mapAzureBlobEvent(event: EventGridEvent, workspaceId: string): StorageBridgeEvent {
+  const data = event.data as AzureBlobEventData;
+  const url = new URL(data.url);
+  // url.pathname: /{container}/{blobName}
+  const [, container, ...blobParts] = url.pathname.split("/");
+  const blobName = blobParts.join("/");
+  const account = url.hostname.split(".")[0];
+
+  return {
+    eventId: event.id,
+    occurredAt: event.eventTime,
+    detectedAt: new Date().toISOString(),
+    source: "azure_blob",
+    changeType: event.eventType === "Microsoft.Storage.BlobCreated" ? "created" : "deleted",
+    relayfilePath: `/azure/${account}/${container}/${blobName}`,
+    resourceId: data.url,
+    sizeBytes: data.contentLength ?? null,
+    fingerprint: data.eTag ?? null,
+    metadata: {
+      "azure.account": account,
+      "azure.container": container,
+      "azure.blob": blobName,
+      "azure.content_type": data.contentType ?? "",
+      "azure.blob_type": data.blobType ?? "",
+    },
+    workspaceId,
+  };
+}
+```
+
+---
+
+## Nango Scheduled Sync Integration
+
+For backends where real-time event bridges are not deployed, Nango's scheduled sync provides a near-real-time alternative. The flow:
+
+```
+Nango sync runs on schedule
+  │  detects added/updated/deleted objects since last cursor
+  ▼
+Nango fires sync-complete webhook to storage adapter worker
+  │
+  ▼
+Adapter worker translates each changed object into a StorageBridgeEvent
+  │  (source: "s3" | "postgres" etc., changeType per Nango's delta)
+  ▼
+Events published to pub/sub topic
+  │
+  ▼
+Same storage adapter worker picks them up and ingests into relayfile
+```
+
+### Nango sync webhook payload
+
+Nango delivers this payload to the configured webhook endpoint when a sync run completes:
+
+```json
+{
+  "connectionId": "conn_s3_acme",
+  "providerConfigKey": "s3",
+  "syncName": "s3-objects",
+  "model": "S3Object",
+  "responseResults": {
+    "added": 12,
+    "updated": 3,
+    "deleted": 1
+  },
+  "syncType": "INCREMENTAL",
+  "queryTimeStamp": "2026-05-09T10:05:00Z",
+  "records": [
+    {
+      "_nango_metadata": { "action": "ADDED", "cursor": "2026-05-09T10:04:58Z" },
+      "key": "reports/q1.csv",
+      "bucket": "my-bucket",
+      "size": 204800,
+      "etag": "d41d8cd98f00b204e9800998ecf8427e",
+      "lastModified": "2026-05-09T10:04:58Z",
+      "contentType": "text/csv"
+    }
+  ]
+}
+```
+
+### Nango webhook → StorageBridgeEvent mapping
+
+```typescript
+function mapNangoSyncRecord(
+  record: NangoSyncRecord,
+  meta: NangoSyncWebhook,
+  workspaceId: string
+): StorageBridgeEvent {
+  const action = record._nango_metadata.action;
+  const changeType: StorageBridgeEvent["changeType"] =
+    action === "ADDED" ? "created" :
+    action === "DELETED" ? "deleted" : "updated";
+
+  // Source-specific path computation based on providerConfigKey
+  const relayfilePath = computeRelayfilePath(meta.providerConfigKey, record);
+
+  return {
+    eventId: `nango-${meta.connectionId}-${meta.syncName}-${record.key ?? record.id}-${meta.queryTimeStamp}`,
+    occurredAt: record.lastModified ?? meta.queryTimeStamp,
+    detectedAt: new Date().toISOString(),
+    source: mapNangoProviderToSource(meta.providerConfigKey),
+    changeType,
+    relayfilePath,
+    resourceId: computeResourceId(meta.providerConfigKey, record),
+    sizeBytes: record.size ?? null,
+    fingerprint: record.etag ?? null,
+    metadata: {
+      "nango.connection_id": meta.connectionId,
+      "nango.sync_name": meta.syncName,
+      "nango.model": meta.model,
+      "nango.sync_type": meta.syncType,
+    },
+    workspaceId,
+  };
+}
+```
+
+### Nango sync configuration per backend
+
+```yaml
+# nango integrations for storage backends
+integrations:
+  s3:
+    syncs:
+      s3-objects:
+        runs: every 2 minutes
+        output: S3Object
+        endpoint: GET /objects
+        track_deletes: true
+        cursor_field: lastModified
+
+  postgres:
+    syncs:
+      postgres-rows:
+        runs: every 1 minute
+        output: PostgresRow
+        endpoint: GET /rows
+        track_deletes: true
+        cursor_field: updated_at   # requires updated_at column
+
+  gcs:
+    syncs:
+      gcs-objects:
+        runs: every 2 minutes
+        output: GCSObject
+        endpoint: GET /objects
+        track_deletes: true
+```
+
+---
+
+## Storage Adapter Worker
+
+The storage adapter worker is a single process that:
+1. Subscribes to the pub/sub topic for `StorageBridgeEvent` messages
+2. Fetches file content from the source system if not included in the event
+3. Translates to a relayfile webhook envelope
+4. Calls `POST /v1/workspaces/{id}/webhooks/ingest`
+
+### Content fetching
+
+Most bridge events include metadata but not file content. The adapter fetches content on demand before ingestion:
+
+```typescript
+async function fetchContent(event: StorageBridgeEvent, config: AdapterConfig): Promise<Buffer | null> {
+  if (event.changeType === "deleted") return null;
+
+  switch (event.source) {
+    case "s3": {
+      const s3 = new S3Client({ region: config.s3.region });
+      const [, bucket, ...keyParts] = event.relayfilePath.split("/").slice(1);
+      const result = await s3.send(new GetObjectCommand({
+        Bucket: bucket,
+        Key: keyParts.join("/"),
+      }));
+      return Buffer.from(await result.Body!.transformToByteArray());
+    }
+    case "gcs": {
+      const storage = new Storage();
+      const [, bucket, ...nameParts] = event.relayfilePath.split("/").slice(1);
+      const [content] = await storage.bucket(bucket).file(nameParts.join("/")).download();
+      return content;
+    }
+    case "postgres": {
+      // Content was fetched by the bridge process and included in event metadata
+      return Buffer.from(event.metadata["postgres.row_json"] ?? "null");
+    }
+    case "redis": {
+      // Content was fetched by the bridge process and included in event metadata
+      return Buffer.from(event.metadata["redis.value"] ?? "null");
+    }
+    case "azure_blob": {
+      const client = new BlobServiceClient(config.azure.connectionString);
+      const [, account, container, ...nameParts] = event.relayfilePath.split("/").slice(1);
+      const containerClient = client.getContainerClient(container);
+      const blobClient = containerClient.getBlobClient(nameParts.join("/"));
+      const download = await blobClient.download();
+      return Buffer.concat(await streamToBuffers(download.readableStreamBody!));
+    }
+  }
+  return null;
+}
+```
+
+### Webhook envelope construction
+
+```typescript
+async function ingestEvent(
+  event: StorageBridgeEvent,
+  content: Buffer | null,
+  relayfileClient: RelayFileClient
+): Promise<void> {
+  const envelope: IngestWebhookInput = {
+    provider: event.source,
+    event_type: event.changeType === "created" ? "file.created" :
+                event.changeType === "deleted" ? "file.deleted" : "file.updated",
+    path: event.relayfilePath,
+    delivery_id: event.eventId,
+    timestamp: event.occurredAt,
+    data: content ? {
+      content: content.toString("base64"),
+      encoding: "base64",
+      content_type: inferContentType(event.relayfilePath),
+    } : null,
+    headers: {
+      "X-Storage-Source": event.source,
+      "X-Storage-Resource-Id": event.resourceId,
+    },
+  };
+
+  // Merge source-specific metadata into semantics properties
+  const properties: Record<string, string> = {
+    "storage.source": event.source,
+    "storage.resource_id": event.resourceId,
+    "storage.fingerprint": event.fingerprint ?? "",
+    "storage.size_bytes": String(event.sizeBytes ?? ""),
+    ...event.metadata,
+  };
+
+  await relayfileClient.ingestWebhook(event.workspaceId, {
+    ...envelope,
+    semantics: { properties },
+  });
+}
+```
+
+---
+
+## Pub/Sub Layer
+
+The pub/sub topic is the decoupling point between per-system bridges and the storage adapter worker. Any pub/sub implementation works; the bridge and adapter only depend on the `StorageBridgeEvent` envelope.
+
+### Supported backends
+
+| Pub/Sub system | When to use |
+|---|---|
+| **Google Cloud Pub/Sub** | GCP deployments; native for GCS bridge |
+| **AWS SQS** | AWS deployments; native for S3 bridge |
+| **NATS JetStream** | Self-hosted; low latency, simple ops |
+| **Redis Streams** | Already running Redis; zero additional infra |
+| **Kafka** | Already running Kafka (e.g., Debezium output) |
+
+### Topic naming convention
+
+```
+relayfile.storage.events.{workspace_id}
+```
+
+One topic per workspace. Bridge processes publish to the workspace topic. The adapter worker subscribes per workspace. For multi-tenant deployments, a single topic fan-out with workspace-level filtering is also acceptable.
+
+### Message format on the wire
+
+```json
+{
+  "messageId": "pub-sub-native-id",
+  "publishTime": "2026-05-09T10:00:02Z",
+  "data": "<base64-encoded StorageBridgeEvent JSON>",
+  "attributes": {
+    "source": "s3",
+    "workspaceId": "ws_acme",
+    "changeType": "created"
+  }
+}
+```
+
+Attributes allow the subscriber to filter by source or changeType without deserializing the full payload.
+
+---
+
+## Semantic Properties
+
+All storage bridge files carry standard `semantics.properties` in the relayfile workspace:
+
+```json
+{
+  "semantics": {
+    "properties": {
+      "storage.source": "s3",
+      "storage.resource_id": "s3://my-bucket/reports/q1.csv",
+      "storage.fingerprint": "d41d8cd98f00b204e9800998ecf8427e",
+      "storage.size_bytes": "204800",
+      "storage.last_seen_at": "2026-05-09T10:00:02Z",
+      "s3.bucket": "my-bucket",
+      "s3.key": "reports/q1.csv",
+      "s3.region": "us-east-1",
+      "s3.storage_class": "STANDARD"
+    }
+  }
+}
+```
+
+Agents can query across all storage bridge files with:
+
+```
+GET /v1/workspaces/{id}/fs/query?property=storage.source:s3
+GET /v1/workspaces/{id}/fs/query?property=s3.bucket:my-bucket
+```
+
+---
+
+## Writeback
+
+Writeback from relayfile to infrastructure storage backends is simpler than to SaaS providers — most storage systems have straightforward PUT/DELETE semantics with no field-level mapping.
+
+### S3 writeback
+
+```typescript
+async function writebackToS3(item: WritebackItem, config: S3WritebackConfig): Promise<void> {
+  const s3 = new S3Client({ region: config.region });
+  const [, bucket, ...keyParts] = item.path.split("/").slice(1); // strip /s3/
+  const key = keyParts.join("/");
+
+  if (item.operation === "delete") {
+    await s3.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+  } else {
+    await s3.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: Buffer.from(item.content, "base64"),
+      ContentType: item.contentType,
+    }));
+  }
+}
+```
+
+### Postgres writeback
+
+Postgres writeback requires an upsert. The adapter extracts the PK from the file path and performs an `INSERT ... ON CONFLICT DO UPDATE`:
+
+```typescript
+async function writebackToPostgres(item: WritebackItem, config: PostgresWritebackConfig): Promise<void> {
+  // path: /postgres/{db}/{schema}/{table}/{pk}.json
+  const [, , schema, table, pkFile] = item.path.split("/").slice(1);
+  const pk = pkFile.replace(".json", "");
+  const tableConfig = config.tables.find(t => t.schema === schema && t.table === table);
+  if (!tableConfig) throw new Error(`No writeback config for ${schema}.${table}`);
+
+  const row = JSON.parse(Buffer.from(item.content, "base64").toString());
+  const pkColumn = tableConfig.pk_columns[0]; // simplified; composite PK needs expansion
+
+  await config.client.query(
+    `INSERT INTO ${schema}.${table} SELECT * FROM json_populate_record(null::${schema}.${table}, $1)
+     ON CONFLICT (${pkColumn}) DO UPDATE SET ${
+       Object.keys(row).filter(k => k !== pkColumn).map(k => `${k} = EXCLUDED.${k}`).join(", ")
+     }`,
+    [JSON.stringify(row)]
+  );
+}
+```
+
+### Redis writeback
+
+```typescript
+async function writebackToRedis(item: WritebackItem, config: RedisWritebackConfig): Promise<void> {
+  // path: /redis/{db}/{key} or /redis/{db}/{key}.json
+  const [, , db, ...keyParts] = item.path.split("/").slice(1);
+  const key = keyParts.join("/").replace(/\.json$/, "");
+  const redis = config.clients[parseInt(db)];
+
+  if (item.operation === "delete") {
+    await redis.del(key);
+  } else {
+    const value = Buffer.from(item.content, "base64").toString();
+    if (item.path.endsWith(".json")) {
+      // Hash type
+      const hash = JSON.parse(value);
+      await redis.hset(key, hash);
+    } else {
+      await redis.set(key, value);
+    }
+  }
+}
+```
+
+Writeback is optional per source and requires explicit `writeback_enabled: true` in the bridge config. Destructive writebacks (Postgres row delete, Redis key delete) require a separate `writeback_destructive: true` flag.
+
+---
+
+## Error Handling and Reliability
+
+### Bridge process reliability
+
+| Failure | Behavior | Recovery |
+|---|---|---|
+| Source system unavailable | Bridge retries with exponential backoff (1s, 2s, 4s… up to 60s) | Auto-recovers when source is available |
+| Pub/sub publish fails | Bridge retries up to 5 times, then logs and skips | Next event will be processed; missed event caught by Nango schedule if configured |
+| Pub/sub unavailable | Bridge buffers up to 10,000 events in memory; drains when reconnected | Events older than buffer age are lost; Nango schedule provides eventual catch-up |
+| Bridge process crash | Events since last checkpoint are re-processed on restart (at-least-once) | Relayfile deduplicates by `deliveryId` |
+| Content fetch fails | Event is published with `sizeBytes: null` and `fingerprint: null`; adapter re-fetches | Adapter retries content fetch up to 3 times before acking as failed |
+
+### Adapter worker reliability
+
+| Failure | Behavior | Recovery |
+|---|---|---|
+| Relayfile ingest returns 429 | Adapter respects `Retry-After`, re-queues message | Pub/sub redelivers after nack |
+| Relayfile ingest returns 409 (duplicate) | Adapter acks and discards — idempotent | No action needed |
+| Relayfile unavailable | Adapter nacks; pub/sub holds message for retention period | Auto-recovers; messages delivered when relayfile is back |
+| Content fetch from source times out | Adapter nacks for redelivery | Retried up to 3 times; dead-lettered after max attempts |
+
+### Dead-letter handling
+
+Messages that fail after max retry attempts are routed to a dead-letter topic:
+
+```
+relayfile.storage.deadletter.{workspace_id}
+```
+
+Operators subscribe to this topic for alerting. A separate reconciliation job runs every 6 hours to re-process dead-lettered events using the Nango fallback path.
+
+---
+
+## Configuration Schema
+
+```yaml
+# storage-bridge-config.yaml
+workspace_id: ws_acme
+relayfile_url: https://relayfile.internal
+relayfile_token: ${RELAYFILE_WORKSPACE_TOKEN}
+
+pubsub:
+  backend: google_cloud_pubsub  # | aws_sqs | nats | redis_streams
+  project_id: my-gcp-project
+  topic: relayfile.storage.events.ws_acme
+  subscription: relayfile-storage-adapter-ws-acme
+
+sources:
+  - type: s3
+    enabled: true
+    tier: real_time  # | nango_scheduled
+    region: us-east-1
+    buckets:
+      - name: my-bucket
+        sqs_queue_url: https://sqs.us-east-1.amazonaws.com/123456789/relayfile-s3-my-bucket-events
+        writeback_enabled: true
+        writeback_destructive: false
+
+  - type: postgres
+    enabled: true
+    tier: real_time
+    connection_string: ${POSTGRES_CONNECTION_STRING}
+    database: prod
+    bridge_mode: listen_notify  # | debezium
+    tables:
+      - schema: public
+        table: orders
+        pk_columns: [id]
+        writeback_enabled: true
+      - schema: public
+        table: customers
+        pk_columns: [id]
+        writeback_enabled: false
+        excluded_columns: [password_hash, ssn]
+
+  - type: redis
+    enabled: true
+    tier: real_time
+    host: redis.internal
+    port: 6379
+    databases: [0, 1]
+    key_patterns:
+      - "user:*"
+      - "session:*"
+      - "order:*"
+    writeback_enabled: false
+
+  - type: gcs
+    enabled: true
+    tier: real_time
+    project_id: my-gcp-project
+    subscription: projects/my-gcp-project/subscriptions/relayfile-gcs-events
+    writeback_enabled: true
+
+  - type: azure_blob
+    enabled: false
+    tier: nango_scheduled
+    nango_connection_id: conn_azure_acme
+    writeback_enabled: false
+
+nango:
+  base_url: https://api.nango.dev
+  secret_key: ${NANGO_SECRET_KEY}
+  webhook_secret: ${NANGO_WEBHOOK_SECRET}
+  # Endpoint that receives Nango sync-complete webhooks
+  webhook_receiver_url: https://bridge.internal/nango/webhook
+```
+
+---
+
+## Observability
+
+### Metrics
+
+| Metric | Labels | Description |
+|---|---|---|
+| `storage_bridge_events_total` | `source`, `change_type`, `workspace_id` | Events received from source system |
+| `storage_bridge_publish_duration_ms` | `source`, `status` | Time to publish event to pub/sub |
+| `storage_bridge_publish_errors_total` | `source`, `error_type` | Failed pub/sub publishes |
+| `storage_adapter_ingest_total` | `source`, `change_type`, `status` | Relayfile ingest outcomes |
+| `storage_adapter_ingest_duration_ms` | `source` | End-to-end ingest latency |
+| `storage_adapter_content_fetch_duration_ms` | `source` | Time to fetch file content from source |
+| `storage_adapter_deadletter_total` | `source` | Events routed to dead-letter |
+| `storage_bridge_source_lag_seconds` | `source` | Time between event occurrence and relayfile ingest |
+
+### Alerting thresholds
+
+| Alert | Condition | Severity |
+|---|---|---|
+| High dead-letter rate | `storage_adapter_deadletter_total` > 10 in 5m | Warning |
+| Ingest lag | `storage_bridge_source_lag_seconds` p99 > 30s | Warning |
+| Ingest lag severe | `storage_bridge_source_lag_seconds` p99 > 120s | Critical |
+| Bridge process down | No events from source in 10m (when source is known active) | Critical |
+| Pub/sub backlog | Undelivered message count > 50,000 | Warning |
+
+### Structured logging
+
+Each bridge event and adapter ingest is logged as a single JSON line:
+
+```json
+{
+  "ts": "2026-05-09T10:00:02Z",
+  "level": "info",
+  "msg": "storage_event_ingested",
+  "workspace_id": "ws_acme",
+  "source": "s3",
+  "change_type": "created",
+  "relayfile_path": "/s3/my-bucket/reports/q1.csv",
+  "event_id": "s3-evt-abc123",
+  "occurred_at": "2026-05-09T10:00:00Z",
+  "lag_ms": 2140,
+  "content_size_bytes": 204800,
+  "ingest_status": "ok"
+}
+```
+
+---
+
+## Security
+
+### Authentication
+
+- Bridge processes authenticate to the source system using service account credentials (IAM role for S3/GCS, connection string for Postgres/Redis, managed identity for Azure).
+- Credentials are never stored in the bridge config file — always injected via environment variables or a secrets manager.
+- The adapter worker authenticates to relayfile using a workspace-scoped JWT with `sync:trigger` scope.
+
+### Network isolation
+
+- Bridge processes run in the same VPC as the source systems. No public internet exposure required for ingest.
+- The adapter worker communicates with relayfile over TLS. If relayfile is self-hosted in the same VPC, mTLS is recommended.
+- Pub/sub topics are private; access controlled by IAM/ACL.
+
+### Data handling
+
+- File content transits the pub/sub topic only for small objects (< 1 MB). Larger objects are fetched directly by the adapter from the source, never passing through pub/sub.
+- Excluded columns (Postgres) and excluded key patterns (Redis) are enforced in the bridge before publishing — they never reach pub/sub or relayfile.
+- Writeback payloads are validated against the original file schema before forwarding to prevent injection of unexpected fields.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — S3 + Nango scheduled fallback
+
+Delivers value for the most common use case immediately with minimal operational complexity.
+
+- S3 bridge (SQS poller)
+- Nango webhook receiver translating sync-complete webhooks to `StorageBridgeEvent`
+- Storage adapter worker (pub/sub → relayfile ingest)
+- Google Cloud Pub/Sub as the default pub/sub backend
+- Basic metrics and structured logging
+
+**Estimated effort:** 2–3 weeks
+
+### Phase 2 — GCS + Postgres (LISTEN/NOTIFY)
+
+- GCS bridge (native Pub/Sub subscription)
+- Postgres LISTEN/NOTIFY bridge with per-table trigger setup script
+- Writeback for S3 and Postgres
+- Dead-letter handling and reconciliation job
+
+**Estimated effort:** 2 weeks
+
+### Phase 3 — Redis + Azure Blob + Debezium
+
+- Redis keyspace notification bridge
+- Azure Blob Event Grid bridge
+- Debezium adapter (for Postgres teams that already run Kafka)
+- Multi-pubsub-backend support (AWS SQS, NATS, Redis Streams)
+
+**Estimated effort:** 2–3 weeks
+
+### Phase 4 — SFTP + local filesystem + hardening
+
+- SFTP polling bridge (no native event system; poll on schedule)
+- Local filesystem bridge using inotify/FSEvents (for on-prem agent deployments)
+- End-to-end latency SLO enforcement
+- Chaos testing for bridge process failures
+
+**Estimated effort:** 2 weeks
+
+---
+
+## Open Questions
+
+1. **Content size limit in pub/sub**: Should the pub/sub envelope always omit content (fetched by adapter), or include it for objects under a threshold (e.g., 256 KB) to avoid a second round-trip? Tradeoff: lower latency vs. higher pub/sub message costs.
+
+2. **Postgres schema changes**: What happens when a watched table gains or loses a column between sync runs? The adapter should detect schema drift and re-serialize rows with the new shape. Needs a schema registry or a "fetch current schema on startup" step.
+
+3. **Redis cluster mode**: Keyspace notifications require a subscriber per shard. Do we ship a cluster-aware bridge, or document that Redis Cluster is unsupported in phase 1?
+
+4. **Nango S3 integration**: Does Nango's S3 integration support `track_deletes: true`? If not, the Nango fallback path cannot detect S3 object deletions — only the real-time SQS path handles deletes. Need to verify with Nango docs.
+
+5. **Writeback conflict resolution**: If an agent writes a file and the source system also updates the same object before the writeback completes, the writeback overwrites the source change. Should writeback use ETag/`If-Match` where the source system supports it (S3, GCS support conditional PUT)?
+
+6. **Multi-workspace routing**: A single S3 bucket may serve multiple workspaces (e.g., different prefixes for different tenants). The bridge config needs a per-prefix workspace routing table, or we route all events for a bucket to a single topic and filter at the adapter.
+
+7. **SFTP change detection**: SFTP has no event system. The only option is recursive `LIST` diffing against a stored directory snapshot. What scan interval is acceptable? 5 minutes? Configurable per source?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "relayfile-pr-96",
-  "version": "0.6.11",
+  "name": "relayfile",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.6.11",
+      "version": "0.7.0",
       "workspaces": [
         "packages/core",
         "packages/sdk/typescript",
@@ -2736,7 +2736,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2748,7 +2748,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2761,7 +2761,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -2790,10 +2790,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.6.11",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.6.11"
+        "@relayfile/core": "0.7.0"
       },
       "devDependencies": {
         "typescript": "^5.7.3",

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -167,11 +167,16 @@ export function startAutoSync(
     pendingDebounces.set(absPath, t);
   };
 
-  const subscribeTo = (root: string): Promise<AsyncSubscription> =>
+  const subscribeTo = (root: string, markUnhealthy: () => void): Promise<AsyncSubscription> =>
     watcher.subscribe(
       root,
       (err, events) => {
-        if (err) { onError(err); return; }
+        if (err) {
+          markUnhealthy();
+          recomputeWatchersHealthy();
+          onError(err);
+          return;
+        }
         for (const ev of events) {
           schedulePathSync(root, ev.path);
         }
@@ -182,19 +187,26 @@ export function startAutoSync(
   let mountSub: AsyncSubscription | undefined;
   let projectSub: AsyncSubscription | undefined;
   let _watchersHealthy = false;
+  let _mountWatcherHealthy = false;
+  let _projectWatcherHealthy = false;
+  const recomputeWatchersHealthy = (): void => {
+    _watchersHealthy = _mountWatcherHealthy && _projectWatcherHealthy;
+  };
   // Subscribe in parallel but track each outcome independently. With
   // Promise.all, a failure on one side would reject before the other's
   // assignment ran and leak the succeeded subscription. allSettled lets us
   // tear down whichever fulfilled before re-throwing the first failure.
   const watchersReady = (async () => {
     const [mountResult, projectResult] = await Promise.allSettled([
-      subscribeTo(ctx.realMountDir),
-      subscribeTo(ctx.realProjectDir),
+      subscribeTo(ctx.realMountDir, () => { _mountWatcherHealthy = false; }),
+      subscribeTo(ctx.realProjectDir, () => { _projectWatcherHealthy = false; }),
     ]);
     if (mountResult.status === 'fulfilled') mountSub = mountResult.value;
     if (projectResult.status === 'fulfilled') projectSub = projectResult.value;
     if (mountResult.status === 'fulfilled' && projectResult.status === 'fulfilled') {
-      _watchersHealthy = true;
+      _mountWatcherHealthy = true;
+      _projectWatcherHealthy = true;
+      recomputeWatchersHealthy();
       return;
     }
     await Promise.allSettled([
@@ -235,6 +247,8 @@ export function startAutoSync(
         projectSub?.unsubscribe(),
       ]);
       _watchersHealthy = false;
+      _mountWatcherHealthy = false;
+      _projectWatcherHealthy = false;
       // Clear debounces *after* unsubscribe resolves: any timer scheduled
       // between stop() being called and the watcher actually quiescing is
       // gathered here, so none fire after stop() returns.

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -64,10 +64,22 @@ export interface AutoSyncHandle {
   stop(opts?: { signal?: AbortSignal }): Promise<void>;
   /** Force a reconcile now; returns number of files copied/deleted. */
   reconcile(opts?: { signal?: AbortSignal }): Promise<number>;
+  /**
+   * Flush any pending debounced file events and run a full reconcile.
+   * Call this before checkpointing or exiting to ensure all recent writes
+   * have been synced — debounced events that haven't fired yet would
+   * otherwise be lost if the process exits before their timers expire.
+   */
+  flushPending(opts?: { signal?: AbortSignal }): Promise<number>;
   /** Cumulative files changed (copied or deleted) since autosync started. */
   totalChanges(): number;
   /** Resolves once both watchers have completed their initial scan. */
   ready(): Promise<void>;
+  /**
+   * True once both filesystem watchers are subscribed and active.
+   * When false, change detection relies solely on the periodic reconcile scan.
+   */
+  watchersHealthy(): boolean;
 }
 
 interface FileState {
@@ -169,6 +181,7 @@ export function startAutoSync(
 
   let mountSub: AsyncSubscription | undefined;
   let projectSub: AsyncSubscription | undefined;
+  let _watchersHealthy = false;
   // Subscribe in parallel but track each outcome independently. With
   // Promise.all, a failure on one side would reject before the other's
   // assignment ran and leak the succeeded subscription. allSettled lets us
@@ -181,6 +194,7 @@ export function startAutoSync(
     if (mountResult.status === 'fulfilled') mountSub = mountResult.value;
     if (projectResult.status === 'fulfilled') projectSub = projectResult.value;
     if (mountResult.status === 'fulfilled' && projectResult.status === 'fulfilled') {
+      _watchersHealthy = true;
       return;
     }
     await Promise.allSettled([
@@ -220,6 +234,7 @@ export function startAutoSync(
         mountSub?.unsubscribe(),
         projectSub?.unsubscribe(),
       ]);
+      _watchersHealthy = false;
       // Clear debounces *after* unsubscribe resolves: any timer scheduled
       // between stop() being called and the watcher actually quiescing is
       // gathered here, so none fire after stop() returns.
@@ -232,10 +247,18 @@ export function startAutoSync(
       await runReconcile(opts);
     },
     reconcile: runReconcile,
+    async flushPending(opts?: { signal?: AbortSignal }): Promise<number> {
+      // Cancel pending debounce timers — the reconcile below will catch
+      // any files those timers would have synced via mtime comparison.
+      for (const t of pendingDebounces.values()) clearTimeout(t);
+      pendingDebounces.clear();
+      return runReconcile(opts);
+    },
     totalChanges: () => totalChanges,
     ready: async () => {
       await watchersReady;
     },
+    watchersHealthy: () => _watchersHealthy,
   };
 }
 

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -47,6 +47,7 @@ export {
 } from "./setup-types.js";
 export {
   RelayFileSync,
+  type RelayFileSyncHealthStatus,
   type RelayFileSyncOptions,
   type RelayFileSyncPong,
   type RelayFileSyncReconnectOptions,

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -309,6 +309,59 @@ describe("RelayFileSync", () => {
     await sync.stop();
   });
 
+  it("reports open health before invoking onRecovered", async () => {
+    const sockets: MockWebSocket[] = [];
+    let recoveredState: string | undefined;
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      webSocketFactory: (url) => {
+        const socket = new MockWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      },
+      onRecovered: () => {
+        recoveredState = sync.getHealthStatus().state;
+      }
+    });
+
+    sync.start();
+    (sync as unknown as { degraded: boolean; degradedReason?: string; state: string }).degraded = true;
+    (sync as unknown as { degraded: boolean; degradedReason?: string; state: string }).degradedReason = "test";
+    (sync as unknown as { degraded: boolean; degradedReason?: string; state: string }).state = "polling";
+
+    sockets[0]!.emit("open", {});
+
+    expect(recoveredState).toBe("open");
+    expect(sync.getHealthStatus()).toEqual(expect.objectContaining({
+      state: "open",
+      degraded: false,
+      degradedReason: undefined
+    }));
+
+    await sync.stop();
+  });
+
+  it("stamps health state entry time for an already-aborted signal", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const before = Date.now();
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      signal: controller.signal,
+      webSocketFactory: (url) => new MockWebSocket(url)
+    });
+
+    const health = sync.getHealthStatus();
+    expect(health.state).toBe("closed");
+    expect(health.stateEnteredAt).toBeGreaterThanOrEqual(before);
+  });
+
   it("re-resolves the token on every reconnect (handles mid-session token rotation)", async () => {
     // Bug 4: the previous implementation captured `token` once at
     // construction. If the JWT rotated mid-session, the watchdog reconnected

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -17,6 +17,33 @@ export interface RelayFileSyncPong {
   timestamp?: string;
 }
 
+/**
+ * Point-in-time snapshot of sync connection health. Retrieve via
+ * {@link RelayFileSync.getHealthStatus}. Useful for long-running agent
+ * processes that need to surface connectivity issues or detect silent
+ * degradation to polling mode.
+ */
+export interface RelayFileSyncHealthStatus {
+  state: RelayFileSyncState;
+  /**
+   * True when the sync has involuntarily fallen back to HTTP polling.
+   * Live events will be delayed by `pollIntervalMs` while degraded.
+   */
+  degraded: boolean;
+  /** Reason string passed to the degradation path, if currently degraded. */
+  degradedReason?: string;
+  /** Unix timestamp (ms) when the current state was entered. */
+  stateEnteredAt: number;
+  /**
+   * Unix timestamp (ms) of the last inbound WebSocket frame (event or pong).
+   * Zero until the first frame arrives. A large gap between now and this value
+   * suggests a silent socket death that the watchdog has not yet detected.
+   */
+  lastFrameAt: number;
+  /** Reconnect attempts since the last successful WebSocket open. */
+  reconnectAttempts: number;
+}
+
 export interface RelayFileSyncReconnectOptions {
   enabled?: boolean;
   minDelayMs?: number;
@@ -58,6 +85,18 @@ export interface RelayFileSyncOptions {
    * `error` event regardless of whether this is wired.
    */
   onPollingFallback?: (info: { reason: string; cause?: unknown }) => void;
+  /**
+   * Called when the connection enters a degraded state (involuntary polling
+   * fallback). Long-running agents should monitor this and surface it to
+   * operators — degraded mode means events are delayed by `pollIntervalMs`.
+   */
+  onDegraded?: (info: { reason: string; state: RelayFileSyncState; cause?: unknown }) => void;
+  /**
+   * Called when the connection recovers from a degraded state back to a live
+   * WebSocket. Pair with {@link RelayFileSyncOptions.onDegraded} to track
+   * connectivity health over long-running sessions.
+   */
+  onRecovered?: () => void;
 }
 
 export interface RelayFileSyncSocket {
@@ -98,7 +137,7 @@ interface RelayFileSyncWireEvent {
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
-const DEFAULT_PING_INTERVAL_MS = 30000;
+const DEFAULT_PING_INTERVAL_MS = 15000;
 const DEFAULT_RECONNECT_MIN_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
 // Cap on the dedupe cache used in polling mode. Sized large enough that no
@@ -236,6 +275,8 @@ export class RelayFileSync {
   private readonly signal?: AbortSignal;
   private readonly webSocketFactory: (url: string) => RelayFileSyncSocket;
   private readonly onPollingFallback?: (info: { reason: string; cause?: unknown }) => void;
+  private readonly onDegraded?: (info: { reason: string; state: RelayFileSyncState; cause?: unknown }) => void;
+  private readonly onRecovered?: () => void;
   private readonly handlers: {
     [K in RelayFileSyncEventName]: Set<RelayFileSyncHandlerMap[K]>;
   } = {
@@ -248,6 +289,9 @@ export class RelayFileSync {
   };
 
   private state: RelayFileSyncState = "idle";
+  private stateEnteredAt: number = Date.now();
+  private degraded = false;
+  private degradedReason?: string;
   private cursor?: string;
   private readonly polledEventIds: Set<string> = new Set();
   private readonly polledEventOrder: string[] = [];
@@ -295,6 +339,8 @@ export class RelayFileSync {
     }
     this.cursor = options.cursor;
     this.onPollingFallback = options.onPollingFallback;
+    this.onDegraded = options.onDegraded;
+    this.onRecovered = options.onRecovered;
     this.pollIntervalMs = Math.max(1, Math.floor(options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS));
     this.pingIntervalMs = Math.max(1, Math.floor(options.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS));
     // Default the pong timeout to 2x ping interval so a single missed pong
@@ -338,6 +384,17 @@ export class RelayFileSync {
 
   getState(): RelayFileSyncState {
     return this.state;
+  }
+
+  getHealthStatus(): RelayFileSyncHealthStatus {
+    return {
+      state: this.state,
+      degraded: this.degraded,
+      degradedReason: this.degradedReason,
+      stateEnteredAt: this.stateEnteredAt,
+      lastFrameAt: this.lastFrameAt,
+      reconnectAttempts: this.reconnectAttempts,
+    };
   }
 
   start(): void {
@@ -488,6 +545,15 @@ export class RelayFileSync {
       // timeout until we actually send our first ping.
       this.lastFrameAt = Date.now();
       this.lastPingSentAt = 0;
+      if (this.degraded) {
+        this.degraded = false;
+        this.degradedReason = undefined;
+        try {
+          this.onRecovered?.();
+        } catch (error) {
+          debugLog("onRecovered handler threw", error);
+        }
+      }
       this.setState("open");
       this.startPingLoop(socket);
       debugLog("ws open", { workspaceId: this.workspaceId });
@@ -599,6 +665,15 @@ export class RelayFileSync {
         this.onPollingFallback?.({ reason, cause });
       } catch (error) {
         debugLog("onPollingFallback handler threw", error);
+      }
+      if (!this.degraded) {
+        this.degraded = true;
+        this.degradedReason = reason;
+        try {
+          this.onDegraded?.({ reason, state: "polling", cause });
+        } catch (error) {
+          debugLog("onDegraded handler threw", error);
+        }
       }
     }
     this.setState("polling");
@@ -893,6 +968,7 @@ export class RelayFileSync {
       return;
     }
     this.state = state;
+    this.stateEnteredAt = Date.now();
     this.emit("state", state);
   }
 

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -370,6 +370,7 @@ export class RelayFileSync {
       if (this.signal.aborted) {
         this.stopped = true;
         this.state = "closed";
+        this.stateEnteredAt = Date.now();
       } else {
         this.signal.addEventListener("abort", this.abortHandler, { once: true });
       }
@@ -548,13 +549,15 @@ export class RelayFileSync {
       if (this.degraded) {
         this.degraded = false;
         this.degradedReason = undefined;
+        this.setState("open");
         try {
           this.onRecovered?.();
         } catch (error) {
           debugLog("onRecovered handler threw", error);
         }
+      } else {
+        this.setState("open");
       }
-      this.setState("open");
       this.startPingLoop(socket);
       debugLog("ws open", { workspaceId: this.workspaceId });
       this.emit("open", event);


### PR DESCRIPTION
- Lower default ping interval from 30s to 15s, halving the worst-case silent-failure detection window (~90s -> ~45s for NAT/LB idle drops)
- Add RelayFileSyncHealthStatus and getHealthStatus() so long-running agents can inspect connection state, degradation reason, last frame time, and reconnect attempts without parsing log output
- Add onDegraded/onRecovered callbacks to RelayFileSyncOptions; fired when sync involuntarily falls back to polling and when it recovers to a live WebSocket
- Track stateEnteredAt so callers can measure how long a session has been in the current state
- Add flushPending() to AutoSyncHandle so recent writes can be synced before checkpoint or process exit
- Add watchersHealthy() to AutoSyncHandle and track per-watcher degradation when runtime watcher errors occur
- Add storage bridge specification docs covering StorageBridgeEvent, per-system mappings, adapter worker behavior, Nango fallback, writeback, reliability, observability, rollout phases, and integration prioritization

Review follow-up in this branch also clarifies storage bridge roadmap tiers, markdown fences, Postgres/Redis metadata examples, Nango record id normalization, SQL identifier safety, and pub/sub content threshold cost controls.

https://claude.ai/code/session_01Lbmw1Cj23tw8LovrfFpv24