### PR TITLE
feat(integration): post-OAuth accessible-resources picker + set-metadata CLI/SDK

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -558,12 +558,21 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	}
 
 	if selectedProvider != "" && selectedProvider != "none" && selectedProvider != "skip" {
+		createdConnection := false
 		if createdWorkspace {
 			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
 				return err
 			}
+			createdConnection = true
 		} else {
-			if err := ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+			var err error
+			createdConnection, err = ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout)
+			if err != nil {
+				return err
+			}
+		}
+		if createdConnection && isAtlassianProvider(selectedProvider) {
+			if err := runAtlassianSitePicker(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, stdin, stdout); err != nil {
 				return err
 			}
 		}
@@ -1118,17 +1127,20 @@ func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser 
 	}
 }
 
-func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
+func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (bool, error) {
 	savedConnection := loadSavedConnection(localDir, provider)
 	connectionID := strings.TrimSpace(savedConnection.ConnectionID)
 	savedBackend := strings.TrimSpace(savedConnection.Backend)
 	if connectionID != "" && (requestedBackend == "" || requestedBackend == savedBackend) {
 		if ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID); err == nil && ready {
 			fmt.Fprintf(stdout, "%s already connected\n", provider)
-			return nil
+			return false, nil
 		}
 	}
-	return connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir, timeout, shouldOpenBrowser, stdout)
+	if err := connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir, timeout, shouldOpenBrowser, stdout); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) error {
@@ -1451,7 +1463,8 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err := persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir); err != nil {
 		return err
 	}
-	if err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout); err != nil {
+	createdConnection, err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout)
+	if err != nil {
 		return err
 	}
 	// Atlassian-family providers: a single OAuth grant can cover multiple
@@ -1461,7 +1474,7 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	// on the initial sync, so the operator picks a target without having
 	// to dive into the Nango dashboard. For other providers this is a
 	// no-op so we preserve the existing flow.
-	if isAtlassianProvider(provider) {
+	if createdConnection && isAtlassianProvider(provider) {
 		if err := runAtlassianSitePicker(cloudCreds.APIURL, record.ID, joined.Token, provider, stdin, stdout); err != nil {
 			return err
 		}
@@ -2051,6 +2064,9 @@ func runIntegrationSetMetadata(args []string, stdin io.Reader, stdout io.Writer)
 		value = strings.TrimSpace(value)
 		if key == "" {
 			return fmt.Errorf("metadata argument %q has an empty key", raw)
+		}
+		if strings.ContainsAny(key, ".[]") {
+			return fmt.Errorf("metadata key %q must be flat; nested keys are not supported yet", key)
 		}
 		metadata[key] = value
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -394,11 +394,13 @@ Usage:
   relayfile workspace current [--verbose]
   relayfile workspace delete NAME [--yes]
   relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME]
+    (for jira/confluence: prompts for the Atlassian site to bind after OAuth completes)
   relayfile integration available [--search QUERY] [--backend BACKEND] [--json] [--refresh]
   relayfile integration search QUERY [--backend BACKEND] [--json] [--refresh]
   relayfile integration list [--workspace NAME] [--json]
   relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
   relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]
+  relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]
   relayfile ops list [--workspace NAME] [--json]
   relayfile ops replay OPID [--workspace NAME]
   relayfile writeback status [WORKSPACE] [--json]
@@ -1387,7 +1389,7 @@ func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 
 func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("integration subcommand is required: connect, available, search, list, disconnect, or adopt")
+		return errors.New("integration subcommand is required: connect, available, search, list, disconnect, adopt, or set-metadata")
 	}
 	switch args[0] {
 	case "connect":
@@ -1402,6 +1404,8 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 		return runIntegrationDisconnect(args[1:], stdin, stdout)
 	case "adopt":
 		return runIntegrationAdopt(args[1:], stdin, stdout)
+	case "set-metadata":
+		return runIntegrationSetMetadata(args[1:], stdin, stdout)
 	default:
 		return fmt.Errorf("unknown integration subcommand %q", args[0])
 	}
@@ -1450,7 +1454,168 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout); err != nil {
 		return err
 	}
+	// Atlassian-family providers: a single OAuth grant can cover multiple
+	// sites (cloudIds). Cloud's Jira/Confluence sync bails with a clear
+	// error if `metadata.cloudId` is unset and the grant has >1 site.
+	// Run the site picker here, after OAuth completes but before we wait
+	// on the initial sync, so the operator picks a target without having
+	// to dive into the Nango dashboard. For other providers this is a
+	// no-op so we preserve the existing flow.
+	if isAtlassianProvider(provider) {
+		if err := runAtlassianSitePicker(cloudCreds.APIURL, record.ID, joined.Token, provider, stdin, stdout); err != nil {
+			return err
+		}
+	}
 	return waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, provider, record.LocalDir, *timeout, stdout)
+}
+
+func isAtlassianProvider(provider string) bool {
+	switch provider {
+	case "jira", "confluence":
+		return true
+	}
+	return false
+}
+
+// accessibleResourceEntry mirrors the SDK-facing shape returned by Cloud's
+// GET .../accessible-resources route. Cloud already normalizes the upstream
+// Atlassian payload, so the CLI only needs id+url here. We keep name and
+// avatarUrl so the picker can render a friendly label.
+type accessibleResourceEntry struct {
+	ID        string   `json:"id"`
+	URL       string   `json:"url"`
+	Name      string   `json:"name,omitempty"`
+	Scopes    []string `json:"scopes,omitempty"`
+	AvatarURL string   `json:"avatarUrl,omitempty"`
+}
+
+type accessibleResourcesResponse struct {
+	OK        bool                      `json:"ok"`
+	Resources []accessibleResourceEntry `json:"resources"`
+}
+
+// runAtlassianSitePicker fetches the accessible resources for `provider`
+// and, depending on how many came back, either:
+//   - 0: warns and exits (something is upstream-wrong; surfacing as error
+//     prevents the operator from sitting through a 5-minute initial-sync
+//     wait that will never succeed).
+//   - 1: auto-binds the single site as { cloudId, baseUrl } and logs a
+//     "auto-selected" line so the operator sees what happened.
+//   - >1: prompts interactively with a numbered picker. Default to 1 on
+//     blank input, validate range, retry up to 3 times on invalid input.
+//
+// The picked metadata is forwarded to Cloud's PUT .../metadata which
+// hands it to nango.setMetadata. On success the CLI prints a confirmation
+// before falling through to the initial-sync wait so the operator knows
+// which site they bound.
+func runAtlassianSitePicker(cloudAPIURL, workspaceID, workspaceToken, provider string, stdin io.Reader, stdout io.Writer) error {
+	client, err := newAPIClient(cloudAPIURL, workspaceToken)
+	if err != nil {
+		return err
+	}
+	var resp accessibleResourcesResponse
+	if err := client.getJSON(
+		context.Background(),
+		fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/accessible-resources", url.PathEscape(workspaceID), url.PathEscape(provider)),
+		&resp,
+	); err != nil {
+		return fmt.Errorf("list %s accessible resources: %w", provider, err)
+	}
+	resources := resp.Resources
+	if len(resources) == 0 {
+		// Upstream gave us zero sites — there's nothing we can bind, so
+		// continuing the connect flow would just bake in a guaranteed
+		// failure later. Fail fast with a message that points at the
+		// likely root causes (revoked OAuth grant or missing scopes).
+		fmt.Fprintf(stdout, "Warning: %s reports zero accessible sites for this OAuth grant.\n", provider)
+		fmt.Fprintln(stdout, "  Check that the operator who completed OAuth has access to at least one Atlassian site,")
+		fmt.Fprintln(stdout, "  and that the grant covers the required scopes.")
+		return fmt.Errorf("%s accessible-resources returned 0 sites", provider)
+	}
+	var chosen accessibleResourceEntry
+	if len(resources) == 1 {
+		chosen = resources[0]
+		label := chosen.URL
+		if chosen.Name != "" {
+			label = fmt.Sprintf("%s (%s)", chosen.Name, chosen.URL)
+		}
+		fmt.Fprintf(stdout, "Auto-selected site %s for %s\n", label, provider)
+	} else {
+		picked, err := promptAtlassianSiteChoice(resources, stdin, stdout)
+		if err != nil {
+			return err
+		}
+		chosen = picked
+	}
+	metadata := map[string]any{
+		"cloudId": chosen.ID,
+		"baseUrl": chosen.URL,
+	}
+	bodyBytes, err := json.Marshal(map[string]any{"metadata": metadata})
+	if err != nil {
+		return err
+	}
+	if _, _, err := client.do(
+		context.Background(),
+		http.MethodPut,
+		fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/metadata", url.PathEscape(workspaceID), url.PathEscape(provider)),
+		bodyBytes,
+	); err != nil {
+		return fmt.Errorf("set %s metadata: %w", provider, err)
+	}
+	fmt.Fprintf(stdout, "%s metadata set: cloudId=%s baseUrl=%s\n", provider, chosen.ID, chosen.URL)
+	return nil
+}
+
+// promptAtlassianSiteChoice renders the numbered picker and parses the
+// operator's response. Defaults to entry 1 on blank input. Retries up to
+// 3 times on invalid input (non-numeric or out-of-range) before erroring
+// out so an automated/dumb-pipe stdin doesn't loop forever.
+//
+// We construct a single bufio.Reader for the entire picker rather than
+// going through `promptLine`, because `promptLine` creates a new bufio
+// reader per call and drops any bytes the previous call buffered past
+// the first newline — which breaks the retry loop when stdin is a
+// pre-loaded reader (as in tests / piped scripts).
+func promptAtlassianSiteChoice(resources []accessibleResourceEntry, stdin io.Reader, stdout io.Writer) (accessibleResourceEntry, error) {
+	fmt.Fprintln(stdout, "Multiple Atlassian sites available; choose which to bind to this workspace:")
+	for i, r := range resources {
+		label := r.URL
+		if r.Name != "" {
+			label = fmt.Sprintf("%s  (%s)", r.URL, r.Name)
+		}
+		fmt.Fprintf(stdout, "  [%d] %s  (cloudId=%s)\n", i+1, label, r.ID)
+	}
+	reader := bufio.NewReader(stdin)
+	const maxAttempts = 3
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if _, err := io.WriteString(stdout, "Site number [1]: "); err != nil {
+			return accessibleResourceEntry{}, err
+		}
+		raw, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return accessibleResourceEntry{}, err
+		}
+		answer := strings.TrimSpace(raw)
+		if answer == "" {
+			// Two cases: operator hit enter (default to 1) OR stdin is
+			// closed/exhausted. Either way the "default to 1" behaviour
+			// is operator-friendly and matches the prompt text.
+			if errors.Is(err, io.EOF) && raw == "" {
+				// Truly empty stdin — accept default and bail before we
+				// loop forever on the same EOF.
+				return resources[0], nil
+			}
+			return resources[0], nil
+		}
+		idx, err := strconv.Atoi(answer)
+		if err != nil || idx < 1 || idx > len(resources) {
+			fmt.Fprintf(stdout, "Invalid choice %q; pick a number between 1 and %d.\n", answer, len(resources))
+			continue
+		}
+		return resources[idx-1], nil
+	}
+	return accessibleResourceEntry{}, fmt.Errorf("could not read a valid site selection after %d attempts", maxAttempts)
 }
 
 func runIntegrationSearch(args []string, stdout io.Writer) error {
@@ -1839,6 +2004,107 @@ func runIntegrationAdopt(args []string, stdin io.Reader, stdout io.Writer) error
 	} else {
 		fmt.Fprintf(stdout, "%s adopted into workspace %s (connectionId=%s)\n", provider, record.Name, boundConnectionID)
 	}
