### PR TITLE
feat(cli): show active workspace via `workspace current` and list marker

### DIFF
--- a/.trajectories/completed/2026-05/traj_h99ldnvo1d26.json
+++ b/.trajectories/completed/2026-05/traj_h99ldnvo1d26.json
@@ -1,0 +1,25 @@
+{
+  "id": "traj_h99ldnvo1d26",
+  "version": 1,
+  "task": {
+    "title": "relayfile workspace current + active marker in 'workspace list'"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-09T18:44:54.122Z",
+  "completedAt": "2026-05-09T18:48:09.889Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Added 'relayfile workspace current' subcommand and active marker (* ) in 'workspace list' (with --names-only escape hatch). Reuses existing resolveWorkspaceRecord precedence (env > token > default). 4 new tests, 2 existing list tests updated for marker contract.",
+    "approach": "Standard approach",
+    "confidence": 0.85
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "9de722a6c6c747fca3e90fb62a9899253e742264",
+    "endRef": "9de722a6c6c747fca3e90fb62a9899253e742264"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_h99ldnvo1d26.md
+++ b/.trajectories/completed/2026-05/traj_h99ldnvo1d26.md
@@ -1,0 +1,14 @@
+# Trajectory: relayfile workspace current + active marker in 'workspace list'
+
+> **Status:** ✅ Completed
+> **Confidence:** 85%
+> **Started:** May 9, 2026 at 08:44 PM
+> **Completed:** May 9, 2026 at 08:48 PM
+
+---
+
+## Summary
+
+Added 'relayfile workspace current' subcommand and active marker (* ) in 'workspace list' (with --names-only escape hatch). Reuses existing resolveWorkspaceRecord precedence (env > token > default). 4 new tests, 2 existing list tests updated for marker contract.
+
+**Approach:** Standard approach

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-09T18:27:13.442Z",
+  "lastUpdated": "2026-05-09T18:48:10.008Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -228,6 +228,13 @@
       "startedAt": "2026-05-09T18:25:18.473Z",
       "completedAt": "2026-05-09T18:27:13.341Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_4vdcwo2iy630.json"
+    },
+    "traj_h99ldnvo1d26": {
+      "title": "relayfile workspace current + active marker in 'workspace list'",
+      "status": "completed",
+      "startedAt": "2026-05-09T18:44:54.122Z",
+      "completedAt": "2026-05-09T18:48:09.889Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile/.trajectories/completed/2026-05/traj_h99ldnvo1d26.json"
     }
   }
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -381,7 +381,8 @@ Usage:
   relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]
   relayfile workspace create NAME
   relayfile workspace use NAME
-  relayfile workspace list
+  relayfile workspace list [--names-only]
+  relayfile workspace current [--verbose]
   relayfile workspace delete NAME [--yes]
   relayfile integration connect PROVIDER [--workspace NAME]
   relayfile integration list [--workspace NAME] [--json]
@@ -406,7 +407,7 @@ Usage:
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
   login       Sign in via the Relayfile Cloud browser flow (or --api-key for self-hosted)
-  workspace   Create, select, list, or delete locally tracked workspaces
+  workspace   Create, select, list, show current, or delete locally tracked workspaces
   integration Connect, list, or disconnect workspace integrations
   ops         List or replay dead-lettered writeback ops
   writeback   Inspect or retry local writeback failures
@@ -1227,7 +1228,7 @@ func loginWithAPIKey(serverValue, tokenValue string, stdout io.Writer) error {
 
 func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("workspace subcommand is required: create, use, list, or delete")
+		return errors.New("workspace subcommand is required: create, use, list, current, or delete")
 	}
 	switch args[0] {
 	case "create":
@@ -1236,6 +1237,8 @@ func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 		return runWorkspaceUse(args[1:], stdout)
 	case "list":
 		return runWorkspaceList(args[1:], stdout)
+	case "current":
+		return runWorkspaceCurrent(args[1:], stdout)
 	case "delete":
 		return runWorkspaceDelete(args[1:], stdin, stdout)
 	default:
@@ -2265,15 +2268,30 @@ func runWorkspaceList(args []string, stdout io.Writer) error {
 	fs.SetOutput(io.Discard)
 	server := fs.String("server", "", "relayfile server URL override")
 	token := fs.String("token", "", "relayfile token override")
+	namesOnly := fs.Bool("names-only", false, "print bare workspace names without an active marker")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"server": true,
-		"token":  true,
+		"server":     true,
+		"token":      true,
+		"names-only": false,
 	})); err != nil {
 		return err
 	}
 
 	creds, _ := loadCredentials()
 	tokenValue := resolveToken(*token, creds)
