### PR TITLE
feat(integration): adopt verb to bind an existing Nango connection

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -398,6 +398,7 @@ Usage:
   relayfile integration search QUERY [--backend BACKEND] [--json] [--refresh]
   relayfile integration list [--workspace NAME] [--json]
   relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
+  relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]
   relayfile ops list [--workspace NAME] [--json]
   relayfile ops replay OPID [--workspace NAME]
   relayfile writeback status [WORKSPACE] [--json]
@@ -419,7 +420,7 @@ Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
   login       Sign in via the Relayfile Cloud browser flow (or --api-key for self-hosted)
   workspace   Create, select, list, show current, or delete locally tracked workspaces
-  integration Connect, discover, list, or disconnect workspace integrations
+  integration Connect, discover, list, disconnect, or adopt workspace integrations
   ops         List or replay dead-lettered writeback ops
   writeback   Inspect or retry local writeback failures
   writeback status
@@ -1367,7 +1368,7 @@ func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 
 func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("integration subcommand is required: connect, available, search, list, or disconnect")
+		return errors.New("integration subcommand is required: connect, available, search, list, disconnect, or adopt")
 	}
 	switch args[0] {
 	case "connect":
@@ -1380,6 +1381,8 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 		return runIntegrationList(args[1:], stdout)
 	case "disconnect":
 		return runIntegrationDisconnect(args[1:], stdin, stdout)
+	case "adopt":
+		return runIntegrationAdopt(args[1:], stdin, stdout)
 	default:
 		return fmt.Errorf("unknown integration subcommand %q", args[0])
 	}
@@ -1689,6 +1692,128 @@ func runIntegrationDisconnect(args []string, stdin io.Reader, stdout io.Writer) 
 		return err
 	}
 	fmt.Fprintf(stdout, "%s disconnected from workspace %s\n", provider, record.Name)
+	return nil
+}
+
+// runIntegrationAdopt asks Cloud to bind an existing Nango connection to the
+// current workspace + provider slot without re-running OAuth. Mirrors
+// runIntegrationDisconnect's flag parsing and confirmation prompt because the
+// failure mode of a bad adopt (overwriting a live binding for a different
+// tenant) is comparable to that of a bad disconnect.
+//
+// The local on-disk state is updated via saveIntegrationConnection so the
+// mount + status probes pick up the new connectionId without requiring the
+// operator to also run `relayfile integration connect` afterwards. We do this
+// only after Cloud reports success, so a 409/404 from Cloud leaves the local
+// state untouched.
+func runIntegrationAdopt(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration adopt", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	connectionID := fs.String("connection-id", "", "Nango connection id to adopt (required)")
+	providerConfigKey := fs.String("provider-config-key", "", "optional Nango providerConfigKey override")
+	yes := fs.Bool("yes", false, "skip confirmation")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":           true,
+		"cloud-api-url":       true,
+		"connection-id":       true,
+		"provider-config-key": true,
+		"yes":                 false,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]")
+	}
+	provider := normalizeProviderID(fs.Arg(0))
+	trimmedConnectionID := strings.TrimSpace(*connectionID)
+	if trimmedConnectionID == "" {
+		return errors.New("--connection-id is required")
+	}
+	trimmedProviderConfigKey := strings.TrimSpace(*providerConfigKey)
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	if !*yes {
+		answer, err := promptLine(stdin, stdout, fmt.Sprintf("Adopt %s connection %q into workspace %q? [y/N]: ", provider, trimmedConnectionID, record.Name))
+		if err != nil {
+			return err
+		}
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintln(stdout, "Aborted")
+			return nil
+		}
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, io.Discard)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	if err != nil {
+		return err
+	}
+	requestBody := map[string]string{"connectionId": trimmedConnectionID}
+	if trimmedProviderConfigKey != "" {
+		requestBody["providerConfigKey"] = trimmedProviderConfigKey
+	}
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+	respBody, _, err := client.do(
+		context.Background(),
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/adopt", url.PathEscape(record.ID), url.PathEscape(provider)),
+		bodyBytes,
+	)
+	if err != nil {
+		return err
+	}
+	var parsed struct {
+		Ok                   bool   `json:"ok"`
+		ConnectionID         string `json:"connectionId"`
+		ReplacedConnectionID string `json:"replacedConnectionId"`
+	}
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &parsed); err != nil {
+			return fmt.Errorf("parse adopt response: %w", err)
+		}
+	}
+	boundConnectionID := strings.TrimSpace(parsed.ConnectionID)
+	if boundConnectionID == "" {
+		boundConnectionID = trimmedConnectionID
+	}
+	// Persist the new binding locally only after Cloud confirms success.
+	// On a 4xx the saved connection on disk still reflects the previous
+	// state, which is what the operator wants — a failed adopt is a no-op
+	// for the workspace's local view.
+	if err := saveIntegrationConnection(record.LocalDir, integrationConnectionState{
+		Provider:     provider,
+		ConnectionID: boundConnectionID,
+		Backend:      "nango",
+		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		return err
+	}
+	// Remove any disconnect marker left from a prior `disconnect` so the
+	// status probe doesn't keep reporting the workspace as disconnected.
+	if record.LocalDir != "" {
+		_ = os.Remove(filepath.Join(record.LocalDir, ".relay", "disconnected", provider+".json"))
+	}
+	replaced := strings.TrimSpace(parsed.ReplacedConnectionID)
+	if replaced != "" {
+		fmt.Fprintf(stdout, "%s adopted into workspace %s (connectionId=%s, replaced previous connection %s)\n", provider, record.Name, boundConnectionID, replaced)
+	} else {
+		fmt.Fprintf(stdout, "%s adopted into workspace %s (connectionId=%s)\n", provider, record.Name, boundConnectionID)
+	}
 	return nil
 }
 