+	return nil
+}
+
+// runIntegrationSetMetadata is a general-purpose verb for writing operator-
+// controlled connection metadata. Today the Atlassian post-OAuth picker
+// (`integration connect jira`) uses the same endpoint to set `cloudId` and
+// `baseUrl` automatically. This verb exists for the cases the auto-picker
+// doesn't cover: changing metadata post-connect, setting non-Atlassian
+// connection-level config (e.g. linear `team_id`, a custom API host), or
+// scripting metadata writes from CI.
+//
+// Cloud forwards the payload to `nango.setMetadata` (full replacement, not
+// merge). v1 accepts flat KEY=VALUE pairs only; nested keys are documented
+// as a future enhancement so the prompt and confirmation stay legible.
+func runIntegrationSetMetadata(args []string, stdin io.Reader, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration set-metadata", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	yes := fs.Bool("yes", false, "skip confirmation")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace":     true,
+		"cloud-api-url": true,
+		"yes":           false,
+	})); err != nil {
+		return err
+	}
+	rest := fs.Args()
+	if len(rest) < 2 {
+		return errors.New("usage: relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]\n\n" +
+			"  v1 accepts flat KEY=VALUE pairs only; nested keys are not yet supported.\n" +
+			"  Example: relayfile integration set-metadata jira cloudId=abc-123 baseUrl=https://foo.atlassian.net")
+	}
+	provider := normalizeProviderID(rest[0])
+	if err := validateLocalProviderID(provider); err != nil {
+		return err
+	}
+	metadata := map[string]any{}
+	for _, raw := range rest[1:] {
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok {
+			return fmt.Errorf("metadata argument %q is not in KEY=VALUE form", raw)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return fmt.Errorf("metadata argument %q has an empty key", raw)
+		}
+		metadata[key] = value
+	}
+	record, err := resolveWorkspaceRecord(strings.TrimSpace(*workspaceName))
+	if err != nil {
+		return err
+	}
+	if !*yes {
+		fmt.Fprintf(stdout, "About to set %s metadata in workspace %q:\n", provider, record.Name)
+		// Print keys in alphabetical order so the confirmation is stable
+		// across runs and easy to eyeball.
+		keys := make([]string, 0, len(metadata))
+		for k := range metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(stdout, "  %s = %v\n", k, metadata[k])
+		}
+		answer, err := promptLine(stdin, stdout, "Continue? [y/N]: ")
+		if err != nil {
+			return err
+		}
+		answer = strings.ToLower(strings.TrimSpace(answer))
+		if answer != "y" && answer != "yes" {
+			fmt.Fprintln(stdout, "Aborted")
+			return nil
+		}
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), "", 5*time.Minute, false, io.Discard)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	if err != nil {
+		return err
+	}
+	bodyBytes, err := json.Marshal(map[string]any{"metadata": metadata})
+	if err != nil {
+		return err
+	}
+	if _, _, err := client.do(
+		context.Background(),
+		http.MethodPut,
+		fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/metadata", url.PathEscape(record.ID), url.PathEscape(provider)),
+		bodyBytes,
+	); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "%s metadata updated in workspace %s\n", provider, record.Name)
 	return nil
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -601,6 +601,72 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 	}
 }
 
+func TestSetupJiraRunsSitePickerAfterFreshConnect(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	seen := map[string]bool{}
+	var picked map[string]any
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces":
+			seen["create"] = true
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","relayfileUrl":"https://relayfile.test","createdAt":"2026-05-01T00:00:00Z","name":"demo"}`))
+		case "/api/v1/workspaces/ws_123/join":
+			seen["join"] = true
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+		case "/api/v1/workspaces/ws_123/integrations/connect-session":
+			seen["connect"] = true
+			_, _ = w.Write([]byte(`{"connectionId":"conn_jira","connectLink":"","backend":"nango"}`))
+		case "/api/v1/workspaces/ws_123/integrations/jira/status":
+			seen["status"] = true
+			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"jira","backend":"nango"}`))
+		case "/api/v1/workspaces/ws_123/integrations/jira/accessible-resources":
+			seen["accessible-resources"] = true
+			_, _ = w.Write([]byte(`{"ok":true,"resources":[{"id":"cloud-1","url":"https://foo.atlassian.net","name":"Foo"}]}`))
+		case "/api/v1/workspaces/ws_123/integrations/jira/metadata":
+			seen["metadata"] = true
+			if r.Method != http.MethodPut {
+				t.Fatalf("expected metadata PUT, got %s", r.Method)
+			}
+			var body map[string]map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode metadata body failed: %v", err)
+			}
+			picked = body["metadata"]
+			_, _ = w.Write([]byte(`{"ok":true,"metadata":` + jsonMarshalOrPanic(picked) + `}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"setup",
+		"--cloud-api-url", server.URL,
+		"--cloud-token", "cld_test",
+		"--workspace", "demo",
+		"--provider", "jira",
+		"--local-dir", "./vfs",
+		"--no-open",
+		"--skip-mount",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("run setup failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	for _, key := range []string{"create", "join", "connect", "status", "accessible-resources", "metadata"} {
+		if !seen[key] {
+			t.Fatalf("expected %s request", key)
+		}
+	}
+	if picked["cloudId"] != "cloud-1" || picked["baseUrl"] != "https://foo.atlassian.net" {
+		t.Fatalf("unexpected site metadata: %#v", picked)
+	}
+}
+
 func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -2558,6 +2624,23 @@ func TestIntegrationSetMetadataRejectsMalformedPair(t *testing.T) {
 	}
 }
 
+func TestIntegrationSetMetadataRejectsNestedKey(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "set-metadata", "jira",
+		"site.cloudId=cloud-1",
+		"--workspace", "demo",
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error for nested-looking metadata key")
+	}
+	if !strings.Contains(err.Error(), "must be flat") {
+		t.Fatalf("expected flat key error, got: %v", err)
+	}
+}
+
 // newConnectJiraTestServer stubs the cloud routes the
 // `integration connect jira` path touches: refresh+join, the
 // connect-session POST, the status GET (which the wait loop polls), the
@@ -2600,19 +2683,16 @@ func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, cho
 				*chosen = body["metadata"]
 			}
 			_, _ = w.Write([]byte(`{"ok":true,"metadata":` + jsonMarshalOrPanic(body["metadata"]) + `}`))
-		case strings.HasPrefix(r.URL.Path, "/v1/workspaces/ws_123/syncs/jira"):
+		case r.URL.Path == "/v1/workspaces/ws_123/sync/status":
 			// waitForInitialSync calls the relayfile data plane; stub it
 			// out with a "complete" reading so the test doesn't hang.
 			seen["sync-status"]++
