### PR TITLE
fix(mount): add low-memory sync diagnostics

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3415,6 +3415,9 @@ func runMount(args []string) error {
 	intervalJitter := fs.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := fs.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", defaultMountTimeout), "per-sync timeout")
 	websocketEnabled := fs.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
+	lowMemory := fs.Bool("low-memory", boolEnv("RELAYFILE_MOUNT_LOW_MEMORY", false), "reduce mount memory use by omitting per-file public state and deferring content reads")
+	pprofAddr := fs.String("pprof-addr", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PPROF_ADDR")), "optional pprof listen address, e.g. 127.0.0.1:6060")
+	memlogInterval := fs.Duration("memlog-interval", durationEnv("RELAYFILE_MOUNT_MEMLOG_INTERVAL", 0), "optional interval for logging runtime memory stats")
 	background := fs.Bool("background", false, "detach and keep syncing in the background")
 	pidFileFlag := fs.String("pid-file", "", "pid file path for background mode")
 	logFileFlag := fs.String("log-file", "", "log file path for background mode")
@@ -3431,6 +3434,9 @@ func runMount(args []string) error {
 		"interval-jitter": true,
 		"timeout":         true,
 		"websocket":       false,
+		"low-memory":      false,
+		"pprof-addr":      true,
+		"memlog-interval": true,
 		"background":      false,
 		"pid-file":        true,
 		"log-file":        true,
@@ -3540,11 +3546,15 @@ func runMount(args []string) error {
 		LocalRoot:     absLocalDir,
 		StateFile:     strings.TrimSpace(*stateFile),
 		WebSocket:     boolPtr(*websocketEnabled),
+		LowMemory:     boolPtr(*lowMemory),
 		RootCtx:       rootCtx,
 		Logger:        log.Default(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize mount syncer: %w", err)
+	}
+	if _, err := mountsync.StartDiagnostics(rootCtx, strings.TrimSpace(*pprofAddr), *memlogInterval, log.Default()); err != nil {
+		return fmt.Errorf("start diagnostics: %w", err)
 	}
 	if _, err := upsertWorkspace(workspaceID); err != nil {
 		return err
@@ -3611,6 +3621,9 @@ Common flags:
   --once               run one sync cycle and exit (used by setup/CI)
   --timeout 5m         per-sync timeout
   --no-websocket       disable websocket event streaming
+  --low-memory         skip detailed per-file public state and defer content reads
+  --pprof-addr ADDR    expose pprof diagnostics, e.g. 127.0.0.1:6060
+  --memlog-interval 1m log runtime memory stats periodically
 
 See 'relayfile help' for the full command list and
 docs/guides/vfs-cloud-setup.md#known-limitations for details.`)

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -43,6 +43,9 @@ type mountConfig struct {
 	timeout          time.Duration
 	websocketEnabled bool
 	lazyRepos        bool
+	lowMemory        bool
+	pprofAddr        string
+	memlogInterval   time.Duration
 	scopes           []string
 	once             bool
 	mode             string
@@ -68,6 +71,9 @@ func main() {
 	timeout := flag.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
 	websocketEnabled := flag.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
 	lazyRepos := flag.Bool("lazy-repos", lazyReposEnv(), "lazily materialize GitHub repo subtrees on first access")
+	lowMemory := flag.Bool("low-memory", boolEnv("RELAYFILE_MOUNT_LOW_MEMORY", false), "reduce mount memory use by omitting per-file public state and deferring content reads")
+	pprofAddr := flag.String("pprof-addr", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PPROF_ADDR")), "optional pprof listen address, e.g. 127.0.0.1:6060")
+	memlogInterval := flag.Duration("memlog-interval", durationEnv("RELAYFILE_MOUNT_MEMLOG_INTERVAL", 0), "optional interval for logging runtime memory stats")
 	mode := flag.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", mountModePoll), "mount mode: poll (synced mirror, recommended) or fuse")
 	fuse := flag.Bool("fuse", boolEnv("RELAYFILE_MOUNT_FUSE", false), "shortcut for --mode=fuse")
 	once := flag.Bool("once", false, "run one sync cycle and exit")
@@ -110,6 +116,9 @@ func main() {
 		timeout:          *timeout,
 		websocketEnabled: *websocketEnabled,
 		lazyRepos:        *lazyRepos,
+		lowMemory:        *lowMemory,
+		pprofAddr:        strings.TrimSpace(*pprofAddr),
+		memlogInterval:   *memlogInterval,
 		scopes:           parseTokenScopes(strings.TrimSpace(*token)),
 		once:             *once,
 		mode:             resolvedMode,
@@ -165,9 +174,13 @@ func runPollingMount(rootCtx context.Context, cfg mountConfig) error {
 		Mode:          cfg.mode,
 		Interval:      cfg.interval,
 		LazyRepos:     boolPtr(cfg.lazyRepos),
+		LowMemory:     boolPtr(cfg.lowMemory),
 	})
 	if err != nil {
 		return fmt.Errorf("initialize mount syncer: %w", err)
+	}
+	if _, err := mountsync.StartDiagnostics(rootCtx, cfg.pprofAddr, cfg.memlogInterval, log.Default()); err != nil {
+		return fmt.Errorf("start diagnostics: %w", err)
 	}
 	log.Printf("Mirror started at %s. Sync interval %s +/- %.0f%%. Public state: %s", cfg.localDir, cfg.interval.Round(time.Second), cfg.intervalJitter*100, filepath.Join(cfg.localDir, ".relay", "state.json"))
 

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2684,12 +2684,14 @@ func (s *Syncer) savePublicState() error {
 		case tracked.Dirty:
 			fileStatus = "writeback-pending"
 		}
-		if snapshot, ok := currentFiles[remotePath]; ok {
-			if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
+		if !s.lowMemory {
+			if snapshot, ok := currentFiles[remotePath]; ok {
+				if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
+					fileStatus = "writeback-pending"
+				}
+			} else if !tracked.Denied && !tracked.WriteDenied && tracked.Hash != "" && fileStatus == "ready" {
 				fileStatus = "writeback-pending"
 			}
-		} else if !tracked.Denied && !tracked.WriteDenied && tracked.Hash != "" && fileStatus == "ready" {
-			fileStatus = "writeback-pending"
 		}
 		if fileStatus == "writeback-pending" {
 			pendingWriteback++

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -13,9 +13,11 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -433,6 +435,9 @@ type SyncerOptions struct {
 	FullPullEvery int
 	// LazyRepos controls lazy GitHub repo subtree hydration. nil falls back to env.
 	LazyRepos *bool
+	// LowMemory avoids expensive diagnostic/public-state scans and large
+	// in-memory snapshots. nil falls back to RELAYFILE_MOUNT_LOW_MEMORY.
+	LowMemory *bool
 	// ProviderLayoutRegistrar receives deterministic per-provider layout
 	// manifests derived from remote snapshots. The FUSE layer can implement
 	// this to expose virtual <provider>/.layout.md files without coupling
@@ -442,6 +447,94 @@ type SyncerOptions struct {
 
 type Logger interface {
 	Printf(format string, args ...any)
+}
+
+func StartDiagnostics(ctx context.Context, addr string, memlogInterval time.Duration, logger Logger) (*http.Server, error) {
+	addr = strings.TrimSpace(addr)
+	if addr == "" && memlogInterval <= 0 {
+		return nil, nil
+	}
+	if logger == nil {
+		logger = noopLogger{}
+	}
+	if memlogInterval > 0 {
+		go logMemoryStats(ctx, memlogInterval, logger)
+	}
+	if addr == "" {
+		return nil, nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+	go func() {
+		logger.Printf("relayfile diagnostics listening on http://%s/debug/pprof/", addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Printf("relayfile diagnostics server failed: %v", err)
+		}
+	}()
+	return server, nil
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Printf(string, ...any) {}
+
+func logMemoryStats(ctx context.Context, interval time.Duration, logger Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		logMemoryStatSample(logger)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func logMemoryStatSample(logger Logger) {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	logger.Printf(
+		"relayfile memory: alloc=%s total_alloc=%s sys=%s heap_alloc=%s heap_sys=%s heap_objects=%d goroutines=%d next_gc=%s num_gc=%d",
+		formatBytes(stats.Alloc),
+		formatBytes(stats.TotalAlloc),
+		formatBytes(stats.Sys),
+		formatBytes(stats.HeapAlloc),
+		formatBytes(stats.HeapSys),
+		stats.HeapObjects,
+		runtime.NumGoroutine(),
+		formatBytes(stats.NextGC),
+		stats.NumGC,
+	)
+}
+
+func formatBytes(value uint64) string {
+	const unit = 1024
+	if value < unit {
+		return fmt.Sprintf("%dB", value)
+	}
+	div, exp := uint64(unit), 0
+	for n := value / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%ciB", float64(value)/float64(div), "KMGTPE"[exp])
 }
 
 type Syncer struct {
@@ -472,6 +565,7 @@ type Syncer struct {
 	fullPullEvery        int
 	incrementalCycles    int
 	lazyRepos            bool
+	lowMemory            bool
 	layoutRegistrar      ProviderLayoutRegistrar
 	mu                   sync.Mutex
 }
@@ -552,6 +646,7 @@ type publicState struct {
 	FailedWritebacks          uint64                     `json:"failedWritebacks,omitempty"`
 	LastError                 *statusError               `json:"lastError,omitempty"`
 	Files                     map[string]publicFileState `json:"files,omitempty"`
+	LowMemory                 bool                       `json:"lowMemory,omitempty"`
 }
 
 type publicStateFlags struct {
@@ -659,6 +754,20 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 			opts.Logger.Printf("ignoring invalid RELAYFILE_MOUNT_LAZY_GITHUB_REPOS=%q: %v", raw, perr)
 		}
 	}
+	lowMemory := false
+	if opts.LowMemory != nil {
+		lowMemory = *opts.LowMemory
+	} else if raw := strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_LOW_MEMORY")); raw != "" {
+		if parsed, perr := strconv.ParseBool(raw); perr == nil {
+			lowMemory = parsed
+		} else if opts.Logger != nil {
+			opts.Logger.Printf("ignoring invalid RELAYFILE_MOUNT_LOW_MEMORY=%q: %v", raw, perr)
+		}
+	}
+	bulkFlushThreshold := defaultBulkFlushThreshold
+	if lowMemory {
+		bulkFlushThreshold = 16
+	}
 	return &Syncer{
 		client:               client,
 		workspace:            workspace,
@@ -676,11 +785,12 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		rootCtx:              rootCtx,
 		logger:               opts.Logger,
 		denialLogPath:        filepath.Join(localRoot, ".relay", "permissions-denied.log"),
-		bulkFlushThreshold:   defaultBulkFlushThreshold,
+		bulkFlushThreshold:   bulkFlushThreshold,
 		mode:                 strings.TrimSpace(opts.Mode),
 		interval:             opts.Interval,
 		fullPullEvery:        fullPullEvery,
 		lazyRepos:            lazyRepos,
+		lowMemory:            lowMemory,
 		layoutRegistrar:      opts.ProviderLayoutRegistrar,
 		state: mountState{
 			Files: map[string]trackedFile{},
@@ -806,14 +916,13 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 }
 
 func (s *Syncer) handleLocalWriteOrCreate(ctx context.Context, remotePath, localPath string) error {
-	snapshotContent, err := os.ReadFile(localPath)
+	snapshot, err := readLocalSnapshot(localPath, true)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return s.pushSingleDelete(ctx, remotePath, localPath)
 		}
 		return err
 	}
-	snapshot := newLocalSnapshot(localPath, snapshotContent)
 	tracked, exists := s.state.Files[remotePath]
 	if exists && tracked.ReadOnly {
 		return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, snapshot.ContentType)
@@ -1624,9 +1733,12 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 		}
 		return true, err
 	}
-	remoteFiles := map[string]RemoteFile{}
-	for _, file := range files {
-		remotePath := normalizeRemotePath(file.Path)
+	sort.Slice(files, func(i, j int) bool {
+		return normalizeRemotePath(files[i].Path) < normalizeRemotePath(files[j].Path)
+	})
+	remotePaths := map[string]struct{}{}
+	for i := range files {
+		remotePath := normalizeRemotePath(files[i].Path)
 		if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 			continue
 		}
@@ -1637,10 +1749,14 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 		if tracked, ok := s.state.Files[remotePath]; ok && tracked.Denied {
 			continue
 		}
-		file.Path = remotePath
-		remoteFiles[remotePath] = file
+		files[i].Path = remotePath
+		if err := s.applyRemoteFile(remotePath, files[i], conflicted); err != nil {
+			return true, err
+		}
+		remotePaths[remotePath] = struct{}{}
+		files[i].Content = ""
 	}
-	return true, s.applyRemoteSnapshot(remoteFiles, conflicted)
+	return true, s.applyRemoteSnapshotDeletes(remotePaths, conflicted)
 }
 
 func exportSnapshotUnsupported(err error) bool {
@@ -1670,7 +1786,7 @@ func isUnderLazyGithubRepoSubtree(remoteRoot, remotePath string) bool {
 }
 
 func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]struct{}) error {
-	remoteFiles := map[string]RemoteFile{}
+	remotePaths := map[string]struct{}{}
 	cursor := ""
 	for {
 		page, err := s.client.ListTree(ctx, s.workspace, s.remoteRoot, 10, cursor)
@@ -1719,7 +1835,10 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 				}
 				return err
 			}
-			remoteFiles[remotePath] = file
+			if err := s.applyRemoteFile(remotePath, file, conflicted); err != nil {
+				return err
+			}
+			remotePaths[remotePath] = struct{}{}
 		}
 		if page.NextCursor == nil || *page.NextCursor == "" {
 			break
@@ -1727,7 +1846,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		cursor = *page.NextCursor
 	}
 
-	return s.applyRemoteSnapshot(remoteFiles, conflicted)
+	return s.applyRemoteSnapshotDeletes(remotePaths, conflicted)
 }
 
 func (s *Syncer) applyRemoteSnapshot(remoteFiles map[string]RemoteFile, conflicted map[string]struct{}) error {
@@ -1762,13 +1881,46 @@ func (s *Syncer) applyRemoteSnapshot(remoteFiles map[string]RemoteFile, conflict
 	return nil
 }
 
+func (s *Syncer) applyRemoteSnapshotDeletes(remotePaths map[string]struct{}, conflicted map[string]struct{}) error {
+	if err := s.materializeProviderLayoutsFromPaths(remotePaths); err != nil {
+		return err
+	}
+
+	statePaths := make([]string, 0, len(s.state.Files))
+	for remotePath := range s.state.Files {
+		statePaths = append(statePaths, remotePath)
+	}
+	sort.Strings(statePaths)
+	for _, remotePath := range statePaths {
+		if _, ok := remotePaths[remotePath]; ok {
+			continue
+		}
+		if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Syncer) materializeProviderLayouts(remoteFiles map[string]RemoteFile) error {
 	if s.layoutRegistrar == nil {
 		return nil
 	}
 
-	providerResources := map[string]map[string]struct{}{}
+	remotePaths := make(map[string]struct{}, len(remoteFiles))
 	for remotePath := range remoteFiles {
+		remotePaths[remotePath] = struct{}{}
+	}
+	return s.materializeProviderLayoutsFromPaths(remotePaths)
+}
+
+func (s *Syncer) materializeProviderLayoutsFromPaths(remotePaths map[string]struct{}) error {
+	if s.layoutRegistrar == nil {
+		return nil
+	}
+
+	providerResources := map[string]map[string]struct{}{}
+	for remotePath := range remotePaths {
 		provider, resource, ok := providerLayoutParts(s.remoteRoot, remotePath)
 		if !ok {
 			continue
@@ -2299,6 +2451,11 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 		if exists && tracked.WriteDenied && tracked.DeniedHash == snapshot.Hash {
 			continue
 		}
+		fullSnapshot, err := readLocalSnapshot(localPath, true)
+		if err != nil {
+			return nil, err
+		}
+		snapshot = fullSnapshot
 		pendingWrite, err := s.preparePendingBulkWrite(ctx, remotePath, localPath, snapshot, tracked, exists)
 		if err != nil {
 			return nil, err
@@ -2426,11 +2583,11 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 		if err != nil {
 			return nil
 		}
-		data, err := os.ReadFile(path)
+		snapshot, err := readLocalSnapshot(path, false)
 		if err != nil {
 			return err
 		}
-		results[remotePath] = newLocalSnapshot(path, data)
+		results[remotePath] = snapshot
 		return nil
 	})
 	if err != nil {
@@ -2495,9 +2652,13 @@ func (s *Syncer) saveState() error {
 }
 
 func (s *Syncer) savePublicState() error {
-	currentFiles, err := s.scanLocalFiles()
-	if err != nil {
-		return err
+	currentFiles := map[string]localSnapshot{}
+	if !s.lowMemory {
+		var err error
+		currentFiles, err = s.scanLocalFiles()
+		if err != nil {
+			return err
+		}
 	}
 	conflictsByPath, pendingConflicts, err := s.listConflictArtifacts()
 	if err != nil {
@@ -2506,7 +2667,10 @@ func (s *Syncer) savePublicState() error {
 	failedWritebacks := s.readPublicFailedWritebacks()
 	deniedPaths := 0
 	pendingWriteback := 0
-	files := make(map[string]publicFileState, len(s.state.Files))
+	var files map[string]publicFileState
+	if !s.lowMemory {
+		files = make(map[string]publicFileState, len(s.state.Files))
+	}
 
 	for remotePath, tracked := range s.state.Files {
 		fileStatus := "ready"
@@ -2533,26 +2697,30 @@ func (s *Syncer) savePublicState() error {
 		if tracked.Denied || tracked.WriteDenied {
 			deniedPaths++
 		}
-		files[remotePath] = publicFileState{
-			Revision:    tracked.Revision,
-			ContentType: tracked.ContentType,
-			Encoding:    tracked.Encoding,
-			Dirty:       tracked.Dirty,
-			Denied:      tracked.Denied,
-			WriteDenied: tracked.WriteDenied,
-			ReadOnly:    tracked.ReadOnly,
-			Status:      fileStatus,
+		if !s.lowMemory {
+			files[remotePath] = publicFileState{
+				Revision:    tracked.Revision,
+				ContentType: tracked.ContentType,
+				Encoding:    tracked.Encoding,
+				Dirty:       tracked.Dirty,
+				Denied:      tracked.Denied,
+				WriteDenied: tracked.WriteDenied,
+				ReadOnly:    tracked.ReadOnly,
+				Status:      fileStatus,
+			}
 		}
 	}
-	for remotePath, snapshot := range currentFiles {
-		if _, ok := files[remotePath]; ok {
-			continue
-		}
-		pendingWriteback++
-		files[remotePath] = publicFileState{
-			ContentType: snapshot.ContentType,
-			Encoding:    snapshot.Encoding,
-			Status:      "writeback-pending",
+	if !s.lowMemory {
+		for remotePath, snapshot := range currentFiles {
+			if _, ok := files[remotePath]; ok {
+				continue
+			}
+			pendingWriteback++
+			files[remotePath] = publicFileState{
+				ContentType: snapshot.ContentType,
+				Encoding:    snapshot.Encoding,
+				Status:      "writeback-pending",
+			}
 		}
 	}
 
@@ -2600,6 +2768,7 @@ func (s *Syncer) savePublicState() error {
 		FailedWritebacks:          failedWritebacks,
 		LastError:                 s.state.LastError,
 		Files:                     files,
+		LowMemory:                 s.lowMemory,
 	}
 	if err := os.MkdirAll(filepath.Dir(s.publicStatePath), 0o755); err != nil {
 		return err
@@ -2755,12 +2924,35 @@ func newLocalSnapshot(path string, data []byte) localSnapshot {
 		wireContent = base64.StdEncoding.EncodeToString(data)
 	}
 	return localSnapshot{
-		RawContent:  append([]byte(nil), data...),
+		RawContent:  data,
 		WireContent: wireContent,
 		ContentType: contentType,
 		Encoding:    encoding,
 		Hash:        hashBytes(data),
 	}
+}
+
+func readLocalSnapshot(path string, includeContent bool) (localSnapshot, error) {
+	if includeContent {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return localSnapshot{}, err
+		}
+		return newLocalSnapshot(path, data), nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return localSnapshot{}, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return localSnapshot{}, err
+	}
+	return localSnapshot{
+		ContentType: detectContentType(path),
+		Hash:        hex.EncodeToString(h.Sum(nil)),
+	}, nil
 }
 
 func shouldEncodeLocalContentAsBase64(data []byte, contentType string) bool {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3094,8 +3094,50 @@ func TestScanLocalFilesSkipsSymlinkedDirectories(t *testing.T) {
 	if _, ok := files["/note.md"]; !ok {
 		t.Fatalf("expected regular file to be scanned, got keys %#v", files)
 	}
+	if got := files["/note.md"]; len(got.RawContent) != 0 || got.WireContent != "" {
+		t.Fatalf("expected scanLocalFiles to defer content reads, got raw=%d wire=%q", len(got.RawContent), got.WireContent)
+	}
 	if _, ok := files["/node_modules_link"]; ok {
 		t.Fatalf("expected symlinked directory to be skipped")
+	}
+}
+
+func TestLowMemoryPublicStateOmitsPerFileDetails(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "new.md"), []byte("# local"), 0o644); err != nil {
+		t.Fatalf("seed local file failed: %v", err)
+	}
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_low_memory_public_state",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		LowMemory:   boolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	syncer.state.Files["/tracked.md"] = trackedFile{
+		Revision:    "rev_1",
+		ContentType: "text/markdown",
+		Hash:        hashString("# tracked"),
+		Dirty:       true,
+	}
+
+	if err := syncer.saveState(); err != nil {
+		t.Fatalf("save state failed: %v", err)
+	}
+
+	state := readPublicState(t, localDir)
+	if !state.LowMemory {
+		t.Fatalf("expected public state to record low-memory mode")
+	}
+	if len(state.Files) != 0 {
+		t.Fatalf("expected low-memory public state to omit per-file details, got %#v", state.Files)
+	}
+	if state.PendingWriteback != 1 {
+		t.Fatalf("expected only tracked dirty file to count as pending, got %d", state.PendingWriteback)
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3124,6 +3124,11 @@ func TestLowMemoryPublicStateOmitsPerFileDetails(t *testing.T) {
 		Hash:        hashString("# tracked"),
 		Dirty:       true,
 	}
+	syncer.state.Files["/clean.md"] = trackedFile{
+		Revision:    "rev_2",
+		ContentType: "text/markdown",
+		Hash:        hashString("# clean"),
+	}
 
 	if err := syncer.saveState(); err != nil {
 		t.Fatalf("save state failed: %v", err)
@@ -3138,6 +3143,9 @@ func TestLowMemoryPublicStateOmitsPerFileDetails(t *testing.T) {
 	}
 	if state.PendingWriteback != 1 {
 		t.Fatalf("expected only tracked dirty file to count as pending, got %d", state.PendingWriteback)
+	}
+	if !state.States.HasPendingWriteback {
+		t.Fatalf("expected dirty tracked file to keep pending writeback flag set")
 	}
 }
 


### PR DESCRIPTION
## Summary
- stream full-pull application instead of retaining a full remote file map
- stream local scan hashing and only hydrate file contents when a writeback is needed
- add low-memory mount mode plus pprof and runtime memory logging flags

## Notes
- `--low-memory` / `RELAYFILE_MOUNT_LOW_MEMORY=true` omits detailed per-file public state and reduces bulk write batch size.
- Diagnostics are available with `--pprof-addr` / `RELAYFILE_MOUNT_PPROF_ADDR` and `--memlog-interval` / `RELAYFILE_MOUNT_MEMLOG_INTERVAL`.
- The shared 429 blast radius still needs a separate cloud/CLI isolation fix: rate limits should be per user/workspace/token and invalid polling should back off.

## Tests
- `go test ./...`