### PR TITLE
Explain zero-lag lagging sync providers

### DIFF
--- a/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.json
+++ b/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.json
@@ -1,0 +1,31 @@
+{
+  "id": "traj_nxbsptr6c5q0",
+  "version": 1,
+  "task": {
+    "title": "Investigate local lag and open status diagnostics PR"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-14T09:46:57.122Z",
+  "completedAt": "2026-05-14T09:50:46.065Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Investigated current local lag state and opened PR #153. Found the local daemon is current and polling, with no local pending writebacks/conflicts/denials; remote sync status marks six providers lagging because they lack cursor/watermark/ingress progress, while Linear has the only accepted ingress events. The PR adds inline CLI diagnostics for this ambiguous zero-lag lagging status.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "dd37469"
+  ],
+  "filesChanged": [
+    "cmd/relayfile-cli/main.go",
+    "cmd/relayfile-cli/main_test.go"
+  ],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "2381effe51055a5c5071d4173f5735f422bc463c",
+    "endRef": "dd37469def96ee6c2868b11649839b69dce09c4a",
+    "traceId": "b0f91259-f493-48b6-9f58-c3d211e12fac"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.md
+++ b/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.md
@@ -1,0 +1,21 @@
+# Trajectory: Investigate local lag and open status diagnostics PR
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** May 14, 2026 at 11:46 AM
+> **Completed:** May 14, 2026 at 11:50 AM
+
+---
+
+## Summary
+
+Investigated current local lag state and opened PR #153. Found the local daemon is current and polling, with no local pending writebacks/conflicts/denials; remote sync status marks six providers lagging because they lack cursor/watermark/ingress progress, while Linear has the only accepted ingress events. The PR adds inline CLI diagnostics for this ambiguous zero-lag lagging status.
+
+**Approach:** Standard approach
+
+---
+
+## Artifacts
+
+**Commits:** dd37469
+**Files changed:** 2

--- a/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.trace.json
+++ b/.trajectories/completed/2026-05/traj_nxbsptr6c5q0.trace.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "id": "b0f91259-f493-48b6-9f58-c3d211e12fac",
+  "timestamp": "2026-05-14T09:50:46.136Z",
+  "trajectory": "traj_nxbsptr6c5q0",
+  "files": [
+    {
+      "path": "cmd/relayfile-cli/main.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 144,
+              "end_line": 170,
+              "revision": "dd37469def96ee6c2868b11649839b69dce09c4a"
+            },
+            {
+              "start_line": 3732,
+              "end_line": 3743,
+              "revision": "dd37469def96ee6c2868b11649839b69dce09c4a"
+            },
+            {
+              "start_line": 3764,
+              "end_line": 3772,
+              "revision": "dd37469def96ee6c2868b11649839b69dce09c4a"
+            },
+            {
+              "start_line": 4813,
+              "end_line": 4855,
+              "revision": "dd37469def96ee6c2868b11649839b69dce09c4a"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "cmd/relayfile-cli/main_test.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1178,
+              "end_line": 1231,
+              "revision": "dd37469def96ee6c2868b11649839b69dce09c4a"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.trajectories/completed/2026-05/traj_qrt7hh3ht8nk.json
+++ b/.trajectories/completed/2026-05/traj_qrt7hh3ht8nk.json
@@ -1,0 +1,73 @@
+{
+  "id": "traj_qrt7hh3ht8nk",
+  "version": 1,
+  "task": {
+    "title": "Investigate confusing relayfile lagging status"
+  },
+  "status": "completed",
+  "startedAt": "2026-05-14T09:38:05.074Z",
+  "completedAt": "2026-05-14T09:42:53.566Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-05-14T09:41:44.573Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_1xpjmwjpbxtk",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-05-14T09:41:44.573Z",
+      "endedAt": "2026-05-14T09:42:53.566Z",
+      "events": [
+        {
+          "ts": 1778751704574,
+          "type": "decision",
+          "content": "Explain lagging providers with zero measured lag in relayfile status: Explain lagging providers with zero measured lag in relayfile status",
+          "raw": {
+            "question": "Explain lagging providers with zero measured lag in relayfile status",
+            "chosen": "Explain lagging providers with zero measured lag in relayfile status",
+            "alternatives": [],
+            "reasoning": "The server can report status=lagging with lagSeconds=0 when a provider has no cursor or watermark; querying ingress lets the CLI show whether events are pending, accepted, or absent."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1778751735895,
+          "type": "reflection",
+          "content": "Diagnosed live lagging status as absent provider cursor/watermark rather than a timed backlog; CLI now renders the missing diagnostic from ingress state.",
+          "raw": {
+            "focalPoints": [
+              "status-ux",
+              "current-workspace",
+              "ingress"
+            ],
+            "confidence": 0.86
+          },
+          "significance": "high",
+          "tags": [
+            "focal:status-ux",
+            "focal:current-workspace",
+            "focal:ingress",
+            "confidence:0.86"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Investigated relayfile status reporting lagging with zero visible lag. Confirmed live backend reports lagging providers with lagSeconds=0, nil cursor, nil watermark, no errors, no dead letters, and no ingress events recorded; only Linear has ingress/cursor progress. Added CLI diagnostics that query sync ingress for this ambiguous case and render a reason in relayfile status. Verified with go test ./cmd/relayfile-cli and go run ./cmd/relayfile-cli status.",
+    "approach": "Standard approach",
+    "confidence": 0.86
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "2381effe51055a5c5071d4173f5735f422bc463c",
+    "endRef": "2381effe51055a5c5071d4173f5735f422bc463c"
+  }
+}

--- a/.trajectories/completed/2026-05/traj_qrt7hh3ht8nk.md
+++ b/.trajectories/completed/2026-05/traj_qrt7hh3ht8nk.md
@@ -1,0 +1,32 @@
+# Trajectory: Investigate confusing relayfile lagging status
+
+> **Status:** ✅ Completed
+> **Confidence:** 86%
+> **Started:** May 14, 2026 at 11:38 AM
+> **Completed:** May 14, 2026 at 11:42 AM
+
+---
+
+## Summary
+
+Investigated relayfile status reporting lagging with zero visible lag. Confirmed live backend reports lagging providers with lagSeconds=0, nil cursor, nil watermark, no errors, no dead letters, and no ingress events recorded; only Linear has ingress/cursor progress. Added CLI diagnostics that query sync ingress for this ambiguous case and render a reason in relayfile status. Verified with go test ./cmd/relayfile-cli and go run ./cmd/relayfile-cli status.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Explain lagging providers with zero measured lag in relayfile status
+- **Chose:** Explain lagging providers with zero measured lag in relayfile status
+- **Reasoning:** The server can report status=lagging with lagSeconds=0 when a provider has no cursor or watermark; querying ingress lets the CLI show whether events are pending, accepted, or absent.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Explain lagging providers with zero measured lag in relayfile status: Explain lagging providers with zero measured lag in relayfile status
+- Diagnosed live lagging status as absent provider cursor/watermark rather than a timed backlog; CLI now renders the missing diagnostic from ingress state.

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -144,6 +144,27 @@ type syncProviderStatus struct {
 	WebhookHealthy        *bool          `json:"webhookHealthy,omitempty"`
 }
 
+type syncIngressStatusResponse struct {
+	WorkspaceID          string                               `json:"workspaceId"`
+	QueueDepth           int                                  `json:"queueDepth"`
+	PendingTotal         int                                  `json:"pendingTotal"`
+	DeadLetterTotal      int                                  `json:"deadLetterTotal"`
+	DeadLetterByProvider map[string]int                       `json:"deadLetterByProvider"`
+	AcceptedTotal        int                                  `json:"acceptedTotal"`
+	IngressByProvider    map[string]syncIngressProviderStatus `json:"ingressByProvider"`
+}
+
+type syncIngressProviderStatus struct {
+	AcceptedTotal           int `json:"acceptedTotal"`
+	DroppedTotal            int `json:"droppedTotal"`
+	DedupedTotal            int `json:"dedupedTotal"`
+	CoalescedTotal          int `json:"coalescedTotal"`
+	PendingTotal            int `json:"pendingTotal"`
+	OldestPendingAgeSeconds int `json:"oldestPendingAgeSeconds"`
+	SuppressedTotal         int `json:"suppressedTotal"`
+	StaleTotal              int `json:"staleTotal"`
+}
+
 type exportedFile struct {
 	Path        string `json:"path"`
 	Revision    string `json:"revision"`
@@ -3711,6 +3732,12 @@ func runStatus(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	var ingress *syncIngressStatusResponse
+	if statusNeedsIngressDiagnostics(status) {
+		if ingressStatus, err := fetchWorkspaceSyncIngressStatus(client, workspaceID); err == nil {
+			ingress = &ingressStatus
+		}
+	}
 	if _, err := upsertWorkspace(workspaceID); err != nil {
 		return err
 	}
@@ -3736,6 +3763,9 @@ func runStatus(args []string, stdout io.Writer) error {
 		}
 		if provider.LastError != nil && strings.TrimSpace(*provider.LastError) != "" {
 			line += "   last error: " + strings.TrimSpace(*provider.LastError)
+		}
+		if reason := syncProviderLagReason(provider, ingress); reason != "" {
+			line += "   reason: " + reason
 		}
 		fmt.Fprintln(stdout, line)
 		// Contract §7.4: warn when the webhook is unhealthy and the watermark
@@ -4781,6 +4811,43 @@ func fetchWorkspaceSyncStatus(client *apiClient, workspaceID string) (syncStatus
 		return syncStatusResponse{}, err
 	}
 	return status, nil
+}
+
+func fetchWorkspaceSyncIngressStatus(client *apiClient, workspaceID string) (syncIngressStatusResponse, error) {
+	var status syncIngressStatusResponse
+	if err := client.getJSON(context.Background(), fmt.Sprintf("/v1/workspaces/%s/sync/ingress", url.PathEscape(workspaceID)), &status); err != nil {
+		return syncIngressStatusResponse{}, err
+	}
+	return status, nil
+}
+
+func statusNeedsIngressDiagnostics(status syncStatusResponse) bool {
+	for _, provider := range status.Providers {
+		if provider.Status == "lagging" && provider.LagSeconds == 0 && provider.Cursor == nil && provider.WatermarkTs == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func syncProviderLagReason(provider syncProviderStatus, ingress *syncIngressStatusResponse) string {
+	if provider.Status != "lagging" || provider.LagSeconds != 0 || provider.Cursor != nil || provider.WatermarkTs != nil {
+		return ""
+	}
+	if ingress == nil {
+		return "no sync cursor or watermark reported"
+	}
+	providerIngress, ok := ingress.IngressByProvider[provider.Provider]
+	if !ok {
+		return "no sync cursor or watermark; no ingress events recorded"
+	}
+	if providerIngress.PendingTotal > 0 {
+		return fmt.Sprintf("%d pending ingress event(s), oldest %s", providerIngress.PendingTotal, formatLag(providerIngress.OldestPendingAgeSeconds))
+	}
+	if providerIngress.AcceptedTotal > 0 {
+		return fmt.Sprintf("%d ingress event(s) accepted but no cursor or watermark reported", providerIngress.AcceptedTotal)
+	}
+	return "no sync cursor or watermark; no ingress events recorded"
 }
 
 func syncProviderByName(status syncStatusResponse, provider string) (syncProviderStatus, bool) {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -151,6 +151,11 @@ type syncIngressStatusResponse struct {
 	DeadLetterTotal      int                                  `json:"deadLetterTotal"`
 	DeadLetterByProvider map[string]int                       `json:"deadLetterByProvider"`
 	AcceptedTotal        int                                  `json:"acceptedTotal"`
+	DroppedTotal         int                                  `json:"droppedTotal"`
+	DedupedTotal         int                                  `json:"dedupedTotal"`
+	CoalescedTotal       int                                  `json:"coalescedTotal"`
+	SuppressedTotal      int                                  `json:"suppressedTotal"`
+	StaleTotal           int                                  `json:"staleTotal"`
 	IngressByProvider    map[string]syncIngressProviderStatus `json:"ingressByProvider"`
 }
 
@@ -3754,7 +3759,7 @@ func runStatus(args []string, stdout io.Writer) error {
 	fmt.Fprintf(stdout, "workspace %s   mode: %s   lag: %s\n", workspaceLabel, snapshot.Mode, formatLag(maxLagSeconds(status.Providers)))
 	for _, provider := range status.Providers {
 		lastEvent := "-"
-		if provider.WatermarkTs != nil {
+		if hasNonEmptyString(provider.WatermarkTs) {
 			lastEvent = humanizeRecentTime(strings.TrimSpace(*provider.WatermarkTs))
 		}
 		line := fmt.Sprintf("  %-12s %-8s lag %s", provider.Provider, provider.Status, formatLag(provider.LagSeconds))
@@ -4823,7 +4828,7 @@ func fetchWorkspaceSyncIngressStatus(client *apiClient, workspaceID string) (syn
 
 func statusNeedsIngressDiagnostics(status syncStatusResponse) bool {
 	for _, provider := range status.Providers {
-		if provider.Status == "lagging" && provider.LagSeconds == 0 && provider.Cursor == nil && provider.WatermarkTs == nil {
+		if provider.Status == "lagging" && provider.LagSeconds == 0 && !hasNonEmptyString(provider.Cursor) && !hasNonEmptyString(provider.WatermarkTs) {
 			return true
 		}
 	}
@@ -4831,15 +4836,18 @@ func statusNeedsIngressDiagnostics(status syncStatusResponse) bool {
 }
 
 func syncProviderLagReason(provider syncProviderStatus, ingress *syncIngressStatusResponse) string {
-	if provider.Status != "lagging" || provider.LagSeconds != 0 || provider.Cursor != nil || provider.WatermarkTs != nil {
+	if provider.Status != "lagging" || provider.LagSeconds != 0 || hasNonEmptyString(provider.Cursor) || hasNonEmptyString(provider.WatermarkTs) {
 		return ""
 	}
 	if ingress == nil {
 		return "no sync cursor or watermark reported"
 	}
-	providerIngress, ok := ingress.IngressByProvider[provider.Provider]
+	providerIngress, ok := ingressProviderStatusFor(ingress, provider.Provider)
 	if !ok {
-		return "no sync cursor or watermark; no ingress events recorded"
+		if observed := unattributedIngressObservedTotal(ingress); observed > 0 {
+			return fmt.Sprintf("no sync cursor or watermark; %d workspace ingress event(s) observed without provider breakdown", observed)
+		}
+		return "no sync cursor or watermark; no provider-specific ingress events recorded"
 	}
 	if providerIngress.PendingTotal > 0 {
 		return fmt.Sprintf("%d pending ingress event(s), oldest %s", providerIngress.PendingTotal, formatLag(providerIngress.OldestPendingAgeSeconds))
@@ -4847,7 +4855,51 @@ func syncProviderLagReason(provider syncProviderStatus, ingress *syncIngressStat
 	if providerIngress.AcceptedTotal > 0 {
 		return fmt.Sprintf("%d ingress event(s) accepted but no cursor or watermark reported", providerIngress.AcceptedTotal)
 	}
-	return "no sync cursor or watermark; no ingress events recorded"
+	if observed := ingressProviderObservedTotal(providerIngress); observed > 0 {
+		return fmt.Sprintf("%d ingress event(s) observed but no cursor or watermark reported", observed)
+	}
+	return "no sync cursor or watermark; no provider-specific ingress events recorded"
+}
+
+func hasNonEmptyString(value *string) bool {
+	return value != nil && strings.TrimSpace(*value) != ""
+}
+
+func ingressProviderStatusFor(ingress *syncIngressStatusResponse, provider string) (syncIngressProviderStatus, bool) {
+	if ingress == nil || len(ingress.IngressByProvider) == 0 {
+		return syncIngressProviderStatus{}, false
+	}
+	if status, ok := ingress.IngressByProvider[provider]; ok {
+		return status, true
+	}
+	normalizedProvider := normalizeProviderID(provider)
+	if status, ok := ingress.IngressByProvider[normalizedProvider]; ok {
+		return status, true
+	}
+	for key, status := range ingress.IngressByProvider {
+		if normalizeProviderID(key) == normalizedProvider {
+			return status, true
+		}
+	}
+	return syncIngressProviderStatus{}, false
+}
+
+func ingressProviderObservedTotal(status syncIngressProviderStatus) int {
+	return status.DroppedTotal + status.DedupedTotal + status.CoalescedTotal + status.SuppressedTotal + status.StaleTotal
+}
+
+func unattributedIngressObservedTotal(ingress *syncIngressStatusResponse) int {
+	if ingress == nil {
+		return 0
+	}
+	total := ingress.DroppedTotal + ingress.DedupedTotal + ingress.CoalescedTotal + ingress.SuppressedTotal + ingress.StaleTotal
+	for _, provider := range ingress.IngressByProvider {
+		total -= ingressProviderObservedTotal(provider)
+	}
+	if total < 0 {
+		return 0
+	}
+	return total
 }
 
 func syncProviderByName(status syncStatusResponse, provider string) (syncProviderStatus, bool) {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1196,12 +1197,14 @@ func TestStatusExplainsLaggingProviderWithoutWatermark(t *testing.T) {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
 
+	var ingressCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/v1/workspaces/ws_demo/sync/status":
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"github","status":"lagging","lagSeconds":0}]}`))
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"github","status":"lagging","cursor":"","watermarkTs":" ","lagSeconds":0}]}`))
 		case "/v1/workspaces/ws_demo/sync/ingress":
+			ingressCalls.Add(1)
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","queueDepth":0,"pendingTotal":0,"deadLetterTotal":0,"acceptedTotal":55,"ingressByProvider":{"linear":{"acceptedTotal":55,"pendingTotal":0}}}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -1221,8 +1224,31 @@ func TestStatusExplainsLaggingProviderWithoutWatermark(t *testing.T) {
 	if !strings.Contains(got, "github       lagging  lag 0s") {
 		t.Fatalf("expected lagging provider row, got: %q", got)
 	}
-	if !strings.Contains(got, "reason: no sync cursor or watermark; no ingress events recorded") {
+	if !strings.Contains(got, "reason: no sync cursor or watermark; no provider-specific ingress events recorded") {
 		t.Fatalf("expected lag reason in status output, got: %q", got)
+	}
+	if ingressCalls.Load() != 1 {
+		t.Fatalf("expected status command to request /sync/ingress once, got %d", ingressCalls.Load())
+	}
+}
+
+func TestSyncProviderLagReasonUsesAliasesAndObservedCounters(t *testing.T) {
+	blank := ""
+	provider := syncProviderStatus{
+		Provider:    "slack-sage",
+		Status:      "lagging",
+		Cursor:      &blank,
+		WatermarkTs: &blank,
+	}
+	ingress := &syncIngressStatusResponse{
+		IngressByProvider: map[string]syncIngressProviderStatus{
+			"slack": {DedupedTotal: 2, CoalescedTotal: 1},
+		},
+	}
+
+	got := syncProviderLagReason(provider, ingress)
+	if !strings.Contains(got, "3 ingress event(s) observed") {
+		t.Fatalf("expected alias ingress observation reason, got %q", got)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1178,6 +1178,54 @@ func TestStatusRendersWebhookUnhealthyWarning(t *testing.T) {
 	}
 }
 
+func TestStatusExplainsLaggingProviderWithoutWatermark(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[{"provider":"github","status":"lagging","lagSeconds":0}]}`))
+		case "/v1/workspaces/ws_demo/sync/ingress":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","queueDepth":0,"pendingTotal":0,"deadLetterTotal":0,"acceptedTotal":55,"ingressByProvider":{"linear":{"acceptedTotal":55,"pendingTotal":0}}}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "github       lagging  lag 0s") {
+		t.Fatalf("expected lagging provider row, got: %q", got)
+	}
+	if !strings.Contains(got, "reason: no sync cursor or watermark; no ingress events recorded") {
+		t.Fatalf("expected lag reason in status output, got: %q", got)
+	}
+}
+
 func TestStatusOmitsWebhookWarningWhenHealthy(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)


### PR DESCRIPTION
## Summary
- Add a best-effort `/sync/ingress` diagnostic lookup for `relayfile status` when a provider is reported as `lagging` with `lagSeconds=0` and no cursor/watermark.
- Render an inline reason so users can distinguish a real backlog from missing sync progress metadata.
- Add CLI coverage for the no-watermark/no-ingress case.

## Investigation
- Local daemon for `rw_517d60b6` is running and polling; `lastReconcileAt` was current, with pending writebacks/conflicts/denied all zero.
- Raw sync status shows confluence/github/jira/notion/slack/slack-sage as `lagging` with `lagSeconds=0`, `cursor=null`, `watermarkTs=null`, no last error, and no dead letters.
- Raw ingress status shows queueDepth=0, pending=0, deadLetters=0, and only Linear has accepted ingress events/cursor progress.

## Test
- `go test ./cmd/relayfile-cli`
- `go run ./cmd/relayfile-cli status`