-			_, _ = w.Write([]byte(`{"provider":"jira","initialSync":{"state":"complete"}}`))
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"jira","status":"ready","lagSeconds":0}]}`))
 		case strings.HasPrefix(r.URL.Path, "/v1/workspaces/ws_123/fs/tree"):
 			_, _ = w.Write([]byte(`{"entries":[]}`))
 		default:
-			// Don't fail on unexpected paths in this test — the connect
-			// flow can poke a few internal endpoints depending on local
-			// state; we only care about the picker assertions.
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"unexpected request"}`))
 		}
 	}))
 	return server, seen
@@ -2759,6 +2839,59 @@ func TestIntegrationConnectJiraRetriesOnInvalidInputThenErrors(t *testing.T) {
 	}
 }
 
+func TestIntegrationConnectJiraAlreadyConnectedSkipsPicker(t *testing.T) {
+	_, localDir := setupAdoptWorkspace(t)
+	if err := saveIntegrationConnection(localDir, integrationConnectionState{
+		Provider:     "jira",
+		ConnectionID: "conn_jira",
+		Backend:      "nango",
+		ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("save integration connection failed: %v", err)
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/token/refresh":
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/status":
+			if got := r.URL.Query().Get("connectionId"); got != "conn_jira" {
+				t.Fatalf("unexpected connectionId: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"jira","backend":"nango"}`))
+		case r.URL.Path == "/v1/workspaces/ws_123/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"jira","status":"ready","lagSeconds":0}]}`))
+		case strings.Contains(r.URL.Path, "/accessible-resources"):
+			t.Fatalf("accessible-resources must not be called for already-connected jira, hit: %s", r.URL.Path)
+		case strings.HasSuffix(r.URL.Path, "/metadata"):
+			t.Fatalf("metadata PUT must not fire for already-connected jira, hit: %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "jira",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration connect jira failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "jira already connected") {
+		t.Fatalf("expected already-connected message, got: %q", stdout.String())
+	}
+}
+
 func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
 	// Non-Atlassian providers must NOT invoke the picker — the existing
 	// connect flow has to keep working unchanged. We verify by stubbing a
@@ -2776,13 +2909,14 @@ func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
 			_, _ = w.Write([]byte(`{"connectionId":"conn_github","connectLink":"","backend":"nango"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/status":
 			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"github","backend":"nango"}`))
+		case r.URL.Path == "/v1/workspaces/ws_123/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"github","status":"ready","lagSeconds":0}]}`))
 		case strings.Contains(r.URL.Path, "/accessible-resources"):
 			t.Fatalf("accessible-resources must not be called for non-Atlassian providers, hit: %s", r.URL.Path)
 		case strings.HasSuffix(r.URL.Path, "/metadata"):
 			t.Fatalf("metadata PUT must not fire for non-Atlassian providers, hit: %s", r.URL.Path)
 		default:
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 	}))
 	defer server.Close()

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2450,3 +2450,352 @@ func TestIntegrationAdoptClearsDisconnectMarker(t *testing.T) {
 		t.Fatalf("expected disconnect marker to be removed, got: %v", err)
 	}
 }
