### PR TITLE
feat(cli): request Composio backend for integration connect

### DIFF
--- a/cmd/relayfile-cli/catalog_test.go
+++ b/cmd/relayfile-cli/catalog_test.go
@@ -54,7 +54,7 @@ func TestA12CatalogRevalidatedAfterCloudConflict(t *testing.T) {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
 
-	err := connectCloudIntegration(server.URL, "ws_demo", "tok", "deprecated-provider", localDir, 0, false, &stubWriter{})
+	err := connectCloudIntegration(server.URL, "ws_demo", "tok", "deprecated-provider", "", localDir, 0, false, &stubWriter{})
 	if err == nil {
 		t.Fatalf("expected error from connect-session 409, got nil")
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -206,6 +206,7 @@ type cloudConnectSessionResponse struct {
 	ExpiresAt    string `json:"expiresAt,omitempty"`
 	ConnectLink  string `json:"connectLink,omitempty"`
 	ConnectionID string `json:"connectionId,omitempty"`
+	Backend      string `json:"backend,omitempty"`
 }
 
 type cloudIntegrationReadyResponse struct {
@@ -272,6 +273,7 @@ type syncStateDaemon struct {
 type integrationConnectionState struct {
 	Provider     string `json:"provider"`
 	ConnectionID string `json:"connectionId,omitempty"`
+	Backend      string `json:"backend,omitempty"`
 	ConnectedAt  string `json:"connectedAt,omitempty"`
 	UpdatedAt    string `json:"updatedAt,omitempty"`
 }
@@ -1037,8 +1039,10 @@ func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser 
 }
 
 func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
-	connectionID := loadSavedConnectionID(localDir, provider)
-	if connectionID != "" && requestedBackend == "" {
+	savedConnection := loadSavedConnection(localDir, provider)
+	connectionID := strings.TrimSpace(savedConnection.ConnectionID)
+	savedBackend := strings.TrimSpace(savedConnection.Backend)
+	if connectionID != "" && (requestedBackend == "" || requestedBackend == savedBackend) {
 		if ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID); err == nil && ready {
 			fmt.Fprintf(stdout, "%s already connected\n", provider)
 			return nil
@@ -1071,9 +1075,14 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 	if connectionID == "" {
 		connectionID = workspaceID
 	}
+	backend := strings.TrimSpace(session.Backend)
+	if backend == "" {
+		backend = requestedBackend
+	}
 	_ = saveIntegrationConnection(localDir, integrationConnectionState{
 		Provider:     provider,
 		ConnectionID: connectionID,
+		Backend:      backend,
 		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
 		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
 	})
@@ -4383,18 +4392,23 @@ func saveIntegrationConnection(localDir string, state integrationConnectionState
 	return writeFileAtomically(integrationConnectionPath(localDir, state.Provider), payload, 0o644)
 }
 
-func loadSavedConnectionID(localDir, provider string) string {
+func loadSavedConnection(localDir, provider string) integrationConnectionState {
 	if localDir == "" || strings.TrimSpace(provider) == "" {
-		return ""
+		return integrationConnectionState{}
 	}
 	payload, err := os.ReadFile(integrationConnectionPath(localDir, provider))
 	if err != nil {
-		return ""
+		return integrationConnectionState{}
 	}
 	var state integrationConnectionState
 	if err := json.Unmarshal(payload, &state); err != nil {
-		return ""
+		return integrationConnectionState{}
 	}
+	return state
+}
+
+func loadSavedConnectionID(localDir, provider string) string {
+	state := loadSavedConnection(localDir, provider)
 	return strings.TrimSpace(state.ConnectionID)
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -198,6 +198,7 @@ type cloudWorkspaceJoinResponse struct {
 
 type cloudConnectSessionRequest struct {
 	AllowedIntegrations []string `json:"allowedIntegrations,omitempty"`
+	RequestedBackend    string   `json:"requestedBackend,omitempty"`
 }
 
 type cloudConnectSessionResponse struct {
@@ -377,14 +378,14 @@ func printUsage(w io.Writer) {
 
 Usage:
   relayfile
-  relayfile setup [--provider PROVIDER] [--workspace NAME] [--local-dir DIR]
+  relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]
   relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]
   relayfile workspace create NAME
   relayfile workspace use NAME
   relayfile workspace list [--names-only]
   relayfile workspace current [--verbose]
   relayfile workspace delete NAME [--yes]
-  relayfile integration connect PROVIDER [--workspace NAME]
+  relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME]
   relayfile integration list [--workspace NAME] [--json]
   relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
   relayfile ops list [--workspace NAME] [--json]
@@ -436,6 +437,7 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	cloudToken := fs.String("cloud-token", strings.TrimSpace(os.Getenv("RELAYFILE_CLOUD_TOKEN")), "Relayfile Cloud access token; skips browser login when set")
 	workspaceName := fs.String("workspace", "", "workspace name to create")
 	provider := fs.String("provider", "", "integration provider to connect; use none to skip")
+	backend := fs.String("backend", "", "integration backend to request (nango or composio)")
 	localDirFlag := fs.String("local-dir", "", "local mount directory")
 	noOpen := fs.Bool("no-open", false, "print browser URLs instead of opening them")
 	skipMount := fs.Bool("skip-mount", false, "finish after setup without starting the mount process")
@@ -447,6 +449,7 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 		"cloud-token":     true,
 		"workspace":       true,
 		"provider":        true,
+		"backend":         true,
 		"local-dir":       true,
 		"no-open":         false,
 		"skip-mount":      false,
@@ -457,7 +460,7 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 		return err
 	}
 	if fs.NArg() > 0 {
-		return errors.New("usage: relayfile setup [--provider PROVIDER] [--workspace NAME] [--local-dir DIR]")
+		return errors.New("usage: relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]")
 	}
 
 	cloudAPI := strings.TrimRight(strings.TrimSpace(*cloudAPIURL), "/")
@@ -498,6 +501,10 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 		}
 	}
 	selectedProvider = normalizeProviderID(selectedProvider)
+	requestedBackend, err := normalizeIntegrationBackend(*backend)
+	if err != nil {
+		return err
+	}
 
 	localDir := strings.TrimSpace(*localDirFlag)
 	if localDir == "" {
@@ -539,11 +546,11 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 
 	if selectedProvider != "" && selectedProvider != "none" && selectedProvider != "skip" {
 		if createdWorkspace {
-			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
 				return err
 			}
 		} else {
-			if err := ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+			if err := ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
 				return err
 			}
 		}
@@ -724,6 +731,18 @@ func normalizeProviderID(value string) string {
 		return "slack-sage"
 	default:
 		return value
+	}
+}
+
+func normalizeIntegrationBackend(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "", "default":
+		return "", nil
+	case "nango", "composio":
+		return value, nil
+	default:
+		return "", fmt.Errorf("unsupported integration backend %q (expected nango or composio)", value)
 	}
 }
 
@@ -1017,18 +1036,18 @@ func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser 
 	}
 }
 
