### PR TITLE
Stop poisoning slack connect requests with the demoted slack-sage alias

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -726,7 +726,7 @@ func providerPromptText(entries []integrationCatalogEntry) string {
 		ids = append(ids, id)
 	}
 	if len(ids) == 0 {
-		ids = []string{"github", "notion", "linear", "slack-sage", "none"}
+		ids = []string{"github", "notion", "linear", "slack", "none"}
 	}
 	if !containsString(ids, "none") {
 		ids = append(ids, "none")
@@ -738,7 +738,7 @@ func normalizeProviderID(value string) string {
 	value = strings.ToLower(strings.TrimSpace(value))
 	switch value {
 	case "slack", "slack-sage":
-		return "slack-sage"
+		return "slack"
 	default:
 		return value
 	}
@@ -899,7 +899,7 @@ func fallbackIntegrationCatalog() []integrationCatalogEntry {
 		{ID: "github", DisplayName: "GitHub", VFSRoot: "/github"},
 		{ID: "notion", DisplayName: "Notion", VFSRoot: "/notion"},
 		{ID: "linear", DisplayName: "Linear", VFSRoot: "/linear"},
-		{ID: "slack-sage", DisplayName: "Slack", VFSRoot: "/slack"},
+		{ID: "slack", DisplayName: "Slack", VFSRoot: "/slack"},
 		{ID: "slack-my-senior-dev", DisplayName: "Slack (MSD)", VFSRoot: "/slack-msd"},
 		{ID: "slack-nightcto", DisplayName: "Slack (NightCTO)", VFSRoot: "/slack-nightcto"},
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1815,6 +1815,55 @@ func TestWorkspaceCurrentErrorsWhenNoneActive(t *testing.T) {
 	}
 }
 
+// TestNormalizeProviderIDCanonicalizesSlackAlias asserts that both the
+// canonical provider id ("slack") and the demoted alias ("slack-sage")
+// normalize to the canonical id. Before this fix the function returned
+// "slack-sage" for both inputs, poisoning every connect-session request
+// with the demoted alias even after the cloud registry migrated to
+// "slack" with "slack-sage" retained only as a backwards-compat alias.
+func TestNormalizeProviderIDCanonicalizesSlackAlias(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"slack", "slack"},
+		{"slack-sage", "slack"},
+		{"Slack", "slack"},
+		{"  slack-sage  ", "slack"},
+		{"github", "github"},
+		{"linear", "linear"},
+		{"notion", "notion"},
+		{"slack-my-senior-dev", "slack-my-senior-dev"},
+	}
+	for _, tc := range cases {
+		if got := normalizeProviderID(tc.input); got != tc.want {
+			t.Fatalf("normalizeProviderID(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestFallbackIntegrationCatalogUsesCanonicalSlackId guards the offline
+// fallback catalog so it advertises "slack" rather than "slack-sage"
+// when the cloud catalog endpoint is unreachable.
+func TestFallbackIntegrationCatalogUsesCanonicalSlackId(t *testing.T) {
+	entries := fallbackIntegrationCatalog()
+	var slack *integrationCatalogEntry
+	for i := range entries {
+		if entries[i].ID == "slack-sage" {
+			t.Fatalf("fallback catalog still advertises legacy id slack-sage: %#v", entries[i])
+		}
+		if entries[i].ID == "slack" {
+			slack = &entries[i]
+		}
+	}
+	if slack == nil {
+		t.Fatalf("fallback catalog missing canonical slack entry: %#v", entries)
+	}
+	if slack.VFSRoot != "/slack" {
+		t.Fatalf("expected slack VFSRoot /slack, got %q", slack.VFSRoot)
+	}
+}
+
 // TestWorkspaceListNamesOnlyRestoresBareOutput verifies the --names-only
 // escape hatch for scripts that parsed the legacy unmarked output.
 func TestWorkspaceListNamesOnlyRestoresBareOutput(t *testing.T) {


### PR DESCRIPTION
## Summary
`normalizeProviderID` rewrites both `slack` and `slack-sage` inputs to `slack-sage` before any CLI request reaches the cloud, so every `relayfile integration connect slack` mints a Nango Connect session under the demoted alias regardless of cloud-side fixes — observed live today even after AgentWorkforce/cloud#525 was merged and deployed:

```
$ relayfile integration connect slack --workspace rw_<id>
Connect slack-sage: https://connect.nango.dev/?session_token=...
```

The cloud registry has migrated to `slack` canonical with `slack-sage` retained as a backwards-compat alias resolved via `resolveWorkspaceIntegrationProvider`. Returning the canonical id from the CLI lets the cloud either short-circuit (`slack` == canonical) or alias-back (`slack-sage` → `slack`); both paths land on the same `providerConfigKey` cloud-side.

## Changes
- `normalizeProviderID` returns `slack` for both `slack` and `slack-sage` inputs (was `slack-sage` for both).
- Offline fallback catalog (`fallbackIntegrationCatalog`) advertises canonical `slack`.
- Prompt-default list in `providerPromptText` uses `slack` instead of `slack-sage`.
- `providerRootDir` already accepted both ids and returned `/slack` — left untouched as a defensive backstop for existing local `state.json` files still tagged `slack-sage`.

## Test plan
- [x] `go test ./cmd/relayfile-cli/` — full suite green (4.6s, no regressions).
- [x] `go build ./cmd/relayfile-cli/` clean.
- [x] New `TestNormalizeProviderIDCanonicalizesSlackAlias` — table-driven, covers canonical id, demoted alias, mixed case, whitespace, unrelated providers, and the `slack-my-senior-dev` sibling that must not be affected.
- [x] New `TestFallbackIntegrationCatalogUsesCanonicalSlackId` — fails if `slack-sage` ever creeps back into the fallback catalog.
- [ ] Manual on `rw_517d60b6`: after this lands, `relayfile integration disconnect slack` → `relayfile integration connect slack` should print `Connect slack: ...` and `state.json` should record `provider: slack`.

## Related
- AgentWorkforce/cloud#525 — narrowed the cloud-side env-var override; necessary but not sufficient because the CLI was the second leak.
- AgentWorkforce/cloud#528 — independently adds jira/confluence forward-webhook handlers (separate gap surfaced during the same verification pass).
- AgentWorkforce/relayfile#137 — login workspace-token refresh (separate fix on the same CLI, kept on its own branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)