### PR TITLE
Refresh workspace token in relayfile login when one is registered

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1290,6 +1290,8 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 				if perr := persistJoinedWorkspace(record, joined, creds.APIURL, record.LocalDir); perr == nil {
 					fmt.Fprintf(stdout, "Refreshed workspace token for %s (%s)\n", record.Name, record.ID)
 					return nil
+				} else if strings.TrimSpace(*workspaceFlag) != "" {
+					return fmt.Errorf("refresh workspace token: persist refreshed credentials: %w", perr)
 				} else {
 					fmt.Fprintf(stdout, "warning: workspace token refresh succeeded but persisting it failed: %v\n", perr)
 				}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1251,6 +1251,10 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		return err
 	}
 
+	if *skipWorkspace && strings.TrimSpace(*workspaceFlag) != "" {
+		return errors.New("--workspace cannot be used with --skip-workspace-refresh: pick one")
+	}
+
 	tokenValue := strings.TrimSpace(*token)
 
 	// Token explicitly provided → legacy server-credential flow.

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1235,14 +1235,18 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 	apiKey := fs.Bool("api-key", false, "use the legacy API-key flow against --server instead of the cloud browser login")
 	noOpen := fs.Bool("no-open", false, "print the cloud sign-in URL instead of opening it")
 	loginTimeout := fs.Duration("login-timeout", 5*time.Minute, "cloud login timeout")
+	workspaceFlag := fs.String("workspace", "", "workspace name or id to refresh; defaults to the active workspace")
+	skipWorkspace := fs.Bool("skip-workspace-refresh", false, "sign into the cloud only; do not refresh the workspace token")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"server":        true,
-		"token":         true,
-		"cloud-api-url": true,
-		"cloud-token":   true,
-		"api-key":       false,
-		"no-open":       false,
-		"login-timeout": true,
+		"server":                 true,
+		"token":                  true,
+		"cloud-api-url":          true,
+		"cloud-token":            true,
+		"api-key":                false,
+		"no-open":                false,
+		"login-timeout":          true,
+		"workspace":              true,
+		"skip-workspace-refresh": false,
 	})); err != nil {
 		return err
 	}
@@ -1277,6 +1281,28 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		return err
 	}
 	fmt.Fprintf(stdout, "Signed in to Relayfile Cloud at %s\n", creds.APIURL)
+
+	if !*skipWorkspace {
+		record, rerr := resolveWorkspaceRecord(strings.TrimSpace(*workspaceFlag))
+		if rerr == nil {
+			joined, jerr := joinWorkspaceViaCloud(creds, record.ID, record.AgentName, record.Scopes)
+			if jerr == nil {
+				if perr := persistJoinedWorkspace(record, joined, creds.APIURL, record.LocalDir); perr == nil {
+					fmt.Fprintf(stdout, "Refreshed workspace token for %s (%s)\n", record.Name, record.ID)
+					return nil
+				} else {
+					fmt.Fprintf(stdout, "warning: workspace token refresh succeeded but persisting it failed: %v\n", perr)
+				}
+			} else if strings.TrimSpace(*workspaceFlag) != "" {
+				return fmt.Errorf("refresh workspace token: %w", jerr)
+			} else {
+				fmt.Fprintf(stdout, "warning: could not refresh workspace token for %s: %v\n", record.Name, jerr)
+			}
+		} else if strings.TrimSpace(*workspaceFlag) != "" {
+			return rerr
+		}
+	}
+
 	fmt.Fprintln(stdout, "Run 'relayfile setup' to create or join a workspace, or 'relayfile mount WORKSPACE' if you already have one.")
 	return nil
 }

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1811,6 +1811,36 @@ func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
 	}
 }
 
+// TestLoginRejectsWorkspaceWithSkipFlag asserts that passing both
+// --workspace and --skip-workspace-refresh fails fast with a clear
+// error. The two are contradictory — --skip-workspace-refresh silently
+// winning would make an explicit --workspace a no-op while the command
+// still reports success.
+func TestLoginRejectsWorkspaceWithSkipFlag(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"login",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_browser_token",
+		"--workspace", "demo",
+		"--skip-workspace-refresh",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error for contradictory flag combo, got nil\noutput:\n%s", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "--workspace cannot be used with --skip-workspace-refresh") {
+		t.Fatalf("expected mutually-exclusive flag error, got %v", err)
+	}
+}
+
 // TestLoginExplicitWorkspaceReturnsErrorWhenPersistFails asserts that with
 // an explicit --workspace target, a failure to write the refreshed
 // workspace token to credentials.json surfaces as a non-zero exit / error

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1712,6 +1712,105 @@ func TestLoginDefaultsToCloudBrowserFlow(t *testing.T) {
 	}
 }
 
