### PR TITLE
fix(cli): clarify connect wait and accept GitHub status fallback

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -237,7 +237,10 @@ type cloudConnectSessionResponse struct {
 }
 
 type cloudIntegrationReadyResponse struct {
-	Ready bool `json:"ready"`
+	Ready        bool   `json:"ready"`
+	Provider     string `json:"provider,omitempty"`
+	ConnectionID string `json:"connectionId,omitempty"`
+	State        string `json:"state,omitempty"`
 }
 
 type cloudTokenRefreshRequest struct {
@@ -1392,12 +1395,28 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 	}
 	deadline := time.Now().Add(timeout)
 	for {
-		ready, err := cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID)
+		status, err := cloudIntegrationStatus(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID)
 		if err != nil {
 			return err
 		}
-		if ready {
-			fmt.Fprintf(stdout, "%s connected. Files will appear under %s/%s within ~30s.\n", provider, localDir, providerRootDir(provider))
+		if !cloudIntegrationConnected(status) && connectionID != "" {
+			fallbackStatus, fallbackErr := cloudIntegrationStatus(cloudAPIURL, workspaceID, workspaceToken, provider, "")
+			if fallbackErr == nil && cloudIntegrationConnected(fallbackStatus) {
+				status = fallbackStatus
+			}
+		}
+		if cloudIntegrationConnected(status) {
+			if resolvedConnectionID := strings.TrimSpace(status.ConnectionID); resolvedConnectionID != "" && resolvedConnectionID != connectionID {
+				connectionID = resolvedConnectionID
+				_ = saveIntegrationConnection(localDir, integrationConnectionState{
+					Provider:     provider,
+					ConnectionID: connectionID,
+					Backend:      backend,
+					ConnectedAt:  time.Now().UTC().Format(time.RFC3339),
+					UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
+				})
+			}
+			fmt.Fprintf(stdout, "%s connected. Relayfile is preparing files in the background; keep this command running while initial sync finishes. Files will appear under %s/%s.\n", provider, localDir, providerRootDir(provider))
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -1408,9 +1427,17 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 }
 
 func cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID string) (bool, error) {
-	client, err := newAPIClient(cloudAPIURL, workspaceToken)
+	status, err := cloudIntegrationStatus(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID)
 	if err != nil {
 		return false, err
+	}
+	return cloudIntegrationConnected(status), nil
+}
+
+func cloudIntegrationStatus(cloudAPIURL, workspaceID, workspaceToken, provider, connectionID string) (cloudIntegrationReadyResponse, error) {
+	client, err := newAPIClient(cloudAPIURL, workspaceToken)
+	if err != nil {
+		return cloudIntegrationReadyResponse{}, err
 	}
 	query := url.Values{}
 	if strings.TrimSpace(connectionID) != "" {
@@ -1418,9 +1445,21 @@ func cloudIntegrationReady(cloudAPIURL, workspaceID, workspaceToken, provider, c
 	}
 	var status cloudIntegrationReadyResponse
 	if err := client.getJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations/%s/status?%s", url.PathEscape(workspaceID), url.PathEscape(provider), query.Encode()), &status); err != nil {
-		return false, fmt.Errorf("check %s connection: %w", provider, err)
+		return cloudIntegrationReadyResponse{}, fmt.Errorf("check %s connection: %w", provider, err)
 	}
-	return status.Ready, nil
+	return status, nil
+}
+
+func cloudIntegrationConnected(status cloudIntegrationReadyResponse) bool {
+	if status.Ready {
+		return true
+	}
+	switch strings.TrimSpace(strings.ToLower(status.State)) {
+	case "connected", "oauth_connected", "sync_queued", "syncing", "ready":
+		return true
+	default:
+		return false
+	}
 }
 
 func waitForInitialSync(serverURL, token, workspaceID, provider, localDir string, timeout time.Duration, stdout io.Writer) error {
@@ -1431,6 +1470,7 @@ func waitForInitialSync(serverURL, token, workspaceID, provider, localDir string
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(stdout, "Waiting for %s initial sync. Leave this command running; Relayfile is preparing files in the background.\n", provider)
 	deadline := time.Now().Add(timeout)
 	lastPrinted := time.Time{}
 	for {
@@ -1446,6 +1486,8 @@ func waitForInitialSync(serverURL, token, workspaceID, provider, localDir string
 			lastPrinted = time.Now()
 			if ok {
 				fmt.Fprintf(stdout, "Syncing %s... lag %ds status=%s\n", provider, providerStatus.LagSeconds, providerStatus.Status)
+			} else {
+				fmt.Fprintf(stdout, "Waiting for %s sync status...\n", provider)
 			}
 		}
 		if time.Now().After(deadline) {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -846,12 +846,65 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 			t.Fatalf("expected %s request", key)
 		}
 	}
-	if got := stdout.String(); !strings.Contains(got, "notion connected") {
+	got := stdout.String()
+	if !strings.Contains(got, "notion connected") {
 		t.Fatalf("unexpected integration connect output: %q", got)
+	}
+	if !strings.Contains(got, "keep this command running while initial sync finishes") {
+		t.Fatalf("expected connected-but-still-working guidance, got %q", got)
+	}
+	if !strings.Contains(got, "Waiting for notion initial sync. Leave this command running") {
+		t.Fatalf("expected initial sync wait guidance, got %q", got)
 	}
 	state := loadSavedConnection(localDir, "notion")
 	if state.ConnectionID != "conn_789" || state.Backend != "composio" {
 		t.Fatalf("unexpected saved integration connection: %#v", state)
+	}
+}
+
+func TestConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	seenWorkspaceStatus := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations/connect-session":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected connect POST, got %s", r.Method)
+			}
+			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/github","connectionId":"conn_session","backend":"nango"}`))
+		case "/api/v1/workspaces/ws_123/integrations/github/status":
+			switch r.URL.Query().Get("connectionId") {
+			case "conn_session":
+				_, _ = w.Write([]byte(`{"ready":false,"state":"not_connected","connectionId":"conn_session"}`))
+			case "":
+				seenWorkspaceStatus = true
+				_, _ = w.Write([]byte(`{"ready":false,"state":"oauth_connected","provider":"github","connectionId":"conn_actual"}`))
+			default:
+				t.Fatalf("unexpected connectionId query: %q", r.URL.Query().Get("connectionId"))
+			}
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := connectCloudIntegration(server.URL, "ws_123", "rf_join", "github", "nango", localDir, time.Second, false, &stdout); err != nil {
+		t.Fatalf("connectCloudIntegration failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if !seenWorkspaceStatus {
+		t.Fatalf("expected workspace-scoped status fallback")
+	}
+	if got := stdout.String(); !strings.Contains(got, "github connected") {
+		t.Fatalf("expected connected output, got %q", got)
+	}
+	state := loadSavedConnection(localDir, "github")
+	if state.ConnectionID != "conn_actual" || state.Backend != "nango" {
+		t.Fatalf("expected resolved github connection to be saved, got %#v", state)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -867,7 +867,8 @@ func TestConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus(t *testing.T)
 	clearRelayfileEnv(t)
 
 	localDir := t.TempDir()
-	seenWorkspaceStatus := false
+	var seenConnectionScopedStatus atomic.Bool
+	var seenWorkspaceStatus atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -879,9 +880,10 @@ func TestConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus(t *testing.T)
 		case "/api/v1/workspaces/ws_123/integrations/github/status":
 			switch r.URL.Query().Get("connectionId") {
 			case "conn_session":
+				seenConnectionScopedStatus.Store(true)
 				_, _ = w.Write([]byte(`{"ready":false,"state":"not_connected","connectionId":"conn_session"}`))
 			case "":
-				seenWorkspaceStatus = true
+				seenWorkspaceStatus.Store(true)
 				_, _ = w.Write([]byte(`{"ready":false,"state":"oauth_connected","provider":"github","connectionId":"conn_actual"}`))
 			default:
 				t.Fatalf("unexpected connectionId query: %q", r.URL.Query().Get("connectionId"))
@@ -896,7 +898,10 @@ func TestConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus(t *testing.T)
 	if err := connectCloudIntegration(server.URL, "ws_123", "rf_join", "github", "nango", localDir, time.Second, false, &stdout); err != nil {
 		t.Fatalf("connectCloudIntegration failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	if !seenWorkspaceStatus {
+	if !seenConnectionScopedStatus.Load() {
+		t.Fatalf("expected connection-scoped status probe before workspace fallback")
+	}
+	if !seenWorkspaceStatus.Load() {
 		t.Fatalf("expected workspace-scoped status fallback")
 	}
 	if got := stdout.String(); !strings.Contains(got, "github connected") {


### PR DESCRIPTION
## Summary
- clarify CLI output after provider OAuth connects so users know initial sync is still running
- accept connected state values from integration status responses, not only `ready: true`
- retry fresh connect polling with the workspace-scoped status probe and save the resolved `connectionId` when Cloud reports one

## User feedback addressed
- After the provider connects, the CLI looked stuck before returning. The CLI now tells users Relayfile is preparing files and to keep the process running while initial sync finishes.
- GitHub could complete OAuth but the CLI would still time out when the provisional session `connectionId` did not match the persisted integration row yet. The CLI now falls back to the workspace-scoped status probe allowed by the contract.

## Tests
- `go test ./cmd/relayfile-cli -run 'Test(ConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus|IntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace)'`\n- `go test ./cmd/relayfile-cli`