-func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
+func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
 	connectionID := loadSavedConnectionID(localDir, provider)
-	if connectionID != "" {
+	if connectionID != "" && requestedBackend == "" {
 		if ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID); err == nil && ready {
 			fmt.Fprintf(stdout, "%s already connected\n", provider)
 			return nil
 		}
 	}
-	return connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir, timeout, shouldOpenBrowser, stdout)
+	return connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir, timeout, shouldOpenBrowser, stdout)
 }
 
-func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
+func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
 	client, err := newAPIClient(cloudAPIURL, workspaceToken)
 	if err != nil {
 		return err
@@ -1036,6 +1055,7 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 	var session cloudConnectSessionResponse
 	if err := client.postJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations/connect-session", url.PathEscape(workspaceID)), cloudConnectSessionRequest{
 		AllowedIntegrations: []string{provider},
+		RequestedBackend:    requestedBackend,
 	}, &session); err != nil {
 		// Per contract verdict §A12, a 409 from connect-session means the
 		// requested provider is no longer in the catalog. Drop the cached
@@ -1267,20 +1287,26 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	fs.SetOutput(io.Discard)
 	workspaceName := fs.String("workspace", "", "workspace name or id")
 	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	backend := fs.String("backend", "", "integration backend to request (nango or composio)")
 	noOpen := fs.Bool("no-open", false, "print the hosted URL instead of opening it")
 	timeout := fs.Duration("timeout", 5*time.Minute, "integration readiness timeout")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"workspace":     true,
 		"cloud-api-url": true,
+		"backend":       true,
 		"no-open":       false,
 		"timeout":       true,
 	})); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return errors.New("usage: relayfile integration connect PROVIDER [--workspace NAME] [--no-open] [--timeout 5m]")
+		return errors.New("usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m]")
 	}
 	provider := normalizeProviderID(fs.Arg(0))
+	requestedBackend, err := normalizeIntegrationBackend(*backend)
+	if err != nil {
+		return err
+	}
 	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
 	if err != nil {
 		return err
@@ -1296,7 +1322,7 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err := persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir); err != nil {
 		return err
 	}
