### PR TITLE
local-mount: use reflink copies for initial mirror

### DIFF
--- a/.trajectories/completed/2026-05/traj_tdywz0ni0z1a.json
+++ b/.trajectories/completed/2026-05/traj_tdywz0ni0z1a.json
@@ -1,0 +1,75 @@
+{
+  "id": "traj_tdywz0ni0z1a",
+  "version": 1,
+  "task": {
+    "title": "Fix issue 132",
+    "source": {
+      "system": "plain",
+      "id": "#132"
+    }
+  },
+  "status": "completed",
+  "startedAt": "2026-05-11T18:12:11.347Z",
+  "completedAt": "2026-05-11T18:14:13.466Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-11T18:12:57.719Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_pcfs7tpnv9vn",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-11T18:12:57.719Z",
+      "endedAt": "2026-05-11T18:14:13.466Z",
+      "events": [
+        {
+          "ts": 1778523177720,
+          "type": "decision",
+          "content": "Use COPYFILE_FICLONE only for initial mount copies: Use COPYFILE_FICLONE only for initial mount copies",
+          "raw": {
+            "question": "Use COPYFILE_FICLONE only for initial mount copies",
+            "chosen": "Use COPYFILE_FICLONE only for initial mount copies",
+            "alternatives": [],
+            "reasoning": "Issue 132 targets createMount's project-to-mount mirror; sync-back and autosync behavior should remain unchanged unless separately scoped."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778523250026,
+          "type": "reflection",
+          "content": "Implemented COPYFILE_FICLONE for initial local-mount copies; focused tests and build pass, full suite is limited by local FSEvents failures and a pre-existing abort timing race.",
+          "raw": {
+            "focalPoints": [
+              "implementation",
+              "verification"
+            ],
+            "confidence": 0.82
+          },
+          "significance": "high",
+          "tags": [
+            "focal:implementation",
+            "focal:verification",
+            "confidence:0.82"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Fixed issue 132 by using Node's non-forcing COPYFILE_FICLONE flag for createMount initial project-to-mount copies, added a mocked copy-mode regression test, and documented same-filesystem reflink fallback behavior.",
+    "approach": "Standard approach",
+    "confidence": 0.82
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/will/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "1829ddc7488ba1f978f3a405ff3319dc762d6570",
+    "endRef": "1829ddc7488ba1f978f3a405ff3319dc762d6570"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_tdywz0ni0z1a.md
+++ b/.trajectories/completed/2026-05/traj_tdywz0ni0z1a.md
@@ -1,0 +1,33 @@
+# Trajectory: Fix issue 132
+
+> **Status:** ✅ Completed
+> **Task:** #132
+> **Confidence:** 82%
+> **Started:** May 11, 2026 at 02:12 PM
+> **Completed:** May 11, 2026 at 02:14 PM
+
+---
+
+## Summary
+
+Fixed issue 132 by using Node's non-forcing COPYFILE_FICLONE flag for createMount initial project-to-mount copies, added a mocked copy-mode regression test, and documented same-filesystem reflink fallback behavior.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Use COPYFILE_FICLONE only for initial mount copies
+- **Chose:** Use COPYFILE_FICLONE only for initial mount copies
+- **Reasoning:** Issue 132 targets createMount's project-to-mount mirror; sync-back and autosync behavior should remain unchanged unless separately scoped.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Use COPYFILE_FICLONE only for initial mount copies: Use COPYFILE_FICLONE only for initial mount copies
+- Implemented COPYFILE_FICLONE for initial local-mount copies; focused tests and build pass, full suite is limited by local FSEvents failures and a pre-existing abort timing race.

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-09T19:29:16.149Z",
+  "lastUpdated": "2026-05-11T18:14:13.633Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -242,6 +242,13 @@
       "startedAt": "2026-05-09T19:25:53.348Z",
       "completedAt": "2026-05-09T19:29:16.033Z",
       "path": ".trajectories/completed/2026-05/traj_brjdrgcnnwhs.json"
+    },
+    "traj_tdywz0ni0z1a": {
+      "title": "Fix issue 132",
+      "status": "completed",
+      "startedAt": "2026-05-11T18:12:11.347Z",
+      "completedAt": "2026-05-11T18:14:13.466Z",
+      "path": ".trajectories/completed/2026-05/traj_tdywz0ni0z1a.json"
     }
   }
 }

--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- `createMount` now requests non-forcing filesystem reflink clones for initial project-to-mount file copies, falling back to ordinary byte copies on unsupported filesystems or cross-device mounts. (#132)
 
 ## [0.7.6] - 2026-05-11
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -30,7 +30,7 @@ interface MountHandle {
 `createMount` returns `Promise<MountHandle>`. The walker yields the event loop between directory entries so consumer-side timers (e.g. an `ora` spinner driven by `setInterval`) keep firing while the mount is being built.
 
 Behavior:
-- Copies regular files into the mount
+- Copies regular files into the mount, requesting a filesystem reflink clone when the source and mount are on a compatible same-volume filesystem and falling back to a byte copy otherwise
 - Applies ignore rules from `ignoredPatterns`
 - Marks read-only matches as mode `0o444`
 - Excludes `.git`, `node_modules`, `.npm-cache`, and common build/cache output directories by default. Pass `includeGit: true` to opt the project's `.git` directory back in (see [Including `.git`](#including-git))
@@ -291,6 +291,8 @@ The mount is built by copying files rather than symlinking them. Symlinks would 
 5. **`.agentignore` hiding works fine with symlinks** (just don't link), but the readonly and conflict semantics still need copies — so a hybrid would be more complex than just copying everything.
 
 Source-side symlinks that resolve to regular files inside the project *are* followed when building the mount; the resolved bytes are copied. Symlinks the agent creates inside the mount are skipped on sync-back.
+
+On filesystems that support copy-on-write clones (for example APFS on macOS and btrfs/xfs/zfs on Linux), initial mount creation requests a non-forcing reflink copy. This preserves the distinct inode and copy-on-write semantics required above while avoiding an up-front byte copy when `projectDir` and `mountDir` are on the same filesystem. Unsupported filesystems and cross-device mounts fall back to ordinary copies.
 
 ## Notes
 

--- a/packages/local-mount/src/mount-reflink.test.ts
+++ b/packages/local-mount/src/mount-reflink.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    copyFileSync: vi.fn(actual.copyFileSync),
+  };
+});
+
+import {
+  constants as fsConstants,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createMount } from './mount.js';
+
+const copyFileSyncMock = vi.mocked(copyFileSync);
+
+function tmpDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'local-mount-reflink-test-'));
+}
+
+function write(file: string, body: string): void {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body, 'utf8');
+}
+
+describe('createMount reflink copies', () => {
+  let projectDir: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountDir = path.join(tmpDir(), 'mount');
+    copyFileSyncMock.mockClear();
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(path.dirname(mountDir), { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('requests non-forcing filesystem reflinks for initial mount files', async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'original');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    expect(copyFileSyncMock).toHaveBeenCalledWith(
+      expect.stringMatching(/src[/\\]code\.ts$/),
+      expect.stringMatching(/src[/\\]code\.ts$/),
+      fsConstants.COPYFILE_FICLONE
+    );
+    expect(existsSync(path.join(handle.mountDir, 'src/code.ts'))).toBe(true);
+
+    writeFileSync(path.join(handle.mountDir, 'src/code.ts'), 'mount-only edit', 'utf8');
+    expect(readFileSync(path.join(projectDir, 'src/code.ts'), 'utf8')).toBe('original');
+
+    handle.cleanup();
+  });
+});

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -1,5 +1,6 @@
 import {
   chmodSync,
+  constants as fsConstants,
   copyFileSync,
   existsSync,
   lstatSync,
@@ -399,7 +400,7 @@ function copyMountedFile(
     return;
   }
 
-  copyFileSync(safeSourcePath, safeMountPath);
+  copyFileSync(safeSourcePath, safeMountPath, fsConstants.COPYFILE_FICLONE);
 
   if (isPathMatched(relativePath, readonlyMatcher)) {
     chmodSync(safeMountPath, 0o444);


### PR DESCRIPTION
## Summary
- request Node's non-forcing COPYFILE_FICLONE mode for createMount's initial project-to-mount file copies
- add a regression test that verifies the copy mode without requiring reflink-capable CI storage
- document same-filesystem reflink behavior and fallback semantics in the README/changelog

Closes #132

## Verification
- npm run typecheck --workspace=packages/local-mount
- npm run build --workspace=packages/local-mount
- npx vitest run src/mount-reflink.test.ts
- npx vitest run src/mount.test.ts --testNamePattern "happy path|includeGit|syncBack: writes back|syncBack: skips files|yields the event loop"
- npx vitest run src/auto-sync.test.ts --testNamePattern "periodic full scan catches changes"

Note: full npm run test --workspace=packages/local-mount was attempted locally but did not complete cleanly in this sandbox because native watcher tests fail to start FSEvents streams, and the existing abort-timing test raced to sync all three files before cancellation.