### PR TITLE
docs: surface mountWorkspace SDK helper in README; fix guide code-fence langs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,42 @@ Use the OSS repo when you want to run the file server yourself. Use hosted Agent
 
 For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant [adapters](https://github.com/AgentWorkforce/relayfile-adapters), [providers](https://github.com/AgentWorkforce/relayfile-providers), and Nango. Relayfile itself does not store third-party OAuth credentials.
 
+### Mount a workspace from a sandbox (TypeScript SDK)
+
+Once a user has signed in and connected their providers in Agent Relay Cloud, a sandbox (Daytona, E2B, an ephemeral container, your own runtime) can attach the workspace as local files in a single SDK call:
+
+```ts
+import { RelayfileSetup } from "@relayfile/sdk"
+
+const setup = new RelayfileSetup({ accessToken })
+
+const handle = await setup.mountWorkspace({
+  workspaceId: "rw_…",
+  localDir: "/workspace",
+})
+
+// /workspace is now a live mount of the workspace
+console.log(handle.status().expiresAt)
+await handle.stop()
+```
+
+Use `ensureMountedWorkspace` when you also want provider-readiness gating in the same call:
+
+```ts
+const handle = await setup.ensureMountedWorkspace({
+  workspace: { id: "rw_…" },
+  provider: "notion",
+  verifyProvider: true,
+  localDir: "/workspace",
+})
+```
+
+`ensureMountedWorkspace` throws `ProviderNotConnectedError` when the provider isn't connected, and `ProviderNotReadyError({ provider, state, initialSyncState })` when the connection exists but isn't ready by `providerReadyTimeoutMs`. Pass `verifyProvider: false` to skip the probe.
+
+The handle exposes `ready`, `expiresAt`, `suggestedRefreshAt`, `env()`, `status()`, and `stop()`. The SDK supervises the local `relayfile-mount` process for you and only resolves once the mount is reachable.
+
+This is the programmatic sibling of the `relayfile setup` CLI above — same outcome (a workspace mounted at a local directory), different entry point. Use the CLI for human-driven setup; use the SDK from inside an already-authorized sandbox or agent runtime. Full details in [docs/guides/post-auth-mount-session.md](docs/guides/post-auth-mount-session.md).
+
 ## Bring Existing Connections
 
 Relayfile tracks provider identity as `connectionId` metadata. The core OSS server can ingest events and queue writebacks with a `connectionId`, but the OAuth provider must be able to use that ID.
@@ -268,6 +304,7 @@ Pipedream:
 
 - [Getting started](docs/guides/getting-started.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
+- [Post-auth mount session (SDK)](docs/guides/post-auth-mount-session.md)
 - [Adapters](https://github.com/AgentWorkforce/relayfile-adapters)
 - [Providers](https://github.com/AgentWorkforce/relayfile-providers)
 - [API reference](docs/api-reference.md)

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ const handle = await setup.mountWorkspace({
 })
 
 // /workspace is now a live mount of the workspace
-console.log(handle.status().expiresAt)
+console.log(handle.expiresAt)
 await handle.stop()
 ```
 
@@ -268,7 +268,7 @@ Use `ensureMountedWorkspace` when you also want provider-readiness gating in the
 
 ```ts
 const handle = await setup.ensureMountedWorkspace({
-  workspace: { id: "rw_…" },
+  workspaceId: "rw_…",
   provider: "notion",
   verifyProvider: true,
   localDir: "/workspace",

--- a/docs/guides/post-auth-mount-session.md
+++ b/docs/guides/post-auth-mount-session.md
@@ -15,7 +15,7 @@ The post-auth mount flow requires **two prior steps** before a sandbox can mount
 
 Only after these steps does the SDK issue the mount-session request. The resulting mounted workspace handle gives the sandbox access to the workspace's virtual filesystem as ordinary files in a local directory.
 
-```
+```text
 [Cloud auth] → [Provider connect] → mountWorkspace() → local files on disk
                      ↑
                skipped if verifyProvider: false
@@ -42,7 +42,7 @@ The scopes on the minted JWT are a subset of the caller's grant. If the caller p
 
 ## Cloud Endpoint Reference
 
-```
+```http
 POST /api/v1/workspaces/{workspaceId}/relayfile/mount-session
 Authorization: Bearer <workspace-JWT or cloud-access-token>
 Content-Type: application/json


### PR DESCRIPTION
## Summary

Two small follow-ups after #122 merged:

1. **README** — Add a "Mount a workspace from a sandbox (TypeScript SDK)" subsection under *Hosted Agent Relay*. The CLI path (`relayfile setup`) was already documented; this surfaces the new programmatic equivalent from #122 (`RelayfileSetup.mountWorkspace` / `ensureMountedWorkspace`) right next to it so integrators see both entry points. Links the new guide from the *Docs* section.
2. **Guide nits** — Address two CodeRabbit findings on `docs/guides/post-auth-mount-session.md` by adding language specifiers to fenced code blocks: `text` for the ASCII flow diagram (line 18), `http` for the endpoint reference (line 45).

## Verification

- README rendered review (markdown only).
- All fenced blocks in the guide now have a language specifier (verified by `awk '/^\`\`\`/{print}'`).