### PR TITLE
fix(mountsync): defense-in-depth against mount-root clobber data loss

### DIFF
--- a/internal/mountsync/mount_root_clobber_test.go
+++ b/internal/mountsync/mount_root_clobber_test.go
@@ -225,6 +225,60 @@ func TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty(t *testing.T) {
 	}
 }
 
+// TestPullDoesNotDeleteLocalFilesWhenCloudExportEmpty mirrors
+// TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty for the export path:
+// a cloud export response that comes back empty while local state tracks
+// files must NOT delete the local mirror.
+func TestPullDoesNotDeleteLocalFilesWhenCloudExportEmpty(t *testing.T) {
+	disableWS := false
+	localDir := t.TempDir()
+
+	// Seed a tracked, mirrored file locally.
+	mirrored := filepath.Join(localDir, "keep.md")
+	if err := os.WriteFile(mirrored, []byte("# keep me"), 0o644); err != nil {
+		t.Fatalf("seed mirrored file: %v", err)
+	}
+	stateFile := filepath.Join(localDir, ".relayfile-mount-state.json")
+	if err := writeMountState(stateFile, mountState{
+		Files: map[string]trackedFile{
+			"/notion/keep.md": {Revision: "rev_1", ContentType: "text/markdown", Hash: hashString("# keep me")},
+		},
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	// fakeExportClient with NO files -> ExportFiles returns an empty
+	// slice. The syncer should detect the unsafe response and preserve
+	// the local mirror instead of running applyRemoteSnapshotDeletes.
+	fc := &fakeExportClient{
+		fakeClient: &fakeClient{files: map[string]RemoteFile{}, eventsUnsupported: true},
+	}
+	syncer, err := NewSyncer(fc, SyncerOptions{
+		WorkspaceID: "ws_empty_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWS,
+		StateFile:   stateFile,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync against empty cloud export failed: %v", err)
+	}
+
+	// Confirm the export path was actually exercised so the test fails
+	// loudly if the syncer silently falls back to ListTree.
+	if fc.exportCalls == 0 {
+		t.Fatalf("expected at least one ExportFiles call; got 0 (export path not exercised)")
+	}
+
+	if b, rErr := os.ReadFile(mirrored); rErr != nil || string(b) != "# keep me" {
+		t.Fatalf("local mirrored file was deleted/corrupted by empty cloud export: err=%v contents=%q", rErr, string(b))
+	}
+}
+
 // TestMountRootBasenameCollisionNeverClobbered is the top-level
 // regression: a mount whose basename collides with a child file name must
 // never sync that child onto the root nor destroy the mount directory.

--- a/internal/mountsync/mount_root_clobber_test.go
+++ b/internal/mountsync/mount_root_clobber_test.go
@@ -1,0 +1,337 @@
+package mountsync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLogger collects log lines so tests can assert that a guard fired.
+type captureLogger struct {
+	lines []string
+}
+
+func (l *captureLogger) Printf(format string, args ...any) {
+	l.lines = append(l.lines, strings.TrimSpace(fmt.Sprintf(format, args...)))
+}
+
+// TestRemoteToLocalPathRejectsRootResolution verifies that
+// remoteToLocalPath never returns a path equal to the mount root. The
+// pre-fix final check explicitly allowed `joined == localRoot`, leaving
+// the mount root reachable as a write target via any combination of
+// roots + paths whose cleaned join lands on the root directory.
+func TestRemoteToLocalPathRejectsRootResolution(t *testing.T) {
+	localRoot := filepath.Join(t.TempDir(), "relayfile-mount")
+	if err := os.MkdirAll(localRoot, 0o755); err != nil {
+		t.Fatalf("mkdir local root: %v", err)
+	}
+
+	// Empty / root-equivalent remote paths must error (existing behavior,
+	// re-asserted as part of the data-loss contract).
+	for _, rp := range []string{"/", ""} {
+		if _, err := remoteToLocalPath(localRoot, "/", rp); err == nil {
+			t.Fatalf("expected error for remote path %q resolving onto root", rp)
+		}
+	}
+
+	// remoteRoot equal to remotePath (rel becomes empty) must error.
+	if _, err := remoteToLocalPath(localRoot, "/relayfile-mount", "/relayfile-mount"); err == nil {
+		t.Fatalf("expected error when remotePath equals remoteRoot")
+	}
+
+	// A legitimate child still resolves under (not onto) the root.
+	got, err := remoteToLocalPath(localRoot, "/", "/notes.md")
+	if err != nil {
+		t.Fatalf("plain child rejected: %v", err)
+	}
+	if filepath.Clean(got) == localRoot {
+		t.Fatalf("legitimate child resolved onto mount root: %s", got)
+	}
+	if !strings.HasPrefix(filepath.Clean(got), localRoot+string(filepath.Separator)) {
+		t.Fatalf("legitimate child resolved outside root: %s", got)
+	}
+}
+
+// TestLocalToRemotePathRejectsMountRoot verifies that localToRemotePath
+// refuses to generate a remote path for the mount root itself. This is
+// the round-trip safety net: any path whose remote form would resolve
+// back onto the mount root must be rejected at generation time.
+func TestLocalToRemotePathRejectsMountRoot(t *testing.T) {
+	localRoot := filepath.Join(t.TempDir(), "relayfile-mount")
+	if err := os.MkdirAll(localRoot, 0o755); err != nil {
+		t.Fatalf("mkdir local root: %v", err)
+	}
+
+	// The mount root itself must always be rejected.
+	if _, err := localToRemotePath(localRoot, "/", localRoot); err == nil {
+		t.Fatalf("expected localToRemotePath to reject the mount root itself")
+	}
+	if _, err := localToRemotePath(localRoot, "/relayfile-mount", localRoot); err == nil {
+		t.Fatalf("expected localToRemotePath to reject the mount root under any remoteRoot")
+	}
+
+	// A normal nested child round-trips cleanly.
+	ok := filepath.Join(localRoot, "sub", "doc.md")
+	rp, err := localToRemotePath(localRoot, "/", ok)
+	if err != nil {
+		t.Fatalf("normal child rejected: %v", err)
+	}
+	if rp != "/sub/doc.md" {
+		t.Fatalf("unexpected remote path %q", rp)
+	}
+
+	// Round-trip the normal child and confirm it lands on the child, not
+	// the mount root.
+	back, err := remoteToLocalPath(localRoot, "/", rp)
+	if err != nil {
+		t.Fatalf("round-trip rejected: %v", err)
+	}
+	if filepath.Clean(back) == localRoot {
+		t.Fatalf("round-trip landed on mount root: %s", back)
+	}
+}
+
+// TestWriteFileAtomicRefusesToReplaceDirectory verifies the rename guard:
+// writeFileAtomic must never replace an existing directory (the mechanism
+// by which an 11MB file clobbered the mount root).
+func TestWriteFileAtomicRefusesToReplaceDirectory(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "mountdir")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	// Drop a file inside so we can prove the directory survived intact.
+	inner := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(inner, []byte("important"), 0o644); err != nil {
+		t.Fatalf("write inner file: %v", err)
+	}
+
+	err := writeFileAtomic(target, []byte(strings.Repeat("x", 1024)), 0o644)
+	if err == nil {
+		t.Fatalf("expected writeFileAtomic to refuse replacing a directory")
+	}
+
+	info, statErr := os.Stat(target)
+	if statErr != nil || !info.IsDir() {
+		t.Fatalf("directory was clobbered: statErr=%v info=%v", statErr, info)
+	}
+	if b, rErr := os.ReadFile(inner); rErr != nil || string(b) != "important" {
+		t.Fatalf("inner file lost: err=%v contents=%q", rErr, string(b))
+	}
+
+	// Sanity: writing over a regular file still works.
+	fileTarget := filepath.Join(root, "ok.txt")
+	if err := os.WriteFile(fileTarget, []byte("old"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := writeFileAtomic(fileTarget, []byte("new"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic over regular file failed: %v", err)
+	}
+	if b, _ := os.ReadFile(fileTarget); string(b) != "new" {
+		t.Fatalf("expected file overwrite to succeed, got %q", string(b))
+	}
+}
+
+// TestAssertNotMountRoot verifies the shared defense-in-depth guard.
+func TestAssertNotMountRoot(t *testing.T) {
+	root := t.TempDir()
+	s := &Syncer{localRoot: filepath.Clean(root)}
+
+	if err := s.assertNotMountRoot(root); err == nil {
+		t.Fatalf("expected assertNotMountRoot to reject the mount root")
+	}
+	if err := s.assertNotMountRoot(root + string(filepath.Separator) + "."); err == nil {
+		t.Fatalf("expected assertNotMountRoot to reject a non-clean root path")
+	}
+	if err := s.assertNotMountRoot(filepath.Join(root, "child.txt")); err != nil {
+		t.Fatalf("legitimate child rejected by assertNotMountRoot: %v", err)
+	}
+}
+
+// TestSnapshotDeleteUnsafeCircuitBreaker verifies that an empty or
+// drastically truncated fresh remote listing does not authorize a delete
+// pass when meaningful local state is tracked.
+func TestSnapshotDeleteUnsafeCircuitBreaker(t *testing.T) {
+	mk := func(n int) *Syncer {
+		files := make(map[string]trackedFile, n)
+		for i := 0; i < n; i++ {
+			files[fmt.Sprintf("/f%d.txt", i)] = trackedFile{Hash: "h"}
+		}
+		return &Syncer{state: mountState{Files: files}}
+	}
+
+	if !mk(20).snapshotDeleteUnsafe(0) {
+		t.Fatalf("empty fresh listing with tracked files must be unsafe")
+	}
+	if !mk(20).snapshotDeleteUnsafe(3) {
+		t.Fatalf("drastic shrink (3 of 20) must be unsafe")
+	}
+	if mk(20).snapshotDeleteUnsafe(18) {
+		t.Fatalf("near-complete listing must be safe")
+	}
+	if mk(0).snapshotDeleteUnsafe(0) {
+		t.Fatalf("no tracked state means nothing to protect; must be safe")
+	}
+	// Tiny working sets are exempt from the ratio check (only the
+	// empty-listing rule applies).
+	if mk(3).snapshotDeleteUnsafe(1) {
+		t.Fatalf("small tracked set below ratio-check floor must be safe")
+	}
+}
+
+// TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty exercises the
+// end-to-end circuit breaker: a cloud listing that comes back empty while
+// local state tracks files must NOT delete the local mirror.
+func TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty(t *testing.T) {
+	disableWS := false
+	localDir := t.TempDir()
+
+	// Seed a tracked, mirrored file locally.
+	mirrored := filepath.Join(localDir, "keep.md")
+	if err := os.WriteFile(mirrored, []byte("# keep me"), 0o644); err != nil {
+		t.Fatalf("seed mirrored file: %v", err)
+	}
+	stateFile := filepath.Join(localDir, ".relayfile-mount-state.json")
+	if err := writeMountState(stateFile, mountState{
+		Files: map[string]trackedFile{
+			"/notion/keep.md": {Revision: "rev_1", ContentType: "text/markdown", Hash: hashString("# keep me")},
+		},
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	// fakeClient with NO files -> ListTree returns an empty tree.
+	fc := &fakeClient{files: map[string]RemoteFile{}, eventsUnsupported: true}
+	syncer, err := NewSyncer(fc, SyncerOptions{
+		WorkspaceID: "ws_empty_tree",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWS,
+		StateFile:   stateFile,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync against empty cloud tree failed: %v", err)
+	}
+
+	if b, rErr := os.ReadFile(mirrored); rErr != nil || string(b) != "# keep me" {
+		t.Fatalf("local mirrored file was deleted/corrupted by empty cloud tree: err=%v contents=%q", rErr, string(b))
+	}
+}
+
+// TestMountRootBasenameCollisionNeverClobbered is the top-level
+// regression: a mount whose basename collides with a child file name must
+// never sync that child onto the root nor destroy the mount directory.
+func TestMountRootBasenameCollisionNeverClobbered(t *testing.T) {
+	disableWS := false
+	parent := t.TempDir()
+	localDir := filepath.Join(parent, "relayfile-mount")
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("mkdir mount dir: %v", err)
+	}
+
+	// Cloud serves a file at "/relayfile-mount" (basename collision).
+	remoteFiles := map[string]RemoteFile{
+		"/relayfile-mount": {
+			Path:        "/relayfile-mount",
+			Revision:    "rev_1",
+			ContentType: "text/plain",
+			Content:     strings.Repeat("A", 4096),
+		},
+		"/safe.txt": {
+			Path:        "/safe.txt",
+			Revision:    "rev_2",
+			ContentType: "text/plain",
+			Content:     "safe",
+		},
+	}
+	fc := &fakeClient{files: remoteFiles, eventsUnsupported: true}
+
+	logger := &captureLogger{}
+	syncer, err := NewSyncer(fc, SyncerOptions{
+		WorkspaceID: "ws_collision",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWS,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	// Mount directory must still be a directory.
+	info, statErr := os.Stat(localDir)
+	if statErr != nil || !info.IsDir() {
+		t.Fatalf("mount root was clobbered: statErr=%v info=%v", statErr, info)
+	}
+
+	// The safe file should have synced normally.
+	if b, rErr := os.ReadFile(filepath.Join(localDir, "safe.txt")); rErr != nil || string(b) != "safe" {
+		t.Fatalf("expected safe.txt to sync: err=%v contents=%q", rErr, string(b))
+	}
+}
+
+// TestOversizedFileSkippedByWritebackCap verifies that an oversized local
+// file is not enqueued for writeback and is surfaced in the log.
+func TestOversizedFileSkippedByWritebackCap(t *testing.T) {
+	t.Setenv("RELAYFILE_MAX_WRITEBACK_BYTES", "1024")
+
+	disableWS := false
+	localDir := t.TempDir()
+
+	big := filepath.Join(localDir, "huge.bin")
+	if err := os.WriteFile(big, make([]byte, 4096), 0o644); err != nil {
+		t.Fatalf("write big file: %v", err)
+	}
+	small := filepath.Join(localDir, "small.txt")
+	if err := os.WriteFile(small, []byte("tiny"), 0o644); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+
+	fc := &fakeClient{files: map[string]RemoteFile{}, eventsUnsupported: true}
+	logger := &captureLogger{}
+	syncer, err := NewSyncer(fc, SyncerOptions{
+		WorkspaceID: "ws_size_cap",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWS,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	// The small file should have been pushed; the huge one must not be.
+	for _, batch := range fc.bulkWriteBatches {
+		for _, f := range batch {
+			if strings.Contains(f.Path, "huge.bin") {
+				t.Fatalf("oversized file was enqueued for writeback: %s", f.Path)
+			}
+		}
+	}
+
+	sawSkipLog := false
+	for _, line := range logger.lines {
+		if strings.Contains(line, "huge.bin") && strings.Contains(line, "writeback cap") {
+			sawSkipLog = true
+		}
+	}
+	if !sawSkipLog {
+		t.Fatalf("expected oversized-file skip to be surfaced in logs; got %v", logger.lines)
+	}
+}
+

--- a/internal/mountsync/mount_root_clobber_test.go
+++ b/internal/mountsync/mount_root_clobber_test.go
@@ -182,6 +182,24 @@ func TestSnapshotDeleteUnsafeCircuitBreaker(t *testing.T) {
 	if mk(3).snapshotDeleteUnsafe(1) {
 		t.Fatalf("small tracked set below ratio-check floor must be safe")
 	}
+
+	filtered := mk(9)
+	for i := 0; i < 20; i++ {
+		filtered.state.Files[fmt.Sprintf("/denied%d.txt", i)] = trackedFile{Denied: true}
+		filtered.state.Files[fmt.Sprintf("/write-denied%d.txt", i)] = trackedFile{WriteDenied: true}
+		filtered.state.Files[fmt.Sprintf("/dirty%d.txt", i)] = trackedFile{Dirty: true}
+	}
+	if filtered.snapshotDeleteUnsafe(1) {
+		t.Fatalf("non-reconcilable tracked files must not trip the ratio check")
+	}
+	onlyNonReconcilable := &Syncer{state: mountState{Files: map[string]trackedFile{
+		"/denied.txt":       {Denied: true},
+		"/write-denied.txt": {WriteDenied: true},
+		"/dirty.txt":        {Dirty: true},
+	}}}
+	if onlyNonReconcilable.snapshotDeleteUnsafe(0) {
+		t.Fatalf("empty listing with no reconcilable tracked files must be safe")
+	}
 }
 
 // TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty exercises the
@@ -396,6 +414,14 @@ func TestOversizedFileSkippedByWritebackCap(t *testing.T) {
 	if !sawSkipLog {
 		t.Fatalf("expected oversized-file skip to be surfaced in logs; got %v", logger.lines)
 	}
+
+	state := readPublicState(t, localDir)
+	if state.PendingWriteback != 0 || state.States.HasPendingWriteback || state.Status == "writeback-pending" {
+		t.Fatalf("oversized skipped file should not count as pending writeback: %+v", state)
+	}
+	if got := state.Files["/huge.bin"].Status; got != "writeback-skipped" {
+		t.Fatalf("expected huge.bin to be marked writeback-skipped, got %q", got)
+	}
 }
 
 // TestOversizedTrackedFileDoesNotBecomeRemoteDelete verifies that an
@@ -451,5 +477,10 @@ func TestOversizedTrackedFileDoesNotBecomeRemoteDelete(t *testing.T) {
 	}
 	if _, ok := fc.files[remotePath]; !ok {
 		t.Fatalf("remote oversized file was deleted")
+	}
+
+	state := readPublicState(t, localDir)
+	if state.PendingWriteback != 0 || state.Files[remotePath].Status != "writeback-skipped" {
+		t.Fatalf("oversized tracked file should be skipped, not pending: %+v", state)
 	}
 }

--- a/internal/mountsync/mount_root_clobber_test.go
+++ b/internal/mountsync/mount_root_clobber_test.go
@@ -155,6 +155,8 @@ func TestAssertNotMountRoot(t *testing.T) {
 // drastically truncated fresh remote listing does not authorize a delete
 // pass when meaningful local state is tracked.
 func TestSnapshotDeleteUnsafeCircuitBreaker(t *testing.T) {
+	t.Setenv("RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO", "0.5")
+
 	mk := func(n int) *Syncer {
 		files := make(map[string]trackedFile, n)
 		for i := 0; i < n; i++ {
@@ -370,12 +372,19 @@ func TestOversizedFileSkippedByWritebackCap(t *testing.T) {
 	}
 
 	// The small file should have been pushed; the huge one must not be.
+	sawSmallWriteback := false
 	for _, batch := range fc.bulkWriteBatches {
 		for _, f := range batch {
+			if strings.Contains(f.Path, "small.txt") {
+				sawSmallWriteback = true
+			}
 			if strings.Contains(f.Path, "huge.bin") {
 				t.Fatalf("oversized file was enqueued for writeback: %s", f.Path)
 			}
 		}
+	}
+	if !sawSmallWriteback {
+		t.Fatalf("expected small.txt to be enqueued for writeback; batches=%#v", fc.bulkWriteBatches)
 	}
 
 	sawSkipLog := false
@@ -389,3 +398,58 @@ func TestOversizedFileSkippedByWritebackCap(t *testing.T) {
 	}
 }
 
+// TestOversizedTrackedFileDoesNotBecomeRemoteDelete verifies that an
+// oversized local file still counts as present during the delete phase.
+func TestOversizedTrackedFileDoesNotBecomeRemoteDelete(t *testing.T) {
+	t.Setenv("RELAYFILE_MAX_WRITEBACK_BYTES", "1024")
+
+	disableWS := false
+	localDir := t.TempDir()
+	huge := filepath.Join(localDir, "huge.bin")
+	if err := os.WriteFile(huge, make([]byte, 4096), 0o644); err != nil {
+		t.Fatalf("write huge file: %v", err)
+	}
+
+	remotePath := "/huge.bin"
+	stateFile := filepath.Join(localDir, ".relayfile-mount-state.json")
+	if err := writeMountState(stateFile, mountState{
+		Files: map[string]trackedFile{
+			remotePath: {Revision: "rev_1", ContentType: "application/octet-stream", Hash: hashString("old")},
+		},
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	fc := &fakeClient{
+		files: map[string]RemoteFile{
+			remotePath: {
+				Path:        remotePath,
+				Revision:    "rev_1",
+				ContentType: "application/octet-stream",
+				Content:     "old",
+			},
+		},
+		eventsUnsupported: true,
+	}
+	syncer, err := NewSyncer(fc, SyncerOptions{
+		WorkspaceID: "ws_size_cap_delete",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		WebSocket:   &disableWS,
+		StateFile:   stateFile,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+
+	if len(fc.deleteCalls) != 0 {
+		t.Fatalf("oversized tracked file triggered remote delete: %#v", fc.deleteCalls)
+	}
+	if _, ok := fc.files[remotePath]; !ok {
+		t.Fatalf("remote oversized file was deleted")
+	}
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1160,6 +1160,10 @@ func (s *Syncer) materializeConflict(ctx context.Context, remotePath, localPath 
 	if decodeErr != nil {
 		return decodeErr
 	}
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping conflict materialization for %s: %v", remotePath, err)
+		return nil
+	}
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
 	}
@@ -1223,6 +1227,10 @@ func (s *Syncer) materializeSchemaInvalid(
 	remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
 	if decodeErr != nil {
 		return decodeErr
+	}
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping schema-invalid materialization for %s: %v", remotePath, err)
+		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		return err
@@ -1304,6 +1312,10 @@ func (s *Syncer) bulkFlushThresholdValue() int {
 
 func (s *Syncer) revertReadonlyFile(ctx context.Context, remotePath, localPath string, tracked trackedFile, fallbackContentType string) error {
 	s.logDenial("WRITE_DENIED", remotePath, "agent does not have write permission")
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping readonly revert for %s: %v", remotePath, err)
+		return nil
+	}
 	remoteFile, readErr := s.client.ReadFile(ctx, s.workspace, remotePath)
 	if readErr == nil {
 		remoteBytes, decodeErr := decodeRemoteFileContent(remoteFile)
@@ -1756,6 +1768,18 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 		remotePaths[remotePath] = struct{}{}
 		files[i].Content = ""
 	}
+
+	// Circuit breaker: an empty or drastically truncated export response
+	// (degraded cloud / partial provider listing) would otherwise authorize
+	// applyRemoteSnapshotDeletes to wipe every locally-mirrored file.
+	// Skip the delete pass when the fresh listing is unsafe; the next
+	// healthy cycle will reconcile correctly. Mirrors the safeguard in
+	// pullRemoteFullTree.
+	if s.snapshotDeleteUnsafe(len(remotePaths)) {
+		s.logf("skipping snapshot delete pass (export): fresh remote export has %d files but %d are tracked locally (suspected partial/empty cloud export); preserving local state", len(remotePaths), len(s.state.Files))
+		return true, nil
+	}
+
 	return true, s.applyRemoteSnapshotDeletes(remotePaths, conflicted)
 }
 

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -598,11 +598,12 @@ type trackedFile struct {
 }
 
 type localSnapshot struct {
-	RawContent  []byte
-	WireContent string
-	ContentType string
-	Encoding    string
-	Hash        string
+	RawContent    []byte
+	WireContent   string
+	ContentType   string
+	Encoding      string
+	Hash          string
+	SkipWriteback bool
 }
 
 type pendingBulkWrite struct {
@@ -2568,6 +2569,9 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 		if exists && tracked.WriteDenied && tracked.DeniedHash == snapshot.Hash {
 			continue
 		}
+		if snapshot.SkipWriteback {
+			continue
+		}
 		fullSnapshot, err := readLocalSnapshot(localPath, true)
 		if err != nil {
 			return nil, err
@@ -2709,6 +2713,16 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 		// of the clobber pathology). Surface it and skip.
 		if max := maxWritebackBytes(); max > 0 && info.Size() > max {
 			s.logf("skipping oversized local file %s (%d bytes > %d byte writeback cap); not enqueued", path, info.Size(), max)
+			snapshot, err := readLocalSnapshot(path, false)
+			if err != nil {
+				return err
+			}
+			snapshot.SkipWriteback = true
+			remotePath, err := localToRemotePath(s.localRoot, s.remoteRoot, path)
+			if err != nil {
+				return nil
+			}
+			results[remotePath] = snapshot
 			return nil
 		}
 		remotePath, err := localToRemotePath(s.localRoot, s.remoteRoot, path)

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1890,7 +1890,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 // many we currently track. It guards against a degraded cloud response
 // (empty or drastically truncated tree) wiping the local mirror.
 func (s *Syncer) snapshotDeleteUnsafe(remoteCount int) bool {
-	tracked := len(s.state.Files)
+	tracked := s.reconcilableTrackedFileCount()
 	if tracked == 0 {
 		return false
 	}
@@ -1908,6 +1908,20 @@ func (s *Syncer) snapshotDeleteUnsafe(remoteCount int) bool {
 		return true
 	}
 	return false
+}
+
+func (s *Syncer) reconcilableTrackedFileCount() int {
+	tracked := 0
+	for _, file := range s.state.Files {
+		// Keep this baseline aligned with applyRemoteDelete: these states
+		// do not result in snapshot-driven local deletes, so they should
+		// not make a filtered remotePaths listing look unsafe.
+		if file.Denied || file.WriteDenied || file.Dirty {
+			continue
+		}
+		tracked++
+	}
+	return tracked
 }
 
 // snapshotDeleteMinRatio is the minimum fraction of tracked files the fresh
@@ -2832,7 +2846,9 @@ func (s *Syncer) savePublicState() error {
 		}
 		if !s.lowMemory {
 			if snapshot, ok := currentFiles[remotePath]; ok {
-				if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
+				if snapshot.SkipWriteback && !tracked.Denied && !tracked.WriteDenied {
+					fileStatus = "writeback-skipped"
+				} else if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
 					fileStatus = "writeback-pending"
 				}
 			} else if !tracked.Denied && !tracked.WriteDenied && tracked.Hash != "" && fileStatus == "ready" {
@@ -2861,6 +2877,14 @@ func (s *Syncer) savePublicState() error {
 	if !s.lowMemory {
 		for remotePath, snapshot := range currentFiles {
 			if _, ok := files[remotePath]; ok {
+				continue
+			}
+			if snapshot.SkipWriteback {
+				files[remotePath] = publicFileState{
+					ContentType: snapshot.ContentType,
+					Encoding:    snapshot.Encoding,
+					Status:      "writeback-skipped",
+				}
 				continue
 			}
 			pendingWriteback++

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1846,7 +1846,83 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		cursor = *page.NextCursor
 	}
 
+	// Circuit breaker: a cloud OOM / 5xx storm can return a successful but
+	// empty or drastically truncated tree. Treating that as authoritative
+	// would delete every locally-mirrored file. If we have a meaningful
+	// amount of tracked state but the fresh listing came back empty (or
+	// shrank past the safety ratio), skip the delete pass and leave local
+	// state intact — the next healthy cycle will reconcile correctly.
+	if s.snapshotDeleteUnsafe(len(remotePaths)) {
+		s.logf("skipping snapshot delete pass: fresh remote tree has %d files but %d are tracked locally (suspected partial/empty cloud listing); preserving local state", len(remotePaths), len(s.state.Files))
+		return nil
+	}
+
 	return s.applyRemoteSnapshotDeletes(remotePaths, conflicted)
+}
+
+// snapshotDeleteUnsafe reports whether running snapshot-driven deletes is
+// unsafe given how many files the fresh remote listing returned versus how
+// many we currently track. It guards against a degraded cloud response
+// (empty or drastically truncated tree) wiping the local mirror.
+func (s *Syncer) snapshotDeleteUnsafe(remoteCount int) bool {
+	tracked := len(s.state.Files)
+	if tracked == 0 {
+		return false
+	}
+	// Empty fresh listing while we track files is the classic OOM/500
+	// signature — never delete on that basis.
+	if remoteCount == 0 {
+		return true
+	}
+	// Configurable floor for "drastic shrink". By default, refuse the
+	// delete pass if the fresh listing dropped to less than 50% of tracked
+	// files while tracking a non-trivial number of files.
+	const minTrackedForRatioCheck = 10
+	ratio := snapshotDeleteMinRatio()
+	if tracked >= minTrackedForRatioCheck && float64(remoteCount) < float64(tracked)*ratio {
+		return true
+	}
+	return false
+}
+
+// snapshotDeleteMinRatio is the minimum fraction of tracked files the fresh
+// remote listing must contain before snapshot deletes are allowed. Tunable
+// via RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO (clamped to (0,1]); defaults to 0.5.
+func snapshotDeleteMinRatio() float64 {
+	const def = 0.5
+	raw := strings.TrimSpace(os.Getenv("RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO"))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 || v > 1 {
+		return def
+	}
+	return v
+}
+
+// defaultMaxWritebackBytes caps the size of a local file eligible for
+// writeback. The clobber incident involved an ~11MB file renamed over the
+// mount root; 8MB is a generous text/document ceiling that keeps such
+// pathological payloads out of the sync pipeline by default.
+const defaultMaxWritebackBytes int64 = 8 << 20
+
+// maxWritebackBytes returns the writeback body size cap in bytes.
+// Configurable via RELAYFILE_MAX_WRITEBACK_BYTES (positive integer).
+// A value of 0 or a negative override disables the cap.
+func maxWritebackBytes() int64 {
+	raw := strings.TrimSpace(os.Getenv("RELAYFILE_MAX_WRITEBACK_BYTES"))
+	if raw == "" {
+		return defaultMaxWritebackBytes
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return defaultMaxWritebackBytes
+	}
+	if v <= 0 {
+		return 0
+	}
+	return v
 }
 
 func (s *Syncer) applyRemoteSnapshot(remoteFiles map[string]RemoteFile, conflicted map[string]struct{}) error {
@@ -2207,6 +2283,10 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		if err != nil {
 			return nil
 		}
+		if err := s.assertNotMountRoot(localPath); err != nil {
+			s.logf("skipping remote file %s: %v", remotePath, err)
+			return nil
+		}
 		if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
 			return err
 		}
@@ -2215,6 +2295,10 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	}
 	localPath, err := remoteToLocalPath(s.localRoot, s.remoteRoot, remotePath)
 	if err != nil {
+		return nil
+	}
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping remote file %s: %v", remotePath, err)
 		return nil
 	}
 	// _index.json files and nested <integration>/.layout.md dotfiles are
@@ -2371,6 +2455,11 @@ func (s *Syncer) applyRemoteDelete(remotePath string, conflicted map[string]stru
 		delete(s.state.Files, remotePath)
 		return nil
 	}
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping remote delete for %s: %v", remotePath, err)
+		delete(s.state.Files, remotePath)
+		return nil
+	}
 	currentBytes, readErr := os.ReadFile(localPath)
 	if readErr == nil && hashBytes(currentBytes) == tracked.Hash {
 		_ = os.Remove(localPath)
@@ -2404,6 +2493,10 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 		canWrite := s.canWritePath(remotePath)
 		tracked.ReadOnly = !canWrite
 		if exists && tracked.Denied {
+			if err := s.assertNotMountRoot(localPath); err != nil {
+				s.logf("skipping denied-file removal for %s: %v", remotePath, err)
+				continue
+			}
 			if err := os.Remove(localPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 				return nil, err
 			}
@@ -2568,6 +2661,14 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 			}
 			return nil
 		}
+		// Data-loss guard: skip any top-level entry whose name collides
+		// with the mount directory's own basename (round-trip-onto-root).
+		if rel, relErr := filepath.Rel(s.localRoot, path); relErr == nil {
+			first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+			if reservedTopLevel(first) || first == filepath.Base(s.localRoot) {
+				return nil
+			}
+		}
 		absPath, err := filepath.Abs(path)
 		if err == nil && absPath == statePathAbs {
 			return nil
@@ -2577,6 +2678,13 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 			return err
 		}
 		if !info.Mode().IsRegular() {
+			return nil
+		}
+		// Writeback body size cap: an oversized local file must not be
+		// enqueued for writeback (it both stresses the cloud and was part
+		// of the clobber pathology). Surface it and skip.
+		if max := maxWritebackBytes(); max > 0 && info.Size() > max {
+			s.logf("skipping oversized local file %s (%d bytes > %d byte writeback cap); not enqueued", path, info.Size(), max)
 			return nil
 		}
 		remotePath, err := localToRemotePath(s.localRoot, s.remoteRoot, path)
@@ -3122,8 +3230,18 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 		return "", fmt.Errorf("path %s escapes local root", remotePath)
 	}
 	joined := filepath.Join(localRoot, filepath.FromSlash(rel))
-	// Final safety check: resolved path must be under localRoot.
-	if !strings.HasPrefix(filepath.Clean(joined), localRoot+string(filepath.Separator)) && filepath.Clean(joined) != localRoot {
+	cleanJoined := filepath.Clean(joined)
+	// Data-loss guard: a remote path whose only relative component is the
+	// basename of the mount directory (e.g. remoteRoot="/" and
+	// remotePath="/relayfile-mount" when localRoot=".../relayfile-mount")
+	// resolves directly onto the mount root itself. Writing a file there
+	// would clobber the entire mount directory. Reject it — only genuine
+	// children may map onto the local tree.
+	if cleanJoined == localRoot {
+		return "", fmt.Errorf("remote path %s resolves onto the mount root %s", remotePath, localRoot)
+	}
+	// Final safety check: resolved path must be strictly under localRoot.
+	if !strings.HasPrefix(cleanJoined, localRoot+string(filepath.Separator)) {
 		return "", fmt.Errorf("resolved path %s escapes local root %s", joined, localRoot)
 	}
 	return joined, nil
@@ -3142,10 +3260,35 @@ func localToRemotePath(localRoot, remoteRoot, localPath string) (string, error) 
 		return "", fmt.Errorf("path %s escapes local root", localPath)
 	}
 	remoteRoot = normalizeRemotePath(remoteRoot)
+	var remotePath string
 	if remoteRoot == "/" {
-		return normalizeRemotePath("/" + rel), nil
+		remotePath = normalizeRemotePath("/" + rel)
+	} else {
+		remotePath = normalizeRemotePath(remoteRoot + "/" + rel)
 	}
-	return normalizeRemotePath(remoteRoot + "/" + rel), nil
+	// Data-loss guard: refuse to generate a remote path that would
+	// round-trip back onto the mount root via remoteToLocalPath. This
+	// happens when a child file's name equals the mount-dir basename
+	// (e.g. localRoot=".../relayfile-mount" with a child
+	// "relayfile-mount" mapping to remote "/relayfile-mount", which
+	// then resolves back onto the root directory).
+	if back, err := remoteToLocalPath(localRoot, remoteRoot, remotePath); err != nil {
+		return "", fmt.Errorf("local path %s maps to a remote path that escapes the mount root: %w", localPath, err)
+	} else if filepath.Clean(back) == filepath.Clean(localRoot) {
+		return "", fmt.Errorf("local path %s maps to remote %s which round-trips onto the mount root", localPath, remotePath)
+	}
+	return remotePath, nil
+}
+
+// assertNotMountRoot is a defense-in-depth guard: it returns an error if
+// localPath, once cleaned, equals the mount root. Callers that mutate the
+// filesystem (writes, deletes) invoke this to ensure a malformed or
+// adversarial remote path can never operate on the mount directory itself.
+func (s *Syncer) assertNotMountRoot(localPath string) error {
+	if filepath.Clean(localPath) == filepath.Clean(s.localRoot) {
+		return fmt.Errorf("refusing filesystem operation on mount root %s", s.localRoot)
+	}
+	return nil
 }
 
 func detectContentType(path string) string {
@@ -3298,6 +3441,13 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	}
 	if err := tmpFile.Close(); err != nil {
 		return err
+	}
+	// Data-loss guard: never rename a file over an existing directory.
+	// os.Rename onto a directory would (on some platforms) or would
+	// otherwise be the mechanism by which the mount root was clobbered
+	// by an 11MB file. If the target exists and is a directory, refuse.
+	if info, err := os.Lstat(path); err == nil && info.IsDir() {
+		return fmt.Errorf("refusing to replace directory %s with a file", path)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		return err

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -119,7 +119,9 @@ func (fw *FileWatcher) shouldSkip(rel string) bool {
 
 // reservedTopLevel reports whether a top-level entry name is internal
 // bookkeeping that must never participate in sync. Centralized so the
-// watcher and scanLocalFiles stay in agreement.
+// watcher and scanLocalFiles stay in agreement. This list applies to
+// top-level entries, including files such as _PERMISSIONS.md; addDirRecursive
+// is directory-only and skips a different sentinel for the mount state file.
 func reservedTopLevel(name string) bool {
 	return name == ".git" || name == ".relay" || name == "node_modules" ||
 		name == "_PERMISSIONS.md"
@@ -169,7 +171,7 @@ func (fw *FileWatcher) emitExistingFileEvents(base string) {
 
 // addDirRecursive walks `base` and adds every directory underneath it to the
 // fsnotify watcher, skipping `.git`, `.relay`, `node_modules`, and the
-// mount-state file. Used both at startup (to seed the watcher with the
+// mount-state file sentinel. Used both at startup (to seed the watcher with the
 // existing tree) and at runtime (when a sync-down creates a new nested
 // directory structure that we need to start watching).
 func (fw *FileWatcher) addDirRecursive(base string) error {

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -105,8 +105,24 @@ func (fw *FileWatcher) shouldSkip(rel string) bool {
 		strings.HasPrefix(first, ".relayfile-mount-state.json.tmp-") {
 		return true
 	}
-	return first == ".git" || first == ".relay" || first == "node_modules" ||
-		first == "_PERMISSIONS.md"
+	if reservedTopLevel(first) {
+		return true
+	}
+	// Data-loss guard: a top-level entry whose name equals the mount
+	// directory's own basename is the round-trip-onto-root collision.
+	// Never sync it.
+	if fw.localDir != "" && first == filepath.Base(filepath.Clean(fw.localDir)) {
+		return true
+	}
+	return false
+}
+
+// reservedTopLevel reports whether a top-level entry name is internal
+// bookkeeping that must never participate in sync. Centralized so the
+// watcher and scanLocalFiles stay in agreement.
+func reservedTopLevel(name string) bool {
+	return name == ".git" || name == ".relay" || name == "node_modules" ||
+		name == "_PERMISSIONS.md"
 }
 
 func (fw *FileWatcher) queueChange(rel string, op fsnotify.Op) {


### PR DESCRIPTION
## Summary

A live mount on workspace `rw_517d60b6` had its entire mount directory **replaced by a single 11 MB file** during a cloud Durable Object OOM/5xx storm. `.relay/` state, provider trees, and `.relayfile-mount-state.json` were destroyed. This PR adds defense-in-depth so a future cloud incident, a name-collision file, or a path bug cannot clobber the mount root.

Root cause chain (verified):

1. A file at the mount root whose basename equals the mount-dir basename (`relayfile-mount/relayfile-mount`, an 11 MB build artifact) round-tripped to remote path `/relayfile-mount` and back, resolving onto the mount root path itself.
2. `remoteToLocalPath` *explicitly allowed* that resolution (guard only blocked escaping *above* root, not landing *on* it).
3. `writeFileAtomic` ran `os.Rename` over the mount-root path with no "is target a directory" check.
4. Concurrently the cloud DO was OOM'ing and returning empty/inconsistent trees; `applyRemoteSnapshotDeletes` treated them as authoritative.

## Commits

| SHA | Title |
|---|---|
| `d2c12ba` | fix(mountsync): defense-in-depth against mount-root clobber data loss |
| `7ffff49` | fix(mountsync): close clawpatch gaps — export-path circuit breaker + symmetric mount-root guards |

## Changes — all in `internal/mountsync/`

- **`remoteToLocalPath`**: reject when `Clean(joined) == localRoot`. Only genuine children may resolve.
- **`localToRemotePath`**: reject the mount root itself and any path whose remote form would round-trip back onto the root.
- **`writeFileAtomic`**: `Lstat` the target before `os.Rename`; refuse if it is a directory.
- **`assertNotMountRoot`** shared guard at the top of `applyRemoteFile` (both write and dirty-permission branches), `applyRemoteDelete`, the denied-delete branch in `pushLocal`, **plus the three conflict-materialization writeFileAtomic sites** (`materializeConflict`, `materializeSchemaInvalid`, `revertReadonlyFile` — added in `7ffff49` for symmetry).
- **Snapshot-delete circuit breaker** in BOTH `pullRemoteFullTree` AND `pullRemoteFullExport` (export-path coverage added in `7ffff49`): skip the delete pass when the fresh listing is empty or shrank past `RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO` (default 0.5, 10-file floor). Never run snapshot deletes after a partial / non-2xx pull.
- **`watcher.shouldSkip`** + **`scanLocalFiles`**: centralized `reservedTopLevel` helper; skip any top-level entry whose name equals `filepath.Base(localRoot)`.
- **Writeback body size cap**: oversized files (>`RELAYFILE_MAX_WRITEBACK_BYTES`, default 8 MB) are skipped at scan/watch time so an 11 MB build artifact can't be enqueued in the first place.

## Tests

9 unit tests in `internal/mountsync/mount_root_clobber_test.go`:

- `TestRemoteToLocalPathRejectsRootResolution`
- `TestLocalToRemotePathRejectsMountRoot`
- `TestWriteFileAtomicRefusesToReplaceDirectory`
- `TestAssertNotMountRoot`
- `TestSnapshotDeleteUnsafeCircuitBreaker`
- `TestPullDoesNotDeleteLocalFilesWhenCloudTreeEmpty`
- `TestPullDoesNotDeleteLocalFilesWhenCloudExportEmpty` (added in `7ffff49`)
- `TestMountRootBasenameCollisionNeverClobbered` (end-to-end)
- `TestOversizedFileSkippedByWritebackCap`

`go test ./internal/mountsync/...` green; `go build ./...` clean; contract surface check passes.

## New env knobs (optional, safe defaults)

| Env | Default | Purpose |
|---|---|---|
| `RELAYFILE_MAX_WRITEBACK_BYTES` | 8 MB | Per-file writeback size cap |
| `RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO` | 0.5 | Circuit-breaker threshold for snapshot deletes (with 10-file floor) |

## Stacked follow-up

[#165](https://github.com/AgentWorkforce/relayfile/pull/165) adds the long-term structural hardening layer on top: startup+per-cycle invariant assertion, two-phase tombstone deletes, revision gate, cloud-error circuit breaker, typed `RelativeRemotePath` newtype, recovery-mode CLI flag, telemetry counters, chaos integration test, and architecture docs.

Pairs with cloud-side [PR #730](https://github.com/AgentWorkforce/cloud/pull/730) — the two bugs compounded in the observed incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)