### PR TITLE
Support help flags across relayfile commands

### DIFF
--- a/.trajectories/completed/2026-05/traj_6y5t0i2h2tyg.json
+++ b/.trajectories/completed/2026-05/traj_6y5t0i2h2tyg.json
@@ -1,0 +1,65 @@
+{
+  "id": "traj_6y5t0i2h2tyg",
+  "version": 1,
+  "task": {
+    "title": "Support -h help flag for every relayfile command"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-14T08:26:24.958Z",
+  "completedAt": "2026-05-14T08:29:30.495Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-14T08:28:41.392Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_s3jueu42pmi0",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-14T08:28:41.392Z",
+      "endedAt": "2026-05-14T08:29:30.495Z",
+      "events": [
+        {
+          "ts": 1778747321393,
+          "type": "decision",
+          "content": "Intercept help flags at the top-level dispatcher: Intercept help flags at the top-level dispatcher",
+          "raw": {
+            "question": "Intercept help flags at the top-level dispatcher",
+            "chosen": "Intercept help flags at the top-level dispatcher",
+            "alternatives": [],
+            "reasoning": "This lets -h/--help work before subcommand validation, credential loading, or network calls, and keeps aliases consistent."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778747342699,
+          "type": "reflection",
+          "content": "Help handling is centralized and focused CLI/manual checks pass; broad Go tests are running before commit.",
+          "raw": {
+            "confidence": 0.8
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.8"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Added centralized -h/--help handling for relayfile root commands, command groups, subcommands, and aliases, with regression coverage for every CLI help path.",
+    "approach": "Standard approach",
+    "confidence": 0.92
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "5cad81bdbc098cacc615c9f5807728cfb5e6e211",
+    "endRef": "5cad81bdbc098cacc615c9f5807728cfb5e6e211"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_6y5t0i2h2tyg.md
+++ b/.trajectories/completed/2026-05/traj_6y5t0i2h2tyg.md
@@ -1,0 +1,32 @@
+# Trajectory: Support -h help flag for every relayfile command
+
+> **Status:** ✅ Completed
+> **Confidence:** 92%
+> **Started:** May 14, 2026 at 10:26 AM
+> **Completed:** May 14, 2026 at 10:29 AM
+
+---
+
+## Summary
+
+Added centralized -h/--help handling for relayfile root commands, command groups, subcommands, and aliases, with regression coverage for every CLI help path.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Intercept help flags at the top-level dispatcher
+- **Chose:** Intercept help flags at the top-level dispatcher
+- **Reasoning:** This lets -h/--help work before subcommand validation, credential loading, or network calls, and keeps aliases consistent.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Intercept help flags at the top-level dispatcher: Intercept help flags at the top-level dispatcher
+- Help handling is centralized and focused CLI/manual checks pass; broad Go tests are running before commit.

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-12T01:43:49.076Z",
+  "lastUpdated": "2026-05-14T08:29:30.657Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -263,6 +263,13 @@
       "startedAt": "2026-05-12T01:29:17.382Z",
       "completedAt": "2026-05-12T01:43:48.965Z",
       "path": ".trajectories/completed/2026-05/traj_62i8dhll2w9n.json"
+    },
+    "traj_6y5t0i2h2tyg": {
+      "title": "Support -h help flag for every relayfile command",
+      "status": "completed",
+      "startedAt": "2026-05-14T08:26:24.958Z",
+      "completedAt": "2026-05-14T08:29:30.495Z",
+      "path": ".trajectories/completed/2026-05/traj_6y5t0i2h2tyg.json"
     }
   }
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -331,6 +331,10 @@ func main() {
 }
 
 func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	if wantsHelp(args) {
+		printHelpForArgs(args, stdout)
+		return nil
+	}
 	if len(args) == 0 {
 		return runSetup(nil, stdin, stdout)
 	}
@@ -381,6 +385,163 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 	default:
 		printUsage(stderr)
 		return fmt.Errorf("unknown subcommand %q", args[0])
+	}
+}
+
+func wantsHelp(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func printHelpForArgs(args []string, stdout io.Writer) {
+	if len(args) == 0 {
+		printUsage(stdout)
+		return
+	}
+	command := args[0]
+	if command == "-h" || command == "--help" {
+		printUsage(stdout)
+		return
+	}
+	subcommand := ""
+	if len(args) > 1 && !strings.HasPrefix(args[1], "-") {
+		subcommand = args[1]
+	}
+
+	switch command {
+	case "setup":
+		fmt.Fprintln(stdout, "Usage: relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]")
+	case "login":
+		fmt.Fprintln(stdout, "Usage: relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]")
+	case "workspace":
+		printWorkspaceUsage(stdout, subcommand)
+	case "integration":
+		printIntegrationUsage(stdout, subcommand)
+	case "ops":
+		printOpsUsage(stdout, subcommand)
+	case "writeback":
+		printWritebackUsage(stdout, subcommand)
+	case "digest":
+		printDigestUsage(stdout, subcommand)
+	case "pull":
+		fmt.Fprintln(stdout, "Usage: relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]")
+	case "mount", "start":
+		printMountHelp(stdout)
+	case "restart":
+		fmt.Fprintln(stdout, "Usage: relayfile restart [WORKSPACE] [--foreground]")
+	case "tree", "ls":
+		fmt.Fprintln(stdout, "Usage: relayfile tree [WORKSPACE] [PATH] [--depth N] [--json]")
+	case "read", "cat":
+		fmt.Fprintln(stdout, "Usage: relayfile read [WORKSPACE] PATH [--output FILE] [--json]")
+	case "seed":
+		fmt.Fprintln(stdout, "Usage: relayfile seed [WORKSPACE] [DIR]")
+	case "export":
+		fmt.Fprintln(stdout, "Usage: relayfile export [WORKSPACE] --format FORMAT [--output FILE]")
+	case "status":
+		fmt.Fprintln(stdout, "Usage: relayfile status [WORKSPACE] [--json]")
+	case "stop":
+		fmt.Fprintln(stdout, "Usage: relayfile stop [WORKSPACE]")
+	case "logs":
+		fmt.Fprintln(stdout, "Usage: relayfile logs [WORKSPACE] [--lines N]")
+	case "observer":
+		fmt.Fprintln(stdout, "Usage: relayfile observer [WORKSPACE] [--no-open]")
+	case "help":
+		printUsage(stdout)
+	default:
+		printUsage(stdout)
+	}
+}
+
+func printWorkspaceUsage(w io.Writer, subcommand string) {
+	switch subcommand {
+	case "create":
+		fmt.Fprintln(w, "Usage: relayfile workspace create NAME")
+	case "use":
+		fmt.Fprintln(w, "Usage: relayfile workspace use NAME")
+	case "list":
+		fmt.Fprintln(w, "Usage: relayfile workspace list [--names-only]")
+	case "current":
+		fmt.Fprintln(w, "Usage: relayfile workspace current [--verbose]")
+	case "delete":
+		fmt.Fprintln(w, "Usage: relayfile workspace delete NAME [--yes]")
+	default:
+		fmt.Fprintln(w, `Usage:
+  relayfile workspace create NAME
+  relayfile workspace use NAME
+  relayfile workspace list [--names-only]
+  relayfile workspace current [--verbose]
+  relayfile workspace delete NAME [--yes]`)
+	}
+}
+
+func printIntegrationUsage(w io.Writer, subcommand string) {
+	switch subcommand {
+	case "connect":
+		fmt.Fprintln(w, "Usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m]")
+	case "available", "catalog", "providers":
+		fmt.Fprintln(w, "Usage: relayfile integration available [--search QUERY] [--backend BACKEND] [--json] [--refresh]")
+	case "search":
+		fmt.Fprintln(w, "Usage: relayfile integration search QUERY [--backend BACKEND] [--json] [--refresh]")
+	case "list":
+		fmt.Fprintln(w, "Usage: relayfile integration list [--workspace NAME] [--json]")
+	case "disconnect":
+		fmt.Fprintln(w, "Usage: relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]")
+	case "adopt":
+		fmt.Fprintln(w, "Usage: relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]")
+	case "set-metadata":
+		fmt.Fprintln(w, "Usage: relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]")
+	default:
+		fmt.Fprintln(w, `Usage:
+  relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME]
+  relayfile integration available [--search QUERY] [--backend BACKEND] [--json] [--refresh]
+  relayfile integration search QUERY [--backend BACKEND] [--json] [--refresh]
+  relayfile integration list [--workspace NAME] [--json]
+  relayfile integration disconnect PROVIDER [--workspace NAME] [--yes]
+  relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]
+  relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]`)
+	}
+}
+
+func printOpsUsage(w io.Writer, subcommand string) {
+	switch subcommand {
+	case "list":
+		fmt.Fprintln(w, "Usage: relayfile ops list [--workspace NAME] [--json] [--no-refresh]")
+	case "replay":
+		fmt.Fprintln(w, "Usage: relayfile ops replay OPID [--workspace NAME]")
+	default:
+		fmt.Fprintln(w, `Usage:
+  relayfile ops list [--workspace NAME] [--json]
+  relayfile ops replay OPID [--workspace NAME]`)
+	}
+}
+
+func printWritebackUsage(w io.Writer, subcommand string) {
+	switch subcommand {
+	case "list":
+		fmt.Fprintln(w, writebackListUsage)
+	case "status":
+		fmt.Fprintln(w, "Usage: relayfile writeback status [WORKSPACE] [--json]")
+	case "retry":
+		fmt.Fprintln(w, "Usage: relayfile writeback retry --opId OP [WORKSPACE]")
+	default:
+		fmt.Fprintln(w, `Usage:
+  relayfile writeback list --state pending|dead|succeeded|failed [--workspace WS] [--json]
+  relayfile writeback status [WORKSPACE] [--json]
+  relayfile writeback retry --opId OP [WORKSPACE]`)
+	}
+}
+
+func printDigestUsage(w io.Writer, subcommand string) {
+	switch subcommand {
+	case "rebuild":
+		fmt.Fprintln(w, digestRebuildUsage)
+	default:
+		fmt.Fprintln(w, `Usage:
+  relayfile digest rebuild --window yesterday|today [--workspace NAME]`)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -122,6 +122,78 @@ func parseBrowserFragment(t *testing.T, rawURL string) url.Values {
 	return fragment
 }
 
+func TestHelpFlagPrintsUsageForCommandsAndSubcommands(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "root short", args: []string{"-h"}, want: "relayfile is the RelayFile CLI."},
+		{name: "root long", args: []string{"--help"}, want: "relayfile is the RelayFile CLI."},
+		{name: "setup", args: []string{"setup", "-h"}, want: "Usage: relayfile setup"},
+		{name: "login", args: []string{"login", "-h"}, want: "Usage: relayfile login"},
+		{name: "workspace group", args: []string{"workspace", "-h"}, want: "relayfile workspace create NAME"},
+		{name: "workspace create", args: []string{"workspace", "create", "-h"}, want: "Usage: relayfile workspace create NAME"},
+		{name: "workspace use", args: []string{"workspace", "use", "-h"}, want: "Usage: relayfile workspace use NAME"},
+		{name: "workspace list", args: []string{"workspace", "list", "-h"}, want: "Usage: relayfile workspace list"},
+		{name: "workspace current", args: []string{"workspace", "current", "-h"}, want: "Usage: relayfile workspace current"},
+		{name: "workspace delete", args: []string{"workspace", "delete", "-h"}, want: "Usage: relayfile workspace delete NAME"},
+		{name: "integration group", args: []string{"integration", "-h"}, want: "relayfile integration search QUERY"},
+		{name: "integration connect", args: []string{"integration", "connect", "-h"}, want: "Usage: relayfile integration connect PROVIDER"},
+		{name: "integration available", args: []string{"integration", "available", "-h"}, want: "Usage: relayfile integration available"},
+		{name: "integration catalog alias", args: []string{"integration", "catalog", "-h"}, want: "Usage: relayfile integration available"},
+		{name: "integration providers alias", args: []string{"integration", "providers", "-h"}, want: "Usage: relayfile integration available"},
+		{name: "integration search", args: []string{"integration", "search", "-h"}, want: "Usage: relayfile integration search QUERY"},
+		{name: "integration search after query", args: []string{"integration", "search", "docker", "-h"}, want: "Usage: relayfile integration search QUERY"},
+		{name: "integration list", args: []string{"integration", "list", "-h"}, want: "Usage: relayfile integration list"},
+		{name: "integration disconnect", args: []string{"integration", "disconnect", "-h"}, want: "Usage: relayfile integration disconnect PROVIDER"},
+		{name: "integration adopt", args: []string{"integration", "adopt", "-h"}, want: "Usage: relayfile integration adopt PROVIDER"},
+		{name: "integration set metadata", args: []string{"integration", "set-metadata", "-h"}, want: "Usage: relayfile integration set-metadata PROVIDER"},
+		{name: "ops group", args: []string{"ops", "-h"}, want: "relayfile ops replay OPID"},
+		{name: "ops list", args: []string{"ops", "list", "-h"}, want: "Usage: relayfile ops list"},
+		{name: "ops replay", args: []string{"ops", "replay", "-h"}, want: "Usage: relayfile ops replay OPID"},
+		{name: "writeback group", args: []string{"writeback", "-h"}, want: "relayfile writeback retry --opId OP"},
+		{name: "writeback list", args: []string{"writeback", "list", "-h"}, want: writebackListUsage},
+		{name: "writeback status", args: []string{"writeback", "status", "-h"}, want: "Usage: relayfile writeback status"},
+		{name: "writeback retry", args: []string{"writeback", "retry", "-h"}, want: "Usage: relayfile writeback retry --opId OP"},
+		{name: "digest group", args: []string{"digest", "-h"}, want: "relayfile digest rebuild"},
+		{name: "digest rebuild", args: []string{"digest", "rebuild", "-h"}, want: digestRebuildUsage},
+		{name: "pull", args: []string{"pull", "-h"}, want: "Usage: relayfile pull"},
+		{name: "mount", args: []string{"mount", "-h"}, want: "Usage: relayfile mount"},
+		{name: "start alias", args: []string{"start", "-h"}, want: "Usage: relayfile mount"},
+		{name: "restart", args: []string{"restart", "-h"}, want: "Usage: relayfile restart"},
+		{name: "tree", args: []string{"tree", "-h"}, want: "Usage: relayfile tree"},
+		{name: "ls alias", args: []string{"ls", "-h"}, want: "Usage: relayfile tree"},
+		{name: "read", args: []string{"read", "-h"}, want: "Usage: relayfile read"},
+		{name: "cat alias", args: []string{"cat", "-h"}, want: "Usage: relayfile read"},
+		{name: "seed", args: []string{"seed", "-h"}, want: "Usage: relayfile seed"},
+		{name: "export", args: []string{"export", "-h"}, want: "Usage: relayfile export"},
+		{name: "status", args: []string{"status", "-h"}, want: "Usage: relayfile status"},
+		{name: "stop", args: []string{"stop", "-h"}, want: "Usage: relayfile stop"},
+		{name: "logs", args: []string{"logs", "-h"}, want: "Usage: relayfile logs"},
+		{name: "observer", args: []string{"observer", "-h"}, want: "Usage: relayfile observer"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			clearRelayfileEnv(t)
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			if err := run(tc.args, strings.NewReader(""), &stdout, &stderr); err != nil {
+				t.Fatalf("run(%v) returned error: %v\nstdout:\n%s\nstderr:\n%s", tc.args, err, stdout.String(), stderr.String())
+			}
+			if got := stdout.String(); !strings.Contains(got, tc.want) {
+				t.Fatalf("expected help output to contain %q, got:\n%s", tc.want, got)
+			}
+			if got := stderr.String(); got != "" {
+				t.Fatalf("expected no stderr for help, got %q", got)
+			}
+		})
+	}
+}
+
 func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)


### PR DESCRIPTION
## Summary
- intercept -h/--help at the top-level CLI dispatcher before subcommand validation
- add usage output for command groups, subcommands, and aliases
- cover all help paths in cmd/relayfile-cli tests

## Tests
- go test ./cmd/relayfile-cli
- go test ./...
- go run ./cmd/relayfile-cli integration -h
- go run ./cmd/relayfile-cli integration search -h