+// TestLoginRefreshesWorkspaceTokenForDefaultWorkspace covers the fix for
+// the bug where `relayfile login` only refreshed cloud-credentials.json
+// even when a workspace was already registered locally. After login, the
+// data-plane JWT in credentials.json should also be refreshed via the
+// cloud's workspace join endpoint.
+func TestLoginRefreshesWorkspaceTokenForDefaultWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	seen := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/join":
+			seen["join"] = true
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected join POST, got %s", r.Method)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_browser_token" {
+				t.Fatalf("unexpected join Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name: "demo",
+		ID:   "ws_demo",
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("demo"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"login",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_browser_token",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
+	}
+
+	if !seen["join"] {
+		t.Fatalf("expected /workspaces/ws_demo/join request, none seen. output:\n%s", stdout.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Refreshed workspace token for demo") {
+		t.Fatalf("expected refresh confirmation, got %q", got)
+	}
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	if creds.Token != "rf_refreshed" {
+		t.Fatalf("expected refreshed workspace token, got %q", creds.Token)
+	}
+	if creds.Server != "https://relayfile.test" {
+		t.Fatalf("expected refreshed server URL, got %q", creds.Server)
+	}
+}
+
+// TestLoginSkipsWorkspaceRefreshWhenFlagSet covers --skip-workspace-refresh:
+// even with a workspace registered, no /join call should fire and
+// credentials.json must remain absent.
+func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("demo"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"login",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_browser_token",
+		"--skip-workspace-refresh",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
+	}
+
+	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("expected no server credentials written with --skip-workspace-refresh, got err=%v", err)
+	}
+}
+
 // TestLoginAPIKeyFlagPromptsForToken covers the opt-in legacy interactive
 // flow: --api-key forces runLogin to prompt for an API key on stdin instead
 // of running the cloud browser flow.

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1811,6 +1811,114 @@ func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
 	}
 }
 
+// TestLoginExplicitWorkspaceReturnsErrorWhenPersistFails asserts that with
+// an explicit --workspace target, a failure to write the refreshed
+// workspace token to credentials.json surfaces as a non-zero exit / error
+// — symmetric with the join and resolve failure branches. Before this
+// guard, a persist failure was downgraded to a warning even under
+// --workspace, so the command reported success while leaving the on-disk
+// JWT stale.
+func TestLoginExplicitWorkspaceReturnsErrorWhenPersistFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	clearRelayfileEnv(t)
+
+	seen := map[string]bool{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/join":
+			seen["join"] = true
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("demo"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	// Force only the credentials.json rename to fail by pre-creating
+	// that exact path as a directory. writeFileAtomically still
+	// succeeds at CreateTemp/Write/Chmod/Close; only the final
+	// os.Rename(tmp, credentialsPath()) errors because the destination
+	// is a non-empty directory. cloud-credentials.json (different
+	// path) writes normally.
+	if err := os.MkdirAll(credentialsPath(), 0o755); err != nil {
+		t.Fatalf("pre-create credentials path as dir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsPath(), "blocker"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker file failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"login",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_browser_token",
+		"--workspace", "demo",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error for explicit --workspace with persist failure, got nil\noutput:\n%s", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "persist refreshed credentials") {
+		t.Fatalf("expected persist failure in error, got %v", err)
+	}
+	if !seen["join"] {
+		t.Fatalf("expected /workspaces/ws_demo/join to have been called before persist; seen=%v", seen)
+	}
+}
+
+// TestLoginDefaultWorkspaceWarnsWhenPersistFails confirms the unchanged
+// behavior for the implicit default-workspace path: persist failures
+// remain a warning so the cloud login itself still counts as successful.
+func TestLoginDefaultWorkspaceWarnsWhenPersistFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_demo/join":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("demo"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	if err := os.MkdirAll(credentialsPath(), 0o755); err != nil {
+		t.Fatalf("pre-create credentials path as dir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(credentialsPath(), "blocker"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write blocker file failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"login",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_browser_token",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("default-workspace login should not error on persist failure: %v\noutput:\n%s", err, stdout.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "warning: workspace token refresh succeeded but persisting it failed") {
+		t.Fatalf("expected persist-failure warning in output, got %q", got)
+	}
+}
+
 // TestLoginAPIKeyFlagPromptsForToken covers the opt-in legacy interactive
 // flow: --api-key forces runLogin to prompt for an API key on stdin instead
 // of running the cloud browser flow.


### PR DESCRIPTION
## Summary
- Plain `relayfile login` only wrote `~/.relayfile/cloud-credentials.json` and left the data-plane JWT in `~/.relayfile/credentials.json` stale. Every workspace op (`status`, `tree`, `read`, mount auth) returned `http 401 unauthorized: Token has expired` after the cloud sign-in claimed success.
- After `ensureCloudCredentials` succeeds, resolve the active workspace and re-mint the data-plane JWT via `joinWorkspaceViaCloud` + `persistJoinedWorkspace` so both credential files are fresh in one step.
- Adds `--workspace NAME` (errors if refresh fails) and `--skip-workspace-refresh` (retain cloud-only behavior). No-ops silently when no workspace is registered, so the cold-start `TestLoginDefaultsToCloudBrowserFlow` path is unchanged.

## Background
Hit while verifying the v2 file-native adapter rollout against `rw_517d60b6`. After the data-plane JWT expired mid-session, the only documented recoveries were `relayfile login --api-key` (needs an API key the user doesn't have) or `relayfile setup` (re-triggers OAuth and mount). The `refreshMountAuth` loop inside `relayfile mount` already has the right shape — this PR lifts the same join+persist into the user-facing `login` command.

## Test plan
- [x] `go test ./cmd/relayfile-cli/` — full suite green (4.5s).
- [x] `go vet ./cmd/relayfile-cli/` clean.
- [x] New `TestLoginRefreshesWorkspaceTokenForDefaultWorkspace` — asserts `/api/v1/workspaces/<id>/join` fires and `credentials.json` is rewritten with the refreshed token + server URL.
- [x] New `TestLoginSkipsWorkspaceRefreshWhenFlagSet` — asserts `--skip-workspace-refresh` suppresses the join call and leaves `credentials.json` absent.
- [x] Existing `TestLoginDefaultsToCloudBrowserFlow` (cold-start, no workspace) still passes — silent no-op path verified.
- [ ] Manual: run `relayfile login` on a host with an expired `credentials.json`; verify `relayfile status` succeeds without a follow-up command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)