### PR TITLE
Fix local-mount syncBack full-tree walk after healthy autosync

### DIFF
--- a/.trajectories/compacted/compact_5kbxmj590rd2_2026-05-11.json
+++ b/.trajectories/compacted/compact_5kbxmj590rd2_2026-05-11.json
@@ -1,0 +1,37 @@
+{
+  "id": "compact_5kbxmj590rd2",
+  "version": 1,
+  "type": "compacted",
+  "compactedAt": "2026-05-11T19:53:45.799Z",
+  "sourceTrajectories": [
+    "traj_mip7ag0uwuhd"
+  ],
+  "dateRange": {
+    "start": "2026-05-11T19:45:44.947Z",
+    "end": "2026-05-11T19:53:43.104Z"
+  },
+  "summary": {
+    "totalDecisions": 1,
+    "totalEvents": 1,
+    "uniqueAgents": [
+      "default"
+    ]
+  },
+  "decisionGroups": [
+    {
+      "category": "tooling",
+      "decisions": [
+        {
+          "question": "Use explicit syncBack path lists from healthy auto-sync state",
+          "chosen": "Use explicit syncBack path lists from healthy auto-sync state",
+          "reasoning": "Direct syncBack remains the full-walk safety net; launchOnMount only passes dirty mount paths after watcher subscriptions stayed healthy, so degraded or disabled auto-sync keeps existing O(files) behavior.",
+          "fromTrajectory": "traj_mip7ag0uwuhd"
+        }
+      ]
+    }
+  ],
+  "keyLearnings": [],
+  "keyFindings": [],
+  "filesAffected": [],
+  "commits": []
+}

--- a/.trajectories/compacted/compact_5kbxmj590rd2_2026-05-11.md
+++ b/.trajectories/compacted/compact_5kbxmj590rd2_2026-05-11.md
@@ -1,0 +1,18 @@
+# Trajectory Compaction: May 11, 2026 - May 11, 2026
+
+## Summary
+- Sessions: 1
+- Decisions: 1
+- Events: 1
+- Agents: default
+- Files: 0
+- Commits: 0
+
+## Tooling
+- Use explicit syncBack path lists from healthy auto-sync state -> Use explicit syncBack path lists from healthy auto-sync state (traj_mip7ag0uwuhd)
+
+## Key Learnings
+- None
+
+## Key Findings
+- None

--- a/.trajectories/compacted/compact_nebl0ptt2ug0_2026-05-11.json
+++ b/.trajectories/compacted/compact_nebl0ptt2ug0_2026-05-11.json
@@ -1,0 +1,37 @@
+{
+  "id": "compact_nebl0ptt2ug0",
+  "version": 1,
+  "type": "compacted",
+  "compactedAt": "2026-05-11T20:15:59.684Z",
+  "sourceTrajectories": [
+    "traj_akq5gmap5a1c"
+  ],
+  "dateRange": {
+    "start": "2026-05-11T20:12:16.803Z",
+    "end": "2026-05-11T20:15:56.986Z"
+  },
+  "summary": {
+    "totalDecisions": 1,
+    "totalEvents": 1,
+    "uniqueAgents": [
+      "default"
+    ]
+  },
+  "decisionGroups": [
+    {
+      "category": "other",
+      "decisions": [
+        {
+          "question": "Gate launch fast-path on pre-write auto-sync readiness",
+          "chosen": "Gate launch fast-path on pre-write auto-sync readiness",
+          "reasoning": "A healthy watcher after shutdown is not enough if writes happened before subscriptions were ready; launchOnMount now awaits ready before onBeforeLaunch/child writes and only passes dirty paths when that readiness gate succeeded.",
+          "fromTrajectory": "traj_akq5gmap5a1c"
+        }
+      ]
+    }
+  ],
+  "keyLearnings": [],
+  "keyFindings": [],
+  "filesAffected": [],
+  "commits": []
+}

