### PR TITLE
Fast-path hasSameContent on matching size + mtime in syncBack

### DIFF
--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs';
@@ -430,19 +431,27 @@ describe('startAutoSync', () => {
     // Replace both copies with same-size bytes that don't match, then force
     // both sides to the same backdated mtime. Without a strict byte compare
     // the priming / first-reconcile would consider these equal.
-    writeFileSync(path.join(projectDir, 'file.txt'), 'BBB', 'utf8');
-    writeFileSync(path.join(handle.mountDir, 'file.txt'), 'XXX', 'utf8');
+    const projectFile = path.join(projectDir, 'file.txt');
+    const mountFile = path.join(handle.mountDir, 'file.txt');
+    writeFileSync(projectFile, 'BBB', 'utf8');
+    writeFileSync(mountFile, 'XXX', 'utf8');
     const backdated = new Date('2020-01-01T00:00:00Z');
-    utimesSync(path.join(projectDir, 'file.txt'), backdated, backdated);
-    utimesSync(path.join(handle.mountDir, 'file.txt'), backdated, backdated);
+    utimesSync(projectFile, backdated, backdated);
+    utimesSync(mountFile, backdated, backdated);
+    // Sanity-check the precondition: the test only exercises the strict-
+    // compare path if size + mtime really do match on both sides. Some
+    // filesystems round mtime coarsely; if these asserts ever fail the
+    // test is silently passing for the wrong reason.
+    expect(statSync(projectFile).size).toBe(statSync(mountFile).size);
+    expect(statSync(projectFile).mtimeMs).toBe(statSync(mountFile).mtimeMs);
 
     const auto = handle.startAutoSync({ debounceMs: 10, scanIntervalMs: 10_000 });
     await auto.ready();
     try {
       await auto.reconcile();
       // Mount-wins on tiebreak: both sides converge to the mount bytes.
-      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('XXX');
-      expect(readFileSync(path.join(handle.mountDir, 'file.txt'), 'utf8')).toBe('XXX');
+      expect(readFileSync(projectFile, 'utf8')).toBe('XXX');
+      expect(readFileSync(mountFile, 'utf8')).toBe('XXX');
     } finally {
       await auto.stop();
       handle.cleanup();

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -6,6 +6,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
@@ -405,6 +406,43 @@ describe('startAutoSync', () => {
         'ref: refs/heads/main\n'
       );
       expect(existsSync(path.join(projectDir, '.git/COMMIT_EDITMSG'))).toBe(false);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('first-time reconcile detects divergence even when size and mtime match on both sides', async () => {
+    // Regression for the cautious-compare path in primeState / first-time
+    // syncOneFile: those call sites must keep doing a byte comparison rather
+    // than trusting size+mtime, since two independently-created files can
+    // coincide on stats while differing on bytes. If they were to fall back
+    // to a cheap mtime+size check, this test would treat the two files as
+    // equal and leave the project side stale.
+    write(path.join(projectDir, 'file.txt'), 'AAA');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    // Replace both copies with same-size bytes that don't match, then force
+    // both sides to the same backdated mtime. Without a strict byte compare
+    // the priming / first-reconcile would consider these equal.
+    writeFileSync(path.join(projectDir, 'file.txt'), 'BBB', 'utf8');
+    writeFileSync(path.join(handle.mountDir, 'file.txt'), 'XXX', 'utf8');
+    const backdated = new Date('2020-01-01T00:00:00Z');
+    utimesSync(path.join(projectDir, 'file.txt'), backdated, backdated);
+    utimesSync(path.join(handle.mountDir, 'file.txt'), backdated, backdated);
+
+    const auto = handle.startAutoSync({ debounceMs: 10, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      // Mount-wins on tiebreak: both sides converge to the mount bytes.
+      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('XXX');
+      expect(readFileSync(path.join(handle.mountDir, 'file.txt'), 'utf8')).toBe('XXX');
     } finally {
       await auto.stop();
       handle.cleanup();

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -547,10 +547,15 @@ function hasSameContent(left: string, right: string): boolean {
     if (leftStat.size !== rightStat.size) {
       return false;
     }
-    // Same size: fall back to a full byte comparison. Buffer.equals short-
-    // circuits internally but we still read both files; for very large files
-    // callers may want a streaming approach, though in practice mounts are
-    // dominated by source code where this is cheap.
+    // Rsync-style fast path: matching size + mtime means the file hasn't been
+    // touched since we last wrote it through, so the would-be write is a no-op.
+    // Without this, a sync-back walks every reachable file's full bytes even
+    // when nothing has changed.
+    if (leftStat.mtimeMs === rightStat.mtimeMs) {
+      return true;
+    }
+    // Same size, different mtime: fall back to a byte comparison so a real
+    // edit that happens to land on the same length still gets detected.
     const leftContent = readFileSync(left);
     const rightContent = readFileSync(right);
     return leftContent.equals(rightContent);


### PR DESCRIPTION
Fixes #133.

## Summary

`syncMountedFileBack` in `packages/local-mount/src/mount.ts` walks every reachable file in the mount on every sync-back and calls `hasSameContent`, which fully reads both files into memory and `Buffer.equals`'s them — even when nothing has changed since the previous write. On a source-heavy repo this dominates per-file sync-back cost.

This PR adds an rsync-style fast path: when size **and** `mtimeMs` match, treat the would-be write as a no-op without reading the bytes. Same-size-but-different-mtime still falls back to the byte compare, so an edit that happens to land on the same length is still detected.

## Scope note (why only one of the helpers)

Issue #133 proposes applying the same fast path to three guards: `syncMountedFileBack` and the inner no-op guards in `doMountToProject` / `doProjectToMount` (in `auto-sync.ts`).

I left `auto-sync.ts` alone. The headline cost called out in the issue is the syncBack walk, which this PR addresses. The auto-sync guards are riskier than the table suggests: `doMountToProject`/`doProjectToMount` are also called from the no-prev-state tiebreak in `syncOneFile` after `sameContent` has already returned `false`. If the two sides happen to share `size` + `mtimeMs` at that point, an inner cheap-equal guard would (wrongly) skip the copy and leave the project side stale. The new regression test demonstrates exactly that scenario.

If we want the same fast path inside auto-sync, a safer follow-up would be to gate the cheap path on `state.has(relPosix)` so it only fires when prev-state really does exist — happy to do that in a separate PR if reviewers prefer.

## Test plan

- [x] `npx vitest run` in `packages/local-mount` (40 pass, 1 pre-existing failure unrelated to this change: chmod 0o444 doesn't deny writes when the test runs as root)
- [x] `npm run typecheck` in `packages/local-mount`
- [x] New regression test: backdate both sides to the same `mtimeMs` with same-size-but-different bytes; verify the first-time reconcile still picks a winner (mount-wins tiebreak) rather than treating the files as equal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qpk9XXyrsbArEdGGSZAWQG)_