+
+// ----------------------------------------------------------------------
+// Integration set-metadata + post-OAuth Atlassian site picker
+// ----------------------------------------------------------------------
+
+// newSetMetadataTestServer mirrors newAdoptTestServer but stubs the
+// metadata PUT endpoint so set-metadata happy-path tests can record
+// the request body and return a canned response.
+func newSetMetadataTestServer(t *testing.T, metadataHandler func(http.ResponseWriter, *http.Request)) (*httptest.Server, map[string]int) {
+	t.Helper()
+	seen := map[string]int{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/token/refresh":
+			seen["refresh"]++
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			seen["join"]++
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case strings.HasSuffix(r.URL.Path, "/metadata") && r.Method == http.MethodPut:
+			seen["metadata"]++
+			metadataHandler(w, r)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	return server, seen
+}
+
+func TestIntegrationSetMetadataHappyPath(t *testing.T) {
+	// Operator runs `relayfile integration set-metadata jira cloudId=... baseUrl=...`.
+	// The CLI must parse KEY=VALUE args, PUT them under
+	// /api/v1/workspaces/.../metadata wrapped in { metadata: { ... } },
+	// and exit 0 on cloud's 200.
+	_, _ = setupAdoptWorkspace(t)
+	server, seen := newSetMetadataTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode metadata body failed: %v", err)
+		}
+		md := body["metadata"]
+		if md["cloudId"] != "cloud-1" || md["baseUrl"] != "https://foo.atlassian.net" {
+			t.Fatalf("unexpected metadata body: %#v", md)
+		}
+		if r.URL.Path != "/api/v1/workspaces/ws_123/integrations/jira/metadata" {
+			t.Fatalf("unexpected metadata path: %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"metadata":{"cloudId":"cloud-1","baseUrl":"https://foo.atlassian.net"}}`))
+	})
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "set-metadata", "jira",
+		"cloudId=cloud-1",
+		"baseUrl=https://foo.atlassian.net",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("set-metadata failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if seen["metadata"] != 1 {
+		t.Fatalf("expected 1 metadata PUT, got %d", seen["metadata"])
+	}
+	if !strings.Contains(stdout.String(), "jira metadata updated") {
+		t.Fatalf("expected confirmation in output: %q", stdout.String())
+	}
+}
+
+func TestIntegrationSetMetadataRejectsMissingArgs(t *testing.T) {
+	// Missing KEY=VALUE args must fail before we hit the network so the
+	// operator sees usage text instead of a confusing cloud 400.
+	_, _ = setupAdoptWorkspace(t)
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "set-metadata", "jira",
+		"--workspace", "demo",
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error when no KEY=VALUE pairs provided")
+	}
+	if !strings.Contains(err.Error(), "KEY=VALUE") {
+		t.Fatalf("expected usage hint in error, got: %v", err)
+	}
+}
+
+func TestIntegrationSetMetadataRejectsMalformedPair(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "set-metadata", "jira",
+		"this-is-not-a-pair",
+		"--workspace", "demo",
+		"--yes",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error for malformed metadata arg")
+	}
+	if !strings.Contains(err.Error(), "KEY=VALUE form") {
+		t.Fatalf("expected KEY=VALUE form error, got: %v", err)
+	}
+}
+
+// newConnectJiraTestServer stubs the cloud routes the
+// `integration connect jira` path touches: refresh+join, the
+// connect-session POST, the status GET (which the wait loop polls), the
+// accessible-resources GET (post-OAuth picker), and the metadata PUT.
+// `sites` controls how many sites accessible-resources returns; `chosen`
+// receives the metadata PUT body so the test can assert on what was set.
+func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, chosen *map[string]any) (*httptest.Server, map[string]int) {
+	t.Helper()
+	seen := map[string]int{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/token/refresh":
+			seen["refresh"]++
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			seen["join"]++
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/connect-session" && r.Method == http.MethodPost:
+			seen["connect-session"]++
+			_, _ = w.Write([]byte(`{"connectionId":"conn_jira","connectLink":"","backend":"nango"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/status":
+			seen["status"]++
+			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"jira","backend":"nango"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/accessible-resources":
+			seen["accessible-resources"]++
+			payload := struct {
+				OK        bool                      `json:"ok"`
+				Resources []accessibleResourceEntry `json:"resources"`
+			}{OK: true, Resources: sites}
+			_ = json.NewEncoder(w).Encode(payload)
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/metadata" && r.Method == http.MethodPut:
+			seen["metadata"]++
+			var body map[string]map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode metadata body failed: %v", err)
+			}
+			if chosen != nil {
+				*chosen = body["metadata"]
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"metadata":` + jsonMarshalOrPanic(body["metadata"]) + `}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/workspaces/ws_123/syncs/jira"):
+			// waitForInitialSync calls the relayfile data plane; stub it
+			// out with a "complete" reading so the test doesn't hang.
+			seen["sync-status"]++
+			_, _ = w.Write([]byte(`{"provider":"jira","initialSync":{"state":"complete"}}`))
+		case strings.HasPrefix(r.URL.Path, "/v1/workspaces/ws_123/fs/tree"):
+			_, _ = w.Write([]byte(`{"entries":[]}`))
+		default:
+			// Don't fail on unexpected paths in this test — the connect
+			// flow can poke a few internal endpoints depending on local
+			// state; we only care about the picker assertions.
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	return server, seen
+}
+
+func jsonMarshalOrPanic(value any) string {
+	b, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestIntegrationConnectJiraAutoSelectsSingleSite(t *testing.T) {
+	// One Atlassian site: the picker should auto-bind it without prompting.
+	// Importantly this also proves the picker fires at all on jira/confluence
+	// (i.e. isAtlassianProvider returns true and runAtlassianSitePicker is
+	// dispatched).
+	_, _ = setupAdoptWorkspace(t)
+	sites := []accessibleResourceEntry{
+		{ID: "cloud-only", URL: "https://only.atlassian.net", Name: "Only Site"},
+	}
+	var picked map[string]any
+	server, seen := newConnectJiraTestServer(t, sites, &picked)
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "connect", "jira",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("integration connect jira failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if seen["accessible-resources"] == 0 {
+		t.Fatalf("expected accessible-resources to be called for jira")
+	}
+	if seen["metadata"] == 0 {
+		t.Fatalf("expected metadata PUT to fire for the only site")
+	}
+	if picked["cloudId"] != "cloud-only" || picked["baseUrl"] != "https://only.atlassian.net" {
+		t.Fatalf("unexpected auto-selected metadata: %#v", picked)
+	}
+	if !strings.Contains(stdout.String(), "Auto-selected site") {
+		t.Fatalf("expected auto-select log line, got: %q", stdout.String())
+	}
+}
+
+func TestIntegrationConnectJiraPromptsAndSetsSelectedSite(t *testing.T) {
+	// Multi-site path: operator picks site 2 via stdin. We assert (a) the
+	// numbered picker rendered, (b) the chosen site's cloudId+baseUrl were
+	// PUT to /metadata, and (c) the connect flow completed without hanging.
+	_, _ = setupAdoptWorkspace(t)
+	sites := []accessibleResourceEntry{
+		{ID: "cloud-1", URL: "https://foo.atlassian.net"},
+		{ID: "cloud-2", URL: "https://bar.atlassian.net"},
+		{ID: "cloud-3", URL: "https://baz.atlassian.net"},
+	}
+	var picked map[string]any
+	server, _ := newConnectJiraTestServer(t, sites, &picked)
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "jira",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader("2\n"), &stdout, &stdout); err != nil {
+		t.Fatalf("integration connect jira failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if picked["cloudId"] != "cloud-2" || picked["baseUrl"] != "https://bar.atlassian.net" {
+		t.Fatalf("expected site 2 to be picked, got %#v", picked)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Multiple Atlassian sites available") {
+		t.Fatalf("expected multi-site prompt header in output: %q", got)
+	}
+	if !strings.Contains(got, "cloudId=cloud-1") || !strings.Contains(got, "cloudId=cloud-3") {
+		t.Fatalf("expected picker to list all sites, got: %q", got)
+	}
+}
+
+func TestIntegrationConnectJiraDefaultsToFirstSiteOnBlankInput(t *testing.T) {
+	// Operator just hits Enter at the picker. The CLI must default to the
+	// first site rather than re-prompting or erroring out.
+	_, _ = setupAdoptWorkspace(t)
+	sites := []accessibleResourceEntry{
+		{ID: "cloud-a", URL: "https://a.atlassian.net"},
+		{ID: "cloud-b", URL: "https://b.atlassian.net"},
+	}
+	var picked map[string]any
+	server, _ := newConnectJiraTestServer(t, sites, &picked)
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "jira",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader("\n"), &stdout, &stdout); err != nil {
+		t.Fatalf("integration connect jira failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if picked["cloudId"] != "cloud-a" {
+		t.Fatalf("expected default site to be picked, got %#v", picked)
+	}
+}
+
+func TestIntegrationConnectJiraRetriesOnInvalidInputThenErrors(t *testing.T) {
+	// Three invalid attempts in a row must abort with a clear error so a
+	// dumb-pipe stdin doesn't spin forever. We don't care which exact
+	// invalid value we send, only that the CLI gives up after the cap.
+	_, _ = setupAdoptWorkspace(t)
+	sites := []accessibleResourceEntry{
+		{ID: "cloud-1", URL: "https://foo.atlassian.net"},
+		{ID: "cloud-2", URL: "https://bar.atlassian.net"},
+	}
+	server, _ := newConnectJiraTestServer(t, sites, nil)
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "connect", "jira",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader("nope\n9999\nstill-bad\n"), &stdout, &stdout)
+	if err == nil {
+		t.Fatalf("expected error after exhausted prompt attempts; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "valid site selection") {
+		t.Fatalf("expected error to mention site selection, got: %v", err)
+	}
+}
+
+func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
+	// Non-Atlassian providers must NOT invoke the picker — the existing
+	// connect flow has to keep working unchanged. We verify by stubbing a
+	// cloud that fails the test if accessible-resources is ever called.
+	_, _ = setupAdoptWorkspace(t)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/auth/token/refresh":
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/connect-session":
+			_, _ = w.Write([]byte(`{"connectionId":"conn_github","connectLink":"","backend":"nango"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/status":
+			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"github","backend":"nango"}`))
+		case strings.Contains(r.URL.Path, "/accessible-resources"):
+			t.Fatalf("accessible-resources must not be called for non-Atlassian providers, hit: %s", r.URL.Path)
+		case strings.HasSuffix(r.URL.Path, "/metadata"):
+			t.Fatalf("metadata PUT must not fire for non-Atlassian providers, hit: %s", r.URL.Path)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "github",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration connect github failed: %v", err)
+	}
+}

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -174,8 +174,12 @@ func TestA3EnsureCloudIntegrationSkipsConnectWhenAlreadyReady(t *testing.T) {
 	defer server.Close()
 
 	var stdout bytes.Buffer
-	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "notion", "", localDir, 5*time.Second, false, &stdout); err != nil {
+	created, err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "notion", "", localDir, 5*time.Second, false, &stdout)
+	if err != nil {
 		t.Fatalf("ensureCloudIntegration failed: %v", err)
+	}
+	if created {
+		t.Fatalf("expected existing connection to be reused")
 	}
 	if atomic.LoadInt32(&statusCalls) != 1 {
 		t.Fatalf("expected exactly one status check, got %d", statusCalls)
@@ -226,8 +230,12 @@ func TestEnsureCloudIntegrationReusesSavedConnectionForMatchingBackend(t *testin
 	defer server.Close()
 
 	var stdout bytes.Buffer
-	if err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "github", "composio", localDir, 5*time.Second, false, &stdout); err != nil {
+	created, err := ensureCloudIntegration(server.URL, "ws_demo", "rf_token", "github", "composio", localDir, 5*time.Second, false, &stdout)
+	if err != nil {
 		t.Fatalf("ensureCloudIntegration failed: %v", err)
+	}
+	if created {
+		t.Fatalf("expected existing connection to be reused")
 	}
 	if atomic.LoadInt32(&statusCalls) != 1 {
 		t.Fatalf("expected exactly one status check, got %d", statusCalls)

--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -254,6 +254,16 @@ def _coerce_resource_entries(payload: Any) -> list[dict[str, Any]]:
     return out
 
 
+def _coerce_metadata_response(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, dict):
+        metadata = payload.get("metadata")
+        if isinstance(metadata, dict):
+            return metadata
+    raise ValueError(
+        f"invalid cloud response: expected object field `metadata`, got {payload!r}"
+    )
+
+
 class RelayFileClient:
     """Synchronous RelayFile SDK client with retry support."""
 
@@ -877,11 +887,7 @@ class RelayFileClient:
             correlation_id=correlation_id,
             base_url=self._cloud_base_url,
         )
-        if isinstance(payload, dict):
-            updated = payload.get("metadata")
-            if isinstance(updated, dict):
-                return updated
-        return metadata
+        return _coerce_metadata_response(payload)
 
 
 # ======================================================================
@@ -1497,8 +1503,4 @@ class AsyncRelayFileClient:
             correlation_id=correlation_id,
             base_url=self._cloud_base_url,
         )
-        if isinstance(payload, dict):
-            updated = payload.get("metadata")
-            if isinstance(updated, dict):
-                return updated
-        return metadata
+        return _coerce_metadata_response(payload)

--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -220,6 +220,38 @@ def _throw_for_error(status: int, payload: Any, headers: httpx.Headers) -> None:
 
 
 DEFAULT_RELAYFILE_BASE_URL = "https://api.relayfile.dev"
+DEFAULT_RELAYFILE_CLOUD_BASE_URL = "https://agentrelay.com/cloud"
+
+
+def _normalize_provider_id(provider: str) -> str:
+    # Mirrors the TS SDK: the metadata + accessible-resources verbs accept
+    # any string so operators can target dynamically-discovered providers.
+    # We only trim + lowercase here; cloud rejects unknown ids with a typed
+    # 404 (`unknown_provider`).
+    if not isinstance(provider, str):
+        raise ValueError("provider must be a string")
+    trimmed = provider.strip()
+    if not trimmed:
+        raise ValueError("provider is required")
+    return trimmed.lower()
+
+
+def _coerce_resource_entries(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    resources = payload.get("resources")
+    if not isinstance(resources, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in resources:
+        if not isinstance(entry, dict):
+            continue
+        rid = entry.get("id")
+        url = entry.get("url")
+        if not isinstance(rid, str) or not rid or not isinstance(url, str) or not url:
+            continue
+        out.append(dict(entry))
+    return out
 
 
 class RelayFileClient:
@@ -234,8 +266,15 @@ class RelayFileClient:
         user_agent: str | None = None,
         retry: RetryOptions | None = None,
         http_client: httpx.Client | None = None,
+        cloud_base_url: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        # Integration setup verbs (list_accessible_resources +
+        # set_integration_metadata) target the cloud control plane, which
+        # is a different service from the relayfile data plane. Default to
+        # the public agentrelay.com/cloud host when the caller hasn't
+        # supplied an override.
+        self._cloud_base_url = (cloud_base_url or DEFAULT_RELAYFILE_CLOUD_BASE_URL).rstrip("/")
         self._token_provider = token
         self._user_agent = user_agent
         self._retry = _normalize_retry(retry)
@@ -264,6 +303,7 @@ class RelayFileClient:
         headers: dict[str, str] | None = None,
         json_body: Any = None,
         correlation_id: str | None = None,
+        base_url: str | None = None,
     ) -> Any:
         resp = self._request_response(
             method,
@@ -271,6 +311,7 @@ class RelayFileClient:
             headers=headers,
             json_body=json_body,
             correlation_id=correlation_id,
+            base_url=base_url,
         )
         return _read_payload(resp)
 
@@ -282,6 +323,7 @@ class RelayFileClient:
         headers: dict[str, str] | None = None,
         json_body: Any = None,
         correlation_id: str | None = None,
+        base_url: str | None = None,
     ) -> httpx.Response:
         base_headers = _merge_headers(
             headers,
@@ -290,7 +332,7 @@ class RelayFileClient:
             has_json_body=json_body is not None,
         )
 
-        url = f"{self._base_url}{path}"
+        url = f"{(base_url or self._base_url).rstrip('/')}{path}"
         retries = 0
 
         while True:
@@ -776,6 +818,71 @@ class RelayFileClient:
             correlation_id=correlation_id,
         )
 
+    # ------------------------------------------------------------------
+    # Integration setup (cloud control plane)
+    # ------------------------------------------------------------------
+
+    def list_accessible_resources(
+        self,
+        workspace_id: str,
+        provider: str,
+        *,
+        correlation_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List the upstream resources the connection's OAuth grant covers.
+
+        Today this is only meaningful for Atlassian-family providers
+        (``jira``, ``confluence``); for everything else cloud returns a
+        400 with ``code="provider_has_no_accessible_resources"`` which
+        surfaces here as a ``RelayFileApiError`` so callers can branch on
+        the code rather than treating an empty list as ambiguous.
+
+        Use the returned ``id`` / ``url`` pair to call
+        :meth:`set_integration_metadata` with ``{"cloudId": id,
+        "baseUrl": url}``.
+        """
+        normalized = _normalize_provider_id(provider)
+        payload = self._request(
+            "GET",
+            f"/api/v1/workspaces/{_enc(workspace_id)}/integrations/{_enc(normalized)}/accessible-resources",
+            correlation_id=correlation_id,
+            base_url=self._cloud_base_url,
+        )
+        return _coerce_resource_entries(payload)
+
+    def set_integration_metadata(
+        self,
+        workspace_id: str,
+        provider: str,
+        metadata: dict[str, Any],
+        *,
+        correlation_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Replace the connection metadata namespace for ``provider``.
+
+        Wraps cloud's PUT .../metadata, which forwards to
+        ``nango.setMetadata`` (full replacement, not merge). The cloud
+        side rejects top-level keys that look like Nango plumbing
+        (``_*``, ``connection_*``, ``auth_*``,
+        ``provider_config_key``, ``connection_id``) with
+        ``code="invalid_metadata"``.
+        """
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be a dict")
+        normalized = _normalize_provider_id(provider)
+        payload = self._request(
+            "PUT",
+            f"/api/v1/workspaces/{_enc(workspace_id)}/integrations/{_enc(normalized)}/metadata",
+            json_body={"metadata": metadata},
+            correlation_id=correlation_id,
+            base_url=self._cloud_base_url,
+        )
+        if isinstance(payload, dict):
+            updated = payload.get("metadata")
+            if isinstance(updated, dict):
+                return updated
+        return metadata
+
 
 # ======================================================================
 # Async client
@@ -794,8 +901,12 @@ class AsyncRelayFileClient:
         user_agent: str | None = None,
         retry: RetryOptions | None = None,
         http_client: httpx.AsyncClient | None = None,
+        cloud_base_url: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        # See the sync client for why integration setup verbs target a
+        # different base URL.
+        self._cloud_base_url = (cloud_base_url or DEFAULT_RELAYFILE_CLOUD_BASE_URL).rstrip("/")
         self._token_provider = token
         self._user_agent = user_agent
         self._retry = _normalize_retry(retry)
@@ -824,6 +935,7 @@ class AsyncRelayFileClient:
         headers: dict[str, str] | None = None,
         json_body: Any = None,
         correlation_id: str | None = None,
+        base_url: str | None = None,
     ) -> Any:
         import asyncio
         resp = await self._request_response(
@@ -832,6 +944,7 @@ class AsyncRelayFileClient:
             headers=headers,
             json_body=json_body,
             correlation_id=correlation_id,
+            base_url=base_url,
         )
         return _read_payload(resp)
 
@@ -843,6 +956,7 @@ class AsyncRelayFileClient:
         headers: dict[str, str] | None = None,
         json_body: Any = None,
         correlation_id: str | None = None,
+        base_url: str | None = None,
     ) -> httpx.Response:
         import asyncio
         base_headers = _merge_headers(
@@ -852,7 +966,7 @@ class AsyncRelayFileClient:
             has_json_body=json_body is not None,
         )
 
-        url = f"{self._base_url}{path}"
+        url = f"{(base_url or self._base_url).rstrip('/')}{path}"
         retries = 0
 
         while True:
@@ -1342,3 +1456,49 @@ class AsyncRelayFileClient:
             f"/v1/admin/replay/op/{_enc(op_id)}",
             correlation_id=correlation_id,
         )
+
+    # ------------------------------------------------------------------
+    # Integration setup (cloud control plane)
+    # ------------------------------------------------------------------
+
+    async def list_accessible_resources(
+        self,
+        workspace_id: str,
+        provider: str,
+        *,
+        correlation_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Async version of :meth:`RelayFileClient.list_accessible_resources`."""
+        normalized = _normalize_provider_id(provider)
+        payload = await self._request(
+            "GET",
+            f"/api/v1/workspaces/{_enc(workspace_id)}/integrations/{_enc(normalized)}/accessible-resources",
+            correlation_id=correlation_id,
+            base_url=self._cloud_base_url,
+        )
+        return _coerce_resource_entries(payload)
+
+    async def set_integration_metadata(
+        self,
+        workspace_id: str,
+        provider: str,
+        metadata: dict[str, Any],
+        *,
+        correlation_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Async version of :meth:`RelayFileClient.set_integration_metadata`."""
+        if not isinstance(metadata, dict):
+            raise ValueError("metadata must be a dict")
+        normalized = _normalize_provider_id(provider)
+        payload = await self._request(
+            "PUT",
+            f"/api/v1/workspaces/{_enc(workspace_id)}/integrations/{_enc(normalized)}/metadata",
+            json_body={"metadata": metadata},
+            correlation_id=correlation_id,
+            base_url=self._cloud_base_url,
+        )
+        if isinstance(payload, dict):
+            updated = payload.get("metadata")
+            if isinstance(updated, dict):
+                return updated
+        return metadata

--- a/packages/sdk/python/tests/test_client.py
+++ b/packages/sdk/python/tests/test_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import httpx
 import pytest
@@ -15,6 +16,7 @@ from relayfile import (
     QueueFullError,
     RelayFileApiError,
     RelayFileClient,
+    RetryOptions,
     RevisionConflictError,
     compute_canonical_path,
 )
@@ -516,3 +518,189 @@ class TestAsyncClient:
             )
             res = await client.ingest_webhook(inp)
             assert res["status"] == "queued"
+
+
+# ---------------------------------------------------------------------------
+# Integration setup (accessible-resources + metadata)
+# ---------------------------------------------------------------------------
+
+
+CLOUD_BASE = "https://cloud.test"
+
+
+class TestIntegrationSetupSync:
+    @respx.mock
+    def test_list_accessible_resources_normalizes_payload(self) -> None:
+        # Sync path mirrors the TS SDK contract: cloud returns
+        # { ok, resources: [...] }, the SDK strips entries missing id/url
+        # so the CLI's picker can't crash on partial Atlassian output.
+        respx.get(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/accessible-resources"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "resources": [
+                        {"id": "cloud-1", "url": "https://foo.atlassian.net", "name": "Foo"},
+                        {"id": "cloud-2", "url": "https://bar.atlassian.net"},
+                        {"id": "cloud-3"},
+                        {"url": "https://baz.atlassian.net"},
+                        None,
+                    ],
+                },
+            )
+        )
+        client = RelayFileClient(BASE, "tok_test", cloud_base_url=CLOUD_BASE)
+        resources = client.list_accessible_resources("ws_acme", "jira")
+        assert resources == [
+            {"id": "cloud-1", "url": "https://foo.atlassian.net", "name": "Foo"},
+            {"id": "cloud-2", "url": "https://bar.atlassian.net"},
+        ]
+        # Authorization header must come from the token provider.
+        req = respx.calls.last.request
+        assert req.headers["Authorization"] == "Bearer tok_test"
+
+    @respx.mock
+    def test_list_accessible_resources_surfaces_cloud_error(self) -> None:
+        respx.get(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/github/accessible-resources"
+        ).mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "ok": False,
+                    "code": "provider_has_no_accessible_resources",
+                    "error": "Provider \"github\" does not expose accessible resources",
+                },
+            )
+        )
+        client = RelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE,
+            retry=RetryOptions(max_retries=0, base_delay_ms=1),
+        )
+        with pytest.raises(RelayFileApiError) as exc_info:
+            client.list_accessible_resources("ws_acme", "github")
+        assert exc_info.value.status == 400
+        assert exc_info.value.code == "provider_has_no_accessible_resources"
+
+    @respx.mock
+    def test_set_integration_metadata_forwards_payload(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            captured["method"] = request.method
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "metadata": {
+                        "cloudId": "cloud-1",
+                        "baseUrl": "https://foo.atlassian.net",
+                    },
+                },
+            )
+
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(side_effect=handler)
+
+        client = RelayFileClient(BASE, "tok_test", cloud_base_url=CLOUD_BASE)
+        result = client.set_integration_metadata(
+            "ws_acme",
+            "jira",
+            {"cloudId": "cloud-1", "baseUrl": "https://foo.atlassian.net"},
+        )
+        assert result == {
+            "cloudId": "cloud-1",
+            "baseUrl": "https://foo.atlassian.net",
+        }
+        assert captured["method"] == "PUT"
+        assert captured["body"] == {
+            "metadata": {
+                "cloudId": "cloud-1",
+                "baseUrl": "https://foo.atlassian.net",
+            }
+        }
+
+    def test_set_integration_metadata_rejects_non_dict_locally(self) -> None:
+        # Operator-facing guard: we don't even hit cloud for type errors,
+        # so the failure mode is a Python ValueError instead of a cloud
+        # 400 round-trip.
+        client = RelayFileClient(BASE, "tok_test", cloud_base_url=CLOUD_BASE)
+        with pytest.raises(ValueError):
+            client.set_integration_metadata("ws_acme", "jira", "not-a-dict")  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            client.set_integration_metadata("ws_acme", "", {})
+
+    @respx.mock
+    def test_set_integration_metadata_surfaces_cloud_invalid_metadata(self) -> None:
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "ok": False,
+                    "code": "invalid_metadata",
+                    "error": "metadata key \"_internal\" is reserved by the Nango backend",
+                },
+            )
+        )
+        client = RelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE,
+            retry=RetryOptions(max_retries=0, base_delay_ms=1),
+        )
+        with pytest.raises(RelayFileApiError) as exc_info:
+            client.set_integration_metadata("ws_acme", "jira", {"_internal": "nope"})
+        assert exc_info.value.status == 400
+        assert exc_info.value.code == "invalid_metadata"
+
+
+class TestIntegrationSetupAsync:
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_accessible_resources(self) -> None:
+        respx.get(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/accessible-resources"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "resources": [
+                        {"id": "cloud-1", "url": "https://foo.atlassian.net"}
+                    ],
+                },
+            )
+        )
+        async with AsyncRelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE
+        ) as client:
+            resources = await client.list_accessible_resources("ws_acme", "jira")
+        assert resources == [
+            {"id": "cloud-1", "url": "https://foo.atlassian.net"}
+        ]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_set_integration_metadata(self) -> None:
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "metadata": {"cloudId": "cloud-1"},
+                },
+            )
+        )
+        async with AsyncRelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE
+        ) as client:
+            result = await client.set_integration_metadata(
+                "ws_acme", "jira", {"cloudId": "cloud-1"}
+            )
+        assert result == {"cloudId": "cloud-1"}

--- a/packages/sdk/python/tests/test_client.py
+++ b/packages/sdk/python/tests/test_client.py
@@ -657,6 +657,15 @@ class TestIntegrationSetupSync:
         assert exc_info.value.status == 400
         assert exc_info.value.code == "invalid_metadata"
 
+    @respx.mock
+    def test_set_integration_metadata_rejects_malformed_cloud_response(self) -> None:
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(return_value=httpx.Response(200, json={"ok": True, "metadata": []}))
+        client = RelayFileClient(BASE, "tok_test", cloud_base_url=CLOUD_BASE)
+        with pytest.raises(ValueError, match="expected object field"):
+            client.set_integration_metadata("ws_acme", "jira", {"cloudId": "cloud-1"})
+
 
 class TestIntegrationSetupAsync:
     @respx.mock
@@ -704,3 +713,83 @@ class TestIntegrationSetupAsync:
                 "ws_acme", "jira", {"cloudId": "cloud-1"}
             )
         assert result == {"cloudId": "cloud-1"}
+
+    @pytest.mark.asyncio
+    async def test_set_integration_metadata_rejects_non_dict_locally(self) -> None:
+        async with AsyncRelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE
+        ) as client:
+            with pytest.raises(ValueError):
+                await client.set_integration_metadata(
+                    "ws_acme", "jira", "not-a-dict"  # type: ignore[arg-type]
+                )
+            with pytest.raises(ValueError):
+                await client.set_integration_metadata("ws_acme", "", {})
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_list_accessible_resources_surfaces_cloud_error(self) -> None:
+        respx.get(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/github/accessible-resources"
+        ).mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "ok": False,
+                    "code": "provider_has_no_accessible_resources",
+                    "error": "Provider \"github\" does not expose accessible resources",
+                },
+            )
+        )
+        async with AsyncRelayFileClient(
+            BASE,
+            "tok_test",
+            cloud_base_url=CLOUD_BASE,
+            retry=RetryOptions(max_retries=0, base_delay_ms=1),
+        ) as client:
+            with pytest.raises(RelayFileApiError) as exc_info:
+                await client.list_accessible_resources("ws_acme", "github")
+        assert exc_info.value.status == 400
+        assert exc_info.value.code == "provider_has_no_accessible_resources"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_set_integration_metadata_surfaces_cloud_invalid_metadata(self) -> None:
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(
+            return_value=httpx.Response(
+                400,
+                json={
+                    "ok": False,
+                    "code": "invalid_metadata",
+                    "error": "metadata key \"_internal\" is reserved by the Nango backend",
+                },
+            )
+        )
+        async with AsyncRelayFileClient(
+            BASE,
+            "tok_test",
+            cloud_base_url=CLOUD_BASE,
+            retry=RetryOptions(max_retries=0, base_delay_ms=1),
+        ) as client:
+            with pytest.raises(RelayFileApiError) as exc_info:
+                await client.set_integration_metadata(
+                    "ws_acme", "jira", {"_internal": "nope"}
+                )
+        assert exc_info.value.status == 400
+        assert exc_info.value.code == "invalid_metadata"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_set_integration_metadata_rejects_malformed_cloud_response(self) -> None:
+        respx.put(
+            f"{CLOUD_BASE}/api/v1/workspaces/ws_acme/integrations/jira/metadata"
+        ).mock(return_value=httpx.Response(200, json={"ok": True}))
+        async with AsyncRelayFileClient(
+            BASE, "tok_test", cloud_base_url=CLOUD_BASE
+        ) as client:
+            with pytest.raises(ValueError, match="expected object field"):
+                await client.set_integration_metadata(
+                    "ws_acme", "jira", {"cloudId": "cloud-1"}
+                )

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -464,6 +464,31 @@ describe("RelayfileSetup", () => {
     expect(readRequestHeaders(fetchMock, 1).Authorization).toBe("Bearer rf_jwt_1")
   })
 
+  it("normalizes listAccessibleResources provider casing and rejects blank providers", async () => {
+    const fetchMock = queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        resources: [{ id: "cloud-1", url: "https://foo.atlassian.net" }]
+      })
+    )
+
+    const setup = new RelayfileSetup({ cloudApiUrl: "https://cloud.test" })
+    const handle = await setup.joinWorkspace("ws_123")
+    await expect(handle.listAccessibleResources("  JiRa  ")).resolves.toEqual([
+      { id: "cloud-1", url: "https://foo.atlassian.net" }
+    ])
+    expect(readRequestUrl(fetchMock, 1)).toBe(
+      "https://cloud.test/api/v1/workspaces/ws_123/integrations/jira/accessible-resources"
+    )
+    expect(readRequestHeaders(fetchMock, 1).Authorization).toBe("Bearer rf_jwt_1")
+
+    await expect(handle.listAccessibleResources("")).rejects.toThrow(
+      /provider is required/
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it("listAccessibleResources filters out entries missing id or url", async () => {
     // Defense in depth: if Cloud ever loosens its normalization, the SDK
     // still refuses to return junk entries that the CLI would crash on.
@@ -569,21 +594,34 @@ describe("RelayfileSetup", () => {
     // We catch this in the SDK so the operator-facing error message is
     // immediate ("metadata must be a plain object") rather than an
     // unhelpful Cloud 400 round-trip.
-    queueFetch(makeJoinResponse())
+    const fetchMock = queueFetch(makeJoinResponse())
     const setup = new RelayfileSetup({ cloudApiUrl: "https://cloud.test" })
     const handle = await setup.joinWorkspace("ws_123")
     // @ts-expect-error - exercising runtime guard
     await expect(handle.setIntegrationMetadata("jira", "nope")).rejects.toThrow(
       /metadata must be a plain object/
     )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     // @ts-expect-error - exercising runtime guard
     await expect(handle.setIntegrationMetadata("jira", null)).rejects.toThrow(
       /metadata must be a plain object/
     )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     await expect(
       // @ts-expect-error - exercising runtime guard
       handle.setIntegrationMetadata("jira", ["array"])
     ).rejects.toThrow(/metadata must be a plain object/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await expect(
+      // @ts-expect-error - exercising runtime guard
+      handle.setIntegrationMetadata("jira", new Date())
+    ).rejects.toThrow(/metadata must be a plain object/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    await expect(
+      // @ts-expect-error - exercising runtime guard
+      handle.setIntegrationMetadata("jira", new Map())
+    ).rejects.toThrow(/metadata must be a plain object/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
   it("setIntegrationMetadata surfaces Cloud 400 invalid_metadata as CloudApiError", async () => {
@@ -610,6 +648,22 @@ describe("RelayfileSetup", () => {
       httpStatus: 400,
       httpBody: expect.objectContaining({ code: "invalid_metadata" })
     } satisfies Partial<CloudApiError>)
+  })
+
+  it("setIntegrationMetadata rejects malformed Cloud metadata responses", async () => {
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        metadata: []
+      })
+    )
+
+    const setup = new RelayfileSetup({ cloudApiUrl: "https://cloud.test" })
+    const handle = await setup.joinWorkspace("ws_123")
+    await expect(
+      handle.setIntegrationMetadata("jira", { cloudId: "cloud-1" })
+    ).rejects.toThrow(/expected metadata to be a plain object/)
   })
 
   it("throws CloudApiError with parsed body on createWorkspace failure", async () => {

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -421,6 +421,197 @@ describe("RelayfileSetup", () => {
     } satisfies Partial<CloudApiError>)
   })
 
+  it("lists accessible resources via GET /integrations/{provider}/accessible-resources", async () => {
+    // The post-OAuth picker flow for Jira/Confluence: the CLI calls this to
+    // figure out which Atlassian sites the operator's OAuth grant covers
+    // so it can render a numbered picker. The SDK has to round-trip the
+    // shape exactly because the CLI's prompt parses each entry's id+url
+    // and feeds them into setIntegrationMetadata.
+    const fetchMock = queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        resources: [
+          {
+            id: "cloud-1",
+            url: "https://foo.atlassian.net",
+            name: "Foo",
+            scopes: ["read:jira-work"]
+          },
+          { id: "cloud-2", url: "https://bar.atlassian.net" }
+        ]
+      })
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/base/cloud"
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    const resources = await handle.listAccessibleResources("jira")
+
+    expect(resources).toEqual([
+      {
+        id: "cloud-1",
+        url: "https://foo.atlassian.net",
+        name: "Foo",
+        scopes: ["read:jira-work"]
+      },
+      { id: "cloud-2", url: "https://bar.atlassian.net" }
+    ])
+    expect(readRequestUrl(fetchMock, 1)).toBe(
+      "https://staging.agentrelay.com/base/cloud/api/v1/workspaces/ws_123/integrations/jira/accessible-resources"
+    )
+    expect(readRequestHeaders(fetchMock, 1).Authorization).toBe("Bearer rf_jwt_1")
+  })
+
+  it("listAccessibleResources filters out entries missing id or url", async () => {
+    // Defense in depth: if Cloud ever loosens its normalization, the SDK
+    // still refuses to return junk entries that the CLI would crash on.
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        resources: [
+          { id: "cloud-1", url: "https://foo.atlassian.net" },
+          { id: "cloud-2" },
+          { url: "https://baz.atlassian.net" },
+          null,
+          "not-an-object"
+        ]
+      })
+    )
+
+    const setup = new RelayfileSetup({ cloudApiUrl: "https://cloud.test" })
+    const handle = await setup.joinWorkspace("ws_123")
+    const resources = await handle.listAccessibleResources("jira")
+
+    expect(resources).toEqual([
+      { id: "cloud-1", url: "https://foo.atlassian.net" }
+    ])
+  })
+
+  it("listAccessibleResources surfaces Cloud's provider_has_no_accessible_resources as CloudApiError", async () => {
+    // Cloud returns 400 with code=provider_has_no_accessible_resources for
+    // non-Atlassian providers. The SDK must surface that as CloudApiError
+    // so callers can branch on the code instead of silently treating it
+    // like an empty list.
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse(
+        {
+          ok: false,
+          code: "provider_has_no_accessible_resources",
+          error: "Provider \"github\" does not expose accessible resources"
+        },
+        { status: 400 }
+      )
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://cloud.test",
+      retry: { maxRetries: 0, baseDelayMs: 1 }
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    await expect(
+      handle.listAccessibleResources("github")
+    ).rejects.toMatchObject({
+      httpStatus: 400,
+      httpBody: expect.objectContaining({
+        code: "provider_has_no_accessible_resources"
+      })
+    } satisfies Partial<CloudApiError>)
+  })
+
+  it("sets integration metadata via PUT /integrations/{provider}/metadata", async () => {
+    // The second half of the post-OAuth picker: after listAccessibleResources
+    // returns multiple sites and the operator picks one, the CLI calls
+    // this with { cloudId, baseUrl }. Cloud forwards to nango.setMetadata
+    // and echoes the value back; the SDK returns whatever Cloud echoed so
+    // CLI confirmation messages reflect the canonical stored shape.
+    const fetchMock = queueFetch(
+      makeJoinResponse(),
+      jsonResponse({
+        ok: true,
+        metadata: {
+          cloudId: "cloud-1",
+          baseUrl: "https://foo.atlassian.net"
+        }
+      })
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://staging.agentrelay.com/base/cloud"
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    const updated = await handle.setIntegrationMetadata("jira", {
+      cloudId: "cloud-1",
+      baseUrl: "https://foo.atlassian.net"
+    })
+
+    expect(updated).toEqual({
+      cloudId: "cloud-1",
+      baseUrl: "https://foo.atlassian.net"
+    })
+    expect(readRequestUrl(fetchMock, 1)).toBe(
+      "https://staging.agentrelay.com/base/cloud/api/v1/workspaces/ws_123/integrations/jira/metadata"
+    )
+    expect(readRequestBody(fetchMock, 1)).toEqual({
+      metadata: {
+        cloudId: "cloud-1",
+        baseUrl: "https://foo.atlassian.net"
+      }
+    })
+    const init = fetchMock.mock.calls[1]?.[1] as RequestInit
+    expect(init.method).toBe("PUT")
+  })
+
+  it("setIntegrationMetadata rejects non-object metadata locally before hitting Cloud", async () => {
+    // We catch this in the SDK so the operator-facing error message is
+    // immediate ("metadata must be a plain object") rather than an
+    // unhelpful Cloud 400 round-trip.
+    queueFetch(makeJoinResponse())
+    const setup = new RelayfileSetup({ cloudApiUrl: "https://cloud.test" })
+    const handle = await setup.joinWorkspace("ws_123")
+    // @ts-expect-error - exercising runtime guard
+    await expect(handle.setIntegrationMetadata("jira", "nope")).rejects.toThrow(
+      /metadata must be a plain object/
+    )
+    // @ts-expect-error - exercising runtime guard
+    await expect(handle.setIntegrationMetadata("jira", null)).rejects.toThrow(
+      /metadata must be a plain object/
+    )
+    await expect(
+      // @ts-expect-error - exercising runtime guard
+      handle.setIntegrationMetadata("jira", ["array"])
+    ).rejects.toThrow(/metadata must be a plain object/)
+  })
+
+  it("setIntegrationMetadata surfaces Cloud 400 invalid_metadata as CloudApiError", async () => {
+    queueFetch(
+      makeJoinResponse(),
+      jsonResponse(
+        {
+          ok: false,
+          code: "invalid_metadata",
+          error: "metadata key \"_internal\" is reserved by the Nango backend"
+        },
+        { status: 400 }
+      )
+    )
+
+    const setup = new RelayfileSetup({
+      cloudApiUrl: "https://cloud.test",
+      retry: { maxRetries: 0, baseDelayMs: 1 }
+    })
+    const handle = await setup.joinWorkspace("ws_123")
+    await expect(
+      handle.setIntegrationMetadata("jira", { _internal: "nope" })
+    ).rejects.toMatchObject({
+      httpStatus: 400,
+      httpBody: expect.objectContaining({ code: "invalid_metadata" })
+    } satisfies Partial<CloudApiError>)
+  })
+
   it("throws CloudApiError with parsed body on createWorkspace failure", async () => {
     queueFetch(
       jsonResponse(

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -736,6 +736,121 @@ export class WorkspaceHandle {
       : { connectionId: boundConnectionId }
   }
 
+  /**
+   * List the upstream resources the current connection's OAuth grant
+   * covers. Today only Atlassian-family providers (`jira`, `confluence`)
+   * have meaningful entries here — every Atlassian OAuth grant can cover
+   * multiple sites (cloudIds), and the operator needs to bind one of them
+   * to this workspace via {@link setIntegrationMetadata} before sync can
+   * run.
+   *
+   * Cloud returns 400 `provider_has_no_accessible_resources` for providers
+   * that don't model this concept (currently everything non-Atlassian);
+   * that error surfaces here as a `CloudApiError` so callers can handle
+   * it explicitly rather than treating an empty list as ambiguous.
+   *
+   * @example
+   * ```ts
+   * const sites = await workspace.listAccessibleResources("jira")
+   * if (sites.length > 1) {
+   *   const choice = await promptOperator(sites)
+   *   await workspace.setIntegrationMetadata("jira", {
+   *     cloudId: choice.id,
+   *     baseUrl: choice.url
+   *   })
+   * }
+   * ```
+   */
+  async listAccessibleResources(
+    provider: WorkspaceIntegrationProvider | string
+  ): Promise<
+    Array<{
+      id: string
+      url: string
+      name?: string
+      scopes?: string[]
+      avatarUrl?: string
+    }>
+  > {
+    const normalized = normalizeProviderId(provider)
+    const response = (await this._setup.requestJson({
+      operation: "listAccessibleResources",
+      method: "GET",
+      path: `api/v1/workspaces/${encodeURIComponent(this.workspaceId)}/integrations/${encodeURIComponent(normalized)}/accessible-resources`,
+      tokenProvider: async () => this.getOrRefreshToken()
+    })) as { resources?: unknown }
+    if (!response || !Array.isArray(response.resources)) {
+      return []
+    }
+    return response.resources
+      .filter(
+        (
+          entry: unknown
+        ): entry is {
+          id: string
+          url: string
+          name?: string
+          scopes?: string[]
+          avatarUrl?: string
+        } => {
+          if (!entry || typeof entry !== "object") return false
+          const record = entry as Record<string, unknown>
+          return (
+            typeof record.id === "string" &&
+            record.id.length > 0 &&
+            typeof record.url === "string" &&
+            record.url.length > 0
+          )
+        }
+      )
+      .map((entry) => ({ ...entry }))
+  }
+
+  /**
+   * Set the operator-controlled metadata namespace on the workspace's
+   * connection for `provider`. The cloud route forwards the payload to
+   * Nango's `setMetadata` (full-replacement, not merge), so the value
+   * passed here becomes the connection's metadata wholesale. Callers that
+   * want merge semantics should read existing metadata first.
+   *
+   * This is the second half of the post-OAuth picker flow for Jira /
+   * Confluence (see {@link listAccessibleResources}), but is intentionally
+   * general-purpose — any provider whose sync requires operator-supplied
+   * connection-level config (e.g. a non-default API host) can use this.
+   *
+   * The cloud side rejects top-level keys that look like Nango plumbing
+   * (`_*`, `connection_*`, `auth_*`, `provider_config_key`, `connection_id`)
+   * with `code: "invalid_metadata"` so a typo can't clobber the connection.
+   *
+   * @example
+   * ```ts
+   * await workspace.setIntegrationMetadata("jira", {
+   *   cloudId: "abc-123",
+   *   baseUrl: "https://foo.atlassian.net"
+   * })
+   * ```
+   */
+  async setIntegrationMetadata(
+    provider: WorkspaceIntegrationProvider | string,
+    metadata: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    const normalized = normalizeProviderId(provider)
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      throw new Error("metadata must be a plain object")
+    }
+    const response = (await this._setup.requestJson({
+      operation: "setIntegrationMetadata",
+      method: "PUT",
+      path: `api/v1/workspaces/${encodeURIComponent(this.workspaceId)}/integrations/${encodeURIComponent(normalized)}/metadata`,
+      body: { metadata },
+      tokenProvider: async () => this.getOrRefreshToken()
+    })) as { metadata?: unknown }
+    if (response && typeof response.metadata === "object" && response.metadata !== null) {
+      return response.metadata as Record<string, unknown>
+    }
+    return metadata
+  }
+
   getToken(): string {
     return this._token
   }
@@ -1000,6 +1115,20 @@ class MountedWorkspaceHandleImpl implements MountedWorkspaceHandle {
     }
     await safeStopLauncher(this.launcherInstance)
   }
+}
+
+// The metadata + accessible-resources verbs accept `WorkspaceIntegrationProvider | string`
+// so operators can target dynamically-discovered providers (Composio toolkit
+// slugs, future Atlassian-family additions) without an SDK release. We still
+// strip trailing whitespace and lower-case so consumers don't have to.
+function normalizeProviderId(
+  provider: WorkspaceIntegrationProvider | string
+): string {
+  const trimmed = typeof provider === "string" ? provider.trim() : ""
+  if (!trimmed) {
+    throw new Error("provider is required")
+  }
+  return trimmed.toLowerCase()
 }
 
 function assertProvider(provider: string): asserts provider is WorkspaceIntegrationProvider {

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -835,7 +835,7 @@ export class WorkspaceHandle {
     metadata: Record<string, unknown>
   ): Promise<Record<string, unknown>> {
     const normalized = normalizeProviderId(provider)
-    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    if (!isPlainRecord(metadata)) {
       throw new Error("metadata must be a plain object")
     }
     const response = (await this._setup.requestJson({
@@ -845,10 +845,10 @@ export class WorkspaceHandle {
       body: { metadata },
       tokenProvider: async () => this.getOrRefreshToken()
     })) as { metadata?: unknown }
-    if (response && typeof response.metadata === "object" && response.metadata !== null) {
-      return response.metadata as Record<string, unknown>
+    if (isPlainRecord(response?.metadata)) {
+      return { ...response.metadata }
     }
-    return metadata
+    throw new Error("invalid cloud response: expected metadata to be a plain object")
   }
 
   getToken(): string {
@@ -1129,6 +1129,14 @@ function normalizeProviderId(
     throw new Error("provider is required")
   }
   return trimmed.toLowerCase()
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false
+  }
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
 }
 
 function assertProvider(provider: string): asserts provider is WorkspaceIntegrationProvider {


### PR DESCRIPTION
> Draft until cloud#540 merges + deploys. The new SDK / CLI verbs call endpoints that don't exist on cloud main yet.

## Summary

Cross-repo consumer of cloud's new `GET .../accessible-resources` and `PUT .../metadata` routes (see https://github.com/AgentWorkforce/cloud/pull/540). Together with that change this closes the loop on Jira/Confluence multi-tenant setup (cloud#535): operators no longer need to dive into the Nango dashboard to pick a `cloudId` after OAuth completes.

### TS SDK (`packages/sdk/typescript`)

- `WorkspaceHandle.listAccessibleResources(provider)` returns `[{ id, url, name?, scopes?, avatarUrl? }]` for Atlassian-family providers. Cloud's typed 400 for non-Atlassian providers surfaces as `CloudApiError` so callers can branch on the code.
- `WorkspaceHandle.setIntegrationMetadata(provider, metadata)` PUTs the metadata namespace (full replacement, not merge); rejects non-object metadata locally before hitting Cloud.
- Both accept `WorkspaceIntegrationProvider | string` so callers can target dynamically-discovered providers without an SDK release.

### Python SDK (`packages/sdk/python`)

- `RelayFileClient` and `AsyncRelayFileClient` gain `list_accessible_resources(workspace_id, provider)` and `set_integration_metadata(workspace_id, provider, metadata)`.
- Both clients also accept a `cloud_base_url` constructor arg because cloud's control plane is a different host from the relayfile data plane (`https://agentrelay.com/cloud` vs `https://api.relayfile.dev`).

### Go CLI (`cmd/relayfile-cli/main.go`)

- `relayfile integration connect jira` (and `... confluence`) now calls accessible-resources after OAuth completes:
  - **0 sites**: warn and fail (continuing would queue a sync that cannot succeed)
  - **1 site**: auto-set `{ cloudId, baseUrl }` and log "auto-selected"
  - **>1 sites**: numbered picker with default-to-1 on blank input, validates range, retries up to 3 times then errors out
- Non-Atlassian providers skip the picker entirely so the existing connect flow is preserved.
- New verb: `relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]` — general-purpose, usable for any provider (Jira `cloudId`/`baseUrl`, linear `team_id`, custom API hosts, etc.). v1 is flat-keys-only; nested keys deferred.
- Usage banner updated with both the new verb and a note that `integration connect jira/confluence` does post-OAuth site selection.

## Test plan

- [x] `npm test --workspace packages/sdk/typescript` — 144/144 passing (6 new)
- [x] `pytest packages/sdk/python` — 52/52 passing (6 new)
- [x] `go test ./cmd/relayfile-cli/` — passing (7 new tests: set-metadata happy path, KEY=VALUE validation, single-site auto-select, multi-site interactive pick, blank-input default, retry-then-error, non-Atlassian no-op)
- [x] `go build ./...` — clean
- [ ] After cloud#540 deploys: smoke-test `relayfile integration connect jira` against a workspace with 2+ Atlassian sites, confirm prompt + selection + sync start

## Judgment calls

- Metadata route uses `setMetadata` (full replacement) rather than `updateMetadata` (merge) because the CLI confirmation prompt becomes truthful only with full replacement; callers wanting merge can read existing metadata first.
- The picker constructs its own `bufio.Reader` rather than going through `promptLine` because `promptLine` creates a fresh bufio reader per call and drops bytes buffered past the first newline — that breaks the retry loop when stdin is a pre-loaded reader (tests / piped scripts).
- Cloud-side validation rejects top-level `_*`, `connection_*`, `auth_*`, `provider_config_key`, `connection_id` keys to keep Nango plumbing safe, but allows these as nested keys under operator-supplied parents so legitimate domain metadata like `{ custom: { auth_url: "..." } }` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)