### PR TITLE
fix(local-mount): trailing-slash negations now re-include allow-listed directories

### DIFF
--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -71,6 +71,48 @@ describe('createMount', () => {
     handle.cleanup();
   });
 
+  it('allow-list pattern with trailing-slash negation re-includes the directory', async () => {
+    // Regression: previously `["/*", "!web/", "!web/**"]` produced an empty
+    // mount because isPathMatched OR'd the bare-name check (`/*` matches
+    // `web`) before the trailing-slash negation could counter it. The walker
+    // then skipped `web` and never recursed.
+    write(path.join(projectDir, 'web/content/post.md'), 'post');
+    write(path.join(projectDir, 'web/index.html'), 'home');
+    write(path.join(projectDir, 'secrets/api-key.txt'), 'shhh');
+    write(path.join(projectDir, 'README.md'), 'readme');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: ['/*', '!web/', '!web/**'],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    expect(existsSync(path.join(handle.mountDir, 'web/content/post.md'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'web/index.html'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'secrets'))).toBe(false);
+    expect(existsSync(path.join(handle.mountDir, 'README.md'))).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it('allow-list pattern without trailing slash also works (bare-name negation)', async () => {
+    // The `!web` form (no slash) also keeps working — it negates both the
+    // bare-name and trailing-slash forms.
+    write(path.join(projectDir, 'web/post.md'), 'post');
+    write(path.join(projectDir, 'README.md'), 'readme');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: ['/*', '!web', '!web/**'],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    expect(existsSync(path.join(handle.mountDir, 'web/post.md'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'README.md'))).toBe(false);
+
+    handle.cleanup();
+  });
+
   it('refuses mountDir === projectDir', async () => {
     await expect(
       createMount(projectDir, projectDir, {

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -537,7 +537,18 @@ function addExcludeEntries(
 
 function isPathMatched(relPath: string, matcher: Ignore, isDirectory = false): boolean {
   const normalized = normalizeRelativePosix(relPath);
-  return matcher.ignores(normalized) || (isDirectory && matcher.ignores(`${normalized}/`));
+  // For directories, ask the matcher about the trailing-slash form — that's
+  // the canonical "is this directory ignored?" question in gitignore semantics
+  // and is what makes trailing-slash negations (`!dir/`) actually take effect.
+  // The previous implementation OR'd the bare-name check first, which short-
+  // circuited to "ignored" when a pattern like `/*` matched the bare name —
+  // even if a later `!dir/` negated the directory form. The slash form is
+  // safe for bare-name patterns too: `ignore` treats `node_modules` as
+  // matching both `node_modules` and `node_modules/`.
+  if (isDirectory) {
+    return matcher.ignores(`${normalized}/`);
+  }
+  return matcher.ignores(normalized);
 }
 
 function hasSameContent(left: string, right: string): boolean {


### PR DESCRIPTION
## Summary

Allow-list mount patterns like `["/*", "!web/", "!web/**"]` silently produce empty mounts — the walker never recurses into `web/`. The bug is in `isPathMatched` at `packages/local-mount/src/mount.ts:540`:

```ts
return matcher.ignores(relPath) || (isDirectory && matcher.ignores(\`\${relPath}/\`));
```

The OR short-circuits. For a directory entry `web` with patterns `[/*, !web/, !web/**]`:

| Form | Result |
|------|--------|
| `matcher.ignores('web')` | `true` (`/*` matches the bare name) |
| `matcher.ignores('web/')` | `false` (`!web/` negates the trailing-slash form) |

The bare-name check fires first and returns `true`, so the trailing-slash branch never runs. The walker skips `web` and never copies its contents into the mount. A trailing-slash negation like `!web/` only counters the trailing-slash form, leaving the bare-name check unopposed.

Reported in the wild: a workforce persona authored to scope a blog writer to `web/` had `["/*", "!web/", "!web/**"]` in `ignoredPatterns`. The launched session's mount root contained only `CLAUDE.md`, `_MOUNT_README.md`, and `.relayfile-local-mount`. No `web/`.

## Fix

When the entry is a directory, ask the matcher about the trailing-slash form. That's the canonical "is this directory ignored?" question in gitignore semantics, and it's what makes trailing-slash negations actually take effect.

```ts
if (isDirectory) {
  return matcher.ignores(\`\${normalized}/\`);
}
return matcher.ignores(normalized);
```

Safe for bare-name patterns: `ignore` treats `node_modules` as matching both `node_modules` and `node_modules/`. The existing test for `ignoredPatterns: ['secrets/']` continues to pass, as do all 42 tests in the package.

## New regression tests

Two cases added to `mount.test.ts`:

- `["/*", "!web/", "!web/**"]` — the originally-broken form. The mount now contains `web/content/post.md` and excludes peers (`secrets/`, `README.md`).
- `["/*", "!web", "!web/**"]` — the workaround form (no trailing slash on the negation). Still works.

## Test plan

- [x] `npx vitest run mount.test.ts` — 14/14 pass (12 original + 2 new)
- [x] `npx vitest run` (full package) — 42/42 pass
- [x] Manual end-to-end: `createMount` with `["/*", "!web/", "!web/**"]` on a fixture tree now correctly mounts `web/content/post.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)