-	if err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, record.LocalDir, *timeout, !*noOpen, stdout); err != nil {
+	if err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout); err != nil {
 		return err
 	}
 	return waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, provider, record.LocalDir, *timeout, stdout)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -665,7 +665,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 			if body.RequestedBackend != "composio" {
 				t.Fatalf("expected requested backend composio, got %q", body.RequestedBackend)
 			}
-			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789"}`))
+			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789","backend":"composio"}`))
 		case "/api/v1/workspaces/ws_123/integrations/notion/status":
 			seen["status"] = true
 			if got := r.URL.Query().Get("connectionId"); got != "conn_789" {
@@ -709,6 +709,10 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	}
 	if got := stdout.String(); !strings.Contains(got, "notion connected") {
 		t.Fatalf("unexpected integration connect output: %q", got)
+	}
+	state := loadSavedConnection(localDir, "notion")
+	if state.ConnectionID != "conn_789" || state.Backend != "composio" {
+		t.Fatalf("unexpected saved integration connection: %#v", state)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -655,6 +655,16 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
 				t.Fatalf("unexpected connect Authorization: %q", got)
 			}
+			var body cloudConnectSessionRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode connect body failed: %v", err)
+			}
+			if len(body.AllowedIntegrations) != 1 || body.AllowedIntegrations[0] != "notion" {
+				t.Fatalf("unexpected allowed integrations: %#v", body.AllowedIntegrations)
+			}
+			if body.RequestedBackend != "composio" {
+				t.Fatalf("expected requested backend composio, got %q", body.RequestedBackend)
+			}
 			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789"}`))
 		case "/api/v1/workspaces/ws_123/integrations/notion/status":
 			seen["status"] = true
@@ -685,6 +695,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 		"integration", "connect", "notion",
 		"--workspace", "demo",
 		"--cloud-api-url", server.URL,
+		"--backend", "composio",
 		"--no-open",
 		"--timeout", "1s",
 	}, strings.NewReader(""), &stdout, &stdout)

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -188,6 +188,58 @@ func TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady(t *testing.T) {
 	}
 }
 
+func TestEnsureCloudIntegrationReusesSavedConnectionForMatchingBackend(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := saveIntegrationConnection(localDir, integrationConnectionState{
+		Provider:     "github",
+		ConnectionID: "ca_existing",
+		Backend:      "composio",
+		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveIntegrationConnection failed: %v", err)
+	}
+
+	var statusCalls, connectCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/integrations/github/status":
+			atomic.AddInt32(&statusCalls, 1)
+			if got := r.URL.Query().Get("connectionId"); got != "ca_existing" {
+				t.Fatalf("expected status to use saved connection id, got %q", got)
+			}
+			_, _ = w.Write([]byte(`{"ready":true}`))
+		case "/api/v1/workspaces/ws_demo/integrations/connect-session":
+			atomic.AddInt32(&connectCalls, 1)
+			t.Fatalf("connect-session should be skipped when saved backend matches")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "github", "composio", localDir, 5*time.Second, false, &stdout); err != nil {
+		t.Fatalf("ensureCloudIntegration failed: %v", err)
+	}
+	if atomic.LoadInt32(&statusCalls) != 1 {
+		t.Fatalf("expected exactly one status check, got %d", statusCalls)
+	}
+	if atomic.LoadInt32(&connectCalls) != 0 {
+		t.Fatalf("expected zero connect-session calls, got %d", connectCalls)
+	}
+	if !strings.Contains(stdout.String(), "github already connected") {
+		t.Fatalf("expected 'already connected' notice on re-run, got: %q", stdout.String())
+	}
+}
+
 // TestProviderRootDirHandlesAllSlackVariants pins the mapping between
 // catalog provider ids and the directory each provider occupies inside
 // the local mirror. Drift here breaks status probes, integration disconnect

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -174,7 +174,7 @@ func TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady(t *testing.T) {
 	defer server.Close()
 
 	var stdout bytes.Buffer
-	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "notion", localDir, 5*time.Second, false, &stdout); err != nil {
+	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "notion", "", localDir, 5*time.Second, false, &stdout); err != nil {
 		t.Fatalf("ensureCloudIntegration failed: %v", err)
 	}
 	if atomic.LoadInt32(&statusCalls) != 1 {


### PR DESCRIPTION
## Summary
- add `--backend` to `relayfile setup` and `relayfile integration connect`
- send `requestedBackend` to Cloud connect-session requests
- avoid reusing an existing default connection when a specific backend is requested

## Test
- `go test ./cmd/relayfile-cli`

Companion Cloud PR follows to implement the Composio backend session path.