+	activeName, _ := activeWorkspaceName(tokenValue)
+	emit := func(name string) {
+		if *namesOnly || activeName == "" {
+			fmt.Fprintln(stdout, name)
+			return
+		}
+		marker := "  "
+		if name == activeName {
+			marker = "* "
+		}
+		fmt.Fprintln(stdout, marker+name)
+	}
+
 	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
 	if err == nil {
 		var remote adminWorkspaceList
@@ -2285,7 +2303,7 @@ func runWorkspaceList(args []string, stdout io.Writer) error {
 			names := remoteWorkspaceNames(remote)
 			if len(names) > 0 {
 				for _, name := range names {
-					fmt.Fprintln(stdout, name)
+					emit(name)
 				}
 				return nil
 			}
@@ -2297,7 +2315,72 @@ func runWorkspaceList(args []string, stdout io.Writer) error {
 		return err
 	}
 	for _, name := range workspaceCatalogNames(catalog, tokenValue) {
+		emit(name)
+	}
+	return nil
+}
+
+// activeWorkspaceName returns the name (preferred) or id of the workspace
+// that resolveWorkspaceRecord would pick when no explicit value is passed,
+// alongside a short human-readable source ("env RELAYFILE_WORKSPACE",
+// "token", "default") for diagnostics. Returns "" if no active workspace
+// can be resolved.
+func activeWorkspaceName(token string) (string, string) {
+	if envValue := strings.TrimSpace(os.Getenv("RELAYFILE_WORKSPACE")); envValue != "" {
+		if record, ok := workspaceRecordByName(envValue); ok {
+			return record.Name, "env RELAYFILE_WORKSPACE"
+		}
+		if record, ok := workspaceRecordByID(envValue); ok {
+			return record.Name, "env RELAYFILE_WORKSPACE"
+		}
+		return envValue, "env RELAYFILE_WORKSPACE"
+	}
+	if tokenWS := workspaceIDFromToken(token); tokenWS != "" {
+		if record, ok := workspaceRecordByID(tokenWS); ok {
+			return record.Name, "token"
+		}
+		return tokenWS, "token"
+	}
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return "", ""
+	}
+	if name := strings.TrimSpace(catalog.Default); name != "" {
+		return name, "default"
+	}
+	return "", ""
+}
+
+func runWorkspaceCurrent(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("workspace current", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	token := fs.String("token", "", "relayfile token override")
+	verbose := fs.Bool("verbose", false, "include workspace id and selection source")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"token":   true,
+		"verbose": false,
+	})); err != nil {
+		return err
+	}
+
+	creds, _ := loadCredentials()
+	tokenValue := resolveToken(*token, creds)
+	name, source := activeWorkspaceName(tokenValue)
+	if name == "" {
+		return errors.New("no active workspace; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run 'relayfile workspace use NAME'")
+	}
+	if !*verbose {
 		fmt.Fprintln(stdout, name)
+		return nil
+	}
+	id := name
+	if record, ok := workspaceRecordByName(name); ok && strings.TrimSpace(record.ID) != "" {
+		id = record.ID
+	}
+	if id != "" && id != name {
+		fmt.Fprintf(stdout, "%s (id: %s, source: %s)\n", name, id, source)
+	} else {
+		fmt.Fprintf(stdout, "%s (source: %s)\n", name, source)
 	}
 	return nil
 }

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -193,7 +193,7 @@ func TestWorkspaceListIncludesEnvWorkspaceWhenRemoteListUnavailable(t *testing.T
 		t.Fatalf("run workspace list failed: %v", err)
 	}
 
-	if got := strings.TrimSpace(stdout.String()); got != "ws_env\n.relay/vfs\nrelay-test" {
+	if got := strings.TrimSpace(stdout.String()); got != "* ws_env\n  .relay/vfs\n  relay-test" {
 		t.Fatalf("unexpected workspace list output: %q", got)
 	}
 }
@@ -220,7 +220,7 @@ func TestWorkspaceListIncludesTokenWorkspaceWhenRemoteListUnavailable(t *testing
 		t.Fatalf("run workspace list failed: %v", err)
 	}
 
-	if got := strings.TrimSpace(stdout.String()); got != "ws_token" {
+	if got := strings.TrimSpace(stdout.String()); got != "* ws_token" {
 		t.Fatalf("unexpected workspace list output: %q", got)
 	}
 }