@@ -3696,9 +3821,17 @@ func (c *apiClient) do(ctx context.Context, method, path string, body []byte) ([
 	var errPayload struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
+		// Cloud's Next.js routes typically return `{ error, code }` rather
+		// than `{ message, code }`. Accept either so commands that hit
+		// either shape (e.g. adopt vs. join) produce consistent messages
+		// instead of falling through to the raw JSON blob.
+		Error string `json:"error"`
 	}
 	if len(payload) > 0 {
 		_ = json.Unmarshal(payload, &errPayload)
+	}
+	if errPayload.Message == "" {
+		errPayload.Message = errPayload.Error
 	}
 	if errPayload.Message == "" {
 		errPayload.Message = strings.TrimSpace(string(payload))

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -745,6 +745,25 @@ func normalizeProviderID(value string) string {
 	}
 }
 
+func validateLocalProviderID(provider string) error {
+	if provider == "" {
+		return errors.New("provider is required")
+	}
+	for _, ch := range provider {
+		if ch >= 'a' && ch <= 'z' {
+			continue
+		}
+		if ch >= '0' && ch <= '9' {
+			continue
+		}
+		if ch == '-' || ch == '_' {
+			continue
+		}
+		return fmt.Errorf("invalid provider %q (use lowercase letters, numbers, dashes, or underscores)", provider)
+	}
+	return nil
+}
+
 func normalizeIntegrationBackend(value string) (string, error) {
 	value = strings.ToLower(strings.TrimSpace(value))
 	switch value {
@@ -1727,6 +1746,9 @@ func runIntegrationAdopt(args []string, stdin io.Reader, stdout io.Writer) error
 		return errors.New("usage: relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]")
 	}
 	provider := normalizeProviderID(fs.Arg(0))
+	if err := validateLocalProviderID(provider); err != nil {
+		return err
+	}
 	trimmedConnectionID := strings.TrimSpace(*connectionID)
 	if trimmedConnectionID == "" {
 		return errors.New("--connection-id is required")
@@ -1806,7 +1828,10 @@ func runIntegrationAdopt(args []string, stdin io.Reader, stdout io.Writer) error
 	// Remove any disconnect marker left from a prior `disconnect` so the
 	// status probe doesn't keep reporting the workspace as disconnected.
 	if record.LocalDir != "" {
-		_ = os.Remove(filepath.Join(record.LocalDir, ".relay", "disconnected", provider+".json"))
+		markerPath := filepath.Join(record.LocalDir, ".relay", "disconnected", provider+".json")
+		if err := os.Remove(markerPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove disconnect marker: %w", err)
+		}
 	}
 	replaced := strings.TrimSpace(parsed.ReplacedConnectionID)
 	if replaced != "" {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2143,9 +2143,56 @@ func newAdoptTestServer(t *testing.T, adoptHandler func(http.ResponseWriter, *ht
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/api/v1/auth/token/refresh":
+			if r.Method != http.MethodPost {
+				t.Errorf("expected refresh POST, got %s", r.Method)
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_old" {
+				t.Errorf("unexpected refresh Authorization: %q", got)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			var body cloudTokenRefreshRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode refresh body failed: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if body.RefreshToken != "refresh_123" {
+				t.Errorf("unexpected refresh token: %q", body.RefreshToken)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
 			seen["refresh"]++
 			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			if r.Method != http.MethodPost {
+				t.Errorf("expected join POST, got %s", r.Method)
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Errorf("unexpected join Authorization: %q", got)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			var body cloudWorkspaceJoinRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode join body failed: %v", err)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if body.AgentName != "relayfile-cli" {
+				t.Errorf("unexpected join agentName: %q", body.AgentName)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			if len(body.Scopes) != len(defaultJoinScopes) || body.Scopes[0] != defaultJoinScopes[0] || body.Scopes[1] != defaultJoinScopes[1] {
+				t.Errorf("unexpected join scopes: %#v", body.Scopes)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
 			seen["join"]++
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/adopt" && r.Method == http.MethodPost:
@@ -2186,6 +2233,18 @@ func setupAdoptWorkspace(t *testing.T) (workspaceRecord, string) {
 	return record, localDir
 }
 
+func pointAdoptCloudCredentials(t *testing.T, apiURL string) {
+	t.Helper()
+	creds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	creds.APIURL = apiURL
+	if err := saveCloudCredentials(creds); err != nil {
+		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
+	}
+}
+
 func TestIntegrationAdoptForwardsConnectionIdAndPersistsLocalState(t *testing.T) {
 	// Happy path: operator runs `relayfile integration adopt github
 	// --connection-id conn_adopt` against a workspace whose row Cloud has
@@ -2212,17 +2271,10 @@ func TestIntegrationAdoptForwardsConnectionIdAndPersistsLocalState(t *testing.T)
 		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_adopt_new"}`))
 	})
 	defer server.Close()
-	creds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	creds.APIURL = server.URL
-	if err := saveCloudCredentials(creds); err != nil {
-		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
-	}
+	pointAdoptCloudCredentials(t, server.URL)
 
 	var stdout bytes.Buffer
-	err = run([]string{
+	err := run([]string{
 		"integration", "adopt", "github",
 		"--connection-id", "conn_adopt_new",
 		"--provider-config-key", "github-relay",
@@ -2261,9 +2313,7 @@ func TestIntegrationAdoptReportsReplacedConnection(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_new","replacedConnectionId":"conn_old_dead"}`))
 	})
 	defer server.Close()
-	creds, _ := loadCloudCredentials()
-	creds.APIURL = server.URL
-	_ = saveCloudCredentials(creds)
+	pointAdoptCloudCredentials(t, server.URL)
 
 	var stdout bytes.Buffer
 	if err := run([]string{
@@ -2305,9 +2355,7 @@ func TestIntegrationAdoptReturnsErrorOnConflictAndPreservesLocalState(t *testing
 		_, _ = w.Write([]byte(`{"ok":false,"code":"existing_connection_live_or_unknown","error":"Workspace ws_123 already has a live github connection (conn_live). Disconnect it first."}`))
 	})
 	defer server.Close()
-	creds, _ := loadCloudCredentials()
-	creds.APIURL = server.URL
-	_ = saveCloudCredentials(creds)
+	pointAdoptCloudCredentials(t, server.URL)
 
 	var stdout bytes.Buffer
 	err := run([]string{
@@ -2352,6 +2400,22 @@ func TestIntegrationAdoptRequiresConnectionID(t *testing.T) {
 	}
 }
 
+func TestIntegrationAdoptRejectsUnsafeProvider(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "adopt", "../github",
+		"--connection-id", "conn_adopt",
+		"--workspace", "demo",
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error for unsafe provider; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "invalid provider") {
+		t.Fatalf("expected invalid provider error, got: %v", err)
+	}
+}
+
 func TestIntegrationAdoptClearsDisconnectMarker(t *testing.T) {
 	// After a `disconnect` the CLI writes a marker file under
 	// .relay/disconnected/{provider}.json. Adopting the provider again
@@ -2370,9 +2434,7 @@ func TestIntegrationAdoptClearsDisconnectMarker(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_adopt"}`))
 	})
 	defer server.Close()
-	creds, _ := loadCloudCredentials()
-	creds.APIURL = server.URL
-	_ = saveCloudCredentials(creds)
+	pointAdoptCloudCredentials(t, server.URL)
 
 	var stdout bytes.Buffer
 	if err := run([]string{

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2127,3 +2127,264 @@ func TestWorkspaceListNamesOnlyRestoresBareOutput(t *testing.T) {
 		t.Fatalf("unexpected --names-only output: %q", got)
 	}
 }
+
+// adoptTestServer wires the cloud endpoints the adopt verb exercises:
+// token refresh (so credential bootstrap succeeds), workspace join (mints
+// the relayfile JWT for the workspace), and the new POST .../adopt route.
+// Each test injects its own adopt handler so it can simulate the four
+// distinct outcomes — success (fresh insert), success (replacement),
+// 409 refusal, 404 missing-connection — without rebuilding the rest of
+// the bootstrap chain.
+func newAdoptTestServer(t *testing.T, adoptHandler func(http.ResponseWriter, *http.Request)) (*httptest.Server, map[string]int) {
+	t.Helper()
+	seen := map[string]int{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/token/refresh":
+			seen["refresh"]++
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			seen["join"]++
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/adopt" && r.Method == http.MethodPost:
+			seen["adopt"]++
+			adoptHandler(w, r)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	return server, seen
+}
+
+func setupAdoptWorkspace(t *testing.T) (workspaceRecord, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	localDir := t.TempDir()
+	record, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_123",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:               "https://stale.example.test",
+		AccessToken:          "cld_old",
+		RefreshToken:         "refresh_123",
+		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	return record, localDir
+}
+
+func TestIntegrationAdoptForwardsConnectionIdAndPersistsLocalState(t *testing.T) {
+	// Happy path: operator runs `relayfile integration adopt github
+	// --connection-id conn_adopt` against a workspace whose row Cloud has
+	// not yet seen. Cloud returns ok with no replacedConnectionId; the CLI
+	// must (1) POST the request body in the expected shape, (2) persist
+	// the new local connection state so subsequent mount / status probes
+	// pick it up, and (3) print a single-line confirmation that does NOT
+	// mention a replaced connection.
+	record, localDir := setupAdoptWorkspace(t)
+	server, seen := newAdoptTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode adopt body failed: %v", err)
+		}
+		if body["connectionId"] != "conn_adopt_new" {
+			t.Fatalf("unexpected connectionId: %q", body["connectionId"])
+		}
+		if body["providerConfigKey"] != "github-relay" {
+			t.Fatalf("unexpected providerConfigKey: %q", body["providerConfigKey"])
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			t.Fatalf("unexpected Authorization: %q", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_adopt_new"}`))
+	})
+	defer server.Close()
+	creds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	creds.APIURL = server.URL
+	if err := saveCloudCredentials(creds); err != nil {
+		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{
+		"integration", "adopt", "github",
+		"--connection-id", "conn_adopt_new",
+		"--provider-config-key", "github-relay",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("run integration adopt failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if seen["adopt"] != 1 {
+		t.Fatalf("expected 1 adopt call, got %d", seen["adopt"])
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "github adopted into workspace demo") {
+		t.Fatalf("unexpected output (missing confirmation): %q", got)
+	}
+	if strings.Contains(got, "replaced previous connection") {
+		t.Fatalf("did not expect replacement note on fresh insert: %q", got)
+	}
+	state := loadSavedConnection(localDir, "github")
+	if state.ConnectionID != "conn_adopt_new" || state.Backend != "nango" {
+		t.Fatalf("unexpected saved integration connection: %#v", state)
+	}
+	_ = record
+}
+
+func TestIntegrationAdoptReportsReplacedConnection(t *testing.T) {
+	// Stale-row migration path: Cloud detected the existing row pointed at
+	// a connection Nango reports as gone, swapped it atomically, and
+	// returned replacedConnectionId. The CLI must surface that id to the
+	// operator so they know an old binding was overwritten — silent
+	// replacement here would hide a meaningful state change.
+	_, localDir := setupAdoptWorkspace(t)
+	server, _ := newAdoptTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_new","replacedConnectionId":"conn_old_dead"}`))
+	})
+	defer server.Close()
+	creds, _ := loadCloudCredentials()
+	creds.APIURL = server.URL
+	_ = saveCloudCredentials(creds)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "adopt", "github",
+		"--connection-id", "conn_new",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run integration adopt failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "replaced previous connection conn_old_dead") {
+		t.Fatalf("expected replacement note in output, got: %q", got)
+	}
+	state := loadSavedConnection(localDir, "github")
+	if state.ConnectionID != "conn_new" {
+		t.Fatalf("expected local state to bind conn_new, got %#v", state)
+	}
+}
+
+func TestIntegrationAdoptReturnsErrorOnConflictAndPreservesLocalState(t *testing.T) {
+	// Refusal path: Cloud reports a 409 (e.g. another connection is still
+	// live for this workspace + provider). The CLI must return a non-nil
+	// error so the shell exit code is non-zero, AND must NOT overwrite the
+	// local saved connection — the operator should see no local drift from
+	// a failed adopt.
+	_, localDir := setupAdoptWorkspace(t)
+	// Prime existing local state so we can prove it survives.
+	if err := saveIntegrationConnection(localDir, integrationConnectionState{
+		Provider:     "github",
+		ConnectionID: "conn_existing_local",
+		Backend:      "nango",
+	}); err != nil {
+		t.Fatalf("seed saveIntegrationConnection failed: %v", err)
+	}
+	server, _ := newAdoptTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"ok":false,"code":"existing_connection_live_or_unknown","error":"Workspace ws_123 already has a live github connection (conn_live). Disconnect it first."}`))
+	})
+	defer server.Close()
+	creds, _ := loadCloudCredentials()
+	creds.APIURL = server.URL
+	_ = saveCloudCredentials(creds)
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "adopt", "github",
+		"--connection-id", "conn_intruder",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error on 409, got nil; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "Disconnect it first") {
+		t.Fatalf("expected error to surface Cloud message, got: %v", err)
+	}
+	var httpErr *apiError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusConflict {
+		t.Fatalf("expected apiError with 409 status, got %#v", err)
+	}
+	state := loadSavedConnection(localDir, "github")
+	if state.ConnectionID != "conn_existing_local" {
+		t.Fatalf("expected local state to be preserved, got %#v", state)
+	}
+}
+
+func TestIntegrationAdoptRequiresConnectionID(t *testing.T) {
+	// Flag validation: omitting --connection-id must fail before the CLI
+	// even hits the network. Otherwise the operator could silently POST
+	// an empty body and get a confusing 400 from Cloud.
+	_, _ = setupAdoptWorkspace(t)
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "adopt", "github",
+		"--workspace", "demo",
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error when --connection-id is missing; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "connection-id") {
+		t.Fatalf("expected error to mention --connection-id, got: %v", err)
+	}
+}
+
+func TestIntegrationAdoptClearsDisconnectMarker(t *testing.T) {
+	// After a `disconnect` the CLI writes a marker file under
+	// .relay/disconnected/{provider}.json. Adopting the provider again
+	// must clear that marker so the status probe stops reporting the
+	// workspace as disconnected — otherwise the operator gets a stale
+	// "disconnected" reading for a workspace they just adopted into.
+	_, localDir := setupAdoptWorkspace(t)
+	if err := markProviderDisconnected(localDir, "github"); err != nil {
+		t.Fatalf("markProviderDisconnected failed: %v", err)
+	}
+	markerPath := filepath.Join(localDir, ".relay", "disconnected", "github.json")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("expected disconnect marker to exist, got: %v", err)
+	}
+	server, _ := newAdoptTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_adopt"}`))
+	})
+	defer server.Close()
+	creds, _ := loadCloudCredentials()
+	creds.APIURL = server.URL
+	_ = saveCloudCredentials(creds)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "adopt", "github",
+		"--connection-id", "conn_adopt",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run integration adopt failed: %v", err)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("expected disconnect marker to be removed, got: %v", err)
+	}
+}

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -328,6 +328,99 @@ describe("RelayfileSetup", () => {
     expect(readRequestUrl(fetchMock, 3)).toBe("https://staging.agentrelay.com/base/cloud/api/v1/workspaces/ws_123/integrations/github/status")
   })
 
+  it("adopts an existing Nango connection via POST /integrations/{provider}/adopt", async () => {
+    // Operator path: a Nango connection has already been minted out-of-band
+    // (UI or third-party flow). The SDK's adopt method posts the
+    // connectionId to Cloud's adopt route, threads the auth token, and
+    // surfaces the replacedConnectionId so callers can tell whether they
+    // migrated a stale row. The CLI surface (`relayfile integration adopt`)
+    // sits on top of this method, so any regression in the request shape
+    // or the response parsing would break the operator workflow.
+    const fetchMock = queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        connectionId: "conn_adopt_new",
+        replacedConnectionId: "conn_adopt_old"
+      })
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/base/cloud"
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    const result = await handle.adoptIntegration("github", "conn_adopt_new", {
+      providerConfigKey: "github-relay"
+    })
+
+    expect(result).toEqual({
+      connectionId: "conn_adopt_new",
+      replacedConnectionId: "conn_adopt_old"
+    })
+    expect(readRequestUrl(fetchMock, 1)).toBe(
+      "https://staging.agentrelay.com/base/cloud/api/v1/workspaces/ws_123/integrations/github/adopt"
+    )
+    expect(readRequestBody(fetchMock, 1)).toEqual({
+      connectionId: "conn_adopt_new",
+      providerConfigKey: "github-relay"
+    })
+    expect(readRequestHeaders(fetchMock, 1).Authorization).toBe("Bearer rf_jwt_1")
+  })
+
+  it("omits replacedConnectionId from adoptIntegration result when the row was a fresh insert", async () => {
+    // Cloud only returns replacedConnectionId on the stale-row migration
+    // path; for a fresh insert the field is absent. The SDK must not
+    // fabricate it (e.g. by echoing the request connectionId), because
+    // callers use the presence/absence of replacedConnectionId to decide
+    // whether to warn the operator that an old binding was overwritten.
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse({ ok: true, connectionId: "conn_fresh" })
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/base/cloud"
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    const result = await handle.adoptIntegration("notion", "conn_fresh")
+
+    expect(result).toEqual({ connectionId: "conn_fresh" })
+    expect("replacedConnectionId" in result).toBe(false)
+  })
+
+  it("propagates Cloud 409 conflicts from adoptIntegration as CloudApiError", async () => {
+    // Conflict semantics must surface to the CLI so it can render the
+    // operator-facing message and exit non-zero. The body's `code` field
+    // tells the CLI which mitigation to suggest (disconnect first vs.
+    // re-target a different workspace).
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse(
+        {
+          ok: false,
+          code: "existing_connection_live_or_unknown",
+          error: "Workspace ws_123 already has a live github connection",
+          existingConnectionId: "conn_live"
+        },
+        { status: 409 }
+      )
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/base/cloud",
+      retry: { maxRetries: 0, baseDelayMs: 1 }
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    await expect(
+      handle.adoptIntegration("github", "conn_intruder")
+    ).rejects.toMatchObject({
+      httpStatus: 409,
+      httpBody: expect.objectContaining({
+        code: "existing_connection_live_or_unknown"
+      })
+    } satisfies Partial<CloudApiError>)
+  })
+
   it("throws CloudApiError with parsed body on createWorkspace failure", async () => {
     queueFetch(
       jsonResponse(

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -674,6 +674,68 @@ export class WorkspaceHandle {
     this._pendingConnections.delete(provider)
   }
 
+  /**
+   * Bind an existing Nango connection to this workspace + provider slot
+   * without going through the OAuth re-mint flow. Use this when an operator
+   * has already minted the connection out-of-band (Nango UI, third-party
+   * setup) and just wants Cloud to start routing sync webhooks for it.
+   *
+   * The Cloud-side adopt route validates that the Nango connection exists
+   * upstream and that its end-user/workspace tag matches this workspace.
+   * On success returns the bound `connectionId` and, when a stale prior
+   * row was atomically replaced, a `replacedConnectionId` so callers can
+   * surface that a migration happened.
+   *
+   * Failure modes (HTTP body carries `code`):
+   *   - `connection_not_found` (404): Nango doesn't know this connectionId
+   *   - `workspace_mismatch` (409): connection belongs to a different
+   *     workspace; the body includes `pathWorkspaceId` and
+   *     `connectionWorkspaceId`
+   *   - `existing_connection_live_or_unknown` (409): a different
+   *     connection is already bound here and is either still live
+   *     upstream or has indeterminate state; operator must disconnect
+   *     first
+   */
+  async adoptIntegration(
+    provider: WorkspaceIntegrationProvider,
+    connectionId: string,
+    options: { providerConfigKey?: string } = {}
+  ): Promise<{ connectionId: string; replacedConnectionId?: string }> {
+    assertProvider(provider)
+    const trimmedConnectionId = connectionId?.trim()
+    if (!trimmedConnectionId) {
+      throw new Error("connectionId is required to adopt an integration")
+    }
+    const body: Record<string, unknown> = { connectionId: trimmedConnectionId }
+    const providerConfigKey = options.providerConfigKey?.trim()
+    if (providerConfigKey) {
+      body.providerConfigKey = providerConfigKey
+    }
+    const response = (await this._setup.requestJson({
+      operation: "adoptIntegration",
+      method: "POST",
+      path: `api/v1/workspaces/${encodeURIComponent(this.workspaceId)}/integrations/${encodeURIComponent(provider)}/adopt`,
+      body,
+      tokenProvider: async () => this.getOrRefreshToken()
+    })) as {
+      connectionId?: unknown
+      replacedConnectionId?: unknown
+    }
+    const boundConnectionId =
+      typeof response.connectionId === "string" && response.connectionId.trim()
+        ? response.connectionId.trim()
+        : trimmedConnectionId
+    const replacedConnectionId =
+      typeof response.replacedConnectionId === "string" &&
+      response.replacedConnectionId.trim()
+        ? response.replacedConnectionId.trim()
+        : undefined
+    this._pendingConnections.delete(provider)
+    return replacedConnectionId
+      ? { connectionId: boundConnectionId, replacedConnectionId }
+      : { connectionId: boundConnectionId }
+  }
+
   getToken(): string {
     return this._token
   }


### PR DESCRIPTION
## Summary
- Adds `relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]`. Mirrors the disconnect command's flag parsing and confirmation prompt. Posts to Cloud's new `POST .../integrations/{provider}/adopt` route and on success persists the new connection in the local mirror and clears any prior disconnect marker so the status probe stops reporting the workspace as disconnected.
- Adds `adoptIntegration(provider, connectionId, options)` to the TypeScript SDK next to `disconnectIntegration`. Returns `{ connectionId, replacedConnectionId? }` so callers can surface whether a stale prior row was migrated.
- Teaches `apiClient.do` to read Cloud's `{ error }` field (alongside `{ message }`) so 4xx bodies surface the operator-facing message instead of a raw JSON blob.
- Updates the top-level CLI usage block to advertise `integration adopt`.

## Cloud dependency
The Cloud route is AgentWorkforce/cloud#537 (`agent-relay/integration-adopt-endpoint`, draft pending merge of #536). This PR can be reviewed in parallel but should land after the Cloud endpoint is deployed.

## Test plan
- [x] `go test ./cmd/relayfile-cli/` — full Go CLI suite green, 5 new adopt-specific tests (fresh-insert success, replacement reporting, 409 refusal preserves local state, --connection-id required, disconnect-marker cleared on adopt)
- [x] `npm test --workspace packages/sdk/typescript` — 138 tests green, 3 new SDK tests (request shape, replacedConnectionId presence/absence, 409 surfaces as CloudApiError)
- [x] `tsc --noEmit` in `packages/sdk/typescript` — clean
- [x] `go build ./cmd/relayfile-cli/` — clean
- [ ] Manual: run `relayfile integration adopt github --connection-id <real conn>` against a staging workspace