--- a/.trajectories/compacted/compact_nebl0ptt2ug0_2026-05-11.md
+++ b/.trajectories/compacted/compact_nebl0ptt2ug0_2026-05-11.md
@@ -1,0 +1,18 @@
+# Trajectory Compaction: May 11, 2026 - May 11, 2026
+
+## Summary
+- Sessions: 1
+- Decisions: 1
+- Events: 1
+- Agents: default
+- Files: 0
+- Commits: 0
+
+## Other
+- Gate launch fast-path on pre-write auto-sync readiness -> Gate launch fast-path on pre-write auto-sync readiness (traj_akq5gmap5a1c)
+
+## Key Learnings
+- None
+
+## Key Findings
+- None

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-11T18:14:13.633Z",
+  "lastUpdated": "2026-05-11T20:15:59.690Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",

--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- `launchOnMount` now uses auto-sync's dirty path state for the final sync-back when watcher subscriptions stayed healthy, avoiding a full mount-tree walk on idle or low-change sessions. The full sweep remains the fallback when auto-sync is disabled or watcher state is degraded. (#134)
+- `launchOnMount` now waits for auto-sync watcher readiness before running `onBeforeLaunch` or spawning the child process, so the dirty-path final sync-back cannot miss short-lived writes made before watcher events are trusted. (#134)
 
 ## [0.7.7] - 2026-05-11
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -21,7 +21,7 @@ const handle = await createMount(projectDir, mountDir, options);
 
 interface MountHandle {
   mountDir: string;
-  syncBack(opts?: { signal?: AbortSignal }): Promise<number>;
+  syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number>;
   startAutoSync(opts?: AutoSyncOptions): AutoSyncHandle;
   cleanup(): void;
 }
@@ -58,8 +58,8 @@ const { ignoredPatterns, readonlyPatterns } = readAgentDotfiles(projectDir, {
 
 High-level helper that:
 1. creates a mount,
-2. starts bidirectional auto-sync (see below, controllable via `autoSync`),
-3. runs a CLI inside the mount,
+2. starts bidirectional auto-sync (see below, controllable via `autoSync`) and waits for the watchers to be ready when auto-sync is enabled,
+3. runs `onBeforeLaunch`, then runs a CLI inside the mount,
 4. forwards `SIGINT` and `SIGTERM`,
 5. stops auto-sync and runs a final sync-back pass after the child exits,
 6. cleans up the mount directory.
@@ -84,7 +84,10 @@ interface AutoSyncOptions {
 
 interface AutoSyncHandle {
   stop(opts?: { signal?: AbortSignal }): Promise<void>;
+  flushPending(opts?: { signal?: AbortSignal }): Promise<number>;
   reconcile(opts?: { signal?: AbortSignal }): Promise<number>;
+  getDirtyPaths(): IterableIterator<string>;
+  watchersHealthy(): boolean;
   totalChanges(): number;
   ready(): Promise<void>;
 }
@@ -103,6 +106,7 @@ launchOnMount({ /* ... */, autoSync: { scanIntervalMs: 5_000, debounceMs: 100 } 
 How it works:
 - [@parcel/watcher](https://www.npmjs.com/package/@parcel/watcher) watches both the mount and the project tree using native FSEvents/inotify/ReadDirectoryChangesW
 - every `scanIntervalMs`, a full reconcile walks both trees as a safety net for missed events
+- watcher events are tracked as dirty paths, so shutdown can flush pending path-level work and make the final sync-back proportional to the number of mount-side changes when the watcher state stayed healthy
 - `stop({ signal })` still closes watchers if aborted, but skips the final draining reconcile
 - per-file `mtime` is tracked at the last sync, so the scan skips files that haven't changed
 
@@ -266,6 +270,8 @@ console.log(result.exitCode);
 The returned number is the count of files written back to `projectDir` in that pass. `syncBack()` never deletes — delete propagation is handled by auto-sync.
 
 `syncBack({ signal })` checks for aborts between files. If the signal aborts during shutdown, it returns the partial count accumulated so far instead of throwing, which lets callers report a partial sync and still run cleanup.
+
+`syncBack({ paths })` limits the pass to explicit mount-relative paths. This is used by auto-sync shutdown after `watchersHealthy()` confirms both watchers subscribed and no watcher error was observed; otherwise callers should omit `paths` to keep the full-walk safety net.
 
 `reconcile({ signal })` and the internal tree walk also poll for aborts between file visits so an in-flight draining scan can stop cooperatively.
 

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -72,6 +72,35 @@ describe('startAutoSync', () => {
     }
   });
 
+  it('tracks dirty mount paths and flushes pending debounced writes', async () => {
+    write(path.join(projectDir, 'file.txt'), 'original');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    const auto = handle.startAutoSync({ debounceMs: 10_000, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      expect(auto.watchersHealthy()).toBe(true);
+      writeFileSync(path.join(handle.mountDir, 'file.txt'), 'changed', 'utf8');
+
+      await waitFor(() => Array.from(auto.getDirtyPaths()).includes('file.txt'));
+      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('original');
+
+      const flushed = await auto.flushPending();
+
+      expect(flushed).toBe(1);
+      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('changed');
+      expect(Array.from(auto.getDirtyPaths())).toEqual([]);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
   it('propagates project→mount external edits', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
 

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -62,8 +62,14 @@ export interface AutoSyncOptions {
 
 export interface AutoSyncHandle {
   stop(opts?: { signal?: AbortSignal }): Promise<void>;
+  /** Drain currently debounced watcher events. Falls back to reconcile if watchers are degraded. */
+  flushPending(opts?: { signal?: AbortSignal }): Promise<number>;
   /** Force a reconcile now; returns number of files copied/deleted. */
   reconcile(opts?: { signal?: AbortSignal }): Promise<number>;
+  /** Mount-side paths that still need a final one-shot syncBack check. */
+  getDirtyPaths(): IterableIterator<string>;
+  /** True once both watchers subscribed and no watcher error has been observed. */
+  watchersHealthy(): boolean;
   /** Cumulative files changed (copied or deleted) since autosync started. */
   totalChanges(): number;
   /** Resolves once both watchers have completed their initial scan. */
@@ -74,6 +80,8 @@ interface FileState {
   mountMtimeMs?: number;
   projectMtimeMs?: number;
 }
+
+const STOP_EVENT_SETTLE_MS = 250;
 
 export function startAutoSync(
   ctx: AutoSyncContext,
@@ -89,9 +97,65 @@ export function startAutoSync(
 
   let syncing = false;
   let pending = false;
+  let stopping = false;
   let stopped = false;
+  let watchersReadySettled = false;
+  let watcherDegraded = false;
   let totalChanges = 0;
+  const pendingPaths = new Set<string>();
   const pendingDebounces = new Map<string, NodeJS.Timeout>();
+  const dirtyMountPaths = new Set<string>();
+
+  const watchersHealthy = (): boolean => watchersReadySettled && !watcherDegraded;
+
+  const markWatcherDegraded = (err: Error): void => {
+    watcherDegraded = true;
+    onError(err);
+  };
+
+  const clearPendingDebounces = (): void => {
+    for (const t of pendingDebounces.values()) clearTimeout(t);
+    pendingDebounces.clear();
+  };
+
+  const syncPath = (relPosix: string): number => {
+    if (!isSyncCandidate(relPosix, ctx)) {
+      dirtyMountPaths.delete(relPosix);
+      return 0;
+    }
+    try {
+      const changed = syncOneFile(relPosix, state, ctx);
+      dirtyMountPaths.delete(relPosix);
+      return changed ? 1 : 0;
+    } catch (err) {
+      onError(err as Error);
+      return 0;
+    }
+  };
+
+  const flushPendingPaths = async (opts?: { signal?: AbortSignal }): Promise<number> => {
+    const signal = opts?.signal;
+    if (signal?.aborted) {
+      return 0;
+    }
+
+    let count = 0;
+    let processed = 0;
+    for (const relPosix of Array.from(pendingPaths)) {
+      if (signal?.aborted) {
+        break;
+      }
+      pendingPaths.delete(relPosix);
+      count += syncPath(relPosix);
+      processed += 1;
+      if (signal && processed % 64 === 0 && !signal.aborted) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+    }
+
+    totalChanges += count;
+    return count;
+  };
 
   const runReconcile = async (opts?: { signal?: AbortSignal }): Promise<number> => {
     const signal = opts?.signal;
@@ -104,8 +168,10 @@ export function startAutoSync(
     }
     syncing = true;
     let count = 0;
+    let completed = false;
     try {
       count = reconcile(state, ctx, onError, signal);
+      completed = !signal?.aborted;
     } catch (err) {
       onError(err as Error);
     } finally {
@@ -115,51 +181,71 @@ export function startAutoSync(
       pending = false;
       try {
         count += reconcile(state, ctx, onError, signal);
+        completed = !signal?.aborted;
       } catch (err) {
         onError(err as Error);
+        completed = false;
       }
+    }
+    if (completed) {
+      pendingPaths.clear();
+      dirtyMountPaths.clear();
     }
     totalChanges += count;
     return count;
   };
 
-  const syncPathFromRoot = (root: string, absPath: string): void => {
-    const rel = path.relative(root, absPath);
-    if (rel === '' || rel.startsWith('..')) return;
-    const relPosix = rel.split(path.sep).join('/');
-    if (!isSyncCandidate(relPosix, ctx)) return;
-    try {
-      const changed = syncOneFile(relPosix, state, ctx);
-      if (changed) totalChanges += 1;
-    } catch (err) {
-      onError(err as Error);
+  const flushPending = async (opts?: { signal?: AbortSignal }): Promise<number> => {
+    if (opts?.signal?.aborted) {
+      return 0;
     }
+    try {
+      await watchersReady;
+    } catch {
+      // Subscription setup failure is already marked degraded and surfaced.
+    }
+    if (opts?.signal?.aborted) {
+      return 0;
+    }
+
+    clearPendingDebounces();
+    if (!watchersHealthy()) {
+      return runReconcile(opts);
+    }
+    return flushPendingPaths(opts);
   };
 
   const schedulePathSync = (root: string, absPath: string): void => {
-    // Once stop() has begun, refuse to schedule new timers. Watcher
-    // callbacks can still fire during the unsubscribe await (native
-    // backends deliver queued events asynchronously); without this guard
-    // those events would create timers that outlive stop() and do file
-    // work against a mount the caller may have already cleaned up.
     if (stopped) return;
+    const relPosix = root === ctx.realMountDir
+      ? toRelPosix(absPath, ctx)
+      : toRelPosixFromProject(absPath, ctx);
+    if (relPosix === null || !isSyncCandidate(relPosix, ctx)) return;
+    pendingPaths.add(relPosix);
+    if (root === ctx.realMountDir) {
+      dirtyMountPaths.add(relPosix);
+    }
+    // During stop(), keep accepting queued watcher events so the final flush
+    // can process them, but don't create timers that could outlive teardown.
+    if (stopping) return;
     // Coalesce bursts of events for the same path. The reconcile path
     // re-checks content via mtime+bytes, so a partial-write event that
     // races a later write is harmless.
-    const existing = pendingDebounces.get(absPath);
+    const existing = pendingDebounces.get(relPosix);
     if (existing) clearTimeout(existing);
     const t = setTimeout(() => {
-      pendingDebounces.delete(absPath);
-      syncPathFromRoot(root, absPath);
+      pendingDebounces.delete(relPosix);
+      pendingPaths.delete(relPosix);
+      totalChanges += syncPath(relPosix);
     }, debounceMs);
-    pendingDebounces.set(absPath, t);
+    pendingDebounces.set(relPosix, t);
   };
 
   const subscribeTo = (root: string): Promise<AsyncSubscription> =>
     watcher.subscribe(
       root,
       (err, events) => {
-        if (err) { onError(err); return; }
+        if (err) { markWatcherDegraded(err); return; }
         for (const ev of events) {
           schedulePathSync(root, ev.path);
         }
@@ -181,8 +267,11 @@ export function startAutoSync(
     if (mountResult.status === 'fulfilled') mountSub = mountResult.value;
     if (projectResult.status === 'fulfilled') projectSub = projectResult.value;
     if (mountResult.status === 'fulfilled' && projectResult.status === 'fulfilled') {
+      watchersReadySettled = true;
       return;
     }
+    watchersReadySettled = true;
+    watcherDegraded = true;
     await Promise.allSettled([
       mountSub?.unsubscribe(),
       projectSub?.unsubscribe(),
@@ -196,7 +285,7 @@ export function startAutoSync(
   // If subscription setup fails, surface via onError rather than an unhandled
   // rejection. stop() still awaits the same promise and will observe the
   // rejection after the cleanup above has already run.
-  watchersReady.catch((err) => onError(err as Error));
+  watchersReady.catch((err) => markWatcherDegraded(err as Error));
 
   const interval = setInterval(() => {
     void runReconcile();
@@ -206,32 +295,42 @@ export function startAutoSync(
 
   return {
     async stop(opts?: { signal?: AbortSignal }) {
-      // Flip the flag first so any watcher callbacks delivered during the
-      // awaits below refuse to schedule new timers.
-      stopped = true;
-      clearInterval(interval);
       try {
         await watchersReady;
       } catch {
         // Setup failed and already cleaned up any partial subscription;
         // mountSub / projectSub were reset to undefined before the throw.
       }
+      if (!opts?.signal?.aborted && watchersHealthy()) {
+        await new Promise<void>((resolve) => setTimeout(resolve, STOP_EVENT_SETTLE_MS));
+      }
+      stopping = true;
+      clearInterval(interval);
+      clearPendingDebounces();
       await Promise.allSettled([
         mountSub?.unsubscribe(),
         projectSub?.unsubscribe(),
       ]);
-      // Clear debounces *after* unsubscribe resolves: any timer scheduled
-      // between stop() being called and the watcher actually quiescing is
-      // gathered here, so none fire after stop() returns.
-      for (const t of pendingDebounces.values()) clearTimeout(t);
-      pendingDebounces.clear();
+      clearPendingDebounces();
       if (opts?.signal?.aborted) {
+        stopped = true;
+        stopping = false;
         return;
       }
-      // Drain any pending work so callers can rely on "stopped means quiesced".
-      await runReconcile(opts);
+      // Drain pending watcher work when the watcher state is trusted; otherwise
+      // keep the historical full-reconcile safety net.
+      if (watchersHealthy()) {
+        await flushPendingPaths(opts);
+      } else {
+        await runReconcile(opts);
+      }
+      stopped = true;
+      stopping = false;
     },
+    flushPending,
     reconcile: runReconcile,
+    getDirtyPaths: () => new Set(dirtyMountPaths).values(),
+    watchersHealthy,
     totalChanges: () => totalChanges,
     ready: async () => {
       await watchersReady;

--- a/packages/local-mount/src/launch.test.ts
+++ b/packages/local-mount/src/launch.test.ts
@@ -148,6 +148,56 @@ describe('launchOnMount', () => {
     }
   });
 
+  it('falls back to full syncBack when watchers are healthy but no dirty paths were captured', async () => {
+    // Repro for the dropped-edits race flagged in #138 review: when the
+    // watcher stays healthy but doesn't observe any path before stop()
+    // (e.g. short-lived child writes that race past the watcher, or
+    // edits the watcher missed), getDirtyPaths returns empty. Passing
+    // paths: [] to syncBack would skip the walk entirely and silently
+    // drop those edits. The fix is to fall through to the full walk
+    // when the dirty set is empty.
+    mkdirSync(mountDir, { recursive: true });
+
+    let syncBackPaths: string[] | undefined;
+    let syncBackCalled = false;
+
+    const createSpy = vi.spyOn(mountModule, 'createMount').mockResolvedValue({
+      mountDir,
+      startAutoSync: () => ({
+        stop: async () => {},
+        flushPending: async () => 0,
+        reconcile: async () => 0,
+        getDirtyPaths: () => [][Symbol.iterator](),
+        watchersHealthy: () => true,
+        totalChanges: () => 0,
+        ready: async () => {},
+      }),
+      syncBack: async ({ paths } = {}) => {
+        syncBackCalled = true;
+        syncBackPaths = paths ? Array.from(paths) : undefined;
+        return 0;
+      },
+      cleanup: () => {},
+    });
+
+    try {
+      const result = await launchOnMount({
+        cli: '/bin/sh',
+        projectDir,
+        mountDir,
+        args: ['-c', 'exit 0'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(syncBackCalled).toBe(true);
+      // paths must NOT be passed when the dirty set is empty — otherwise
+      // syncBack({ paths: [] }) iterates zero files and skips the walk.
+      expect(syncBackPaths).toBeUndefined();
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+
   it('falls back to full syncBack when auto-sync readiness fails', async () => {
     mkdirSync(mountDir, { recursive: true });
 

--- a/packages/local-mount/src/launch.test.ts
+++ b/packages/local-mount/src/launch.test.ts
@@ -54,6 +54,26 @@ describe('launchOnMount', () => {
     expect(existsSync(mountDir)).toBe(false);
   });
 
+  it('syncs files written by onBeforeLaunch when auto-sync is enabled', async () => {
+    let syncedSeen = -1;
+    const result = await launchOnMount({
+      cli: '/bin/sh',
+      projectDir,
+      mountDir,
+      args: ['-c', 'exit 0'],
+      onBeforeLaunch: (md) => {
+        writeFileSync(path.join(md, 'prelaunch.txt'), 'ready', 'utf8');
+      },
+      onAfterSync: (n) => {
+        syncedSeen = n;
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(path.join(projectDir, 'prelaunch.txt'), 'utf8')).toBe('ready');
+    expect(syncedSeen).toBe(1);
+  });
+
   it('propagates a non-zero exit code from the child', async () => {
     const result = await launchOnMount({
       cli: '/bin/sh',
@@ -81,6 +101,93 @@ describe('launchOnMount', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it('waits for auto-sync readiness before invoking onBeforeLaunch', async () => {
+    mkdirSync(mountDir, { recursive: true });
+
+    let readyResolved = false;
+    let beforeLaunchSawReady = false;
+    let syncBackPaths: string[] | undefined;
+
+    const createSpy = vi.spyOn(mountModule, 'createMount').mockResolvedValue({
+      mountDir,
+      startAutoSync: () => ({
+        stop: async () => {},
+        flushPending: async () => 0,
+        reconcile: async () => 0,
+        getDirtyPaths: () => ['tracked.txt'][Symbol.iterator](),
+        watchersHealthy: () => true,
+        totalChanges: () => 0,
+        ready: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          readyResolved = true;
+        },
+      }),
+      syncBack: async ({ paths } = {}) => {
+        syncBackPaths = paths ? Array.from(paths) : undefined;
+        return 0;
+      },
+      cleanup: () => {},
+    });
+
+    try {
+      const result = await launchOnMount({
+        cli: '/bin/sh',
+        projectDir,
+        mountDir,
+        args: ['-c', 'exit 0'],
+        onBeforeLaunch: () => {
+          beforeLaunchSawReady = readyResolved;
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(beforeLaunchSawReady).toBe(true);
+      expect(syncBackPaths).toEqual(['tracked.txt']);
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+
+  it('falls back to full syncBack when auto-sync readiness fails', async () => {
+    mkdirSync(mountDir, { recursive: true });
+
+    let syncBackPaths: string[] | undefined;
+
+    const createSpy = vi.spyOn(mountModule, 'createMount').mockResolvedValue({
+      mountDir,
+      startAutoSync: () => ({
+        stop: async () => {},
+        flushPending: async () => 0,
+        reconcile: async () => 0,
+        getDirtyPaths: () => ['tracked.txt'][Symbol.iterator](),
+        watchersHealthy: () => true,
+        totalChanges: () => 0,
+        ready: async () => {
+          throw new Error('watcher failed');
+        },
+      }),
+      syncBack: async ({ paths } = {}) => {
+        syncBackPaths = paths ? Array.from(paths) : undefined;
+        return 0;
+      },
+      cleanup: () => {},
+    });
+
+    try {
+      const result = await launchOnMount({
+        cli: '/bin/sh',
+        projectDir,
+        mountDir,
+        args: ['-c', 'exit 0'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(syncBackPaths).toBeUndefined();
+    } finally {
+      createSpy.mockRestore();
+    }
+  });
+
   it('fires onAfterSync with a partial count and still cleans up when shutdownSignal aborts after child exit', async () => {
     mkdirSync(mountDir, { recursive: true });
 
@@ -94,7 +201,10 @@ describe('launchOnMount', () => {
         stop: async () => {
           stopCalled = true;
         },
+        flushPending: async () => 0,
         reconcile: async () => 0,
+        getDirtyPaths: () => [][Symbol.iterator](),
+        watchersHealthy: () => true,
         totalChanges: () => 0,
         ready: async () => {},
       }),

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -88,7 +88,19 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
         await autoSync.stop({ signal: opts.shutdownSignal });
         autoSyncChanges = autoSync.totalChanges();
         if (autoSyncReadyBeforeWrites && autoSync.watchersHealthy()) {
-          finalSyncBackPaths = Array.from(autoSync.getDirtyPaths());
+          const dirty = Array.from(autoSync.getDirtyPaths());
+          // Only take the fast path when there's at least one dirty
+          // path to sync. An empty dirty set is ambiguous after
+          // autoSync.stop() — the healthy-path flush already drained
+          // pending events, so the set could be empty either because
+          // nothing changed or because edits raced past the watcher
+          // (short-lived runs where the watcher hadn't enqueued
+          // anything before stop). Fall through to the full walk in
+          // that case as a safety net; it's cheap on no-change runs
+          // and prevents dropped mount edits at shutdown.
+          if (dirty.length > 0) {
+            finalSyncBackPaths = dirty;
+          }
         }
         autoSync = undefined;
       }

--- a/packages/local-mount/src/launch.ts
+++ b/packages/local-mount/src/launch.ts
@@ -76,19 +76,27 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
   let syncedCount = 0;
   let finalized = false;
   let autoSync: AutoSyncHandle | undefined;
+  let autoSyncReadyBeforeWrites = false;
 
   const finalize = async (): Promise<void> => {
     if (finalized) return;
     finalized = true;
     try {
       let autoSyncChanges = 0;
+      let finalSyncBackPaths: string[] | undefined;
       if (autoSync) {
         await autoSync.stop({ signal: opts.shutdownSignal });
         autoSyncChanges = autoSync.totalChanges();
+        if (autoSyncReadyBeforeWrites && autoSync.watchersHealthy()) {
+          finalSyncBackPaths = Array.from(autoSync.getDirtyPaths());
+        }
         autoSync = undefined;
       }
       if (!handle) return;
-      const finalSynced = await handle.syncBack({ signal: opts.shutdownSignal });
+      const finalSynced = await handle.syncBack({
+        signal: opts.shutdownSignal,
+        ...(finalSyncBackPaths ? { paths: finalSyncBackPaths } : {}),
+      });
       syncedCount = autoSyncChanges + finalSynced;
       if (opts.onAfterSync) {
         await opts.onAfterSync(syncedCount);
@@ -108,13 +116,21 @@ export async function launchOnMount(opts: LaunchOnMountOptions): Promise<LaunchO
       includeDefaultExcludeDirs: opts.includeDefaultExcludeDirs,
     });
 
-    if (opts.onBeforeLaunch) {
-      await opts.onBeforeLaunch(handle.mountDir);
-    }
-
     if (opts.autoSync !== false) {
       const autoSyncOpts = typeof opts.autoSync === 'object' ? opts.autoSync : undefined;
       autoSync = handle.startAutoSync(autoSyncOpts);
+      try {
+        await autoSync.ready();
+        autoSyncReadyBeforeWrites = autoSync.watchersHealthy();
+      } catch {
+        // Keep launching with degraded auto-sync; shutdown will use the full
+        // syncBack sweep because dirty-path state was never trustworthy.
+        autoSyncReadyBeforeWrites = false;
+      }
+    }
+
+    if (opts.onBeforeLaunch) {
+      await opts.onBeforeLaunch(handle.mountDir);
     }
 
     const envVars: NodeJS.ProcessEnv = {

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -263,6 +263,28 @@ describe('createMount', () => {
     handle.cleanup();
   });
 
+  it('syncBack: explicit paths skip unrelated mount changes', async () => {
+    write(path.join(projectDir, 'a.txt'), 'a0');
+    write(path.join(projectDir, 'b.txt'), 'b0');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    writeFileSync(path.join(handle.mountDir, 'a.txt'), 'a1', 'utf8');
+    writeFileSync(path.join(handle.mountDir, 'b.txt'), 'b1', 'utf8');
+
+    const synced = await handle.syncBack({ paths: ['a.txt'] });
+
+    expect(synced).toBe(1);
+    expect(readFileSync(path.join(projectDir, 'a.txt'), 'utf8')).toBe('a1');
+    expect(readFileSync(path.join(projectDir, 'b.txt'), 'utf8')).toBe('b0');
+
+    handle.cleanup();
+  });
+
   it('syncBack: skips files under default excluded paths', async () => {
     write(path.join(projectDir, 'src/code.ts'), 'original');
 

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -201,6 +201,13 @@ export async function createMount(
         synced += syncedForFile;
 
         if (signal && syncedForFile > 0 && !signal.aborted) {
+          // Intentionally uses setTimeout(resolve, 0) rather than the
+          // setImmediate-based yieldToEventLoop helper below: aborts
+          // mid-walk are scheduled via setTimeout (see mount.test.ts
+          // "syncBack: returns a partial count when aborted mid-walk"),
+          // and matching the same queue makes the abort observable
+          // between file syncs. setImmediate runs after timer
+          // callbacks in a single I/O cycle and races the abort.
           await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
       }

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -54,7 +54,7 @@ export interface MountOptions {
 
 export interface MountHandle {
   mountDir: string;
-  syncBack(opts?: { signal?: AbortSignal }): Promise<number>;
+  syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number>;
   /**
    * Start bidirectional auto-sync: watches both the mount and project trees
    * via @parcel/watcher and runs a full reconcile every `scanIntervalMs`
@@ -175,11 +175,13 @@ export async function createMount(
 
   return {
     mountDir: resolvedMountDir,
-    async syncBack(opts?: { signal?: AbortSignal }): Promise<number> {
+    async syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number> {
       let synced = 0;
       const realProjectDir = realpathSync(resolvedProjectDir);
       const realMountDir = realpathSync(resolvedMountDir);
-      const files = listFiles(realMountDir);
+      const files = opts?.paths
+        ? syncBackPathsToFiles(realMountDir, opts.paths)
+        : listFiles(realMountDir);
       const signal = opts?.signal;
 
       for (const sourceFile of files) {
@@ -199,7 +201,7 @@ export async function createMount(
         synced += syncedForFile;
 
         if (signal && syncedForFile > 0 && !signal.aborted) {
-          await new Promise<void>((resolve) => setImmediate(resolve));
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
       }
 
@@ -446,6 +448,29 @@ function listFiles(baseDir: string): string[] {
     }
   }
   return files;
+}
+
+function syncBackPathsToFiles(mountDir: string, relPaths: Iterable<string>): string[] {
+  const files: string[] = [];
+  const seen = new Set<string>();
+  for (const relPath of relPaths) {
+    const sourceFile = resolveSyncBackSource(mountDir, relPath);
+    if (!sourceFile || seen.has(sourceFile)) {
+      continue;
+    }
+    seen.add(sourceFile);
+    files.push(sourceFile);
+  }
+  return files;
+}
+
+function resolveSyncBackSource(mountDir: string, relPath: string): string | null {
+  const normalized = normalizeRelativePosix(relPath);
+  if (!normalized || path.isAbsolute(normalized)) {
+    return null;
+  }
+  const candidate = path.resolve(mountDir, ...normalized.split('/').filter(Boolean));
+  return isPathWithinRoot(candidate, mountDir) ? candidate : null;
 }
 
 function normalizeRelativePosix(filePath: string): string {


### PR DESCRIPTION
## Summary
- add auto-sync watcher health, pending flush, and mount-side dirty path APIs
- let syncBack accept explicit mount-relative paths while keeping the default full-walk fallback
- use the dirty path fast path from launchOnMount only when auto-sync watcher state stayed healthy

Closes #134.

## Verification
- npm run typecheck --workspace=packages/local-mount
- npm test --workspace=packages/local-mount
- npm run build --workspace=packages/local-mount