@@ -1601,5 +1601,106 @@ func TestLoginAPIKeyFlagPromptsForToken(t *testing.T) {
 	}
 	if creds.Token != "prompted_key" {
 		t.Fatalf("expected stored token prompted_key, got %q", creds.Token)
+	}
+}
+
+// TestWorkspaceCurrentPrintsActiveWorkspace covers the new
+// `relayfile workspace current` subcommand: it returns the workspace
+// resolveWorkspaceRecord("") would pick, and `--verbose` annotates it
+// with the resolution source.
+func TestWorkspaceCurrentPrintsActiveWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspace("alpha"); err != nil {
+		t.Fatalf("upsertWorkspace alpha failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("alpha"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "current"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace current failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "alpha" {
+		t.Fatalf("unexpected workspace current output: %q", got)
+	}
+
+	stdout.Reset()
+	if err := run([]string{"workspace", "current", "--verbose"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace current --verbose failed: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); !strings.Contains(got, "source: default") {
+		t.Fatalf("expected verbose output to include source, got %q", got)
+	}
+}
+
+// TestWorkspaceCurrentReportsEnvOverride confirms env-var override beats
+// the catalog default, matching resolveWorkspaceRecord's precedence.
+func TestWorkspaceCurrentReportsEnvOverride(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspace("alpha"); err != nil {
+		t.Fatalf("upsertWorkspace alpha failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("alpha"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+	t.Setenv("RELAYFILE_WORKSPACE", "from_env")
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "current", "--verbose"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace current failed: %v", err)
+	}
+	got := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(got, "from_env") {
+		t.Fatalf("expected 'from_env' to win, got %q", got)
+	}
+	if !strings.Contains(got, "RELAYFILE_WORKSPACE") {
+		t.Fatalf("expected source to mention RELAYFILE_WORKSPACE, got %q", got)
+	}
+}
+
+// TestWorkspaceCurrentErrorsWhenNoneActive covers the error path: with
+// nothing in env/token/catalog, runWorkspaceCurrent returns an error
+// rather than printing an empty line.
+func TestWorkspaceCurrentErrorsWhenNoneActive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var stdout bytes.Buffer
+	err := run([]string{"workspace", "current"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error when no active workspace, got output %q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "no active workspace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestWorkspaceListNamesOnlyRestoresBareOutput verifies the --names-only
+// escape hatch for scripts that parsed the legacy unmarked output.
+func TestWorkspaceListNamesOnlyRestoresBareOutput(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_WORKSPACE", "ws_env")
+	if _, err := upsertWorkspace("alpha"); err != nil {
+		t.Fatalf("upsertWorkspace alpha failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer server.Close()
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "list", "--names-only"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace list --names-only failed: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "ws_env\nalpha" {
+		t.Fatalf("unexpected --names-only output: %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- New `relayfile workspace current` subcommand: prints the workspace the CLI defaults to when no `WORKSPACE` arg is passed (the same `resolveWorkspaceRecord("")` precedence: env `RELAYFILE_WORKSPACE` → workspace id in the token → catalog `default`). `--verbose` reports the source.
- `relayfile workspace list` now marks the active line with a leading `* ` (git-branch style), pads inactive lines with two spaces, and suppresses the marker when no active workspace can be resolved.
- `relayfile workspace list --names-only` restores the legacy bare-name output for scripts that parse the list.

## Why
Today there's no first-class way to ask "which workspace is active?" — users have to `cat ~/.relayfile/workspaces.json` or run `relayfile status` (which actually contacts the server). And `workspace list` prints names with no indicator of which one any future command will use, so it's easy to lose track of which `default` you're working against.

## Examples

```
$ relayfile workspace list
* alpha
  beta
  staging

$ relayfile workspace current
alpha

$ relayfile workspace current --verbose
alpha (id: ws_abc123, source: default)

$ RELAYFILE_WORKSPACE=beta relayfile workspace current --verbose
beta (id: ws_xyz789, source: env RELAYFILE_WORKSPACE)

$ relayfile workspace list --names-only
alpha
beta
staging
```

## Test plan
- [x] `go test ./cmd/relayfile-cli/` — full suite passes
- [x] `TestWorkspaceCurrentPrintsActiveWorkspace` — default-from-catalog path with and without `--verbose`
- [x] `TestWorkspaceCurrentReportsEnvOverride` — env beats catalog default and source string mentions `RELAYFILE_WORKSPACE`
- [x] `TestWorkspaceCurrentErrorsWhenNoneActive` — exits non-zero with a fix-it message instead of printing an empty line
- [x] `TestWorkspaceListNamesOnlyRestoresBareOutput` — `--names-only` produces unmarked output
- [x] Updated 2 existing `workspace list` tests for the new marked default contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)