### PR TITLE
Fix auto-sync reconcile cadence

### DIFF
--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+- `startAutoSync` now runs periodic full reconciles on a slower default cadence while watcher subscriptions are healthy, falls back to the existing 10s cadence when watchers are degraded, and accepts `scanIntervalMs: 0` or `Infinity` to disable periodic full reconciles. (#135)
 
 ## [0.7.17] - 2026-05-14
 

--- a/packages/local-mount/README.md
+++ b/packages/local-mount/README.md
@@ -74,8 +74,10 @@ By default, `launchOnMount` keeps the mount and project directory in sync contin
 
 ```ts
 interface AutoSyncOptions {
-  /** Full-reconcile interval as a safety net. Default: 10_000 ms. */
+  /** Degraded-watcher full-reconcile interval. Default: 10_000 ms. 0/Infinity disables periodic scans. */
   scanIntervalMs?: number;
+  /** Healthy-watcher full-reconcile interval. Default: 60_000 ms, or scanIntervalMs when set. */
+  healthyScanIntervalMs?: number;
   /** Per-path event debounce in ms. Default: 50 ms. */
   debounceMs?: number;
   /** Invoked on sync errors. Defaults to swallowing them. */
@@ -100,12 +102,16 @@ Control it from `launchOnMount`:
 launchOnMount({ /* ... */, autoSync: false });
 
 // Tune it.
-launchOnMount({ /* ... */, autoSync: { scanIntervalMs: 5_000, debounceMs: 100 } });
+launchOnMount({ /* ... */, autoSync: { healthyScanIntervalMs: 120_000, debounceMs: 100 } });
+
+// Disable periodic full reconciles and rely on watcher events.
+launchOnMount({ /* ... */, autoSync: { scanIntervalMs: 0 } });
 ```
 
 How it works:
 - [@parcel/watcher](https://www.npmjs.com/package/@parcel/watcher) watches both the mount and the project tree using native FSEvents/inotify/ReadDirectoryChangesW
-- every `scanIntervalMs`, a full reconcile walks both trees as a safety net for missed events
+- every `healthyScanIntervalMs` while watchers are healthy, a full reconcile walks both trees as a low-frequency safety net for missed events
+- if watcher setup fails or a watcher reports an error, full reconciles fall back to `scanIntervalMs`
 - watcher events are tracked as dirty paths, so shutdown can flush pending path-level work and make the final sync-back proportional to the number of mount-side changes when the watcher state stayed healthy
 - `stop({ signal })` still closes watchers if aborted, but skips the final draining reconcile
 - per-file `mtime` is tracked at the last sync, so the scan skips files that haven't changed

--- a/packages/local-mount/src/auto-sync-scheduler.test.ts
+++ b/packages/local-mount/src/auto-sync-scheduler.test.ts
@@ -103,6 +103,17 @@ describe('startAutoSync scheduler policy', () => {
     }
   );
 
+  it('rejects scan intervals that exceed the setTimeout maximum', () => {
+    const ctx = syncContext(mountDir, projectDir);
+
+    expect(() =>
+      startAutoSync(ctx, { scanIntervalMs: 2_147_483_648 })
+    ).toThrow(RangeError);
+    expect(() =>
+      startAutoSync(ctx, { healthyScanIntervalMs: 2_147_483_648 })
+    ).toThrow(RangeError);
+  });
+
   it('uses the longer healthy scan interval once watcher subscriptions are ready', async () => {
     write(path.join(projectDir, 'file.txt'), 'original');
     write(path.join(mountDir, 'file.txt'), 'original');

--- a/packages/local-mount/src/auto-sync-scheduler.test.ts
+++ b/packages/local-mount/src/auto-sync-scheduler.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const watcherMock = vi.hoisted(() => ({
+  subscribe: vi.fn(),
+}));
+
+vi.mock('@parcel/watcher', () => ({
+  default: watcherMock,
+}));
+
+import {
+  startAutoSync,
+  type AutoSyncContext,
+  type AutoSyncHandle,
+} from './auto-sync.js';
+
+function tmpDir(): string {
+  return mkdtempSync(path.join(os.tmpdir(), 'local-mount-scheduler-'));
+}
+
+function write(file: string, body: string): void {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, body, 'utf8');
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (check()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+function syncContext(realMountDir: string, realProjectDir: string): AutoSyncContext {
+  return {
+    realMountDir: realpathSync(realMountDir),
+    realProjectDir: realpathSync(realProjectDir),
+    isExcluded: () => false,
+    excludedAnyDepthNames: [],
+    excludedRootPrefixes: [],
+    isIgnored: () => false,
+    isReadonly: () => false,
+    isNoSyncBack: () => false,
+    isReservedFile: () => false,
+  };
+}
+
+async function stopAborted(auto: AutoSyncHandle): Promise<void> {
+  const controller = new AbortController();
+  controller.abort();
+  await auto.stop({ signal: controller.signal });
+}
+
+describe('startAutoSync scheduler policy', () => {
+  let projectDir: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountDir = tmpDir();
+    watcherMock.subscribe.mockReset();
+    watcherMock.subscribe.mockImplementation(async () => ({
+      unsubscribe: vi.fn(async () => { /* noop */ }),
+    }));
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it.each([0, Infinity])(
+    'does not run periodic reconcile when scanIntervalMs is %s',
+    async (scanIntervalMs) => {
+      write(path.join(projectDir, 'file.txt'), 'original');
+      write(path.join(mountDir, 'file.txt'), 'original');
+
+      const auto = startAutoSync(syncContext(mountDir, projectDir), {
+        scanIntervalMs,
+        debounceMs: 10_000,
+      });
+      await auto.ready();
+      try {
+        writeFileSync(path.join(mountDir, 'file.txt'), 'changed', 'utf8');
+        await new Promise((r) => setTimeout(r, 250));
+
+        expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('original');
+      } finally {
+        await stopAborted(auto);
+      }
+    }
+  );
+
+  it('uses the longer healthy scan interval once watcher subscriptions are ready', async () => {
+    write(path.join(projectDir, 'file.txt'), 'original');
+    write(path.join(mountDir, 'file.txt'), 'original');
+
+    const auto = startAutoSync(syncContext(mountDir, projectDir), {
+      scanIntervalMs: 50,
+      healthyScanIntervalMs: 10_000,
+      debounceMs: 10_000,
+    });
+    await auto.ready();
+    try {
+      expect(auto.watchersHealthy()).toBe(true);
+
+      writeFileSync(path.join(mountDir, 'file.txt'), 'changed', 'utf8');
+      await new Promise((r) => setTimeout(r, 250));
+
+      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('original');
+    } finally {
+      await stopAborted(auto);
+    }
+  });
+
+  it('falls back to the degraded scan interval when watcher setup fails', async () => {
+    const realProjectDir = realpathSync(projectDir);
+    watcherMock.subscribe.mockImplementation(async (root: string) => {
+      if (root === realProjectDir) {
+        throw new Error('project watcher failed');
+      }
+      return { unsubscribe: vi.fn(async () => { /* noop */ }) };
+    });
+    write(path.join(mountDir, 'file.txt'), 'from-mount');
+
+    const errors: Error[] = [];
+    const auto = startAutoSync(syncContext(mountDir, projectDir), {
+      scanIntervalMs: 50,
+      healthyScanIntervalMs: 10_000,
+      debounceMs: 10_000,
+      onError: (err) => errors.push(err),
+    });
+
+    try {
+      await expect(auto.ready()).rejects.toThrow('project watcher failed');
+      expect(auto.watchersHealthy()).toBe(false);
+
+      const projectFile = path.join(projectDir, 'file.txt');
+      await waitFor(() =>
+        existsSync(projectFile) && readFileSync(projectFile, 'utf8') === 'from-mount'
+      );
+      expect(errors).toHaveLength(1);
+    } finally {
+      await auto.stop();
+    }
+  });
+});

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -49,8 +49,17 @@ export interface AutoSyncContext {
 }
 
 export interface AutoSyncOptions {
-  /** Full-reconcile interval as a safety net. Default: 10_000ms. */
+  /**
+   * Degraded-watcher full-reconcile interval as a safety net. Default: 10_000ms.
+   * Set to 0 or Infinity to disable periodic full reconciles.
+   */
   scanIntervalMs?: number;
+  /**
+   * Full-reconcile interval while both watcher subscriptions are healthy.
+   * Default: 60_000ms, or `scanIntervalMs` when that option is explicitly set.
+   * Set to 0 or Infinity to disable healthy-watcher full reconciles.
+   */
+  healthyScanIntervalMs?: number;
   /**
    * Per-path event debounce in ms. Rapid watcher events for the same path
    * are coalesced into a single sync. Default: 50.
@@ -82,12 +91,36 @@ interface FileState {
 }
 
 const STOP_EVENT_SETTLE_MS = 250;
+const DEFAULT_SCAN_INTERVAL_MS = 10_000;
+const DEFAULT_HEALTHY_SCAN_INTERVAL_MS = 60_000;
+
+function normalizeScanInterval(
+  name: string,
+  value: number | undefined,
+  fallback: number
+): number | null {
+  const interval = value ?? fallback;
+  if (interval === 0 || interval === Infinity) return null;
+  if (!Number.isFinite(interval) || interval < 0) {
+    throw new RangeError(`${name} must be a finite non-negative number, 0, or Infinity`);
+  }
+  return interval;
+}
 
 export function startAutoSync(
   ctx: AutoSyncContext,
   opts: AutoSyncOptions = {}
 ): AutoSyncHandle {
-  const scanIntervalMs = opts.scanIntervalMs ?? 10_000;
+  const scanIntervalMs = normalizeScanInterval(
+    'scanIntervalMs',
+    opts.scanIntervalMs,
+    DEFAULT_SCAN_INTERVAL_MS
+  );
+  const healthyScanIntervalMs = normalizeScanInterval(
+    'healthyScanIntervalMs',
+    opts.healthyScanIntervalMs,
+    opts.scanIntervalMs === undefined ? DEFAULT_HEALTHY_SCAN_INTERVAL_MS : opts.scanIntervalMs
+  );
   const debounceMs = opts.debounceMs ?? 50;
   const onError = opts.onError ?? (() => { /* ignore by default */ });
 
@@ -107,11 +140,6 @@ export function startAutoSync(
   const dirtyMountPaths = new Set<string>();
 
   const watchersHealthy = (): boolean => watchersReadySettled && !watcherDegraded;
-
-  const markWatcherDegraded = (err: Error): void => {
-    watcherDegraded = true;
-    onError(err);
-  };
 
   const clearPendingDebounces = (): void => {
     for (const t of pendingDebounces.values()) clearTimeout(t);
@@ -195,6 +223,49 @@ export function startAutoSync(
     return count;
   };
 
+  let periodicTimer: NodeJS.Timeout | undefined;
+  let periodicReconcileRunning = false;
+
+  const clearPeriodicReconcile = (): void => {
+    if (periodicTimer) {
+      clearTimeout(periodicTimer);
+      periodicTimer = undefined;
+    }
+  };
+
+  const nextScanInterval = (): number | null => {
+    return watchersHealthy() ? healthyScanIntervalMs : scanIntervalMs;
+  };
+
+  const schedulePeriodicReconcile = (): void => {
+    clearPeriodicReconcile();
+    if (stopping || stopped) return;
+
+    const delay = nextScanInterval();
+    if (delay === null) return;
+
+    periodicTimer = setTimeout(() => {
+      periodicTimer = undefined;
+      periodicReconcileRunning = true;
+      void runReconcile().finally(() => {
+        periodicReconcileRunning = false;
+        schedulePeriodicReconcile();
+      });
+    }, delay);
+    periodicTimer.unref?.();
+  };
+
+  const reschedulePeriodicReconcile = (): void => {
+    if (periodicReconcileRunning) return;
+    schedulePeriodicReconcile();
+  };
+
+  const markWatcherDegraded = (err: Error): void => {
+    watcherDegraded = true;
+    reschedulePeriodicReconcile();
+    onError(err);
+  };
+
   const flushPending = async (opts?: { signal?: AbortSignal }): Promise<number> => {
     if (opts?.signal?.aborted) {
       return 0;
@@ -268,10 +339,12 @@ export function startAutoSync(
     if (projectResult.status === 'fulfilled') projectSub = projectResult.value;
     if (mountResult.status === 'fulfilled' && projectResult.status === 'fulfilled') {
       watchersReadySettled = true;
+      reschedulePeriodicReconcile();
       return;
     }
     watchersReadySettled = true;
     watcherDegraded = true;
+    reschedulePeriodicReconcile();
     await Promise.allSettled([
       mountSub?.unsubscribe(),
       projectSub?.unsubscribe(),
@@ -287,11 +360,7 @@ export function startAutoSync(
   // rejection after the cleanup above has already run.
   watchersReady.catch((err) => markWatcherDegraded(err as Error));
 
-  const interval = setInterval(() => {
-    void runReconcile();
-  }, scanIntervalMs);
-  // Do not keep the event loop alive just because of our scan timer.
-  interval.unref?.();
+  schedulePeriodicReconcile();
 
   return {
     async stop(opts?: { signal?: AbortSignal }) {
@@ -305,7 +374,7 @@ export function startAutoSync(
         await new Promise<void>((resolve) => setTimeout(resolve, STOP_EVENT_SETTLE_MS));
       }
       stopping = true;
-      clearInterval(interval);
+      clearPeriodicReconcile();
       clearPendingDebounces();
       await Promise.allSettled([
         mountSub?.unsubscribe(),

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -93,6 +93,7 @@ interface FileState {
 const STOP_EVENT_SETTLE_MS = 250;
 const DEFAULT_SCAN_INTERVAL_MS = 10_000;
 const DEFAULT_HEALTHY_SCAN_INTERVAL_MS = 60_000;
+const MAX_SCAN_INTERVAL_MS = 2_147_483_647;
 
 function normalizeScanInterval(
   name: string,
@@ -101,8 +102,10 @@ function normalizeScanInterval(
 ): number | null {
   const interval = value ?? fallback;
   if (interval === 0 || interval === Infinity) return null;
-  if (!Number.isFinite(interval) || interval < 0) {
-    throw new RangeError(`${name} must be a finite non-negative number, 0, or Infinity`);
+  if (!Number.isFinite(interval) || interval < 0 || interval > MAX_SCAN_INTERVAL_MS) {
+    throw new RangeError(
+      `${name} must be between 0 and ${MAX_SCAN_INTERVAL_MS}, or Infinity`
+    );
   }
   return interval;
 }
@@ -261,8 +264,11 @@ export function startAutoSync(
   };
 
   const markWatcherDegraded = (err: Error): void => {
+    const alreadyDegraded = watcherDegraded;
     watcherDegraded = true;
-    reschedulePeriodicReconcile();
+    if (!alreadyDegraded) {
+      reschedulePeriodicReconcile();
+    }
     onError(err);
   };
 

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -57,8 +57,9 @@ export interface MountHandle {
   syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number>;
   /**
    * Start bidirectional auto-sync: watches both the mount and project trees
-   * via @parcel/watcher and runs a full reconcile every `scanIntervalMs`
-   * as a safety net. Returns a handle you must `stop()` before teardown.
+   * via @parcel/watcher and runs periodic full reconciles as a safety net,
+   * with a slower cadence while watchers are healthy. Returns a handle you
+   * must `stop()` before teardown.
    */
   startAutoSync(opts?: AutoSyncOptions): AutoSyncHandle;
   cleanup(): void;


### PR DESCRIPTION
## Summary
- Confirmed #135 is still relevant on current origin/main: startAutoSync still used a 10s fixed full-reconcile timer.
- Replaced the fixed interval with a watcher-health-aware scheduler: healthy watchers default to 60s full scans, degraded watchers keep the 10s safety cadence, and explicit scanIntervalMs remains backwards-compatible unless healthyScanIntervalMs is set.
- Added scanIntervalMs 0/Infinity disable support, docs/changelog updates, and mocked scheduler tests for disabled, healthy, and degraded modes.

Closes #135

## Verification
- npm run typecheck --workspace=packages/local-mount
- npm run test --workspace=packages/local-mount
- npm run build
- go test ./...
- ./scripts/check-contract-surface.sh

Note: root npm run test currently passes core, SDK, and local-mount, then fails in packages/file-observer because jsdom is not installed; that package is not touched by this PR and is not part of the current CI workflow.