### PR TITLE
feat(workspace): complete PR-39 local primitives and digest runtime

### DIFF
--- a/.claude/rules/relayfile-integration-digests.md
+++ b/.claude/rules/relayfile-integration-digests.md
@@ -1,0 +1,62 @@
+---
+description: Runtime ingest paths must update Relayfile digest artifacts
+paths:
+  - internal/relayfile/**
+  - internal/httpapi/**
+  - internal/mountsync/**
+  - cmd/relayfile-cli/**
+  - packages/sdk/**
+---
+
+# Relayfile integration digests
+
+Digest files are first-class Relayfile artifacts. Provider mutations must keep
+`/digests/today.md` and `/digests/yesterday.md` in sync with the event log.
+
+## Runtime requirements
+
+- New ingest or mutation paths must append filesystem events before digest
+  regeneration runs.
+- Digest writes must be visible to mounted workspaces as normal file events.
+- Digest generation must ignore `/digests/*` source events so digest writes do
+  not recurse forever or count themselves as provider activity.
+- Terminal provider states must remain readable as records. Do not collapse
+  closed, merged, archived, completed, canceled, or resolved provider objects
+  into file deletes unless the upstream object was actually deleted.
+- Tests must cover the mutation event, the generated digest content, and the
+  non-recursion behavior for `/digests/*`.
+
+## yesterday.md immutability and the workspace-local boundary
+
+- `/digests/yesterday.md` is the closing-window artifact for the prior local
+  calendar day. The rotation boundary is **workspace-local midnight in the
+  configured TZ**, not UTC.
+- After the close write for a given local day produces `yesterday.md`,
+  subsequent ingest events for *the same local day* must NOT mutate the file.
+  The implementation pins the close via the per-workspace marker
+  `.relay/digests/yesterday.lock`; the marker contains the closed
+  `YYYY-MM-DD`, and a re-close call for that same date short-circuits with
+  `Skipped=true`. The marker lives under `.relay/` (not `/digests/.state/`)
+  because a marker write inside `/digests/` would surface as a `/digests/*`
+  file event and re-enter digest regeneration. The mount watcher already
+  excludes `.relay/`, so the marker is invisible to regen and cannot recurse.
+- Rotation forward is the only permitted overwrite. When the local day
+  advances, the close pipeline writes the new day's content atomically
+  (temp + rename) and overwrites the marker.
+- Self-host closing-window rendering is exhaustive: `RunClosing` emits every
+  source event in the closed local day and must not silently truncate. The
+  historical coverage-cap identifiers (`digest.DigestCoverageCap` and
+  `digest.WarningCoverageTruncated`) stay stable for downstream parsers and
+  future cloud-side policy code; if a caller outside the shared self-host
+  renderer engages a cap, it must surface
+  `digest.coverage.truncated events_seen=N events_emitted=M` in
+  `Meta.Warnings`.
+- Scheduler responsibility: a tick-driven scheduler closes any local day
+  that has elapsed since the marker. On restart, every missing day is
+  closed in chronological order before normal operation resumes.
+
+## SDK/API contract
+
+If an API or SDK change affects `DigestContext`, `DigestHandler`, change-event
+shape, or digest file paths, update all SDKs and the OpenAPI spec in the same
+change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,21 @@ Keep it in sync with `internal/httpapi/server.go` at all times:
 - Adding a new status code → add it to the endpoint's `responses` map.
 
 After server changes, run `scripts/check-contract-surface.sh` to check for drift.
+
+# Digest Runtime Contract
+
+Relayfile runtime changes that write provider records must keep
+`/digests/today.md` and `/digests/yesterday.md` current.
+
+- Any new ingest, sync, bulk-write, or provider mutation path must emit
+  filesystem events and trigger digest regeneration for non-digest paths.
+- Digest regeneration must not recurse on `/digests/*` writes, but digest file
+  updates must still emit normal file events so mounted workspaces receive the
+  changed digest files.
+- Preserve terminal provider state as data. Do not represent `closed`,
+  `merged`, `archived`, `completed`, `canceled`, or `resolved` as a file delete
+  unless the upstream object was actually deleted.
+- Add tests for both the event path and the digest artifact path when changing
+  ingest behavior.
+
+Full rule: `.claude/rules/relayfile-integration-digests.md`.

--- a/cmd/relayfile-cli/digest.go
+++ b/cmd/relayfile-cli/digest.go
@@ -15,7 +15,7 @@ import (
 	digestpkg "github.com/agentworkforce/relayfile/internal/digest"
 )
 
-const digestRebuildUsage = "usage: relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]"
+const digestRebuildUsage = "usage: relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME] [--json]"
 
 // digestRebuilder is the seam over the internal/digest generator. The CLI ships
 // a stub today; the real implementation lands when work item 1 of the
@@ -170,10 +170,12 @@ func (localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptio
 		warnings = append(warnings, res.Report.Meta.Warnings...)
 	case "yesterday":
 		closedDay := localDateOnlyCLI(now.In(tz).AddDate(0, 0, -1), tz)
-		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.YesterdayPath)))
-		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.YesterdayMarkerPath)))
 		dateStampedPath := digestpkg.DateStampedPath(closedDay, tz)
-		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(dateStampedPath)))
+		for _, p := range []string{digestpkg.YesterdayPath, digestpkg.YesterdayMarkerPath, dateStampedPath} {
+			if err := removeForRebuild(filepath.Join(localDir, filepath.FromSlash(p))); err != nil {
+				return digestRebuildResult{}, err
+			}
+		}
 		res, err := digestpkg.CloseLocalDayFor(ctx, localDir, src, closedDay, now, providers, tz)
 		if err != nil {
 			return digestRebuildResult{}, err
@@ -195,7 +197,9 @@ func (localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptio
 		warnings = append(warnings, res.Report.Meta.Warnings...)
 	case "last-week":
 		weekStart := digestpkg.MondayStart(now, tz).AddDate(0, 0, -7)
-		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.LastWeekPath)))
+		if err := removeForRebuild(filepath.Join(localDir, filepath.FromSlash(digestpkg.LastWeekPath))); err != nil {
+			return digestRebuildResult{}, err
+		}
 		w := digestpkg.LastWeekWindow(weekStart, now, providers, tz)
 		res, err := digestpkg.WriteLastWeek(ctx, localDir, src, w)
 		if err != nil {
@@ -213,7 +217,9 @@ func (localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptio
 			return digestRebuildResult{}, fmt.Errorf("digest window %s is in the future", opts.Window)
 		}
 		target := digestpkg.DateStampedPath(date, tz)
-		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(target)))
+		if err := removeForRebuild(filepath.Join(localDir, filepath.FromSlash(target))); err != nil {
+			return digestRebuildResult{}, err
+		}
 		res, err := digestpkg.WriteDateStamped(ctx, localDir, src, digestpkg.DateStampedWindow(date, now, providers, tz))
 		if err != nil {
 			return digestRebuildResult{}, err
@@ -250,7 +256,11 @@ func (s localMirrorDigestSource) Events(_ digestpkg.Window) ([]digestpkg.ChangeE
 		rel = filepath.ToSlash(rel)
 		if entry.IsDir() {
 			switch strings.Split(rel, "/")[0] {
-			case ".git", ".relay", "node_modules":
+			// `digests` holds generated output, never source change events
+			// (each file is skipped individually below anyway). Skip the
+			// whole subtree — consistent with collectDigestProviders — so a
+			// large accumulated digests/ tree isn't walked file-by-file.
+			case ".git", ".relay", "node_modules", "digests":
 				return filepath.SkipDir
 			}
 			return nil
@@ -298,4 +308,16 @@ func collectDigestProviders(localDir string) ([]string, error) {
 func localDateOnlyCLI(t time.Time, tz *time.Location) time.Time {
 	t = t.In(tz)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, tz)
+}
+
+// removeForRebuild deletes an artifact/marker ahead of a forced rebuild.
+// A missing file is the expected case (nothing to clear). Any other
+// failure (permission/IO) must surface: silently ignoring it lets a
+// surviving immutability marker make the "rebuild" a no-op that returns
+// stale content while reporting success.
+func removeForRebuild(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("digest rebuild: clear %s: %w", path, err)
+	}
+	return nil
 }

--- a/cmd/relayfile-cli/digest.go
+++ b/cmd/relayfile-cli/digest.go
@@ -2,18 +2,25 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
+	"time"
+
+	digestpkg "github.com/agentworkforce/relayfile/internal/digest"
 )
 
-const digestRebuildUsage = "usage: relayfile digest rebuild --window yesterday|today [--workspace NAME]"
+const digestRebuildUsage = "usage: relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]"
 
-// digestRebuilder is the seam over the internal/digest generator. The CLI ships
-// a stub today; the real implementation lands when work item 1 of the
-// workspace-primitives spec wires the daemon-side generator.
+// digestRebuilder is the seam over the internal/digest generator. Tests swap
+// this out so CLI parsing can stay focused while the default implementation
+// rebuilds local mirror digests.
 type digestRebuilder interface {
 	Rebuild(ctx context.Context, opts digestRebuildOptions) (digestRebuildResult, error)
 }
@@ -30,12 +37,61 @@ type digestRebuildResult struct {
 }
 
 // activeDigestRebuilder is overridden by tests via withDigestRebuilder.
-var activeDigestRebuilder digestRebuilder = stubDigestRebuilder{}
+var activeDigestRebuilder digestRebuilder = localDigestRebuilder{now: time.Now}
 
-type stubDigestRebuilder struct{}
+type localDigestRebuilder struct {
+	now func() time.Time
+}
 
-func (stubDigestRebuilder) Rebuild(context.Context, digestRebuildOptions) (digestRebuildResult, error) {
-	return digestRebuildResult{}, errors.New("digest generator not yet wired; see WI 1 in workspace-primitives-implementation-spec")
+func (r localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptions) (digestRebuildResult, error) {
+	localDir := strings.TrimSpace(opts.LocalDir)
+	if localDir == "" {
+		return digestRebuildResult{}, fmt.Errorf("workspace %s has no local mirror", opts.WorkspaceID)
+	}
+	now := time.Now
+	if r.now != nil {
+		now = r.now
+	}
+	generatedAt := now().UTC()
+	windows, err := resolveDigestWindows(opts.Window, generatedAt)
+	if err != nil {
+		return digestRebuildResult{}, err
+	}
+	remoteRoot := readMountRemoteRoot(localDir)
+	providers, err := localDigestProviders(localDir, remoteRoot)
+	if err != nil {
+		return digestRebuildResult{}, err
+	}
+	src := localDigestSource{localDir: localDir, remoteRoot: remoteRoot}
+
+	paths := make([]string, 0, len(windows)*2)
+	totalEvents := 0
+	for _, w := range windows {
+		w.GeneratedAt = generatedAt
+		w.Providers = providers
+		w.TZ = time.UTC
+		rep, err := digestpkg.Run(ctx, src, w)
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		body := digestpkg.Render(rep)
+		outPath := filepath.Join(localDir, "digests", digestOutputFilename(w))
+		if err := writeFileAtomically(outPath, body, 0o644); err != nil {
+			return digestRebuildResult{}, err
+		}
+		paths = append(paths, outPath)
+		totalEvents += rep.Meta.Events
+
+		switch strings.ToLower(strings.TrimSpace(opts.Window)) {
+		case "today", "yesterday":
+			aliasPath := filepath.Join(localDir, "digests", strings.ToLower(strings.TrimSpace(opts.Window))+".md")
+			if err := writeFileAtomically(aliasPath, body, 0o644); err != nil {
+				return digestRebuildResult{}, err
+			}
+			paths = append(paths, aliasPath)
+		}
+	}
+	return digestRebuildResult{Path: strings.Join(paths, ", "), Events: totalEvents}, nil
 }
 
 func withDigestRebuilder(r digestRebuilder, fn func()) {
@@ -60,7 +116,7 @@ func runDigest(args []string, stdout io.Writer) error {
 func runDigestRebuild(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("digest rebuild", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	window := fs.String("window", "", "digest window: yesterday or today")
+	window := fs.String("window", "", "digest window: today, yesterday, YYYY-MM-DD, this-week, or last-week")
 	workspace := fs.String("workspace", "", "workspace name or id")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"window":    true,
@@ -76,9 +132,7 @@ func runDigestRebuild(args []string, stdout io.Writer) error {
 		return errors.New(digestRebuildUsage)
 	}
 	normalizedWindow := strings.ToLower(strings.TrimSpace(*window))
-	switch normalizedWindow {
-	case "yesterday", "today":
-	default:
+	if _, err := resolveDigestWindows(normalizedWindow, time.Now().UTC()); err != nil {
 		return fmt.Errorf("unknown window %q: %s", *window, digestRebuildUsage)
 	}
 
@@ -101,4 +155,236 @@ func runDigestRebuild(args []string, stdout io.Writer) error {
 	}
 	fmt.Fprintf(stdout, "Regenerated %s (events=%d)\n", path, result.Events)
 	return nil
+}
+
+func resolveDigestWindows(window string, now time.Time) ([]digestpkg.Window, error) {
+	window = strings.ToLower(strings.TrimSpace(window))
+	today := dateOnlyUTC(now)
+	switch window {
+	case "today":
+		return []digestpkg.Window{{Date: today, Cover: "today"}}, nil
+	case "yesterday":
+		return []digestpkg.Window{{Date: today.AddDate(0, 0, -1), Cover: "yesterday"}}, nil
+	case "this-week":
+		start := today.AddDate(0, 0, -daysSinceMonday(today))
+		return []digestpkg.Window{{Date: start, Cover: "this-week"}}, nil
+	case "last-week":
+		thisMonday := today.AddDate(0, 0, -daysSinceMonday(today))
+		start := thisMonday.AddDate(0, 0, -7)
+		return []digestpkg.Window{{Date: start, Cover: "last-week"}}, nil
+	default:
+		parsed, err := time.ParseInLocation("2006-01-02", window, time.UTC)
+		if err != nil {
+			return nil, err
+		}
+		return []digestpkg.Window{{Date: parsed, Cover: window}}, nil
+	}
+}
+
+func digestOutputFilename(w digestpkg.Window) string {
+	switch strings.TrimSpace(w.Cover) {
+	case "this-week", "last-week":
+		return w.Cover + ".md"
+	default:
+		return dateOnlyUTC(w.Date).Format("2006-01-02") + ".md"
+	}
+}
+
+func dateOnlyUTC(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func daysSinceMonday(t time.Time) int {
+	return (int(t.UTC().Weekday()) + 6) % 7
+}
+
+func localDigestProviders(localDir, remoteRoot string) ([]string, error) {
+	if provider := providerFromPath(remoteRoot); provider != "" {
+		return []string{provider}, nil
+	}
+	entries, err := os.ReadDir(localDir)
+	if err != nil {
+		return nil, err
+	}
+	providers := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := strings.TrimSpace(entry.Name())
+		switch name {
+		case "", ".relay", ".skills", "digests", "node_modules":
+			continue
+		default:
+			if strings.HasPrefix(name, ".") {
+				continue
+			}
+			providers = append(providers, name)
+		}
+	}
+	sort.Strings(providers)
+	return providers, nil
+}
+
+type localDigestSource struct {
+	localDir    string
+	remoteRoot string
+}
+
+func (s localDigestSource) Events(window digestpkg.Window) ([]digestpkg.ChangeEvent, error) {
+	start := dateOnlyUTC(window.Date)
+	end := start.AddDate(0, 0, 1)
+	switch strings.TrimSpace(window.Cover) {
+	case "this-week", "last-week":
+		end = start.AddDate(0, 0, 7)
+	}
+	var events []digestpkg.ChangeEvent
+	err := filepath.WalkDir(s.localDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			rel, relErr := filepath.Rel(s.localDir, path)
+			if relErr == nil && rel != "." {
+				first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+				if first == entry.Name() {
+					switch entry.Name() {
+					case ".relay", ".git", ".skills", "digests", "node_modules":
+						return filepath.SkipDir
+					}
+				}
+			}
+			return nil
+		}
+		if entry.Name() != "_index.json" {
+			return nil
+		}
+		items, err := readDigestIndexItems(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(s.localDir, path)
+		if err != nil {
+			return err
+		}
+		indexRemotePath := remotePathForLocalRel(s.remoteRoot, filepath.ToSlash(rel))
+		provider := providerFromPath(indexRemotePath)
+		for _, item := range items {
+			ts, ok := digestItemTimestamp(item)
+			if !ok || ts.Before(start) || !ts.Before(end) {
+				continue
+			}
+			events = append(events, digestpkg.ChangeEvent{
+				Provider:      defaultIfBlank(stringField(item, "provider"), provider),
+				Timestamp:     ts,
+				Identifier:    digestItemIdentifier(item, indexRemotePath),
+				Verb:          defaultIfBlank(stringField(item, "verb"), "updated"),
+				CanonicalPath: digestItemPath(item, indexRemotePath),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func readDigestIndexItems(path string) ([]map[string]any, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil, fmt.Errorf("read digest index %s: %w", path, err)
+	}
+	return digestIndexItems(raw), nil
+}
+
+func digestIndexItems(raw any) []map[string]any {
+	switch value := raw.(type) {
+	case []any:
+		return digestMapsFromSlice(value)
+	case map[string]any:
+		for _, key := range []string{"rows", "items", "entries", "results", "files", "data"} {
+			if nested, ok := value[key].([]any); ok {
+				return digestMapsFromSlice(nested)
+			}
+		}
+		return []map[string]any{value}
+	default:
+		return nil
+	}
+}
+
+func digestMapsFromSlice(values []any) []map[string]any {
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		if item, ok := value.(map[string]any); ok {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func digestItemTimestamp(item map[string]any) (time.Time, bool) {
+	for _, key := range []string{"updated", "updatedAt", "updated_at", "lastEditedTime", "last_edited_time", "lastEditedAt", "last_edited_at", "lastModifiedAt", "last_modified_at", "modified", "modifiedAt", "modified_at", "created", "createdAt", "created_at", "ts", "timestamp"} {
+		if parsed, ok := parseDigestTimestamp(stringField(item, key)); ok {
+			return parsed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseDigestTimestamp(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
+}
+
+func digestItemIdentifier(item map[string]any, fallbackPath string) string {
+	for _, key := range []string{"identifier", "key", "number", "title", "name", "id"} {
+		if value := stringField(item, key); value != "" {
+			return value
+		}
+	}
+	return strings.TrimSuffix(filepath.Base(fallbackPath), filepath.Ext(fallbackPath))
+}
+
+func digestItemPath(item map[string]any, fallbackPath string) string {
+	for _, key := range []string{"canonicalPath", "path", "file", "href"} {
+		if value := normalizeWritebackListPath(stringField(item, key)); value != "" {
+			return value
+		}
+	}
+	return fallbackPath
+}
+
+func stringField(item map[string]any, key string) string {
+	value, ok := item[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return strings.TrimSpace(v.String())
+	case float64:
+		if v == float64(int64(v)) {
+			return fmt.Sprintf("%d", int64(v))
+		}
+		return strings.TrimSpace(fmt.Sprint(v))
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
 }

--- a/cmd/relayfile-cli/digest.go
+++ b/cmd/relayfile-cli/digest.go
@@ -9,18 +9,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	digestpkg "github.com/agentworkforce/relayfile/internal/digest"
 )
 
-const digestRebuildUsage = "usage: relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]"
+const digestRebuildUsage = "usage: relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]"
 
-// digestRebuilder is the seam over the internal/digest generator. Tests swap
-// this out so CLI parsing can stay focused while the default implementation
-// rebuilds local mirror digests.
+// digestRebuilder is the seam over the internal/digest generator. The CLI ships
+// a stub today; the real implementation lands when work item 1 of the
+// workspace-primitives spec wires the daemon-side generator.
 type digestRebuilder interface {
 	Rebuild(ctx context.Context, opts digestRebuildOptions) (digestRebuildResult, error)
 }
@@ -29,70 +28,22 @@ type digestRebuildOptions struct {
 	WorkspaceID string
 	LocalDir    string
 	Window      string
+	Timezone    string
+	Now         time.Time
 }
 
 type digestRebuildResult struct {
-	Path   string
-	Events int
+	WorkspaceID string   `json:"workspaceId,omitempty"`
+	Window      string   `json:"window"`
+	Path        string   `json:"path"`
+	Events      int      `json:"events"`
+	Warnings    []string `json:"warnings,omitempty"`
 }
+
+var digestNow = time.Now
 
 // activeDigestRebuilder is overridden by tests via withDigestRebuilder.
-var activeDigestRebuilder digestRebuilder = localDigestRebuilder{now: time.Now}
-
-type localDigestRebuilder struct {
-	now func() time.Time
-}
-
-func (r localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptions) (digestRebuildResult, error) {
-	localDir := strings.TrimSpace(opts.LocalDir)
-	if localDir == "" {
-		return digestRebuildResult{}, fmt.Errorf("workspace %s has no local mirror", opts.WorkspaceID)
-	}
-	now := time.Now
-	if r.now != nil {
-		now = r.now
-	}
-	generatedAt := now().UTC()
-	windows, err := resolveDigestWindows(opts.Window, generatedAt)
-	if err != nil {
-		return digestRebuildResult{}, err
-	}
-	remoteRoot := readMountRemoteRoot(localDir)
-	providers, err := localDigestProviders(localDir, remoteRoot)
-	if err != nil {
-		return digestRebuildResult{}, err
-	}
-	src := localDigestSource{localDir: localDir, remoteRoot: remoteRoot}
-
-	paths := make([]string, 0, len(windows)*2)
-	totalEvents := 0
-	for _, w := range windows {
-		w.GeneratedAt = generatedAt
-		w.Providers = providers
-		w.TZ = time.UTC
-		rep, err := digestpkg.Run(ctx, src, w)
-		if err != nil {
-			return digestRebuildResult{}, err
-		}
-		body := digestpkg.Render(rep)
-		outPath := filepath.Join(localDir, "digests", digestOutputFilename(w))
-		if err := writeFileAtomically(outPath, body, 0o644); err != nil {
-			return digestRebuildResult{}, err
-		}
-		paths = append(paths, outPath)
-		totalEvents += rep.Meta.Events
-
-		switch strings.ToLower(strings.TrimSpace(opts.Window)) {
-		case "today", "yesterday":
-			aliasPath := filepath.Join(localDir, "digests", strings.ToLower(strings.TrimSpace(opts.Window))+".md")
-			if err := writeFileAtomically(aliasPath, body, 0o644); err != nil {
-				return digestRebuildResult{}, err
-			}
-			paths = append(paths, aliasPath)
-		}
-	}
-	return digestRebuildResult{Path: strings.Join(paths, ", "), Events: totalEvents}, nil
-}
+var activeDigestRebuilder digestRebuilder = localDigestRebuilder{}
 
 func withDigestRebuilder(r digestRebuilder, fn func()) {
 	prev := activeDigestRebuilder
@@ -116,11 +67,13 @@ func runDigest(args []string, stdout io.Writer) error {
 func runDigestRebuild(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("digest rebuild", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	window := fs.String("window", "", "digest window: today, yesterday, YYYY-MM-DD, this-week, or last-week")
+	window := fs.String("window", "", "digest window: today, yesterday, this-week, last-week, or YYYY-MM-DD")
 	workspace := fs.String("workspace", "", "workspace name or id")
+	jsonOut := fs.Bool("json", false, "print machine-readable JSON")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"window":    true,
 		"workspace": true,
+		"json":      false,
 	})); err != nil {
 		return err
 	}
@@ -132,7 +85,7 @@ func runDigestRebuild(args []string, stdout io.Writer) error {
 		return errors.New(digestRebuildUsage)
 	}
 	normalizedWindow := strings.ToLower(strings.TrimSpace(*window))
-	if _, err := resolveDigestWindows(normalizedWindow, time.Now().UTC()); err != nil {
+	if !isDigestRebuildWindow(normalizedWindow) {
 		return fmt.Errorf("unknown window %q: %s", *window, digestRebuildUsage)
 	}
 
@@ -145,246 +98,204 @@ func runDigestRebuild(args []string, stdout io.Writer) error {
 		WorkspaceID: workspaceID,
 		LocalDir:    record.LocalDir,
 		Window:      normalizedWindow,
+		Timezone:    record.Timezone,
+		Now:         digestNow(),
 	})
 	if err != nil {
 		return err
 	}
+	result.WorkspaceID = workspaceID
+	result.Window = normalizedWindow
 	path := strings.TrimSpace(result.Path)
 	if path == "" {
 		path = fmt.Sprintf("<mount>/digests/%s.md", normalizedWindow)
+	}
+	if *jsonOut {
+		result.Path = path
+		payload, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return err
+		}
+		payload = append(payload, '\n')
+		_, err = stdout.Write(payload)
+		return err
 	}
 	fmt.Fprintf(stdout, "Regenerated %s (events=%d)\n", path, result.Events)
 	return nil
 }
 
-func resolveDigestWindows(window string, now time.Time) ([]digestpkg.Window, error) {
-	window = strings.ToLower(strings.TrimSpace(window))
-	today := dateOnlyUTC(now)
+func isDigestRebuildWindow(window string) bool {
 	switch window {
-	case "today":
-		return []digestpkg.Window{{Date: today, Cover: "today"}}, nil
-	case "yesterday":
-		return []digestpkg.Window{{Date: today.AddDate(0, 0, -1), Cover: "yesterday"}}, nil
-	case "this-week":
-		start := today.AddDate(0, 0, -daysSinceMonday(today))
-		return []digestpkg.Window{{Date: start, Cover: "this-week"}}, nil
-	case "last-week":
-		thisMonday := today.AddDate(0, 0, -daysSinceMonday(today))
-		start := thisMonday.AddDate(0, 0, -7)
-		return []digestpkg.Window{{Date: start, Cover: "last-week"}}, nil
+	case "today", "yesterday", "this-week", "last-week":
+		return true
 	default:
-		parsed, err := time.ParseInLocation("2006-01-02", window, time.UTC)
-		if err != nil {
-			return nil, err
+		if parsed, err := time.Parse("2006-01-02", window); err == nil {
+			return parsed.Format("2006-01-02") == window
 		}
-		return []digestpkg.Window{{Date: parsed, Cover: window}}, nil
+		return false
 	}
 }
 
-func digestOutputFilename(w digestpkg.Window) string {
-	switch strings.TrimSpace(w.Cover) {
-	case "this-week", "last-week":
-		return w.Cover + ".md"
+type localDigestRebuilder struct{}
+
+func (localDigestRebuilder) Rebuild(ctx context.Context, opts digestRebuildOptions) (digestRebuildResult, error) {
+	localDir := strings.TrimSpace(opts.LocalDir)
+	if localDir == "" {
+		return digestRebuildResult{}, errors.New("workspace localDir is required for digest rebuild")
+	}
+	tz, err := digestpkg.ResolveTZ(digestpkg.WorkspaceTZConfig{Timezone: opts.Timezone})
+	if err != nil {
+		return digestRebuildResult{}, err
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	src := localMirrorDigestSource{root: localDir}
+	providers, err := collectDigestProviders(localDir)
+	if err != nil {
+		return digestRebuildResult{}, err
+	}
+
+	var path string
+	var events int
+	var warnings []string
+	switch opts.Window {
+	case "today":
+		res, err := digestpkg.WriteToday(ctx, localDir, src, providers, now, tz, digestpkg.BuildOptions{})
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		path, events = res.Path, res.Report.Meta.Events
+		warnings = append(warnings, res.Report.Meta.Warnings...)
+	case "yesterday":
+		closedDay := localDateOnlyCLI(now.In(tz).AddDate(0, 0, -1), tz)
+		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.YesterdayPath)))
+		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.YesterdayMarkerPath)))
+		dateStampedPath := digestpkg.DateStampedPath(closedDay, tz)
+		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(dateStampedPath)))
+		res, err := digestpkg.CloseLocalDayFor(ctx, localDir, src, closedDay, now, providers, tz)
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		dateRes, err := digestpkg.WriteDateStamped(ctx, localDir, src, digestpkg.DateStampedWindow(closedDay, now, providers, tz))
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		path, events = res.Path, res.Report.Meta.Events
+		warnings = append(warnings, res.Report.Meta.Warnings...)
+		warnings = append(warnings, dateRes.Report.Meta.Warnings...)
+	case "this-week":
+		w := digestpkg.ThisWeekWindow(now, now, providers, tz)
+		res, err := digestpkg.WriteThisWeek(ctx, localDir, src, w)
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		path, events = res.Path, res.Report.Meta.Events
+		warnings = append(warnings, res.Report.Meta.Warnings...)
+	case "last-week":
+		weekStart := digestpkg.MondayStart(now, tz).AddDate(0, 0, -7)
+		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(digestpkg.LastWeekPath)))
+		w := digestpkg.LastWeekWindow(weekStart, now, providers, tz)
+		res, err := digestpkg.WriteLastWeek(ctx, localDir, src, w)
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		path, events = res.Path, res.Report.Meta.Events
+		warnings = append(warnings, res.Report.Meta.Warnings...)
 	default:
-		return dateOnlyUTC(w.Date).Format("2006-01-02") + ".md"
+		date, err := time.ParseInLocation("2006-01-02", opts.Window, tz)
+		if err != nil {
+			return digestRebuildResult{}, fmt.Errorf("malformed digest date %q: %w", opts.Window, err)
+		}
+		today := localDateOnlyCLI(now.In(tz), tz)
+		if date.After(today) {
+			return digestRebuildResult{}, fmt.Errorf("digest window %s is in the future", opts.Window)
+		}
+		target := digestpkg.DateStampedPath(date, tz)
+		_ = os.Remove(filepath.Join(localDir, filepath.FromSlash(target)))
+		res, err := digestpkg.WriteDateStamped(ctx, localDir, src, digestpkg.DateStampedWindow(date, now, providers, tz))
+		if err != nil {
+			return digestRebuildResult{}, err
+		}
+		path, events = res.Path, res.Report.Meta.Events
+		warnings = append(warnings, res.Report.Meta.Warnings...)
 	}
+	return digestRebuildResult{
+		WorkspaceID: opts.WorkspaceID,
+		Window:      opts.Window,
+		Path:        filepath.Join(localDir, filepath.FromSlash(path)),
+		Events:      events,
+		Warnings:    warnings,
+	}, nil
 }
 
-func dateOnlyUTC(t time.Time) time.Time {
-	t = t.UTC()
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+type localMirrorDigestSource struct {
+	root string
 }
 
-func daysSinceMonday(t time.Time) int {
-	return (int(t.UTC().Weekday()) + 6) % 7
+func (s localMirrorDigestSource) Events(_ digestpkg.Window) ([]digestpkg.ChangeEvent, error) {
+	var events []digestpkg.ChangeEvent
+	err := filepath.WalkDir(s.root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == s.root {
+			return nil
+		}
+		rel, err := filepath.Rel(s.root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if entry.IsDir() {
+			switch strings.Split(rel, "/")[0] {
+			case ".git", ".relay", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if digestpkg.IsDigestPath(rel) || strings.HasPrefix(rel, ".relay/") {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		provider := strings.Split(rel, "/")[0]
+		events = append(events, digestpkg.ChangeEvent{
+			Provider:      provider,
+			Timestamp:     info.ModTime(),
+			Identifier:    rel,
+			Verb:          "updated",
+			CanonicalPath: rel,
+		})
+		return nil
+	})
+	return events, err
 }
 
-func localDigestProviders(localDir, remoteRoot string) ([]string, error) {
-	if provider := providerFromPath(remoteRoot); provider != "" {
-		return []string{provider}, nil
-	}
+func collectDigestProviders(localDir string) ([]string, error) {
 	entries, err := os.ReadDir(localDir)
 	if err != nil {
 		return nil, err
 	}
-	providers := make([]string, 0, len(entries))
+	var providers []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		name := strings.TrimSpace(entry.Name())
+		name := entry.Name()
 		switch name {
-		case "", ".relay", ".skills", "digests", "node_modules":
+		case ".git", ".relay", "node_modules", "digests":
 			continue
-		default:
-			if strings.HasPrefix(name, ".") {
-				continue
-			}
-			providers = append(providers, name)
 		}
+		providers = append(providers, name)
 	}
-	sort.Strings(providers)
 	return providers, nil
 }
 
-type localDigestSource struct {
-	localDir    string
-	remoteRoot string
-}
-
-func (s localDigestSource) Events(window digestpkg.Window) ([]digestpkg.ChangeEvent, error) {
-	start := dateOnlyUTC(window.Date)
-	end := start.AddDate(0, 0, 1)
-	switch strings.TrimSpace(window.Cover) {
-	case "this-week", "last-week":
-		end = start.AddDate(0, 0, 7)
-	}
-	var events []digestpkg.ChangeEvent
-	err := filepath.WalkDir(s.localDir, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			rel, relErr := filepath.Rel(s.localDir, path)
-			if relErr == nil && rel != "." {
-				first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
-				if first == entry.Name() {
-					switch entry.Name() {
-					case ".relay", ".git", ".skills", "digests", "node_modules":
-						return filepath.SkipDir
-					}
-				}
-			}
-			return nil
-		}
-		if entry.Name() != "_index.json" {
-			return nil
-		}
-		items, err := readDigestIndexItems(path)
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(s.localDir, path)
-		if err != nil {
-			return err
-		}
-		indexRemotePath := remotePathForLocalRel(s.remoteRoot, filepath.ToSlash(rel))
-		provider := providerFromPath(indexRemotePath)
-		for _, item := range items {
-			ts, ok := digestItemTimestamp(item)
-			if !ok || ts.Before(start) || !ts.Before(end) {
-				continue
-			}
-			events = append(events, digestpkg.ChangeEvent{
-				Provider:      defaultIfBlank(stringField(item, "provider"), provider),
-				Timestamp:     ts,
-				Identifier:    digestItemIdentifier(item, indexRemotePath),
-				Verb:          defaultIfBlank(stringField(item, "verb"), "updated"),
-				CanonicalPath: digestItemPath(item, indexRemotePath),
-			})
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return events, nil
-}
-
-func readDigestIndexItems(path string) ([]map[string]any, error) {
-	payload, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	var raw any
-	if err := json.Unmarshal(payload, &raw); err != nil {
-		return nil, fmt.Errorf("read digest index %s: %w", path, err)
-	}
-	return digestIndexItems(raw), nil
-}
-
-func digestIndexItems(raw any) []map[string]any {
-	switch value := raw.(type) {
-	case []any:
-		return digestMapsFromSlice(value)
-	case map[string]any:
-		for _, key := range []string{"rows", "items", "entries", "results", "files", "data"} {
-			if nested, ok := value[key].([]any); ok {
-				return digestMapsFromSlice(nested)
-			}
-		}
-		return []map[string]any{value}
-	default:
-		return nil
-	}
-}
-
-func digestMapsFromSlice(values []any) []map[string]any {
-	out := make([]map[string]any, 0, len(values))
-	for _, value := range values {
-		if item, ok := value.(map[string]any); ok {
-			out = append(out, item)
-		}
-	}
-	return out
-}
-
-func digestItemTimestamp(item map[string]any) (time.Time, bool) {
-	for _, key := range []string{"updated", "updatedAt", "updated_at", "lastEditedTime", "last_edited_time", "lastEditedAt", "last_edited_at", "lastModifiedAt", "last_modified_at", "modified", "modifiedAt", "modified_at", "created", "createdAt", "created_at", "ts", "timestamp"} {
-		if parsed, ok := parseDigestTimestamp(stringField(item, key)); ok {
-			return parsed, true
-		}
-	}
-	return time.Time{}, false
-}
-
-func parseDigestTimestamp(value string) (time.Time, bool) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return time.Time{}, false
-	}
-	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02"} {
-		if parsed, err := time.Parse(layout, value); err == nil {
-			return parsed.UTC(), true
-		}
-	}
-	return time.Time{}, false
-}
-
-func digestItemIdentifier(item map[string]any, fallbackPath string) string {
-	for _, key := range []string{"identifier", "key", "number", "title", "name", "id"} {
-		if value := stringField(item, key); value != "" {
-			return value
-		}
-	}
-	return strings.TrimSuffix(filepath.Base(fallbackPath), filepath.Ext(fallbackPath))
-}
-
-func digestItemPath(item map[string]any, fallbackPath string) string {
-	for _, key := range []string{"canonicalPath", "path", "file", "href"} {
-		if value := normalizeWritebackListPath(stringField(item, key)); value != "" {
-			return value
-		}
-	}
-	return fallbackPath
-}
-
-func stringField(item map[string]any, key string) string {
-	value, ok := item[key]
-	if !ok || value == nil {
-		return ""
-	}
-	switch v := value.(type) {
-	case string:
-		return strings.TrimSpace(v)
-	case json.Number:
-		return strings.TrimSpace(v.String())
-	case float64:
-		if v == float64(int64(v)) {
-			return fmt.Sprintf("%d", int64(v))
-		}
-		return strings.TrimSpace(fmt.Sprint(v))
-	default:
-		return strings.TrimSpace(fmt.Sprint(v))
-	}
+func localDateOnlyCLI(t time.Time, tz *time.Location) time.Time {
+	t = t.In(tz)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, tz)
 }

--- a/cmd/relayfile-cli/digest_test.go
+++ b/cmd/relayfile-cli/digest_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -46,7 +47,7 @@ func TestDigestUnknownWindowErrors(t *testing.T) {
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
-	upsertDigestWorkspace(t, localDir)
+	upsertDigestWorkspace(t, localDir, "")
 
 	var stderr bytes.Buffer
 	err := run([]string{"digest", "rebuild", "--window", "monday", "--workspace", "demo"}, strings.NewReader(""), &stderr, &stderr)
@@ -72,7 +73,7 @@ func TestDigestUnknownSubcommandErrors(t *testing.T) {
 	}
 }
 
-func TestDigestRebuildCallsRebuilder(t *testing.T) {
+func TestDigestRebuildCallsInjectedRebuilder(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -80,7 +81,7 @@ func TestDigestRebuildCallsRebuilder(t *testing.T) {
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
-	upsertDigestWorkspace(t, localDir)
+	upsertDigestWorkspace(t, localDir, "Europe/Oslo")
 
 	fake := &fakeDigestRebuilder{result: digestRebuildResult{Path: localDir + "/digests/yesterday.md", Events: 3}}
 	var stdout bytes.Buffer
@@ -92,14 +93,11 @@ func TestDigestRebuildCallsRebuilder(t *testing.T) {
 	if !fake.called {
 		t.Fatalf("expected rebuilder to be called")
 	}
-	if fake.opts.Window != "yesterday" {
-		t.Fatalf("expected window=yesterday, got %q", fake.opts.Window)
+	if fake.opts.Window != "yesterday" || fake.opts.WorkspaceID != "ws_demo" || fake.opts.LocalDir != localDir {
+		t.Fatalf("unexpected opts: %+v", fake.opts)
 	}
-	if fake.opts.WorkspaceID != "ws_demo" {
-		t.Fatalf("expected workspaceId=ws_demo, got %q", fake.opts.WorkspaceID)
-	}
-	if fake.opts.LocalDir != localDir {
-		t.Fatalf("expected localDir=%q, got %q", localDir, fake.opts.LocalDir)
+	if fake.opts.Timezone != "Europe/Oslo" {
+		t.Fatalf("expected configured timezone in opts, got %q", fake.opts.Timezone)
 	}
 	if !strings.Contains(stdout.String(), "Regenerated ") || !strings.Contains(stdout.String(), "events=3") {
 		t.Fatalf("expected success line with event count, got %q", stdout.String())
@@ -114,7 +112,7 @@ func TestDigestRebuildSurfacesError(t *testing.T) {
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
-	upsertDigestWorkspace(t, localDir)
+	upsertDigestWorkspace(t, localDir, "")
 
 	fake := &fakeDigestRebuilder{err: errors.New("boom")}
 	var stdout bytes.Buffer
@@ -122,61 +120,168 @@ func TestDigestRebuildSurfacesError(t *testing.T) {
 	withDigestRebuilder(fake, func() {
 		got = run([]string{"digest", "rebuild", "--window", "today", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout)
 	})
-	if got == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if !strings.Contains(got.Error(), "boom") {
-		t.Fatalf("expected error to wrap rebuilder error, got %q", got.Error())
+	if got == nil || !strings.Contains(got.Error(), "boom") {
+		t.Fatalf("expected boom error, got %v", got)
 	}
 }
 
-func TestDigestRebuildWritesDateStampedDigestAndAlias(t *testing.T) {
+func TestDigestRebuildRealWindows(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	withDigestNow(now, func() {
+		localDir := t.TempDir()
+		seedDigestMirror(t, localDir, now)
+		upsertDigestWorkspace(t, localDir, "UTC")
 
-	localDir := t.TempDir()
-	if err := ensureMirrorLayout(localDir); err != nil {
-		t.Fatalf("ensureMirrorLayout failed: %v", err)
-	}
-	indexDir := filepath.Join(localDir, "linear", "issues")
-	if err := os.MkdirAll(indexDir, 0o755); err != nil {
-		t.Fatalf("mkdir index dir failed: %v", err)
-	}
-	indexPayload := `[
-  {"identifier":"LIN-1","title":"Integration Tracking","updated":"2026-05-12T10:00:00Z","path":"/linear/issues/LIN-1.json"},
-  {"identifier":"LIN-2","title":"Outside Window","updated":"2026-05-11T10:00:00Z","path":"/linear/issues/LIN-2.json"}
-]`
-	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
-		t.Fatalf("write index failed: %v", err)
-	}
-	upsertDigestWorkspace(t, localDir)
+		for _, window := range []string{"today", "yesterday", "this-week", "last-week", "2026-05-15", "2026-05-12"} {
+			var stdout bytes.Buffer
+			if err := run([]string{"digest", "rebuild", "--window", window, "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+				t.Fatalf("digest rebuild %s failed: %v", window, err)
+			}
+			if !strings.Contains(stdout.String(), "Regenerated ") {
+				t.Fatalf("digest rebuild %s missing success output: %q", window, stdout.String())
+			}
+		}
 
-	var stdout bytes.Buffer
-	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
-		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
-	}}, func() {
-		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
-			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		for _, rel := range []string{
+			"digests/today.md",
+			"digests/yesterday.md",
+			"digests/this-week.md",
+			"digests/last-week.md",
+			"digests/2026-05-15.md",
+			"digests/2026-05-12.md",
+		} {
+			if _, err := os.Stat(filepath.Join(localDir, filepath.FromSlash(rel))); err != nil {
+				t.Fatalf("expected %s to be written: %v", rel, err)
+			}
 		}
 	})
-	for _, rel := range []string{"digests/2026-05-12.md", "digests/yesterday.md"} {
-		body, err := os.ReadFile(filepath.Join(localDir, filepath.FromSlash(rel)))
+}
+
+func TestDigestRebuildYesterdayWritesDateStampedSibling(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	withDigestNow(now, func() {
+		localDir := t.TempDir()
+		seedDigestMirror(t, localDir, now)
+		upsertDigestWorkspace(t, localDir, "UTC")
+
+		var stdout bytes.Buffer
+		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("digest rebuild yesterday failed: %v", err)
+		}
+		for _, rel := range []string{"digests/yesterday.md", "digests/2026-05-14.md"} {
+			if _, err := os.Stat(filepath.Join(localDir, filepath.FromSlash(rel))); err != nil {
+				t.Fatalf("expected %s to be written by isolated yesterday rebuild: %v", rel, err)
+			}
+		}
+		body, err := os.ReadFile(filepath.Join(localDir, "digests", "2026-05-14.md"))
 		if err != nil {
-			t.Fatalf("read %s failed: %v", rel, err)
+			t.Fatalf("read date-stamped sibling: %v", err)
 		}
-		got := string(body)
-		for _, needle := range []string{"date: 2026-05-12", "covers: yesterday", "events: 1", "LIN-1", "/linear/issues/LIN-1.json"} {
-			if !strings.Contains(got, needle) {
-				t.Fatalf("%s missing %q:\n%s", rel, needle, got)
-			}
+		if !bytes.Contains(body, []byte("linear/issues/2.md")) || bytes.Contains(body, []byte("github/issues/1.md")) {
+			t.Fatalf("date-stamped sibling did not cover only the closed local day:\n%s", body)
 		}
-	}
-	if !strings.Contains(stdout.String(), "events=1") {
-		t.Fatalf("expected event count in stdout, got %q", stdout.String())
-	}
+	})
 }
 
-func TestDigestRebuildUsesRemoteRootForNonRootMount(t *testing.T) {
+func TestDigestRebuildPastDateWithNoEvents(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	withDigestNow(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC), func() {
+		localDir := t.TempDir()
+		if err := ensureMirrorLayout(localDir); err != nil {
+			t.Fatalf("ensureMirrorLayout failed: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(localDir, "github"), 0o755); err != nil {
+			t.Fatalf("mkdir provider: %v", err)
+		}
+		upsertDigestWorkspace(t, localDir, "UTC")
+
+		var stdout bytes.Buffer
+		if err := run([]string{"digest", "rebuild", "--window", "2026-05-12", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("digest rebuild no-events date failed: %v", err)
+		}
+		body, err := os.ReadFile(filepath.Join(localDir, "digests", "2026-05-12.md"))
+		if err != nil {
+			t.Fatalf("read date digest: %v", err)
+		}
+		if !bytes.Contains(body, []byte("events: 0")) || !bytes.Contains(body, []byte("_no activity_")) {
+			t.Fatalf("no-event digest missing expected body:\n%s", body)
+		}
+	})
+}
+
+func TestDigestRebuildPastDateExcludesNewerFiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	withDigestNow(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC), func() {
+		localDir := t.TempDir()
+		if err := ensureMirrorLayout(localDir); err != nil {
+			t.Fatalf("ensureMirrorLayout failed: %v", err)
+		}
+		files := map[string]time.Time{
+			"github/issues/old.md": time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+			"github/issues/new.md": time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC),
+		}
+		for rel, mod := range files {
+			path := filepath.Join(localDir, filepath.FromSlash(rel))
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", rel, err)
+			}
+			if err := os.WriteFile(path, []byte(rel), 0o644); err != nil {
+				t.Fatalf("write %s: %v", rel, err)
+			}
+			if err := os.Chtimes(path, mod, mod); err != nil {
+				t.Fatalf("chtimes %s: %v", rel, err)
+			}
+		}
+		upsertDigestWorkspace(t, localDir, "UTC")
+
+		var stdout bytes.Buffer
+		if err := run([]string{"digest", "rebuild", "--window", "2026-05-12", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("digest rebuild past date failed: %v", err)
+		}
+		body, err := os.ReadFile(filepath.Join(localDir, "digests", "2026-05-12.md"))
+		if err != nil {
+			t.Fatalf("read rebuilt digest: %v", err)
+		}
+		if !bytes.Contains(body, []byte("github/issues/old.md")) || bytes.Contains(body, []byte("github/issues/new.md")) {
+			t.Fatalf("past date rebuild included files outside the requested day:\n%s", body)
+		}
+	})
+}
+
+func TestDigestRebuildDateErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	withDigestNow(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC), func() {
+		localDir := t.TempDir()
+		if err := ensureMirrorLayout(localDir); err != nil {
+			t.Fatalf("ensureMirrorLayout failed: %v", err)
+		}
+		upsertDigestWorkspace(t, localDir, "UTC")
+
+		var stdout bytes.Buffer
+		err := run([]string{"digest", "rebuild", "--window", "2026-05-16", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout)
+		if err == nil || !strings.Contains(err.Error(), "future") {
+			t.Fatalf("expected future date error, got %v", err)
+		}
+		err = run([]string{"digest", "rebuild", "--window", "2026-02-30", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout)
+		if err == nil || !strings.Contains(err.Error(), "unknown window") {
+			t.Fatalf("expected malformed date error, got %v", err)
+		}
+	})
+}
+
+func TestDigestRebuildJSONIncludesWarningsWhenPresent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -184,190 +289,117 @@ func TestDigestRebuildUsesRemoteRootForNonRootMount(t *testing.T) {
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
-	indexDir := filepath.Join(localDir, "pages")
-	if err := os.MkdirAll(indexDir, 0o755); err != nil {
-		t.Fatalf("mkdir index dir failed: %v", err)
-	}
-	indexPayload := `[
-  {"identifier":"page-1","title":"Rooted Page","updated":"2026-05-12T10:00:00Z"}
-]`
-	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
-		t.Fatalf("write index failed: %v", err)
-	}
-	writeWritebackListState(t, localDir, syncStateFile{WorkspaceID: "ws_demo", RemoteRoot: "/notion"})
-	upsertDigestWorkspace(t, localDir)
+	upsertDigestWorkspace(t, localDir, "UTC")
 
+	fake := &fakeDigestRebuilder{result: digestRebuildResult{
+		Path:     filepath.Join(localDir, "digests", "today.md"),
+		Events:   1,
+		Warnings: []string{"example warning"},
+	}}
 	var stdout bytes.Buffer
-	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
-		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
-	}}, func() {
-		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
-			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+	withDigestRebuilder(fake, func() {
+		if err := run([]string{"digest", "rebuild", "--window", "today", "--workspace", "demo", "--json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("digest rebuild json failed: %v", err)
 		}
 	})
-	body, err := os.ReadFile(filepath.Join(localDir, "digests", "yesterday.md"))
-	if err != nil {
-		t.Fatalf("read yesterday digest failed: %v", err)
+	var got digestRebuildResult
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json output invalid: %v\n%s", err, stdout.String())
 	}
-	got := string(body)
-	for _, needle := range []string{"events: 1", "page-1", "/notion/pages/_index.json"} {
-		if !strings.Contains(got, needle) {
-			t.Fatalf("digest missing %q:\n%s", needle, got)
-		}
-	}
-	if strings.Contains(got, "/pages/_index.json") && !strings.Contains(got, "/notion/pages/_index.json") {
-		t.Fatalf("digest used local-relative path instead of remote root:\n%s", got)
+	if len(got.Warnings) != 1 || got.Warnings[0] != "example warning" {
+		t.Fatalf("warnings missing from json result: %+v", got)
 	}
 }
 
-func TestDigestRebuildReadsRowsIndexesAndNestedDigestNamedDirectories(t *testing.T) {
+func TestDigestRebuildJSONAndForceReplace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-
-	localDir := t.TempDir()
-	if err := ensureMirrorLayout(localDir); err != nil {
-		t.Fatalf("ensureMirrorLayout failed: %v", err)
-	}
-	indexDir := filepath.Join(localDir, "notion", "pages")
-	nestedDir := filepath.Join(localDir, "notion", "pages", "by-title", "digests")
-	for _, dir := range []string{indexDir, nestedDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			t.Fatalf("mkdir %s failed: %v", dir, err)
+	t.Setenv("RELAYFILE_TZ", "UTC")
+	withDigestNow(time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC), func() {
+		localDir := t.TempDir()
+		seedDigestMirror(t, localDir, time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC))
+		oldPath := filepath.Join(localDir, "github", "issues", "old.md")
+		if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+			t.Fatalf("mkdir old issue: %v", err)
 		}
-	}
-	indexPayload := `{"rows":[
-  {"id":"page-1","title":"Release Plan","lastEditedAt":"2026-05-12T10:00:00Z","path":"/notion/pages/page-1/content.md"},
-  {"id":"page-2","title":"Nested Digest Page","last_edited_at":"2026-05-12T11:00:00Z","path":"/notion/pages/by-title/digests/page-2.json"}
-]}`
-	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
-		t.Fatalf("write rows index failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(nestedDir, "_index.json"), []byte(`[{"id":"page-3","updated":"2026-05-12T12:00:00Z","path":"/notion/pages/by-title/digests/page-3.json"}]`), 0o644); err != nil {
-		t.Fatalf("write nested index failed: %v", err)
-	}
-	upsertDigestWorkspace(t, localDir)
-
-	var stdout bytes.Buffer
-	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
-		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
-	}}, func() {
-		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
-			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		if err := os.WriteFile(oldPath, []byte("old"), 0o644); err != nil {
+			t.Fatalf("write old issue: %v", err)
 		}
-	})
-	body, err := os.ReadFile(filepath.Join(localDir, "digests", "yesterday.md"))
-	if err != nil {
-		t.Fatalf("read yesterday digest failed: %v", err)
-	}
-	got := string(body)
-	for _, needle := range []string{"events: 3", "Release Plan", "Nested Digest Page", "page-3"} {
-		if !strings.Contains(got, needle) {
-			t.Fatalf("digest missing %q:\n%s", needle, got)
+		oldTime := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+		if err := os.Chtimes(oldPath, oldTime, oldTime); err != nil {
+			t.Fatalf("chtimes old issue: %v", err)
 		}
-	}
-}
+		upsertDigestWorkspace(t, localDir, "UTC")
 
-func TestDigestWindowsResolveInUTC(t *testing.T) {
-	now := time.Date(2026, 5, 18, 1, 2, 3, 0, time.UTC)
-	tests := []struct {
-		window string
-		want   []string
-	}{
-		{window: "today", want: []string{"2026-05-18"}},
-		{window: "yesterday", want: []string{"2026-05-17"}},
-		{window: "2026-05-12", want: []string{"2026-05-12"}},
-		{window: "this-week", want: []string{"2026-05-18"}},
-		{window: "last-week", want: []string{"2026-05-11"}},
-	}
-	for _, tt := range tests {
-		t.Run(tt.window, func(t *testing.T) {
-			windows, err := resolveDigestWindows(tt.window, now)
-			if err != nil {
-				t.Fatalf("resolveDigestWindows failed: %v", err)
-			}
-			if len(windows) != len(tt.want) {
-				t.Fatalf("window count = %d, want %d: %+v", len(windows), len(tt.want), windows)
-			}
-			for i, want := range tt.want {
-				if got := windows[i].Date.Format("2006-01-02"); got != want {
-					t.Fatalf("windows[%d] = %s, want %s", i, got, want)
-				}
-			}
-		})
-	}
-}
+		target := filepath.Join(localDir, "digests", "2026-05-12.md")
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatalf("mkdir digest dir: %v", err)
+		}
+		if err := os.WriteFile(target, []byte("stale"), 0o644); err != nil {
+			t.Fatalf("write stale digest: %v", err)
+		}
 
-func TestDigestRebuildWritesWeeklyDigestFile(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	localDir := t.TempDir()
-	if err := ensureMirrorLayout(localDir); err != nil {
-		t.Fatalf("ensureMirrorLayout failed: %v", err)
-	}
-	indexDir := filepath.Join(localDir, "linear", "issues")
-	if err := os.MkdirAll(indexDir, 0o755); err != nil {
-		t.Fatalf("mkdir index dir failed: %v", err)
-	}
-	indexPayload := `[
-  {"identifier":"LIN-1","updated":"2026-05-12T10:00:00Z","path":"/linear/issues/LIN-1.json"},
-  {"identifier":"LIN-2","updated":"2026-05-17T10:00:00Z","path":"/linear/issues/LIN-2.json"},
-  {"identifier":"LIN-3","updated":"2026-05-18T10:00:00Z","path":"/linear/issues/LIN-3.json"}
-]`
-	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
-		t.Fatalf("write index failed: %v", err)
-	}
-	upsertDigestWorkspace(t, localDir)
-
-	var stdout bytes.Buffer
-	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
-		return time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
-	}}, func() {
-		if err := run([]string{"digest", "rebuild", "--window", "last-week", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
-			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		var stdout bytes.Buffer
+		if err := run([]string{"digest", "rebuild", "--window", "2026-05-12", "--workspace", "demo", "--json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("digest rebuild json failed: %v", err)
+		}
+		var got digestRebuildResult
+		if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+			t.Fatalf("json output invalid: %v\n%s", err, stdout.String())
+		}
+		if got.WorkspaceID != "ws_demo" || got.Window != "2026-05-12" || got.Events == 0 {
+			t.Fatalf("unexpected json result: %+v", got)
+		}
+		if got.Warnings != nil {
+			t.Fatalf("expected warnings to be omitted for clean rebuild, got %+v", got.Warnings)
+		}
+		body, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatalf("read rebuilt digest: %v", err)
+		}
+		if bytes.Equal(body, []byte("stale")) || !bytes.Contains(body, []byte("github/issues/old.md")) {
+			t.Fatalf("force rebuild did not replace stale digest:\n%s", body)
 		}
 	})
-
-	body, err := os.ReadFile(filepath.Join(localDir, "digests", "last-week.md"))
-	if err != nil {
-		t.Fatalf("read last-week digest failed: %v", err)
-	}
-	got := string(body)
-	for _, needle := range []string{"date: 2026-05-11", "covers: last-week", "events: 2", "LIN-1", "LIN-2"} {
-		if !strings.Contains(got, needle) {
-			t.Fatalf("last-week digest missing %q:\n%s", needle, got)
-		}
-	}
-	if strings.Contains(got, "LIN-3") {
-		t.Fatalf("last-week digest included current-week event:\n%s", got)
-	}
-	if _, err := os.Stat(filepath.Join(localDir, "digests", "2026-05-11.md")); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("last-week rebuild should write last-week.md, not first daily file; stat err=%v", err)
-	}
 }
 
-func TestEnsureMirrorLayoutMaterializesActivitySummarySkill(t *testing.T) {
-	localDir := t.TempDir()
+func seedDigestMirror(t *testing.T, localDir string, now time.Time) {
+	t.Helper()
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
-	body, err := os.ReadFile(filepath.Join(localDir, ".skills", "activity-summary.md"))
-	if err != nil {
-		t.Fatalf("read activity-summary skill failed: %v", err)
+	files := map[string]time.Time{
+		"github/issues/1.md": now,
+		"linear/issues/2.md": now.AddDate(0, 0, -1),
 	}
-	for _, needle := range []string{"activity-summary", "digests/yesterday.md", "_index.json", "LAYOUT.md"} {
-		if !strings.Contains(string(body), needle) {
-			t.Fatalf("activity-summary skill missing %q:\n%s", needle, string(body))
+	for rel, mod := range files {
+		path := filepath.Join(localDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(rel), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		if err := os.Chtimes(path, mod, mod); err != nil {
+			t.Fatalf("chtimes %s: %v", rel, err)
 		}
 	}
 }
 
-func upsertDigestWorkspace(t *testing.T, localDir string) {
+func withDigestNow(now time.Time, fn func()) {
+	prev := digestNow
+	digestNow = func() time.Time { return now }
+	defer func() { digestNow = prev }()
+	fn()
+}
+
+func upsertDigestWorkspace(t *testing.T, localDir, timezone string) {
 	t.Helper()
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
 		Name:       "demo",
 		ID:         "ws_demo",
 		LocalDir:   localDir,
+		Timezone:   timezone,
 		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
 		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {

--- a/cmd/relayfile-cli/digest_test.go
+++ b/cmd/relayfile-cli/digest_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -128,7 +130,7 @@ func TestDigestRebuildSurfacesError(t *testing.T) {
 	}
 }
 
-func TestDigestRebuildStubIsNotWired(t *testing.T) {
+func TestDigestRebuildWritesDateStampedDigestAndAlias(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -136,15 +138,227 @@ func TestDigestRebuildStubIsNotWired(t *testing.T) {
 	if err := ensureMirrorLayout(localDir); err != nil {
 		t.Fatalf("ensureMirrorLayout failed: %v", err)
 	}
+	indexDir := filepath.Join(localDir, "linear", "issues")
+	if err := os.MkdirAll(indexDir, 0o755); err != nil {
+		t.Fatalf("mkdir index dir failed: %v", err)
+	}
+	indexPayload := `[
+  {"identifier":"LIN-1","title":"Integration Tracking","updated":"2026-05-12T10:00:00Z","path":"/linear/issues/LIN-1.json"},
+  {"identifier":"LIN-2","title":"Outside Window","updated":"2026-05-11T10:00:00Z","path":"/linear/issues/LIN-2.json"}
+]`
+	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
+		t.Fatalf("write index failed: %v", err)
+	}
 	upsertDigestWorkspace(t, localDir)
 
 	var stdout bytes.Buffer
-	err := run([]string{"digest", "rebuild", "--window", "today", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout)
-	if err == nil {
-		t.Fatalf("expected stub error, got nil")
+	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
+		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	}}, func() {
+		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		}
+	})
+	for _, rel := range []string{"digests/2026-05-12.md", "digests/yesterday.md"} {
+		body, err := os.ReadFile(filepath.Join(localDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s failed: %v", rel, err)
+		}
+		got := string(body)
+		for _, needle := range []string{"date: 2026-05-12", "covers: yesterday", "events: 1", "LIN-1", "/linear/issues/LIN-1.json"} {
+			if !strings.Contains(got, needle) {
+				t.Fatalf("%s missing %q:\n%s", rel, needle, got)
+			}
+		}
 	}
-	if !strings.Contains(err.Error(), "not yet wired") {
-		t.Fatalf("expected not-yet-wired error from stub, got %q", err.Error())
+	if !strings.Contains(stdout.String(), "events=1") {
+		t.Fatalf("expected event count in stdout, got %q", stdout.String())
+	}
+}
+
+func TestDigestRebuildUsesRemoteRootForNonRootMount(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	indexDir := filepath.Join(localDir, "pages")
+	if err := os.MkdirAll(indexDir, 0o755); err != nil {
+		t.Fatalf("mkdir index dir failed: %v", err)
+	}
+	indexPayload := `[
+  {"identifier":"page-1","title":"Rooted Page","updated":"2026-05-12T10:00:00Z"}
+]`
+	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
+		t.Fatalf("write index failed: %v", err)
+	}
+	writeWritebackListState(t, localDir, syncStateFile{WorkspaceID: "ws_demo", RemoteRoot: "/notion"})
+	upsertDigestWorkspace(t, localDir)
+
+	var stdout bytes.Buffer
+	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
+		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	}}, func() {
+		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		}
+	})
+	body, err := os.ReadFile(filepath.Join(localDir, "digests", "yesterday.md"))
+	if err != nil {
+		t.Fatalf("read yesterday digest failed: %v", err)
+	}
+	got := string(body)
+	for _, needle := range []string{"events: 1", "page-1", "/notion/pages/_index.json"} {
+		if !strings.Contains(got, needle) {
+			t.Fatalf("digest missing %q:\n%s", needle, got)
+		}
+	}
+	if strings.Contains(got, "/pages/_index.json") && !strings.Contains(got, "/notion/pages/_index.json") {
+		t.Fatalf("digest used local-relative path instead of remote root:\n%s", got)
+	}
+}
+
+func TestDigestRebuildReadsRowsIndexesAndNestedDigestNamedDirectories(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	indexDir := filepath.Join(localDir, "notion", "pages")
+	nestedDir := filepath.Join(localDir, "notion", "pages", "by-title", "digests")
+	for _, dir := range []string{indexDir, nestedDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s failed: %v", dir, err)
+		}
+	}
+	indexPayload := `{"rows":[
+  {"id":"page-1","title":"Release Plan","lastEditedAt":"2026-05-12T10:00:00Z","path":"/notion/pages/page-1/content.md"},
+  {"id":"page-2","title":"Nested Digest Page","last_edited_at":"2026-05-12T11:00:00Z","path":"/notion/pages/by-title/digests/page-2.json"}
+]}`
+	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
+		t.Fatalf("write rows index failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "_index.json"), []byte(`[{"id":"page-3","updated":"2026-05-12T12:00:00Z","path":"/notion/pages/by-title/digests/page-3.json"}]`), 0o644); err != nil {
+		t.Fatalf("write nested index failed: %v", err)
+	}
+	upsertDigestWorkspace(t, localDir)
+
+	var stdout bytes.Buffer
+	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
+		return time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	}}, func() {
+		if err := run([]string{"digest", "rebuild", "--window", "yesterday", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		}
+	})
+	body, err := os.ReadFile(filepath.Join(localDir, "digests", "yesterday.md"))
+	if err != nil {
+		t.Fatalf("read yesterday digest failed: %v", err)
+	}
+	got := string(body)
+	for _, needle := range []string{"events: 3", "Release Plan", "Nested Digest Page", "page-3"} {
+		if !strings.Contains(got, needle) {
+			t.Fatalf("digest missing %q:\n%s", needle, got)
+		}
+	}
+}
+
+func TestDigestWindowsResolveInUTC(t *testing.T) {
+	now := time.Date(2026, 5, 18, 1, 2, 3, 0, time.UTC)
+	tests := []struct {
+		window string
+		want   []string
+	}{
+		{window: "today", want: []string{"2026-05-18"}},
+		{window: "yesterday", want: []string{"2026-05-17"}},
+		{window: "2026-05-12", want: []string{"2026-05-12"}},
+		{window: "this-week", want: []string{"2026-05-18"}},
+		{window: "last-week", want: []string{"2026-05-11"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.window, func(t *testing.T) {
+			windows, err := resolveDigestWindows(tt.window, now)
+			if err != nil {
+				t.Fatalf("resolveDigestWindows failed: %v", err)
+			}
+			if len(windows) != len(tt.want) {
+				t.Fatalf("window count = %d, want %d: %+v", len(windows), len(tt.want), windows)
+			}
+			for i, want := range tt.want {
+				if got := windows[i].Date.Format("2006-01-02"); got != want {
+					t.Fatalf("windows[%d] = %s, want %s", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDigestRebuildWritesWeeklyDigestFile(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	indexDir := filepath.Join(localDir, "linear", "issues")
+	if err := os.MkdirAll(indexDir, 0o755); err != nil {
+		t.Fatalf("mkdir index dir failed: %v", err)
+	}
+	indexPayload := `[
+  {"identifier":"LIN-1","updated":"2026-05-12T10:00:00Z","path":"/linear/issues/LIN-1.json"},
+  {"identifier":"LIN-2","updated":"2026-05-17T10:00:00Z","path":"/linear/issues/LIN-2.json"},
+  {"identifier":"LIN-3","updated":"2026-05-18T10:00:00Z","path":"/linear/issues/LIN-3.json"}
+]`
+	if err := os.WriteFile(filepath.Join(indexDir, "_index.json"), []byte(indexPayload), 0o644); err != nil {
+		t.Fatalf("write index failed: %v", err)
+	}
+	upsertDigestWorkspace(t, localDir)
+
+	var stdout bytes.Buffer
+	withDigestRebuilder(localDigestRebuilder{now: func() time.Time {
+		return time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC)
+	}}, func() {
+		if err := run([]string{"digest", "rebuild", "--window", "last-week", "--workspace", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+			t.Fatalf("run digest rebuild failed: %v\nstdout:\n%s", err, stdout.String())
+		}
+	})
+
+	body, err := os.ReadFile(filepath.Join(localDir, "digests", "last-week.md"))
+	if err != nil {
+		t.Fatalf("read last-week digest failed: %v", err)
+	}
+	got := string(body)
+	for _, needle := range []string{"date: 2026-05-11", "covers: last-week", "events: 2", "LIN-1", "LIN-2"} {
+		if !strings.Contains(got, needle) {
+			t.Fatalf("last-week digest missing %q:\n%s", needle, got)
+		}
+	}
+	if strings.Contains(got, "LIN-3") {
+		t.Fatalf("last-week digest included current-week event:\n%s", got)
+	}
+	if _, err := os.Stat(filepath.Join(localDir, "digests", "2026-05-11.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("last-week rebuild should write last-week.md, not first daily file; stat err=%v", err)
+	}
+}
+
+func TestEnsureMirrorLayoutMaterializesActivitySummarySkill(t *testing.T) {
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(localDir, ".skills", "activity-summary.md"))
+	if err != nil {
+		t.Fatalf("read activity-summary skill failed: %v", err)
+	}
+	for _, needle := range []string{"activity-summary", "digests/yesterday.md", "_index.json", "LAYOUT.md"} {
+		if !strings.Contains(string(body), needle) {
+			t.Fatalf("activity-summary skill missing %q:\n%s", needle, string(body))
+		}
 	}
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -647,7 +647,7 @@ func printDigestUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, digestRebuildUsage)
 	default:
 		fmt.Fprintln(w, `Usage:
-  relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]`)
+  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME] [--json]`)
 	}
 }
 
@@ -676,7 +676,7 @@ Usage:
   relayfile writeback list --state pending|dead [--workspace WS] [--json]
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]
-  relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]
+  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME] [--json]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount)

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -278,6 +278,7 @@ type cloudIntegrationListEntry struct {
 
 type syncStateFile struct {
 	WorkspaceID      string              `json:"workspaceId"`
+	RemoteRoot       string              `json:"remoteRoot,omitempty"`
 	Mode             string              `json:"mode"`
 	LastReconcileAt  string              `json:"lastReconcileAt,omitempty"`
 	LastEventAt      string              `json:"lastEventAt,omitempty"`
@@ -633,7 +634,7 @@ func printWritebackUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, "Usage: relayfile writeback retry --opId OP [WORKSPACE]")
 	default:
 		fmt.Fprintln(w, `Usage:
-  relayfile writeback list --state pending|dead|succeeded|failed [--workspace WS] [--json]
+  relayfile writeback list --state pending|dead [--workspace WS] [--json]
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]`)
 	}
@@ -645,7 +646,7 @@ func printDigestUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, digestRebuildUsage)
 	default:
 		fmt.Fprintln(w, `Usage:
-  relayfile digest rebuild --window yesterday|today [--workspace NAME]`)
+  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]`)
 	}
 }
 
@@ -671,10 +672,10 @@ Usage:
   relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]
   relayfile ops list [--workspace NAME] [--json]
   relayfile ops replay OPID [--workspace NAME]
-  relayfile writeback list --state pending|dead|succeeded|failed [--workspace WS] [--json]
+  relayfile writeback list --state pending|dead [--workspace WS] [--json]
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]
-  relayfile digest rebuild --window yesterday|today [--workspace NAME]
+  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount)
@@ -703,7 +704,7 @@ Subcommands:
               Re-enqueue a local dead-lettered writeback op
   digest      Regenerate workspace digests
   digest rebuild
-              Regenerate digests/yesterday.md or digests/today.md
+              Regenerate date-stamped digest files and today/yesterday aliases
   pull        Trigger an immediate sync refresh for one or all providers
   mount       Mirror a remote workspace to a local directory; add --background to detach
   start       Alias for mount; pairs naturally with stop and restart
@@ -1287,6 +1288,27 @@ func ensureMirrorLayout(localDir string) error {
 	if err := os.MkdirAll(localDir, 0o755); err != nil {
 		return err
 	}
+	if err := os.MkdirAll(filepath.Join(localDir, "digests"), 0o755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(localDir, ".skills"), 0o755); err != nil {
+		return err
+	}
+	skillPath := filepath.Join(localDir, ".skills", "activity-summary.md")
+	skillContent := []byte(activitySummarySkillMarkdown)
+	if current, err := os.ReadFile(skillPath); err == nil {
+		if !bytes.Equal(current, skillContent) {
+			if err := writeFileAtomically(skillPath, skillContent, 0o644); err != nil {
+				return err
+			}
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		if err := writeFileAtomically(skillPath, skillContent, 0o644); err != nil {
+			return err
+		}
+	} else {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Join(localDir, ".relay"), 0o755); err != nil {
 		return err
 	}
@@ -1298,6 +1320,16 @@ func ensureMirrorLayout(localDir string) error {
 	}
 	return os.MkdirAll(filepath.Join(localDir, ".relay", "conflicts"), 0o755)
 }
+
+const activitySummarySkillMarkdown = `# activity-summary
+
+Start activity questions from the digest surface before walking provider trees.
+
+- Read ` + "`digests/yesterday.md`" + ` for yesterday, ` + "`digests/today.md`" + ` for today, or ` + "`digests/YYYY-MM-DD.md`" + ` for a specific UTC date.
+- If a digest is missing or stale, run ` + "`relayfile digest rebuild --window yesterday`" + `, ` + "`--window today`" + `, ` + "`--window YYYY-MM-DD`" + `, ` + "`--window this-week`" + `, or ` + "`--window last-week`" + `.
+- Use provider ` + "`_index.json`" + ` files for date filtering and only open individual entity files after the index has narrowed the set.
+- Read ` + "`LAYOUT.md`" + ` and provider ` + "`<integration>/.layout.md`" + ` files when you need path conventions or alias views.
+`
 
 func ensureWorkspaceForSetup(cloud cloudCredentials, name, localDir string) (workspaceRecord, bool, error) {
 	if record, ok := workspaceRecordByName(name); ok {
@@ -5462,6 +5494,7 @@ func providerReadyForMirror(client *apiClient, workspaceID, provider string, sta
 func buildSyncStateSnapshot(status syncStatusResponse, workspaceID, mode string, interval time.Duration, localDir string, pid int, stallReason string) syncStateFile {
 	snapshot := syncStateFile{
 		WorkspaceID:      workspaceID,
+		RemoteRoot:       readMountRemoteRoot(localDir),
 		Mode:             defaultIfBlank(mode, defaultMountMode),
 		IntervalMs:       interval.Milliseconds(),
 		PendingWriteback: countDirtyTrackedFiles(localDir),

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -79,6 +79,7 @@ type workspaceRecord struct {
 	CloudAPIURL string   `json:"cloudApiUrl,omitempty"`
 	AgentName   string   `json:"agentName,omitempty"`
 	Scopes      []string `json:"scopes,omitempty"`
+	Timezone    string   `json:"timezone,omitempty"`
 }
 
 type apiClient struct {
@@ -646,7 +647,7 @@ func printDigestUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, digestRebuildUsage)
 	default:
 		fmt.Fprintln(w, `Usage:
-  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]`)
+  relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]`)
 	}
 }
 
@@ -675,7 +676,7 @@ Usage:
   relayfile writeback list --state pending|dead [--workspace WS] [--json]
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]
-  relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME]
+  relayfile digest rebuild --window today|yesterday|this-week|last-week|YYYY-MM-DD [--workspace NAME] [--json]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
   relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount)
@@ -704,7 +705,7 @@ Subcommands:
               Re-enqueue a local dead-lettered writeback op
   digest      Regenerate workspace digests
   digest rebuild
-              Regenerate date-stamped digest files and today/yesterday aliases
+              Regenerate daily, weekly, or date-stamped digest artifacts
   pull        Trigger an immediate sync refresh for one or all providers
   mount       Mirror a remote workspace to a local directory; add --background to detach
   start       Alias for mount; pairs naturally with stop and restart
@@ -5110,6 +5111,7 @@ func upsertWorkspaceDetails(record workspaceRecord) (workspaceRecord, error) {
 	record.Server = strings.TrimRight(strings.TrimSpace(record.Server), "/")
 	record.CloudAPIURL = strings.TrimRight(strings.TrimSpace(record.CloudAPIURL), "/")
 	record.AgentName = strings.TrimSpace(record.AgentName)
+	record.Timezone = strings.TrimSpace(record.Timezone)
 	if len(record.Scopes) == 0 {
 		record.Scopes = append([]string(nil), defaultJoinScopes...)
 	}
@@ -5166,6 +5168,9 @@ func mergeWorkspaceRecords(current, update workspaceRecord) workspaceRecord {
 	}
 	if update.AgentName != "" {
 		merged.AgentName = update.AgentName
+	}
+	if update.Timezone != "" {
+		merged.Timezone = update.Timezone
 	}
 	if len(update.Scopes) > 0 {
 		merged.Scopes = append([]string(nil), update.Scopes...)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -157,7 +157,7 @@ func TestHelpFlagPrintsUsageForCommandsAndSubcommands(t *testing.T) {
 		{name: "writeback list", args: []string{"writeback", "list", "-h"}, want: writebackListUsage},
 		{name: "writeback status", args: []string{"writeback", "status", "-h"}, want: "Usage: relayfile writeback status"},
 		{name: "writeback retry", args: []string{"writeback", "retry", "-h"}, want: "Usage: relayfile writeback retry --opId OP"},
-		{name: "digest group", args: []string{"digest", "-h"}, want: "relayfile digest rebuild"},
+		{name: "digest group", args: []string{"digest", "-h"}, want: "today|yesterday|YYYY-MM-DD|this-week|last-week"},
 		{name: "digest rebuild", args: []string{"digest", "rebuild", "-h"}, want: digestRebuildUsage},
 		{name: "pull", args: []string{"pull", "-h"}, want: "Usage: relayfile pull"},
 		{name: "mount", args: []string{"mount", "-h"}, want: "Usage: relayfile mount"},
@@ -569,6 +569,7 @@ func TestBuildCloudURLKeepsBasePath(t *testing.T) {
 func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	t.Cleanup(func() { _ = os.RemoveAll("vfs") })
 
 	seen := map[string]bool{}
 	var server *httptest.Server
@@ -677,6 +678,7 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 func TestSetupJiraRunsSitePickerAfterFreshConnect(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	t.Cleanup(func() { _ = os.RemoveAll("vfs") })
 
 	seen := map[string]bool{}
 	var picked map[string]any
@@ -1262,6 +1264,43 @@ func TestStatusSurfacesDegradedStallReason(t *testing.T) {
 	}
 	if !strings.Contains(got, "relayfile login") {
 		t.Fatalf("expected recovery hint in status output, got: %q", got)
+	}
+}
+
+func TestEnsureMirrorLayoutDoesNotRewriteUnchangedSkill(t *testing.T) {
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	skillPath := filepath.Join(localDir, ".skills", "activity-summary.md")
+	before, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat skill before second layout failed: %v", err)
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("second ensureMirrorLayout failed: %v", err)
+	}
+	after, err := os.Stat(skillPath)
+	if err != nil {
+		t.Fatalf("stat skill after second layout failed: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Fatalf("expected unchanged skill file not to be atomically replaced")
+	}
+}
+
+func TestBuildSyncStateSnapshotPreservesRemoteRoot(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localDir, ".relay"), 0o755); err != nil {
+		t.Fatalf("mkdir .relay failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, ".relay", "state.json"), []byte(`{"remoteRoot":"/notion"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write state failed: %v", err)
+	}
+
+	snapshot := buildSyncStateSnapshot(syncStatusResponse{}, "ws_demo", defaultMountMode, defaultMountInterval, localDir, 0, "")
+	if snapshot.RemoteRoot != "/notion" {
+		t.Fatalf("expected remoteRoot to be preserved, got %q", snapshot.RemoteRoot)
 	}
 }
 

--- a/cmd/relayfile-cli/writeback_list.go
+++ b/cmd/relayfile-cli/writeback_list.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
 
-const writebackListUsage = "usage: relayfile writeback list --state pending|dead|succeeded|failed [--workspace WS] [--json]"
+const writebackListUsage = "usage: relayfile writeback list --state pending|dead [--workspace WS] [--json]"
 
 // writebackListItem mirrors the WritebackItem TypeScript shape exported from
 // packages/sdk/typescript/src/types.ts. Field names must stay in sync.
@@ -36,7 +39,7 @@ type writebackListItem struct {
 func runWritebackList(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("writeback list", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
-	state := fs.String("state", "", "writeback state: pending, dead, succeeded, or failed")
+	state := fs.String("state", "", "writeback state: pending or dead")
 	workspace := fs.String("workspace", "", "workspace name or id")
 	jsonOutput := fs.Bool("json", false, "emit JSON")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
@@ -75,7 +78,7 @@ func runWritebackList(args []string, stdout io.Writer) error {
 
 func validWritebackListState(state string) bool {
 	switch state {
-	case "pending", "dead", "succeeded", "failed":
+	case "pending", "dead":
 		return true
 	default:
 		return false
@@ -83,19 +86,166 @@ func validWritebackListState(state string) bool {
 }
 
 // listLocalWritebackItems returns per-operation writeback rows for the given
-// state. Only `dead` is sourced from per-op records on disk
-// (`<localDir>/.relay/dead-letter/`). `pending`, `succeeded`, and `failed`
-// are aggregate counters in the writeback status report today and have no
-// row-level history, so this command refuses to fabricate rows for them per
-// the workspace-primitives WI5 lead plan (non-goal #9).
+// state. `pending` is sourced from dirty tracked files in
+// `<localDir>/.relayfile-mount-state.json`; `dead` is sourced from per-op
+// records under `<localDir>/.relay/dead-letter/`. Aggregate counters in
+// `.relay/state.json` are deliberately not expanded into synthetic rows.
 func listLocalWritebackItems(workspaceID, localDir, state string) ([]writebackListItem, error) {
+	if strings.TrimSpace(localDir) == "" {
+		return []writebackListItem{}, nil
+	}
 	if state == "dead" {
-		if strings.TrimSpace(localDir) == "" {
-			return []writebackListItem{}, nil
-		}
 		return readDeadWritebackItems(workspaceID, localDir)
 	}
-	return nil, fmt.Errorf("%s state not yet tracked; see workspace-primitives WI5", state)
+	return readPendingWritebackItems(workspaceID, localDir)
+}
+
+func readPendingWritebackItems(workspaceID, localDir string) ([]writebackListItem, error) {
+	var state struct {
+		Files map[string]struct {
+			Revision    string `json:"revision"`
+			Hash        string `json:"hash"`
+			Dirty       bool   `json:"dirty"`
+			Denied      bool   `json:"denied"`
+			WriteDenied bool   `json:"writeDenied"`
+			ReadOnly    bool   `json:"readonly"`
+		} `json:"files"`
+	}
+	payload, err := os.ReadFile(filepath.Join(localDir, ".relayfile-mount-state.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []writebackListItem{}, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(payload, &state); err != nil {
+		return nil, fmt.Errorf("invalid mount state: %w", err)
+	}
+	remoteRoot := readMountRemoteRoot(localDir)
+	localHashes, err := localWritebackHashes(localDir, remoteRoot)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]writebackListItem, 0, len(state.Files)+len(localHashes))
+	seen := map[string]struct{}{}
+	for rawPath, tracked := range state.Files {
+		path := normalizeWritebackListPath(rawPath)
+		seen[path] = struct{}{}
+		if tracked.ReadOnly {
+			continue
+		}
+		localHash, hasLocal := localHashes[path]
+		pending := tracked.Dirty
+		if !pending && !tracked.Denied && !tracked.WriteDenied {
+			switch {
+			case hasLocal && tracked.Hash != "" && localHash != tracked.Hash:
+				pending = true
+			case !hasLocal && tracked.Hash != "":
+				pending = true
+			}
+		}
+		if !pending {
+			continue
+		}
+		item := writebackListItem{
+			ID:            defaultIfBlank(path, rawPath),
+			WorkspaceID:   workspaceID,
+			Path:          path,
+			Revision:      strings.TrimSpace(tracked.Revision),
+			CorrelationID: defaultIfBlank(path, rawPath),
+			State:         "pending",
+			Provider:      providerFromPath(path),
+		}
+		items = append(items, item)
+	}
+	for path := range localHashes {
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		items = append(items, writebackListItem{
+			ID:            path,
+			WorkspaceID:   workspaceID,
+			Path:          path,
+			CorrelationID: path,
+			State:         "pending",
+			Provider:      providerFromPath(path),
+		})
+	}
+	sortWritebackListItems(items)
+	return items, nil
+}
+
+func localWritebackHashes(localDir, remoteRoot string) (map[string]string, error) {
+	hashes := map[string]string{}
+	err := filepath.WalkDir(localDir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(localDir, path)
+		if relErr != nil || rel == "." {
+			return relErr
+		}
+		first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+		if entry.IsDir() {
+			if first == entry.Name() && writebackListReservedTopLevel(first) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if first == ".relayfile-mount-state.json" ||
+			strings.HasPrefix(first, ".relayfile-mount-state.json.tmp-") ||
+			writebackListReservedTopLevel(first) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		hash, err := hashLocalWritebackFile(path)
+		if err != nil {
+			return err
+		}
+		hashes[remotePathForLocalRel(remoteRoot, filepath.ToSlash(rel))] = hash
+		return nil
+	})
+	return hashes, err
+}
+
+func remotePathForLocalRel(remoteRoot, rel string) string {
+	rel = strings.Trim(strings.TrimSpace(filepath.ToSlash(rel)), "/")
+	root := normalizeWritebackListPath(remoteRoot)
+	if root == "" || root == "/" {
+		if rel == "" {
+			return "/"
+		}
+		return normalizeWritebackListPath(rel)
+	}
+	if rel == "" {
+		return root
+	}
+	return normalizeWritebackListPath(strings.TrimRight(root, "/") + "/" + rel)
+}
+
+func writebackListReservedTopLevel(name string) bool {
+	return name == ".git" || name == ".relay" || name == ".skills" ||
+		name == "digests" || name == "node_modules" ||
+		name == "_PERMISSIONS.md"
+}
+
+func hashLocalWritebackFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 func readDeadWritebackItems(workspaceID, localDir string) ([]writebackListItem, error) {

--- a/cmd/relayfile-cli/writeback_list_test.go
+++ b/cmd/relayfile-cli/writeback_list_test.go
@@ -69,11 +69,187 @@ func TestWritebackListUnknownStateErrors(t *testing.T) {
 	}
 }
 
-// TestWritebackListPendingNotYetTracked guards against fabricating per-op
-// pending rows from aggregate counters. The writeback status report only
-// carries an int count, so this command must error rather than synthesize
-// provider-summary rows.
-func TestWritebackListPendingNotYetTracked(t *testing.T) {
+func TestWritebackListPendingFromDirtyMountState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	mountState := []byte(`{"files":{
+  "/linear/issues/LIN-1.json":{"revision":"rev_1","dirty":true},
+  "/notion/pages/Page.json":{"revision":"rev_2","dirty":false}
+}}`)
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState, 0o644); err != nil {
+		t.Fatalf("write mount state failed: %v", err)
+	}
+	upsertWritebackListWorkspace(t, localDir)
+
+	var out bytes.Buffer
+	if err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out); err != nil {
+		t.Fatalf("run writeback list pending failed: %v", err)
+	}
+	var items []writebackListSDKItem
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("parse pending JSON failed: %v\npayload:\n%s", err, out.String())
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 pending row, got %d: %+v", len(items), items)
+	}
+	if items[0].State != "pending" || items[0].Path != "/linear/issues/LIN-1.json" || items[0].Provider != "linear" || items[0].Revision != "rev_1" {
+		t.Fatalf("unexpected pending row: %+v", items[0])
+	}
+}
+
+func TestWritebackListPendingIncludesHashDriftMissingAndUntrackedFiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	unchangedPath := filepath.Join(localDir, "linear", "issues", "LIN-1.json")
+	changedPath := filepath.Join(localDir, "linear", "issues", "LIN-2.json")
+	untrackedPath := filepath.Join(localDir, "github", "issues", "draft.json")
+	for _, path := range []string{unchangedPath, changedPath, untrackedPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s failed: %v", filepath.Dir(path), err)
+		}
+	}
+	if err := os.WriteFile(unchangedPath, []byte("same"), 0o644); err != nil {
+		t.Fatalf("write unchanged failed: %v", err)
+	}
+	if err := os.WriteFile(changedPath, []byte("new local body"), 0o644); err != nil {
+		t.Fatalf("write changed failed: %v", err)
+	}
+	if err := os.WriteFile(untrackedPath, []byte("new file"), 0o644); err != nil {
+		t.Fatalf("write untracked failed: %v", err)
+	}
+	unchangedHash, err := hashLocalWritebackFile(unchangedPath)
+	if err != nil {
+		t.Fatalf("hash unchanged failed: %v", err)
+	}
+	mountState := []byte(`{"files":{
+  "/linear/issues/LIN-1.json":{"revision":"rev_1","hash":"` + unchangedHash + `"},
+  "/linear/issues/LIN-2.json":{"revision":"rev_2","hash":"old_hash"},
+  "/linear/issues/LIN-3.json":{"revision":"rev_3","hash":"deleted_hash"},
+  "/linear/issues/LIN-4.json":{"revision":"rev_4","hash":"denied_hash","writeDenied":true}
+}}`)
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState, 0o644); err != nil {
+		t.Fatalf("write mount state failed: %v", err)
+	}
+	upsertWritebackListWorkspace(t, localDir)
+
+	var out bytes.Buffer
+	if err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out); err != nil {
+		t.Fatalf("run writeback list pending failed: %v", err)
+	}
+	var items []writebackListSDKItem
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("parse pending JSON failed: %v\npayload:\n%s", err, out.String())
+	}
+	paths := make([]string, 0, len(items))
+	for _, item := range items {
+		paths = append(paths, item.Path)
+	}
+	want := []string{"/github/issues/draft.json", "/linear/issues/LIN-2.json", "/linear/issues/LIN-3.json"}
+	if strings.Join(paths, ",") != strings.Join(want, ",") {
+		t.Fatalf("pending paths = %v, want %v", paths, want)
+	}
+}
+
+func TestWritebackListPendingUsesRemoteRootForNonRootMount(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	changedPath := filepath.Join(localDir, "pages", "page-1.json")
+	untrackedPath := filepath.Join(localDir, "pages", "draft.json")
+	for _, path := range []string{changedPath, untrackedPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s failed: %v", filepath.Dir(path), err)
+		}
+	}
+	if err := os.WriteFile(changedPath, []byte("new local body"), 0o644); err != nil {
+		t.Fatalf("write changed failed: %v", err)
+	}
+	if err := os.WriteFile(untrackedPath, []byte("new draft"), 0o644); err != nil {
+		t.Fatalf("write untracked failed: %v", err)
+	}
+	mountState := []byte(`{"files":{
+  "/notion/pages/page-1.json":{"revision":"rev_1","hash":"old_hash"},
+  "/notion/pages/page-2.json":{"revision":"rev_2","hash":"deleted_hash"}
+}}`)
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState, 0o644); err != nil {
+		t.Fatalf("write mount state failed: %v", err)
+	}
+	writeWritebackListState(t, localDir, syncStateFile{WorkspaceID: "ws_demo", RemoteRoot: "/notion"})
+	upsertWritebackListWorkspace(t, localDir)
+
+	var out bytes.Buffer
+	if err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out); err != nil {
+		t.Fatalf("run writeback list pending failed: %v", err)
+	}
+	var items []writebackListSDKItem
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("parse pending JSON failed: %v\npayload:\n%s", err, out.String())
+	}
+	paths := make([]string, 0, len(items))
+	for _, item := range items {
+		paths = append(paths, item.Path)
+		if item.Provider != "notion" {
+			t.Fatalf("expected notion provider for %+v", item)
+		}
+	}
+	want := []string{"/notion/pages/draft.json", "/notion/pages/page-1.json", "/notion/pages/page-2.json"}
+	if strings.Join(paths, ",") != strings.Join(want, ",") {
+		t.Fatalf("pending paths = %v, want %v", paths, want)
+	}
+}
+
+func TestWritebackListPendingSkipsReadonlyTrackedFiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	readonlyPath := filepath.Join(localDir, "linear", "issues", "LIN-1.json")
+	if err := os.MkdirAll(filepath.Dir(readonlyPath), 0o755); err != nil {
+		t.Fatalf("mkdir readonly dir failed: %v", err)
+	}
+	if err := os.WriteFile(readonlyPath, []byte("changed but readonly"), 0o644); err != nil {
+		t.Fatalf("write readonly failed: %v", err)
+	}
+	mountState := []byte(`{"files":{
+  "/linear/issues/LIN-1.json":{"revision":"rev_1","hash":"old_hash","readonly":true},
+  "/linear/issues/LIN-2.json":{"revision":"rev_2","hash":"deleted_hash","readonly":true}
+}}`)
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState, 0o644); err != nil {
+		t.Fatalf("write mount state failed: %v", err)
+	}
+	upsertWritebackListWorkspace(t, localDir)
+
+	var out bytes.Buffer
+	if err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out); err != nil {
+		t.Fatalf("run writeback list pending failed: %v", err)
+	}
+	var items []writebackListSDKItem
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("parse pending JSON failed: %v\npayload:\n%s", err, out.String())
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no readonly pending rows, got %+v", items)
+	}
+}
+
+func TestWritebackListDoesNotFabricatePendingFromAggregateCounter(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -92,44 +268,15 @@ func TestWritebackListPendingNotYetTracked(t *testing.T) {
 	upsertWritebackListWorkspace(t, localDir)
 
 	var out bytes.Buffer
-	err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out)
-	if err == nil {
-		t.Fatalf("expected pending state not-yet-tracked error, got nil; output: %s", out.String())
+	if err := run([]string{"writeback", "list", "--state", "pending", "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out); err != nil {
+		t.Fatalf("run writeback list pending failed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not yet tracked") {
-		t.Fatalf("expected 'not yet tracked' in error, got %q", err.Error())
+	var items []writebackListSDKItem
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		t.Fatalf("parse pending JSON failed: %v\npayload:\n%s", err, out.String())
 	}
-}
-
-func TestWritebackListSucceededAndFailedNotYetTracked(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	localDir := t.TempDir()
-	if err := ensureMirrorLayout(localDir); err != nil {
-		t.Fatalf("ensureMirrorLayout failed: %v", err)
-	}
-	state := syncStateFile{
-		WorkspaceID: "ws_demo",
-		Providers: []syncStateProvider{
-			{Provider: "linear", LastEventAt: "2026-05-12T10:00:00Z", LastError: "rate limited"},
-		},
-	}
-	writeWritebackListState(t, localDir, state)
-	upsertWritebackListWorkspace(t, localDir)
-
-	for _, st := range []string{"succeeded", "failed"} {
-		var out bytes.Buffer
-		err := run([]string{"writeback", "list", "--state", st, "--workspace", "demo", "--json"}, strings.NewReader(""), &out, &out)
-		if err == nil {
-			t.Fatalf("expected %s not-yet-tracked error, got nil; output: %s", st, out.String())
-		}
-		if !strings.Contains(err.Error(), "not yet tracked") {
-			t.Fatalf("[%s] expected 'not yet tracked' in error, got %q", st, err.Error())
-		}
-		if !strings.Contains(err.Error(), "workspace-primitives WI5") {
-			t.Fatalf("[%s] expected spec reference in error, got %q", st, err.Error())
-		}
+	if len(items) != 0 {
+		t.Fatalf("expected no fabricated pending rows, got %+v", items)
 	}
 }
 

--- a/docs/workspace-primitives-pr39-gap-spec.md
+++ b/docs/workspace-primitives-pr39-gap-spec.md
@@ -1,0 +1,445 @@
+# Workspace Primitive Skills PR 39 Gap Spec
+
+Status: draft  
+Created: 2026-05-15  
+Source contracts:
+- AgentWorkforce/skills#39: `activity-summary`, `daily-digest`, `writeback-as-files`, `workspace-layout`
+- AgentWorkforce/relayfile#146 / commit `e4eaba3`: local copy of the same four skill contracts
+
+## Purpose
+
+The four skills in AgentWorkforce/skills#39 describe agent-facing relayfile
+workspace primitives. This spec tracks which parts exist functionally across:
+
+- `relayfile` — local mount, CLI, HTTP API, SDK contracts, self-host runtime
+- `cloud` — hosted workspace runtime, digest regeneration, provider sync,
+  hosted writeback execution
+- `relayfile-adapters` — provider path mapping, layout manifests, digest
+  handlers, writeback schemas and provider mutations
+
+The goal is not to install the skills in these repos. The goal is to make the
+runtime behavior match what the skills tell agents to rely on.
+
+## Current Verdict
+
+| Skill | Functional Coverage | Summary |
+| --- | --- | --- |
+| `activity-summary` | Partial | `today.md` and `yesterday.md` exist in cloud, but date-stamped and weekly digests, immutable closing windows, complete/no-cap coverage, and `by-edited` fallback do not. |
+| `daily-digest` | Partial | Core rendering and adapter digest exports exist, but cloud does not invoke adapter `digest()` handlers and only supports UTC `today`/`yesterday`. CLI rebuild is stubbed. |
+| `writeback-as-files` | Mostly implemented | File-native writeback, schemas, dead-lettering, retry, provider execution, and Notion markdown write-through exist. Gaps remain in agent-facing discovery consistency and `writeback list` state coverage. |
+| `workspace-layout` | Partial / divergent | `relayfile` supports root `LAYOUT.md` and virtual `<provider>/.layout.md`; cloud/adapters commonly emit `<provider>/LAYOUT.md`; `by-edited/<date>` is absent. |
+
+## Contract Requirements And Gaps
+
+### 1. Activity Summary
+
+Skill contract:
+
+- Agents can read `<mount>/digests/yesterday.md` first for "what did I work on
+  yesterday" and similar time-windowed activity questions.
+- Digest directory includes `today.md`, `yesterday.md`, `YYYY-MM-DD.md`,
+  `this-week.md`, and `last-week.md`.
+- Digest files are deterministic and exhaustive over the requested window.
+- Digest bullets link to canonical mount paths.
+- Fallback for unusual windows is `by-edited/<date>/` indexes.
+
+Implemented:
+
+- `cloud` writes `/digests/today.md` and `/digests/yesterday.md`.
+- `cloud` excludes `/digests/*` writes from digest source events to avoid
+  recursion.
+- `cloud` emits normal file events for digest file updates.
+- `relayfile` has deterministic digest rendering and golden tests.
+- `relayfile-adapters` has provider-level digest handlers in many packages.
+
+Missing:
+
+| Gap | Repo(s) | Notes |
+| --- | --- | --- |
+| Date-stamped daily digests: `/digests/YYYY-MM-DD.md` | `cloud`, `relayfile` | Required so agents can answer specific-date questions without raw provider crawling. |
+| Weekly digests: `/digests/this-week.md`, `/digests/last-week.md` | `cloud`, `relayfile` | Required by both `activity-summary` and `daily-digest`. |
+| Immutable closing windows | `cloud`, `relayfile` | `yesterday.md`, date-stamped files, and `last-week.md` must be produced at window close and not rewritten on later unrelated changes. |
+| Workspace-local timezone windows | `cloud`, `relayfile` | Current cloud window resolution uses UTC. Contract says workspace configured timezone. |
+| Exhaustive digest coverage | `cloud` | Current cloud digest implementation limits source events to 500. The skill says no pagination gaps. This needs either removal, pagination/chunking, or explicit warning semantics. |
+| Header coverage fields matching contract | `cloud`, `relayfile` | Prior skill text called for `window` and `generated`; current implementations use `date`, `generated_at`, `covers`, `providers`, and `events`. Update skill contracts to the runtime shape. |
+| `by-edited/<date>/` fallback indexes | `cloud`, `relayfile-adapters`, `relayfile` | Search found only a type comment, not emitted indexes. |
+| Mounted skill-discovery file `/.skills/activity-summary.md` | `relayfile`, `cloud` | Evals reference it. If the runtime expects agents to read it from the mount, it must be materialized or the eval/spec should stop requiring it. |
+
+Acceptance checks:
+
+- A provider change on 2026-05-12 writes or updates:
+  - `/digests/today.md` when generated during 2026-05-12 local time.
+  - `/digests/2026-05-12.md` after 2026-05-13 00:00 local.
+  - `/digests/yesterday.md` after 2026-05-13 00:00 local.
+- A provider change on 2026-05-13 does not mutate the already-closed
+  `/digests/2026-05-12.md` or closed `yesterday.md` for the prior day.
+- A workspace configured for a non-UTC timezone produces window boundaries in
+  that timezone.
+- A digest with more than 500 source events either includes all events or emits
+  a machine-readable warning that agents can detect before trusting the body.
+- For a Notion page edited on 2026-05-12, an agent can list
+  `/notion/pages/by-edited/2026-05-12/` and find the canonical record.
+
+### 2. Daily Digest Authoring
+
+Skill contract:
+
+- Adapters expose `digest(ctx: DigestContext): Promise<DigestSection | null>`.
+- Digest sections are alphabetical by provider.
+- Bullets are sorted by event time ascending.
+- Bullets contain provider identifier, past-tense verb, and canonical link.
+- Returning `null` means "ran successfully, no activity".
+- Throws surface as warnings in the digest header.
+- Rolling windows rebuild on every relevant change, coalesced to at most once
+  per 30 seconds.
+- Closing windows are built once at window close.
+- `relayfile digest rebuild --window ...` can force regeneration.
+
+Implemented:
+
+- `relayfile-adapters` has `src/digest.ts` handlers across provider packages.
+- `relayfile-adapters` documents and checks the adapter digest/layout contract.
+- `relayfile` has a deterministic digest package and tests.
+- `cloud` has hosted digest regeneration for `today` and `yesterday`.
+
+Missing:
+
+| Gap | Repo(s) | Notes |
+| --- | --- | --- |
+| Cloud invokes adapter `digest()` exports | `cloud`, `relayfile-adapters` | Current cloud rendering appears generic over workspace events. Adapter-specific `DigestSection` output is not wired into hosted digest production. |
+| Warning propagation from adapter digest failures | `cloud`, `relayfile` | Contract says thrown adapter failures surface in digest header warnings. |
+| 30-second coalescing for rolling windows | `cloud`, `relayfile` | Current implementation refreshes during write paths; no clear coalescing gate was found. |
+| Closing-window scheduler | `cloud`, `relayfile` | Need wall-clock jobs for daily and weekly close events. |
+| Force rebuild implementation | `relayfile`, `cloud` | `relayfile digest rebuild` exists but uses a stub rebuilder. Cloud needs an equivalent API/job or CLI bridge if hosted rebuild is supported. |
+| Digest path taxonomy shared constants | `relayfile`, `cloud`, `relayfile-adapters` | SDK has `("digests/yesterday.md", "digests/today.md")`; it needs the expanded taxonomy when the runtime supports it. |
+
+Acceptance checks:
+
+- A test adapter digest handler returning a custom bullet is reflected verbatim
+  in the hosted digest output.
+- A test adapter digest handler returning `null` creates a provider section with
+  `_no activity_` or a documented empty-provider behavior.
+- A test adapter digest handler throwing adds a `warnings` entry but does not
+  prevent other providers from rendering.
+- Multiple current-day changes within 30 seconds produce no more than one
+  digest rebuild per rolling window.
+- `relayfile digest rebuild --window yesterday` regenerates the appropriate
+  artifact and reports path and event count.
+
+### 3. Writebacks As Files
+
+Skill contract:
+
+- Agents mutate providers by writing files, not by calling provider SDKs
+  directly.
+- Writable directories are discoverable next to read-side data via sibling
+  `.schema.json` files.
+- Agent-authored JSON files conventionally use `wb-<timestamp>.json`.
+- The mount validates payloads, queues provider mutations, handles retries,
+  idempotency, dead-lettering, and audit.
+- Agents can monitor with `relayfile writeback list --state pending|dead` and
+  `relayfile status`.
+- Failed writebacks appear under `<mount>/.relay/dead-letter/` with a
+  `.error.json` sidecar.
+- Notion `content.md` is write-through for page markdown updates.
+
+Implemented:
+
+- `relayfile` queues writebacks and exposes pending writeback API surfaces.
+- `relayfile` CLI has `writeback status`, `writeback retry`, and
+  `writeback list`.
+- `relayfile` writes and reads `.relay/dead-letter/*.json` plus
+  `.error.json` sidecars with canonical error codes.
+- `cloud` executes provider writebacks for Notion, Linear, GitHub, Slack, and
+  others through hosted provider executors/bridges.
+- `relayfile-adapters` ships `.schema.json`, `.create.example.json`,
+  `pathPattern`, and `idPattern` discovery for writable resources.
+- Notion markdown `content.md` write-through is implemented in both adapters
+  and cloud provider execution.
+
+Missing or divergent:
+
+| Gap | Repo(s) | Notes |
+| --- | --- | --- |
+| `relayfile writeback list --state pending|succeeded|failed` row coverage | `relayfile` | Current local list only returns per-op rows for `dead`; other states error because only aggregate counters are tracked. |
+| Consistent mounted discovery location | `cloud`, `relayfile`, `relayfile-adapters` | Skills say sibling `.schema.json`; older docs also mention `_PERMISSIONS.md`. Pick one canonical agent-facing discovery surface and make mounts emit it consistently. |
+| Validation timing and local failure artifact contract | `relayfile`, `cloud` | Skill says mount validates before provider delivery. Productized mount docs mention conflicts for schema validation. Need one current contract and tests. |
+| `.tmp` / `.partial` ignore semantics for writeback payloads | `relayfile`, `cloud` | Watcher ignores some mount-state temp files, but the explicit writeback ignore contract needs coverage. |
+| Provider mutation within approximately 30 seconds | `cloud`, `relayfile` | Need an SLO test/metric or remove the promise from the skill. |
+| Agent-safe replay guidance | `relayfile`, `cloud` | Skill says "fix and re-drop"; CLI has `writeback retry`. Decide which is canonical and document both if both remain. |
+
+Acceptance checks:
+
+- Writing a valid JSON payload to a discovered writeback path creates a pending
+  row visible via `relayfile writeback list --state pending`.
+- Successful provider delivery moves the row to `succeeded` or removes it per a
+  documented lifecycle, and emits `writeback.succeeded`.
+- Permanent schema failure creates a local/hosted artifact with:
+  - Original payload.
+  - `.error.json` sidecar.
+  - `code`, `message`, `attempts`, `firstAttemptAt`, `lastAttemptAt`, `opId`.
+- `relayfile writeback list --state dead --json` returns the sidecar fields.
+- A file named `.tmp`, `*.tmp`, `*.partial`, or an agreed ignored suffix in a
+  writeback directory does not enqueue provider mutation until final rename.
+- Editing `/notion/.../content.md` results in a Notion markdown PATCH and an
+  acked writeback op.
+
+### 4. Workspace Layout
+
+Skill contract:
+
+- Every mount has root `LAYOUT.md`.
+- Every provider has `<provider>/.layout.md`.
+- Layouts describe top-level directories, filename conventions, populated
+  `by-*` indexes, writeback directories, schemas, and pagination/materialization.
+- Agents use `by-title/`, `by-id/`, `by-name/`, `by-edited/<date>/`, and
+  `by-state/` indexes instead of recursive search.
+- Canonical filenames use `<identifier>__<uuid>.<ext>` where possible.
+
+Implemented:
+
+- `relayfile` mount FUSE layer exposes virtual `LAYOUT.md` and
+  `<provider>/.layout.md`.
+- `relayfile` registers provider layout manifests from snapshots.
+- `cloud` writes root `LAYOUT.md` and provider `LAYOUT.md` files in Nango sync
+  record writer paths.
+- `relayfile-adapters` has provider layout prompt files for priority providers
+  and layout manifests/tests.
+- `by-title`, `by-id`, `by-name`, and `by-state` aliases exist in multiple
+  adapters and hosted sync paths.
+- `<identifier>__<uuid>` is broadly implemented, with some legacy `--`
+  compatibility in adapters.
+
+Missing or divergent:
+
+| Gap | Repo(s) | Notes |
+| --- | --- | --- |
+| Provider layout path standardization | `relayfile`, `cloud`, `relayfile-adapters` | Skill says `<provider>/.layout.md`; cloud/adapters often emit `<provider>/LAYOUT.md`. Pick one canonical path or support both with equivalent content. |
+| Root layout mentions digests and skills directory | `relayfile`, `cloud` | Skill says root `LAYOUT.md` lists connected providers, digests directory, skills directory, and conventions. Current content is thinner. |
+| `by-edited/<date>/` indexes | `cloud`, `relayfile-adapters`, `relayfile` | Not functionally implemented. |
+| Layout declares actual available alias indexes per workspace/provider | `cloud`, `relayfile-adapters` | Some provider layouts are static or generic. Contract requires they reflect populated indexes and materialization mode. |
+| Symlink/alias semantics | `relayfile`, `cloud` | Skill says aliases are symlinks or directory listings on filesystems without symlink support. Current implementation mostly materializes alias files. Document this explicitly or implement symlink behavior where available. |
+| `__` reserved enforcement | `relayfile-adapters`, `cloud` | Filename convention says provider data must not produce `__` in identifier portion. Need tests for slug sanitation. |
+
+Acceptance checks:
+
+- On a live mount, both root layout and provider layout are readable at the
+  canonical path(s), have markdown content type, and are read-only.
+- Layout content lists the provider's actual alias segments and writeback
+  resource schemas.
+- For a title lookup, an agent can read layout, list the relevant `by-title/`
+  directory, and open the referenced canonical record without recursive search.
+- For an edited-date lookup, an agent can list `by-edited/YYYY-MM-DD/` for at
+  least Notion pages and issue-tracking records.
+- A provider object whose title contains `__` is sanitized so the stable ID can
+  still be recovered from the last `__` segment.
+
+## Cross-Repo Work Plan
+
+### Execution Model
+
+Each work item should be implemented in repo-specific worktrees, not by editing
+the three repos from one shared checkout. These gaps cross runtime boundaries,
+but each repo has its own tests, release cadence, and local dirty state. Use one
+worktree per repo/layer so changes stay reviewable and can land independently.
+
+Recommended worktree layout:
+
+| Layer | Repo | Suggested branch/worktree purpose |
+| --- | --- | --- |
+| Core mount/API/CLI | `relayfile` | `codex/pr39-workspace-primitives-core` |
+| Hosted runtime/sync/writeback | `cloud` | `codex/pr39-workspace-primitives-cloud` |
+| Provider contracts/adapters | `relayfile-adapters` | `codex/pr39-workspace-primitives-adapters` |
+
+For each work item below:
+
+- Start with the repo that owns the contract decision or source of truth.
+- Keep generated/shared type updates in the repo that owns generation.
+- Do not make cross-repo behavior changes in a repo without adding or updating
+  that repo's local tests.
+- When a work item requires coordinated changes, land adapter contract changes
+  first, then hosted/runtime consumption, then local mount/CLI affordances.
+- Record any contract decision that affects multiple repos in this spec before
+  implementing it elsewhere.
+
+Suggested dependency order:
+
+1. `relayfile-adapters`: provider digest/layout/writeback source contracts.
+2. `cloud`: hosted digest, sync, and provider writeback consumption.
+3. `relayfile`: local mount, CLI, SDK, OpenAPI, and agent-facing docs.
+
+### Work Item A: Canonicalize The Contract
+
+Owner: `relayfile` with `cloud` and `relayfile-adapters` review.
+
+Decisions (resolved 2026-05-15):
+
+- Provider layout path: `<provider>/LAYOUT.md` is canonical. Update the skill
+  contracts to match the current runtime names; do not migrate runtime to
+  `.layout.md`.
+- Digest header shape: keep the existing YAML-style frontmatter
+  (`date`, `generated_at`, `covers`, `providers`, `events`). Update the skill
+  contracts to use those fields rather than the skill's blockquote header.
+- Digest windows in v1: ship `today.md` and `yesterday.md` immediately;
+  date-stamped `YYYY-MM-DD.md`, `this-week.md`, and `last-week.md` follow in
+  the same work item per the acceptance checks above.
+- Writeback discovery surface: sibling `.schema.json` (plus
+  `.create.example.json` where present) is the canonical agent-facing surface.
+  `_PERMISSIONS.md` is not a runtime requirement.
+- Replay model: keep `relayfile writeback retry` as the supported path.
+  Document re-drop of a fixed payload as a manual fallback only; do not
+  promise both as first-class.
+- Activity-summary skill discovery: `/.skills/activity-summary.md` is a
+  mounted runtime artifact. Materialize it in `relayfile` and `cloud` so the
+  evals can read it from the mount.
+
+Done when:
+
+- AGENTS/rules/docs in all three repos agree on the decisions above.
+- Tests assert the chosen paths and header fields.
+
+### Work Item B: Complete Digest Runtime
+
+Owners:
+
+- `cloud`: hosted digest scheduler, adapter digest invocation, timezone windows.
+- `relayfile`: self-host/local digest generation, CLI rebuild implementation.
+- `relayfile-adapters`: provider digest handler conformance and exports.
+
+Required changes:
+
+- Add `YYYY-MM-DD`, `this-week`, and `last-week` windows.
+- Make closing windows immutable after close.
+- Add workspace timezone support.
+- Replace or paginate the 500-event cap.
+- Keep digest rendering generic over workspace events in `cloud`; do not
+  require adapter `digest()` handlers to own provider-specific bullet
+  rendering. Remove the unused adapter-handler expectation from the skill
+  contracts and adapter docs accordingly.
+- Surface provider warnings.
+- Implement `relayfile digest rebuild`.
+
+Done when:
+
+- Unit tests cover all windows, timezone boundaries, immutability, warnings,
+  and more-than-500-event behavior.
+- Integration tests prove provider changes regenerate digest artifacts and emit
+  digest file events without recursion.
+
+### Work Item C: Add Edited-Date Indexes
+
+Owners:
+
+- `relayfile-adapters`: emit provider-specific `by-edited/YYYY-MM-DD/` aliases.
+- `cloud`: preserve and serve those aliases in hosted sync output.
+- `relayfile`: ensure local mount sync/FUSE treats the aliases as ordinary
+  readable files/directories and documents them in layouts.
+
+Required changes:
+
+- Scope `by-edited` to resources used by activity-summary fallbacks (Notion
+  pages, Linear issues, GitHub issues/PRs, Jira/Confluence priority paths).
+  Other resources may opt in but are not required.
+- Define date source per in-scope provider/resource (`updated_at`,
+  `last_edited_time`, merged/closed timestamps where appropriate).
+- Emit stable alias filenames that point to current canonical records.
+- Clean up stale aliases when edited date changes.
+- Add layout manifest support for `by-edited`.
+
+Done when:
+
+- Notion, Linear, GitHub, Jira/Confluence priority paths have `by-edited`
+  tests or documented exclusions.
+- Activity-summary evals use `by-edited` fallback successfully.
+
+### Work Item D: Finish Agent-Facing Writeback Discovery
+
+Owners:
+
+- `relayfile-adapters`: schema/example/resource metadata source of truth.
+- `cloud`: materialize the discovery files in hosted mounts.
+- `relayfile`: local validation, CLI list state coverage, dead-letter UX.
+
+Required changes:
+
+- Use sibling `.schema.json` (plus `.create.example.json` where present) as
+  the canonical discovery path; emit it consistently in hosted and local
+  mounts.
+- Ensure `.schema.json` and `.create.example.json` are visible beside every
+  writable resource in hosted and local mounts.
+- Expose only `pending` and `dead` states to agents via `writeback list`.
+  Remove `succeeded` and `failed` from the documented contract; surface
+  long-form history through metrics/logs rather than the CLI.
+- Add ignore coverage for partial writeback filenames.
+- Align schema-validation failure artifacts with current docs.
+
+Done when:
+
+- `relayfile writeback list --state pending|dead --json` works for both
+  documented states; `succeeded`/`failed` are removed from the contract and
+  help text.
+- Dead-letter sidecars round-trip through CLI, FUSE, cloud, and SDK types.
+- Provider writeback E2E covers at least Notion markdown, Linear comment,
+  GitHub issue/comment, and Slack message.
+
+### Work Item E: Align Layout Runtime And Docs
+
+Owners:
+
+- `relayfile`: mount-level virtual layout behavior.
+- `cloud`: hosted sync layout artifacts.
+- `relayfile-adapters`: provider-specific layout content.
+
+Required changes:
+
+- Support the chosen provider layout path(s) everywhere.
+- Expand root layout to include connected providers, digests, skills if
+  materialized, filename convention, and writeback discovery.
+- Ensure provider layouts describe actual aliases and writeback resources.
+- Add `__` sanitation tests.
+
+Done when:
+
+- A mounted workspace passes a layout conformance test that reads root layout,
+  provider layout, index files, alias directories, schemas, and one canonical
+  record for each priority provider.
+
+## Suggested Validation Commands
+
+Run these after each implementation slice, adjusting package filters per repo.
+
+In `relayfile`:
+
+```bash
+go test ./internal/digest ./internal/mountfuse ./internal/mountsync ./cmd/relayfile-cli
+scripts/check-contract-surface.sh
+```
+
+In `cloud`:
+
+```bash
+npx vitest run packages/relayfile/test/digest.test.ts packages/relayfile/test/writeback-list.test.ts
+npx vitest run tests/nango-sync-record-writer.test.ts tests/relayfile-provider-writeback.e2e.test.ts
+```
+
+In `relayfile-adapters`:
+
+```bash
+npm run test:digest-contracts
+npm run test:writeback-discovery
+npm test -- --runInBand
+```
+
+## Execution Mode And Approval Boundary
+
+Execution preference: local/BYOH first. Cloud promotion is a follow-up once
+the local/BYOH path passes its acceptance checks.
+
+Approval boundary for the generated workflow:
+
+- Run validation, render artifacts, write test fixtures, and read provider
+  state automatically.
+- Pause and ask for user approval before any destructive provider mutation
+  (writeback deletes, dead-letter purges, cache resets), before commits or
+  pushes to git, before opening or merging pull requests, and before any
+  deploy or publish step. The default is non-destructive.

--- a/internal/digest/date_stamped.go
+++ b/internal/digest/date_stamped.go
@@ -1,0 +1,184 @@
+package digest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	TodayPath     = "digests/today.md"
+	YesterdayPath = "digests/yesterday.md"
+)
+
+// DateStampedPath returns the canonical closed-window digest path for date.
+func DateStampedPath(date time.Time, tz *time.Location) string {
+	if tz == nil {
+		tz = time.UTC
+	}
+	return fmt.Sprintf("digests/%s.md", date.In(tz).Format("2006-01-02"))
+}
+
+// IsDigestPath recognizes all v1 digest artifacts. The rolling daily files
+// (today.md, yesterday.md) and date-stamped closed-day files share this
+// predicate with the rolling weekly artifact so the mount-sync recursion
+// guard in `.claude/rules/relayfile-integration-digests.md` covers every
+// digest path with a single check.
+func IsDigestPath(path string) bool {
+	normalized := normalizeDigestPath(path)
+	return normalized == TodayPath ||
+		normalized == YesterdayPath ||
+		normalized == ThisWeekPath ||
+		normalized == LastWeekPath ||
+		IsDateStampedPath(normalized)
+}
+
+// IsDateStampedPath reports whether path has the canonical
+// digests/YYYY-MM-DD.md shape and contains a valid calendar date.
+func IsDateStampedPath(path string) bool {
+	normalized := normalizeDigestPath(path)
+	if !strings.HasPrefix(normalized, "digests/") || !strings.HasSuffix(normalized, ".md") {
+		return false
+	}
+	stem := strings.TrimSuffix(strings.TrimPrefix(normalized, "digests/"), ".md")
+	parsed, err := time.Parse("2006-01-02", stem)
+	return err == nil && parsed.Format("2006-01-02") == stem
+}
+
+// DateStampedWindow builds a Window for a closed local day. The `covers`
+// frontmatter uses the date string so the file is self-describing even after
+// `yesterday.md` moves on to a later day.
+func DateStampedWindow(date, generatedAt time.Time, providers []string, tz *time.Location) Window {
+	if tz == nil {
+		tz = time.UTC
+	}
+	localDate := date.In(tz)
+	cover := localDate.Format("2006-01-02")
+	return Window{
+		Date:        localDate,
+		Cover:       cover,
+		GeneratedAt: generatedAt,
+		Providers:   append([]string(nil), providers...),
+		TZ:          tz,
+	}
+}
+
+type DateStampedWriteResult struct {
+	Path    string
+	Report  Report
+	Written bool
+}
+
+// RenderDateStamped renders the closed-window artifact for w.Date.
+func RenderDateStamped(ctx context.Context, src ChangeEventSource, w Window) (string, []byte, Report, error) {
+	if w.TZ == nil {
+		w.TZ = time.UTC
+	}
+	w.Cover = w.Date.In(w.TZ).Format("2006-01-02")
+	rep, err := Run(ctx, closedDailyFilteredSource{inner: src}, w)
+	if err != nil {
+		return "", nil, Report{}, err
+	}
+	return DateStampedPath(w.Date, w.TZ), Render(rep), rep, nil
+}
+
+type closedDailyFilteredSource struct {
+	inner ChangeEventSource
+}
+
+func (s closedDailyFilteredSource) Events(w Window) ([]ChangeEvent, error) {
+	raw, err := s.inner.Events(w)
+	if err != nil {
+		return nil, err
+	}
+	tz := w.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	start := localDayStart(w.Date, tz)
+	return FilterEventsInToday(raw, start, start.AddDate(0, 0, 1), tz), nil
+}
+
+func localDayStart(t time.Time, tz *time.Location) time.Time {
+	if tz == nil {
+		tz = time.UTC
+	}
+	local := t.In(tz)
+	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, tz)
+}
+
+// WriteDateStamped renders and creates digests/YYYY-MM-DD.md under mountRoot.
+// Existing files are treated as immutable closed windows and are not rewritten.
+func WriteDateStamped(ctx context.Context, mountRoot string, src ChangeEventSource, w Window) (DateStampedWriteResult, error) {
+	path, content, rep, err := RenderDateStamped(ctx, src, w)
+	if err != nil {
+		return DateStampedWriteResult{}, err
+	}
+	if strings.TrimSpace(mountRoot) == "" {
+		return DateStampedWriteResult{}, errors.New("digest: mount root is required")
+	}
+
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return DateStampedWriteResult{}, err
+	}
+
+	f, err := os.OpenFile(localPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if errors.Is(err, os.ErrExist) {
+		return DateStampedWriteResult{Path: path, Report: rep, Written: false}, nil
+	}
+	if err != nil {
+		return DateStampedWriteResult{}, err
+	}
+	if _, err := f.Write(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(localPath)
+		return DateStampedWriteResult{}, err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(localPath)
+		return DateStampedWriteResult{}, err
+	}
+	return DateStampedWriteResult{Path: path, Report: rep, Written: true}, nil
+}
+
+// MaybeCloseDateStampedWindow persists the closed-window date-stamped
+// digest for the local day containing prev iff now has crossed into a
+// later local day. It is the relayfile-side primitive cloud rotation
+// calls at the same point today.md is rotated into yesterday.md.
+//
+// Returns Written=false (and a zero Path) when prev and now are the
+// same local day. When the local-date boundary has been crossed,
+// WriteDateStamped is invoked for the local day of prev; the
+// O_CREATE|O_EXCL guard makes repeat invocations a no-op so this is
+// safe to call from a clock-driven loop.
+func MaybeCloseDateStampedWindow(
+	ctx context.Context,
+	now, prev time.Time,
+	tz *time.Location,
+	mountRoot string,
+	src ChangeEventSource,
+	providers []string,
+	generatedAt time.Time,
+) (DateStampedWriteResult, error) {
+	if tz == nil {
+		tz = time.UTC
+	}
+	prevLocal := prev.In(tz)
+	nowLocal := now.In(tz)
+	if prevLocal.Format("2006-01-02") >= nowLocal.Format("2006-01-02") {
+		return DateStampedWriteResult{}, nil
+	}
+	window := DateStampedWindow(prevLocal, generatedAt, providers, tz)
+	return WriteDateStamped(ctx, mountRoot, src, window)
+}
+
+func normalizeDigestPath(path string) string {
+	normalized := filepath.ToSlash(strings.TrimSpace(path))
+	normalized = strings.TrimPrefix(normalized, "/")
+	return strings.Trim(normalized, "/")
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,10 +1,10 @@
 // Package digest builds the deterministic activity-summary file written
 // to `digests/<cover>.md` after every workspace change-event window.
 //
-// The package is intentionally I/O free: callers supply a Window (date,
-// timezone, connected providers, generated-at timestamp) and a
-// ChangeEventSource. The package coalesces events, sorts them
-// deterministically, and renders Markdown with YAML frontmatter.
+// Callers supply a Window (date, timezone, connected providers,
+// generated-at timestamp) and a ChangeEventSource. The package coalesces
+// events, sorts them deterministically, and renders Markdown with YAML
+// frontmatter. Closed date-stamped windows can also be written idempotently.
 package digest
 
 import (
@@ -13,6 +13,25 @@ import (
 	"sort"
 	"time"
 )
+
+// WarningCoverageTruncated is retained as the historical warning prefix so
+// callers and tests can assert self-host runs no longer emit it. Relayfile's
+// shared renderer is exhaustive; any cloud-specific cap must live outside this
+// package with its own explicit policy.
+const WarningCoverageTruncated = "digest.coverage.truncated"
+
+// DigestCoverageCap is retained only for compatibility with older tests and
+// cloud-facing policy code. Run and RunClosing do not enforce it for self-host
+// relayfile digests.
+const DigestCoverageCap = 500
+
+// RunClosing is a convenience wrapper that runs Run with `w.Closing = true`,
+// documenting that the produced artifact covers a closed window. Self-host
+// relayfile digests are exhaustive: no truncation or coverage warning is added.
+func RunClosing(ctx context.Context, src ChangeEventSource, w Window) (Report, error) {
+	w.Closing = true
+	return Run(ctx, src, w)
+}
 
 // Run coalesces the supplied window's events into a Report. The report is
 // deterministic: the same Window + Events input always yields the same

--- a/internal/digest/digest_test.go
+++ b/internal/digest/digest_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -62,6 +63,465 @@ func TestGoldenYesterday(t *testing.T) {
 	}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestGoldenDateStamped(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	w := DateStampedWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+	path, got, rep, err := RenderDateStamped(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderDateStamped: %v", err)
+	}
+	if path != "digests/2026-05-12.md" {
+		t.Fatalf("path = %q, want digests/2026-05-12.md", path)
+	}
+	if rep.Meta.Date != "2026-05-12" {
+		t.Fatalf("date = %q, want 2026-05-12", rep.Meta.Date)
+	}
+	if rep.Meta.Covers != "2026-05-12" {
+		t.Fatalf("covers = %q, want 2026-05-12", rep.Meta.Covers)
+	}
+	want, err := os.ReadFile("testdata/date-stamped-fixture.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestDateStampedFiltersClosedLocalDay(t *testing.T) {
+	events := []ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 11, 23, 59, 59, 0, time.UTC),
+			Identifier:    "before",
+			Verb:          "updated",
+			CanonicalPath: "github/before.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+			Identifier:    "inside",
+			Verb:          "updated",
+			CanonicalPath: "github/inside.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+			Identifier:    "after",
+			Verb:          "updated",
+			CanonicalPath: "github/after.json",
+		},
+	}
+
+	_, body, rep, err := RenderDateStamped(context.Background(), SliceSource{Items: events}, DateStampedWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 5, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	))
+	if err != nil {
+		t.Fatalf("RenderDateStamped: %v", err)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1", rep.Meta.Events)
+	}
+	if !bytes.Contains(body, []byte("inside")) || bytes.Contains(body, []byte("before")) || bytes.Contains(body, []byte("after")) {
+		t.Fatalf("date-stamped digest did not filter to the closed day:\n%s", body)
+	}
+}
+
+func TestDateStampedWriterCreatesClosedWindowOnce(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+	w := DateStampedWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+
+	first, err := WriteDateStamped(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteDateStamped first: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("first write reported not written")
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(first.Path))
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first digest: %v", err)
+	}
+	firstInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat first digest: %v", err)
+	}
+
+	laterEvents := append([]ChangeEvent(nil), events...)
+	laterEvents = append(laterEvents, ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-92",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/92.json",
+	})
+	second, err := WriteDateStamped(context.Background(), root, SliceSource{Items: laterEvents}, w)
+	if err != nil {
+		t.Fatalf("WriteDateStamped second: %v", err)
+	}
+	if second.Written {
+		t.Fatal("second write rewrote immutable closed-window digest")
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second digest: %v", err)
+	}
+	secondInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat second digest: %v", err)
+	}
+	if !bytes.Equal(secondBytes, firstBytes) {
+		t.Fatalf("closed-window digest changed\n--- first ---\n%s\n--- second ---\n%s", firstBytes, secondBytes)
+	}
+	if !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatalf("mtime changed: first %s second %s", firstInfo.ModTime(), secondInfo.ModTime())
+	}
+}
+
+// TestDateStampedCloseBoundary drives a fake clock across 2026-05-12 →
+// 2026-05-13 midnight and asserts the slice's parent-spec acceptance
+// checks #1, #2, #4, #5: pre-close, the date-stamped file does not
+// exist; immediately after the boundary, exactly one write of
+// digests/2026-05-12.md is observed; the rotation forward (yesterday.md
+// renders the closed day) produces the same bullet set as the
+// date-stamped file (i.e. body identity with the pre-close today.md
+// snapshot, since both digests are produced by the same Run+Render
+// path); and a 2026-05-13 event ingested after the boundary leaves the
+// closed-window artifact byte-identical.
+//
+// Note: the Today writer is owned by the sibling `update-today` slice
+// and the orchestrating midnight trigger is owned by a future
+// scheduler slice. This test exercises the rotation primitives
+// (`WriteDateStamped`, `WriteYesterday`) that the trigger will compose,
+// using a hand-rolled "today.md" snapshot to stand in for the
+// pre-close artifact and asserting the body sections match
+// post-rotation.
+func TestDateStampedCloseBoundary(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+
+	// Phase 1: pre-close clock at 2026-05-12 23:59:59 UTC. Simulate that
+	// today.md holds the in-progress digest for 2026-05-12. The
+	// date-stamped artifact must not exist yet.
+	preCloseClock := time.Date(2026, 5, 12, 23, 59, 59, 0, time.UTC)
+	preCloseWindow := Window{
+		Date:        time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		Cover:       "today",
+		GeneratedAt: preCloseClock,
+		Providers:   []string{"github", "linear", "notion"},
+		TZ:          time.UTC,
+	}
+	preCloseRep, err := Run(context.Background(), SliceSource{Items: events}, preCloseWindow)
+	if err != nil {
+		t.Fatalf("pre-close Run: %v", err)
+	}
+	todayPath := filepath.Join(root, filepath.FromSlash(TodayPath))
+	if err := os.MkdirAll(filepath.Dir(todayPath), 0o755); err != nil {
+		t.Fatalf("mkdir digests: %v", err)
+	}
+	if err := os.WriteFile(todayPath, Render(preCloseRep), 0o644); err != nil {
+		t.Fatalf("seed today.md: %v", err)
+	}
+	dateStampedLocal := filepath.Join(root, filepath.FromSlash("digests/2026-05-12.md"))
+	if _, err := os.Stat(dateStampedLocal); !os.IsNotExist(err) {
+		t.Fatalf("pre-close: digests/2026-05-12.md should not exist yet, stat err = %v", err)
+	}
+
+	// Phase 2: clock crosses 2026-05-13 00:00:01. The midnight trigger
+	// composes WriteDateStamped (close the previous day) and
+	// WriteYesterday (rotate today.md → yesterday.md).
+	postCloseClock := time.Date(2026, 5, 13, 0, 0, 1, 0, time.UTC)
+	closedDay := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	dsWindow := DateStampedWindow(closedDay, postCloseClock, []string{"github", "linear", "notion"}, time.UTC)
+	dsResult, err := WriteDateStamped(context.Background(), root, SliceSource{Items: events}, dsWindow)
+	if err != nil {
+		t.Fatalf("WriteDateStamped at boundary: %v", err)
+	}
+	if !dsResult.Written {
+		t.Fatal("WriteDateStamped at boundary reported Written=false on a fresh window")
+	}
+	if dsResult.Path != "digests/2026-05-12.md" {
+		t.Fatalf("WriteDateStamped path = %q, want digests/2026-05-12.md", dsResult.Path)
+	}
+	dsBytes, err := os.ReadFile(dateStampedLocal)
+	if err != nil {
+		t.Fatalf("read date-stamped digest: %v", err)
+	}
+	dsInfo, err := os.Stat(dateStampedLocal)
+	if err != nil {
+		t.Fatalf("stat date-stamped digest: %v", err)
+	}
+
+	yResult, err := CloseLocalDay(context.Background(), root, SliceSource{Items: events}, postCloseClock, []string{"github", "linear", "notion"}, time.UTC)
+	if err != nil {
+		t.Fatalf("CloseLocalDay at boundary: %v", err)
+	}
+	if !yResult.Written {
+		t.Fatal("CloseLocalDay reported not written; expected a fresh yesterday.md rotation")
+	}
+	yesterdayLocal := filepath.Join(root, filepath.FromSlash(YesterdayPath))
+	yesterdayBytes, err := os.ReadFile(yesterdayLocal)
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+
+	// AC #4: bullets in the date-stamped file match those that appeared
+	// in the pre-close today.md, and the rotated yesterday.md uses the
+	// same bullet set (different frontmatter only). We compare body
+	// sections (everything after the YAML frontmatter terminator).
+	preCloseToday, err := os.ReadFile(todayPath)
+	if err != nil {
+		t.Fatalf("read today.md: %v", err)
+	}
+	if got, want := bodyAfterFrontmatter(t, dsBytes), bodyAfterFrontmatter(t, preCloseToday); got != want {
+		t.Fatalf("date-stamped body diverges from pre-close today.md body\n--- date-stamped ---\n%s\n--- today.md (pre-close) ---\n%s", got, want)
+	}
+	if got, want := bodyAfterFrontmatter(t, yesterdayBytes), bodyAfterFrontmatter(t, preCloseToday); got != want {
+		t.Fatalf("rotated yesterday.md body diverges from pre-close today.md body\n--- yesterday.md ---\n%s\n--- today.md (pre-close) ---\n%s", got, want)
+	}
+
+	// AC #5: ingesting a 2026-05-13 event after the boundary leaves the
+	// closed-window artifact byte-identical and produces no new write.
+	laterEvents := append([]ChangeEvent(nil), events...)
+	laterEvents = append(laterEvents, ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-92",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/92.json",
+	})
+	postIngest, err := WriteDateStamped(context.Background(), root, SliceSource{Items: laterEvents}, dsWindow)
+	if err != nil {
+		t.Fatalf("WriteDateStamped after 2026-05-13 ingest: %v", err)
+	}
+	if postIngest.Written {
+		t.Fatal("second WriteDateStamped after boundary rewrote the closed-window digest")
+	}
+	dsBytesAfter, err := os.ReadFile(dateStampedLocal)
+	if err != nil {
+		t.Fatalf("re-read date-stamped digest: %v", err)
+	}
+	if !bytes.Equal(dsBytesAfter, dsBytes) {
+		t.Fatal("closed-window digest mutated by post-boundary ingest")
+	}
+	dsInfoAfter, err := os.Stat(dateStampedLocal)
+	if err != nil {
+		t.Fatalf("stat date-stamped digest after ingest: %v", err)
+	}
+	if !dsInfoAfter.ModTime().Equal(dsInfo.ModTime()) {
+		t.Fatalf("closed-window digest mtime changed: before %s after %s", dsInfo.ModTime(), dsInfoAfter.ModTime())
+	}
+}
+
+func bodyAfterFrontmatter(t *testing.T, content []byte) string {
+	t.Helper()
+	s := string(content)
+	// Frontmatter is `---\n...---\n`. Find the second `---\n`.
+	const sep = "---\n"
+	first := strings.Index(s, sep)
+	if first != 0 {
+		t.Fatalf("content does not start with YAML frontmatter")
+	}
+	rest := s[len(sep):]
+	end := strings.Index(rest, sep)
+	if end < 0 {
+		t.Fatalf("missing frontmatter terminator")
+	}
+	return rest[end+len(sep):]
+}
+
+// TestDateStampedBodyMatchesYesterdaySnapshot pins parent-spec AC #4:
+// the date-stamped renderer and the yesterday renderer produce
+// byte-identical body sections for the same fixture and providers
+// (frontmatter differs only by `covers` and the date-stamped file
+// names the day explicitly). If a future renderer split introduced
+// divergent sorting or path canonicalization between the two paths,
+// this test would catch it before a clock-driven rotation could.
+func TestDateStampedBodyMatchesYesterdaySnapshot(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	closedDay := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	generatedAt := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	providers := []string{"github", "linear", "notion"}
+
+	_, dsBytes, _, err := RenderDateStamped(
+		context.Background(),
+		SliceSource{Items: events},
+		DateStampedWindow(closedDay, generatedAt, providers, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("RenderDateStamped: %v", err)
+	}
+	_, yBytes, _, err := RenderYesterday(
+		context.Background(),
+		SliceSource{Items: events},
+		YesterdayWindow(closedDay, generatedAt, providers, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("RenderYesterday: %v", err)
+	}
+	if got, want := bodyAfterFrontmatter(t, dsBytes), bodyAfterFrontmatter(t, yBytes); got != want {
+		t.Fatalf("body sections diverged between date-stamped and yesterday renderers\n--- date-stamped ---\n%s\n--- yesterday ---\n%s", got, want)
+	}
+}
+
+func TestDigestPathTaxonomyIncludesDateStampedFiles(t *testing.T) {
+	for _, path := range []string{
+		"digests/today.md",
+		"/digests/yesterday.md",
+		"digests/2026-05-12.md",
+		"digests/last-week.md",
+		"/digests/last-week.md",
+	} {
+		if !IsDigestPath(path) {
+			t.Fatalf("%q should be recognized as a digest path", path)
+		}
+	}
+	for _, path := range []string{
+		"digests/2026-02-30.md",
+		"digests/2026-05-12.json",
+		"notion/pages/2026-05-12.md",
+		"digests/last-weak.md",
+		"digests/last-week.txt",
+		"digests/last_week.md",
+	} {
+		if IsDigestPath(path) {
+			t.Fatalf("%q should not be recognized as a digest path", path)
+		}
+	}
+}
+
+// TestMaybeCloseDateStampedWindowDefersWithinSameLocalDay pins parent-spec
+// acceptance check #1: generating digests during 2026-05-12 local time
+// must not yet write digests/2026-05-12.md.
+func TestMaybeCloseDateStampedWindowDefersWithinSameLocalDay(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+	prev := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 12, 23, 59, 0, 0, time.UTC)
+
+	result, err := MaybeCloseDateStampedWindow(
+		context.Background(),
+		now, prev,
+		time.UTC, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("MaybeCloseDateStampedWindow: %v", err)
+	}
+	if result.Written {
+		t.Fatalf("date-stamped digest written before local-day boundary crossed")
+	}
+	if _, err := os.Stat(filepath.Join(root, "digests", "2026-05-12.md")); !os.IsNotExist(err) {
+		t.Fatalf("digests/2026-05-12.md should not exist yet: err=%v", err)
+	}
+}
+
+// TestMaybeCloseDateStampedWindowWritesOnceAtBoundary pins parent-spec
+// acceptance check #2: once the local clock crosses 2026-05-13 00:00, a
+// regeneration writes digests/2026-05-12.md exactly once. Repeat
+// invocation past the boundary is a no-op (O_CREATE|O_EXCL).
+func TestMaybeCloseDateStampedWindowWritesOnceAtBoundary(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+	prev := time.Date(2026, 5, 12, 23, 59, 0, 0, time.UTC)
+	now := time.Date(2026, 5, 13, 0, 0, 1, 0, time.UTC)
+
+	first, err := MaybeCloseDateStampedWindow(
+		context.Background(),
+		now, prev,
+		time.UTC, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("first MaybeCloseDateStampedWindow: %v", err)
+	}
+	if !first.Written {
+		t.Fatalf("expected date-stamped digest to be written at boundary")
+	}
+	if first.Path != "digests/2026-05-12.md" {
+		t.Fatalf("path = %q, want digests/2026-05-12.md", first.Path)
+	}
+	localPath := filepath.Join(root, "digests", "2026-05-12.md")
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first digest: %v", err)
+	}
+
+	second, err := MaybeCloseDateStampedWindow(
+		context.Background(),
+		now.Add(time.Minute), prev,
+		time.UTC, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		now.Add(time.Minute),
+	)
+	if err != nil {
+		t.Fatalf("second MaybeCloseDateStampedWindow: %v", err)
+	}
+	if second.Written {
+		t.Fatalf("expected second invocation past the boundary to be a no-op")
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second digest: %v", err)
+	}
+	if !bytes.Equal(secondBytes, firstBytes) {
+		t.Fatalf("closed-window digest changed under second invocation")
+	}
+}
+
+// TestIsDigestPathFiltersOutDateStampedSourceEvents pins the
+// non-recursion contract from
+// .claude/rules/relayfile-integration-digests.md: watcher events for
+// digest artifacts must not enter the digest regeneration source-event
+// set. In this repo IsDigestPath is the predicate the cloud regen
+// pipeline applies; this test demonstrates the filter drops the
+// date-stamped path while keeping unrelated provider events.
+func TestIsDigestPathFiltersOutDateStampedSourceEvents(t *testing.T) {
+	type fsEvent struct{ Path string }
+	candidates := []fsEvent{
+		{Path: "digests/2026-05-12.md"},
+		{Path: "digests/today.md"},
+		{Path: "digests/yesterday.md"},
+		{Path: "github/repos/AgentWorkforce__workforce/pulls/by-id/92.json"},
+		{Path: "notion/pages/2026-05-12.md"},
+	}
+	var sourceEvents []fsEvent
+	for _, ev := range candidates {
+		if IsDigestPath(ev.Path) {
+			continue
+		}
+		sourceEvents = append(sourceEvents, ev)
+	}
+	if len(sourceEvents) != 2 {
+		t.Fatalf("expected 2 source events after digest filter, got %d: %+v", len(sourceEvents), sourceEvents)
+	}
+	for _, ev := range sourceEvents {
+		if IsDigestPath(ev.Path) {
+			t.Fatalf("digest path %q leaked past the filter into the regen source set", ev.Path)
+		}
 	}
 }
 
@@ -192,4 +652,297 @@ func TestEventFromUnlistedProviderStillRenders(t *testing.T) {
 	if rep.Meta.Events != len(events) {
 		t.Fatalf("meta.events = %d, want %d", rep.Meta.Events, len(events))
 	}
+}
+
+// TestYesterday_HeaderKeys pins parent-spec gate D: the rendered
+// `yesterday.md` frontmatter contains exactly the agreed key set and no
+// rejected keys (no `window`, no blockquote-style header). The test parses
+// the YAML header naively so a future renderer that adds an unrelated key
+// fails this assertion immediately, before any golden-fixture rebaseline.
+func TestYesterday_HeaderKeys(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+	_, content, _, err := RenderYesterday(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderYesterday: %v", err)
+	}
+	keys := frontmatterKeys(t, content)
+	want := []string{"date", "generated_at", "covers", "providers", "events"}
+	if !equalStringSlice(keys, want) {
+		t.Fatalf("yesterday frontmatter keys = %v, want exactly %v (no extra keys, no missing keys, in order)", keys, want)
+	}
+	for _, rejected := range []string{"window", "title", "summary"} {
+		for _, k := range keys {
+			if k == rejected {
+				t.Fatalf("yesterday frontmatter contains rejected key %q (Work Item A)", rejected)
+			}
+		}
+	}
+	if bytes.HasPrefix(content, []byte(">")) {
+		t.Fatal("yesterday output starts with blockquote header — must be YAML frontmatter (Work Item A)")
+	}
+}
+
+// TestYesterday_Determinism_Empty pins gate C for the empty-events path:
+// two close-window runs with zero events produce byte-equal output. The
+// `_no activity_` rendering must be stable across runs.
+func TestYesterday_Determinism_Empty(t *testing.T) {
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+	rep1, err := RunClosing(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("Run empty #1: %v", err)
+	}
+	rep2, err := RunClosing(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("Run empty #2: %v", err)
+	}
+	if !bytes.Equal(Render(rep1), Render(rep2)) {
+		t.Fatal("empty closing window produced different bytes across runs")
+	}
+	if rep1.Meta.Events != 0 {
+		t.Fatalf("empty: events=%d want 0", rep1.Meta.Events)
+	}
+}
+
+// TestYesterday_Determinism_Exhaustive pins gate C for the high-volume path:
+// two runs over the same oversize event set produce byte-equal output without
+// truncating or warning. Self-host relayfile digests are exhaustive; any future
+// cloud-side cap belongs outside this shared renderer.
+func TestYesterday_Determinism_Exhaustive(t *testing.T) {
+	const overCap = DigestCoverageCap + 25
+	events := make([]ChangeEvent, 0, overCap)
+	for i := 0; i < overCap; i++ {
+		events = append(events, ChangeEvent{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 12, 0, i, 0, time.UTC),
+			Identifier:    formatNumeric("PR-", i),
+			Verb:          "updated",
+			CanonicalPath: formatNumeric("github/repos/x/pulls/by-id/", i) + ".json",
+		})
+	}
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	)
+	rep1, err := RunClosing(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("Run exhaustive #1: %v", err)
+	}
+	rep2, err := RunClosing(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("Run exhaustive #2: %v", err)
+	}
+	if !bytes.Equal(Render(rep1), Render(rep2)) {
+		t.Fatal("high-volume closing window produced different bytes across runs")
+	}
+	if rep1.Meta.Events != overCap {
+		t.Fatalf("Meta.Events = %d, want %d (self-host closing digests are exhaustive)", rep1.Meta.Events, overCap)
+	}
+	assertNoDigestTruncationWarning(t, rep1.Meta.Warnings)
+	rendered := Render(rep1)
+	if !bytes.Contains(rendered, []byte("PR-524")) {
+		t.Fatalf("rendered digest missing final over-cap bullet:\n%s", rendered)
+	}
+}
+
+// TestCoverage_OverCap pins gate F for self-host relayfile: when more than
+// 500 events arrive for a closed window, both yesterday and date-stamped
+// digests keep every event and do not emit truncation warnings.
+func TestCoverage_OverCap(t *testing.T) {
+	const overCap = DigestCoverageCap + 7
+	events := make([]ChangeEvent, 0, overCap)
+	for i := 0; i < overCap; i++ {
+		events = append(events, ChangeEvent{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 12, 0, i, 0, time.UTC),
+			Identifier:    formatNumeric("PR-", i),
+			Verb:          "updated",
+			CanonicalPath: formatNumeric("github/repos/x/pulls/by-id/", i) + ".json",
+		})
+	}
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	)
+	rep, err := RunClosing(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RunClosing: %v", err)
+	}
+
+	if rep.Meta.Events != overCap {
+		t.Fatalf("Meta.Events = %d, want %d (self-host closing digests are exhaustive)", rep.Meta.Events, overCap)
+	}
+	assertNoDigestTruncationWarning(t, rep.Meta.Warnings)
+	rendered := Render(rep)
+	if bytes.Contains(rendered, []byte(WarningCoverageTruncated)) {
+		t.Fatalf("rendered frontmatter unexpectedly contains warning string %q:\n%s", WarningCoverageTruncated, rendered)
+	}
+	if !bytes.Contains(rendered, []byte("PR-0")) || !bytes.Contains(rendered, []byte("PR-506")) {
+		t.Fatalf("rendered yesterday digest missing first or last over-cap bullet:\n%s", rendered)
+	}
+
+	dateWindow := DateStampedWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	)
+	_, dateRendered, dateRep, err := RenderDateStamped(context.Background(), SliceSource{Items: events}, dateWindow)
+	if err != nil {
+		t.Fatalf("RenderDateStamped: %v", err)
+	}
+	if dateRep.Meta.Events != overCap {
+		t.Fatalf("date-stamped Meta.Events = %d, want %d", dateRep.Meta.Events, overCap)
+	}
+	assertNoDigestTruncationWarning(t, dateRep.Meta.Warnings)
+	if !bytes.Contains(dateRendered, []byte("PR-0")) || !bytes.Contains(dateRendered, []byte("PR-506")) {
+		t.Fatalf("rendered date-stamped digest missing first or last over-cap bullet:\n%s", dateRendered)
+	}
+
+	// The WarningCoverageTruncated constant remains stable for downstream
+	// parsers even though this shared renderer does not emit it.
+	if WarningCoverageTruncated != "digest.coverage.truncated" {
+		t.Fatalf("WarningCoverageTruncated = %q, want stable string digest.coverage.truncated", WarningCoverageTruncated)
+	}
+}
+
+// TestYesterday_Determinism_OverCap pins gate C over an oversize input set.
+// Renamed from the original review-mandated `TestYesterday_Determinism_Warnings`
+// because the shared renderer is exhaustive: no truncation warning fires, so
+// the `Warnings` suffix was misleading. The current name reflects the actual
+// contract (determinism above the historical cap, no truncation).
+func TestYesterday_Determinism_OverCap(t *testing.T) {
+	TestYesterday_Determinism_Exhaustive(t)
+}
+
+// TestYesterday_OverCapExhaustive pins gate F for self-host relayfile.
+// Renamed from the original review-mandated `TestYesterday_CoverageCapWarning`
+// because the shared renderer is exhaustive: every event over `DigestCoverageCap`
+// is still emitted and no `digest.coverage.truncated` warning fires. The
+// historical name implied the opposite contract.
+func TestYesterday_OverCapExhaustive(t *testing.T) {
+	TestCoverage_OverCap(t)
+}
+
+func assertNoDigestTruncationWarning(t *testing.T, warnings []string) {
+	t.Helper()
+	for _, warn := range warnings {
+		if strings.Contains(warn, "digest.truncated") || strings.Contains(warn, WarningCoverageTruncated) {
+			t.Fatalf("unexpected digest truncation warning: %q", warn)
+		}
+	}
+}
+
+// TestYesterday_TZBoundary pins gate A explicitly: workspace TZ
+// America/New_York, event at 2026-05-13T03:30:00Z (== 2026-05-12T23:30 EDT),
+// close run at 2026-05-13T04:05:00Z (== 2026-05-13T00:05 EDT). The produced
+// yesterday.md must have date=2026-05-12 and contain the late event.
+func TestYesterday_TZBoundary(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York tz not available: %v", err)
+	}
+	root := t.TempDir()
+	events := []ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 13, 3, 30, 0, 0, time.UTC), // 23:30 EDT 2026-05-12
+			Identifier:    "PR-late",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/late.json",
+		},
+	}
+	now := time.Date(2026, 5, 13, 4, 5, 0, 0, time.UTC) // 00:05 EDT 2026-05-13
+	res, err := CloseLocalDay(context.Background(), root, SliceSource{Items: events}, now, []string{"github"}, ny)
+	if err != nil {
+		t.Fatalf("CloseLocalDay: %v", err)
+	}
+	if !res.Written {
+		t.Fatal("CloseLocalDay did not write")
+	}
+	if res.Report.Meta.Date != "2026-05-12" {
+		t.Fatalf("date = %q, want 2026-05-12 (workspace-local boundary in America/New_York)", res.Report.Meta.Date)
+	}
+	if res.Report.Meta.Covers != "yesterday" {
+		t.Fatalf("covers = %q, want yesterday", res.Report.Meta.Covers)
+	}
+	body, err := os.ReadFile(filepath.Join(root, "digests", "yesterday.md"))
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+	if !bytes.Contains(body, []byte("PR-late")) {
+		t.Fatalf("yesterday.md missing the 23:30-EDT bullet:\n%s", body)
+	}
+	if !bytes.Contains(body, []byte("date: 2026-05-12")) {
+		t.Fatalf("yesterday.md missing date: 2026-05-12 frontmatter:\n%s", body)
+	}
+}
+
+// frontmatterKeys returns the YAML keys (in order) from a `---\n...\n---\n`
+// frontmatter block. Naive parser sufficient for the digest contract where
+// keys are always at column 0 and values fit on one line.
+func frontmatterKeys(t *testing.T, content []byte) []string {
+	t.Helper()
+	s := string(content)
+	const sep = "---\n"
+	if !strings.HasPrefix(s, sep) {
+		t.Fatalf("content does not start with YAML frontmatter")
+	}
+	rest := s[len(sep):]
+	end := strings.Index(rest, sep)
+	if end < 0 {
+		t.Fatalf("missing frontmatter terminator")
+	}
+	var keys []string
+	for _, line := range strings.Split(rest[:end], "\n") {
+		if line == "" || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			continue
+		}
+		keys = append(keys, line[:colon])
+	}
+	return keys
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// formatNumeric is a tiny helper for deterministic event IDs without
+// pulling fmt into hot paths the tests rerun a lot.
+func formatNumeric(prefix string, n int) string {
+	digits := ""
+	if n == 0 {
+		digits = "0"
+	}
+	for n > 0 {
+		digits = string(rune('0'+(n%10))) + digits
+		n /= 10
+	}
+	return prefix + digits
 }

--- a/internal/digest/last_week.go
+++ b/internal/digest/last_week.go
@@ -1,0 +1,241 @@
+package digest
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// LastWeekPath is the canonical mount-relative path for the closing-window
+// weekly digest. The artifact is rewritten only when the workspace-local
+// week boundary advances; within a closed week the file is immutable.
+const LastWeekPath = "digests/last-week.md"
+
+// LastWeekCover is the literal value written to the digest's `covers`
+// frontmatter field for weekly closing-window digests.
+const LastWeekCover = "last-week"
+
+// LastWeekStart returns the ISO-week Monday that opens the workspace-local
+// week containing date. It is a thin wrapper over MondayStart so the
+// closing-window writer and the rolling this-week writer share the same
+// boundary logic — the parent spec mandates a single week-start convention
+// for Work Item B.
+func LastWeekStart(date time.Time, tz *time.Location) time.Time {
+	return MondayStart(date, tz)
+}
+
+// IsLastWeekClosingDay reports whether justClosedLocalDay (interpreted in
+// tz) is the final day of the workspace-local ISO week — i.e. a Sunday. The
+// daily closing path uses this to decide whether to *also* persist
+// `/digests/last-week.md` covering the just-closed week.
+func IsLastWeekClosingDay(justClosedLocalDay time.Time, tz *time.Location) bool {
+	if tz == nil {
+		tz = time.UTC
+	}
+	return justClosedLocalDay.In(tz).Weekday() == time.Sunday
+}
+
+// LastWeekWindow builds a Window for a closed workspace-local week.
+// weekStart is the Monday of the covered week; the digest's `date`
+// frontmatter renders to this anchor. Bullets within each provider section
+// remain sorted by event time ascending, matching the daily-digest renderer.
+//
+// Callers that have only the just-closed day in hand should pass
+// `LastWeekStart(justClosedDay, tz)` as weekStart.
+func LastWeekWindow(weekStart, generatedAt time.Time, providers []string, tz *time.Location) Window {
+	if tz == nil {
+		tz = time.UTC
+	}
+	local := weekStart.In(tz)
+	return Window{
+		Date:        time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, tz),
+		Cover:       LastWeekCover,
+		GeneratedAt: generatedAt,
+		Providers:   append([]string(nil), providers...),
+		TZ:          tz,
+	}
+}
+
+// LastWeekWriteResult reports what WriteLastWeek did with the on-disk file.
+// Written is true only when the file was created or replaced this call.
+type LastWeekWriteResult struct {
+	Path     string
+	Report   Report
+	Written  bool
+	Replaced bool
+}
+
+// lastWeekFilteredSource narrows an underlying ChangeEventSource to the
+// seven-day window [Window.Date, Window.Date+7days) in workspace-local time.
+// Sharing FilterEventsInThisWeek with the rolling weekly writer keeps the
+// boundary semantics centralized — both paths agree on what counts as "in
+// the week" down to the second.
+type lastWeekFilteredSource struct {
+	inner ChangeEventSource
+}
+
+func (s lastWeekFilteredSource) Events(w Window) ([]ChangeEvent, error) {
+	raw, err := s.inner.Events(w)
+	if err != nil {
+		return nil, err
+	}
+	tz := w.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	weekStart := w.Date.In(tz)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+	return FilterEventsInThisWeek(raw, weekStart, weekEnd, tz), nil
+}
+
+// RenderLastWeek renders the closing-window weekly artifact for w. The
+// returned path is always LastWeekPath; the returned Report's frontmatter
+// `date` reflects the week-start anchor and `covers` is forced to
+// "last-week" so callers cannot accidentally produce a date-labelled cover.
+func RenderLastWeek(ctx context.Context, src ChangeEventSource, w Window) (string, []byte, Report, error) {
+	if w.TZ == nil {
+		w.TZ = time.UTC
+	}
+	w.Cover = LastWeekCover
+	rep, err := Run(ctx, lastWeekFilteredSource{inner: src}, w)
+	if err != nil {
+		return "", nil, Report{}, err
+	}
+	return LastWeekPath, Render(rep), rep, nil
+}
+
+// WriteLastWeek renders the weekly digest and writes /digests/last-week.md
+// under mountRoot with closing-window semantics:
+//
+//   - If the file does not exist, it is created.
+//   - If the file exists and its `date:` frontmatter already matches the
+//     week-start being written, the call is a no-op (within-week
+//     immutability — same content for the same closed week).
+//   - If the file exists and covers an older week (different `date:`), the
+//     file is replaced *whole* with the new week's content (next-boundary
+//     replacement).
+//
+// Writes use temp+rename so observers see either the old or new file, never
+// a partial write, and the underlying watcher receives a normal filesystem
+// event for the changed path.
+func WriteLastWeek(ctx context.Context, mountRoot string, src ChangeEventSource, w Window) (LastWeekWriteResult, error) {
+	path, content, rep, err := RenderLastWeek(ctx, src, w)
+	if err != nil {
+		return LastWeekWriteResult{}, err
+	}
+	if strings.TrimSpace(mountRoot) == "" {
+		return LastWeekWriteResult{}, errors.New("digest: mount root is required")
+	}
+
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return LastWeekWriteResult{}, err
+	}
+
+	existing, readErr := os.ReadFile(localPath)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return LastWeekWriteResult{}, readErr
+	}
+
+	if readErr == nil {
+		existingDate := readDateFrontmatter(existing)
+		if existingDate != "" && existingDate == rep.Meta.Date {
+			return LastWeekWriteResult{Path: path, Report: rep, Written: false}, nil
+		}
+	}
+
+	tmpDir := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(yesterdayTempDir))
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return LastWeekWriteResult{}, err
+	}
+	tmp, err := os.CreateTemp(tmpDir, ".last-week-*.md.tmp")
+	if err != nil {
+		return LastWeekWriteResult{}, err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return LastWeekWriteResult{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return LastWeekWriteResult{}, err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return LastWeekWriteResult{}, err
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		_ = os.Remove(tmpName)
+		return LastWeekWriteResult{}, err
+	}
+	return LastWeekWriteResult{
+		Path:     path,
+		Report:   rep,
+		Written:  true,
+		Replaced: readErr == nil,
+	}, nil
+}
+
+// MaybeCloseLastWeekWindow persists the closing-window weekly digest iff
+// the local-date transition from prev to now crossed a workspace-local
+// Sunday→Monday boundary. The covered week is the one whose Monday is
+// LastWeekStart(prev, tz). It is safe to call on every daily-close cycle
+// because WriteLastWeek short-circuits when the file's frontmatter `date:`
+// already matches the week being rendered.
+//
+// Mirrors MaybeCloseDateStampedWindow's clock-driven shape so the daily
+// closing path can fire both helpers in sequence without bespoke wiring.
+func MaybeCloseLastWeekWindow(
+	ctx context.Context,
+	now, prev time.Time,
+	tz *time.Location,
+	mountRoot string,
+	src ChangeEventSource,
+	providers []string,
+	generatedAt time.Time,
+) (LastWeekWriteResult, error) {
+	if tz == nil {
+		tz = time.UTC
+	}
+	prevLocal := prev.In(tz)
+	nowLocal := now.In(tz)
+	if prevLocal.Format("2006-01-02") >= nowLocal.Format("2006-01-02") {
+		return LastWeekWriteResult{}, nil
+	}
+	if !IsLastWeekClosingDay(prevLocal, tz) {
+		return LastWeekWriteResult{}, nil
+	}
+	weekStart := LastWeekStart(prevLocal, tz)
+	window := LastWeekWindow(weekStart, generatedAt, providers, tz)
+	return WriteLastWeek(ctx, mountRoot, src, window)
+}
+
+// readDateFrontmatter extracts the value of the `date:` line from the YAML
+// frontmatter at the top of a digest body. Returns "" when no frontmatter
+// or no `date:` line is present. The parser is intentionally minimal — the
+// digest renderer emits a fixed, line-oriented frontmatter shape, so a full
+// YAML parser would be overkill.
+func readDateFrontmatter(body []byte) string {
+	if !bytes.HasPrefix(body, []byte("---\n")) {
+		return ""
+	}
+	rest := body[len("---\n"):]
+	sc := bufio.NewScanner(bytes.NewReader(rest))
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "---" {
+			return ""
+		}
+		if strings.HasPrefix(line, "date:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "date:"))
+		}
+	}
+	return ""
+}

--- a/internal/digest/last_week_test.go
+++ b/internal/digest/last_week_test.go
@@ -1,0 +1,364 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// weekFixtureWindow returns the canonical LastWeekWindow used by the golden
+// + closing-window tests: ISO-week Monday 2026-05-04 through Sunday
+// 2026-05-10, generated_at 2026-05-11T00:00:00Z, three providers.
+func weekFixtureWindow() Window {
+	return LastWeekWindow(
+		time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+}
+
+func TestGoldenLastWeek(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/last-week-events.jsonl")
+	w := weekFixtureWindow()
+
+	path, got, rep, err := RenderLastWeek(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderLastWeek: %v", err)
+	}
+	if path != LastWeekPath {
+		t.Fatalf("path = %q, want %q", path, LastWeekPath)
+	}
+	if rep.Meta.Covers != LastWeekCover {
+		t.Fatalf("covers = %q, want %q", rep.Meta.Covers, LastWeekCover)
+	}
+	if rep.Meta.Date != "2026-05-04" {
+		t.Fatalf("date = %q, want 2026-05-04 (ISO Monday week start)", rep.Meta.Date)
+	}
+	if rep.Meta.Events != len(events) {
+		t.Fatalf("events = %d, want %d", rep.Meta.Events, len(events))
+	}
+
+	want, err := os.ReadFile("testdata/last-week-fixture.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestEmptyLastWeek(t *testing.T) {
+	w := weekFixtureWindow()
+	_, got, rep, err := RenderLastWeek(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("RenderLastWeek: %v", err)
+	}
+	if rep.Meta.Events != 0 {
+		t.Fatalf("events = %d, want 0", rep.Meta.Events)
+	}
+	for _, sec := range rep.Sections {
+		if len(sec.Bullets) != 0 {
+			t.Fatalf("provider %s: bullets %d, want 0", sec.Provider, len(sec.Bullets))
+		}
+	}
+	expected := `---
+date: 2026-05-04
+generated_at: 2026-05-11T00:00:00Z
+covers: last-week
+providers: [github, linear, notion]
+events: 0
+---
+
+# Activity summary for 2026-05-04
+
+## github
+
+_no activity_
+
+## linear
+
+_no activity_
+
+## notion
+
+_no activity_
+`
+	if string(got) != expected {
+		t.Fatalf("empty mismatch\n--- got ---\n%s\n--- want ---\n%s", got, expected)
+	}
+}
+
+func TestLastWeekClosingWindowTriggerOnSundayToMonday(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/last-week-events.jsonl")
+	root := t.TempDir()
+	tz := time.UTC
+
+	// Crossing from Sunday 2026-05-10 into Monday 2026-05-11 must fire the
+	// write exactly once with date = the week's Monday (2026-05-04).
+	prev := time.Date(2026, 5, 10, 23, 50, 0, 0, tz)
+	now := time.Date(2026, 5, 11, 0, 10, 0, 0, tz)
+	generated := time.Date(2026, 5, 11, 0, 0, 0, 0, tz)
+	result, err := MaybeCloseLastWeekWindow(
+		context.Background(),
+		now, prev,
+		tz, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		generated,
+	)
+	if err != nil {
+		t.Fatalf("MaybeCloseLastWeekWindow: %v", err)
+	}
+	if !result.Written {
+		t.Fatal("crossing Sun→Mon must write last-week.md")
+	}
+	if result.Report.Meta.Date != "2026-05-04" {
+		t.Fatalf("date = %q, want 2026-05-04", result.Report.Meta.Date)
+	}
+
+	// Calling again the same Monday is a no-op — the file already exists
+	// with the matching `date:` frontmatter.
+	again, err := MaybeCloseLastWeekWindow(
+		context.Background(),
+		now, prev,
+		tz, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		generated,
+	)
+	if err != nil {
+		t.Fatalf("second MaybeCloseLastWeekWindow: %v", err)
+	}
+	if again.Written {
+		t.Fatal("second call must be a no-op for the same closed week")
+	}
+}
+
+func TestLastWeekClosingWindowSkipsMidweekDays(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/last-week-events.jsonl")
+	root := t.TempDir()
+	tz := time.UTC
+
+	// Crossing from Wednesday into Thursday must NOT write last-week.md —
+	// the week is still open.
+	prev := time.Date(2026, 5, 6, 23, 50, 0, 0, tz)
+	now := time.Date(2026, 5, 7, 0, 10, 0, 0, tz)
+	generated := now
+	result, err := MaybeCloseLastWeekWindow(
+		context.Background(),
+		now, prev,
+		tz, root,
+		SliceSource{Items: events},
+		[]string{"github", "linear", "notion"},
+		generated,
+	)
+	if err != nil {
+		t.Fatalf("MaybeCloseLastWeekWindow: %v", err)
+	}
+	if result.Written {
+		t.Fatal("mid-week boundary must not produce a last-week.md")
+	}
+	if _, err := os.Stat(filepath.Join(root, "digests", "last-week.md")); !os.IsNotExist(err) {
+		t.Fatalf("digests/last-week.md must not exist on mid-week boundaries: %v", err)
+	}
+}
+
+func TestLastWeekImmutabilityWithinSameWeek(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/last-week-events.jsonl")
+	root := t.TempDir()
+	w := weekFixtureWindow()
+
+	first, err := WriteLastWeek(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteLastWeek first: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("first write reported not written")
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(first.Path))
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first digest: %v", err)
+	}
+	firstInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat first digest: %v", err)
+	}
+
+	// Append a week-N+1 event and re-run regeneration before the next
+	// week-boundary. The closed-week file must not change.
+	laterEvents := append([]ChangeEvent(nil), events...)
+	laterEvents = append(laterEvents, ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-200",
+		Verb:          "opened",
+		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/200.json",
+	})
+	second, err := WriteLastWeek(context.Background(), root, SliceSource{Items: laterEvents}, w)
+	if err != nil {
+		t.Fatalf("WriteLastWeek second: %v", err)
+	}
+	if second.Written {
+		t.Fatal("re-running for the same closed week must be a no-op")
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second digest: %v", err)
+	}
+	if !bytes.Equal(secondBytes, firstBytes) {
+		t.Fatalf("closed-week digest changed\n--- first ---\n%s\n--- second ---\n%s", firstBytes, secondBytes)
+	}
+	secondInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat second digest: %v", err)
+	}
+	if !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatalf("mtime changed: first %s second %s", firstInfo.ModTime(), secondInfo.ModTime())
+	}
+}
+
+func TestLastWeekReplacedAtNextWeekBoundary(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/last-week-events.jsonl")
+	root := t.TempDir()
+
+	// Week N: 2026-05-04 — 2026-05-10.
+	wN := weekFixtureWindow()
+	if _, err := WriteLastWeek(context.Background(), root, SliceSource{Items: events}, wN); err != nil {
+		t.Fatalf("WriteLastWeek week N: %v", err)
+	}
+	localPath := filepath.Join(root, "digests", "last-week.md")
+	weekNBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read week N digest: %v", err)
+	}
+	if !strings.Contains(string(weekNBytes), "date: 2026-05-04\n") {
+		t.Fatalf("expected week-N date in digest, got: %s", weekNBytes)
+	}
+
+	// Week N+1: 2026-05-11 — 2026-05-17. Single event on Monday.
+	weekNPlus1Events := []ChangeEvent{{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC),
+		Identifier:    "PR-300",
+		Verb:          "opened",
+		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/300.json",
+	}}
+	wNPlus1 := LastWeekWindow(
+		time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+	result, err := WriteLastWeek(context.Background(), root, SliceSource{Items: weekNPlus1Events}, wNPlus1)
+	if err != nil {
+		t.Fatalf("WriteLastWeek week N+1: %v", err)
+	}
+	if !result.Written {
+		t.Fatal("week N+1 must replace the previous file")
+	}
+	if !result.Replaced {
+		t.Fatal("week N+1 must report Replaced=true")
+	}
+	weekNPlus1Bytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read week N+1 digest: %v", err)
+	}
+	if strings.Contains(string(weekNPlus1Bytes), "2026-05-04") {
+		t.Fatalf("week N+1 digest still references week-N date:\n%s", weekNPlus1Bytes)
+	}
+	if !strings.Contains(string(weekNPlus1Bytes), "date: 2026-05-11\n") {
+		t.Fatalf("week N+1 digest missing week-N+1 date:\n%s", weekNPlus1Bytes)
+	}
+	if !strings.Contains(string(weekNPlus1Bytes), "PR-300 opened") {
+		t.Fatalf("week N+1 digest missing the week's event:\n%s", weekNPlus1Bytes)
+	}
+	if strings.Contains(string(weekNPlus1Bytes), "PR-100 opened") {
+		t.Fatalf("week N+1 digest leaked week-N event:\n%s", weekNPlus1Bytes)
+	}
+}
+
+func TestLastWeekStartIsISOMonday(t *testing.T) {
+	tz := time.UTC
+	cases := []struct {
+		in   time.Time
+		want string // YYYY-MM-DD
+	}{
+		// 2026-05-04 is a Monday.
+		{time.Date(2026, 5, 4, 12, 0, 0, 0, tz), "2026-05-04"},
+		// Same week: Wednesday.
+		{time.Date(2026, 5, 6, 0, 0, 0, 0, tz), "2026-05-04"},
+		// Same week: Sunday (last day of ISO week).
+		{time.Date(2026, 5, 10, 23, 59, 59, 0, tz), "2026-05-04"},
+		// Next-week Monday rolls forward.
+		{time.Date(2026, 5, 11, 0, 0, 0, 0, tz), "2026-05-11"},
+	}
+	for _, tc := range cases {
+		got := LastWeekStart(tc.in, tz).Format("2006-01-02")
+		if got != tc.want {
+			t.Errorf("LastWeekStart(%s) = %s, want %s", tc.in.Format(time.RFC3339), got, tc.want)
+		}
+	}
+}
+
+func TestIsLastWeekClosingDayOnlyFiresOnSunday(t *testing.T) {
+	tz := time.UTC
+	cases := []struct {
+		in   time.Time
+		want bool
+	}{
+		{time.Date(2026, 5, 4, 12, 0, 0, 0, tz), false},  // Monday
+		{time.Date(2026, 5, 9, 12, 0, 0, 0, tz), false},  // Saturday
+		{time.Date(2026, 5, 10, 0, 0, 0, 0, tz), true},   // Sunday
+		{time.Date(2026, 5, 10, 23, 59, 0, 0, tz), true}, // Sunday late
+		{time.Date(2026, 5, 11, 0, 1, 0, 0, tz), false},  // Monday
+	}
+	for _, tc := range cases {
+		got := IsLastWeekClosingDay(tc.in, tz)
+		if got != tc.want {
+			t.Errorf("IsLastWeekClosingDay(%s)=%v, want %v", tc.in.Format(time.RFC3339), got, tc.want)
+		}
+	}
+}
+
+func TestLastWeekFiltersOutEventsOutsideTheClosedWeek(t *testing.T) {
+	// One event the Sunday before the window and one the Monday after must
+	// both be excluded; events at the inclusive Monday 00:00 start and just
+	// before the next Monday 00:00 must be included.
+	tz := time.UTC
+	events := []ChangeEvent{
+		{Provider: "github", Timestamp: time.Date(2026, 5, 3, 23, 59, 0, 0, tz), Identifier: "PR-pre", Verb: "u", CanonicalPath: "github/x.json"},
+		{Provider: "github", Timestamp: time.Date(2026, 5, 4, 0, 0, 0, 0, tz), Identifier: "PR-start", Verb: "u", CanonicalPath: "github/x.json"},
+		{Provider: "github", Timestamp: time.Date(2026, 5, 10, 23, 59, 59, 0, tz), Identifier: "PR-end", Verb: "u", CanonicalPath: "github/x.json"},
+		{Provider: "github", Timestamp: time.Date(2026, 5, 11, 0, 0, 0, 0, tz), Identifier: "PR-post", Verb: "u", CanonicalPath: "github/x.json"},
+	}
+	w := weekFixtureWindow()
+	_, _, rep, err := RenderLastWeek(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderLastWeek: %v", err)
+	}
+	if rep.Meta.Events != 2 {
+		t.Fatalf("events = %d, want 2 (only PR-start and PR-end fall inside the closed week)", rep.Meta.Events)
+	}
+	ids := map[string]bool{}
+	for _, sec := range rep.Sections {
+		for _, b := range sec.Bullets {
+			ids[b.Identifier] = true
+		}
+	}
+	for _, want := range []string{"PR-start", "PR-end"} {
+		if !ids[want] {
+			t.Errorf("missing %s in rendered bullets", want)
+		}
+	}
+	for _, banned := range []string{"PR-pre", "PR-post"} {
+		if ids[banned] {
+			t.Errorf("event %s leaked across the week boundary", banned)
+		}
+	}
+}

--- a/internal/digest/testdata/date-stamped-fixture.md
+++ b/internal/digest/testdata/date-stamped-fixture.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-12
+generated_at: 2026-05-13T00:00:00Z
+covers: 2026-05-12
+providers: [github, linear, notion]
+events: 11
+---
+
+# Activity summary for 2026-05-12
+
+## github
+
+- PR-89 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/89.json]
+- PR-88 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/88.json]
+- PR-554 updated — [github/repos/AgentWorkforce__cloud/pulls/by-id/554.json]
+- PR-91 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/91.json]
+
+## linear
+
+_no activity_
+
+## notion
+
+- product edited — [notion/pages/by-title/product__03eebcd2.json]
+- workforce-proactive-agents edited — [notion/pages/by-title/workforce-proactive-agents__8c591b9a.json]
+- blog edited — [notion/pages/by-title/blog__380aea48.json]
+- proactive-agents edited — [notion/pages/by-title/proactive-agents__252ce9e7.json]
+- relayfile edited — [notion/pages/by-title/relayfile__6eb2ec00.json]
+- integration-tracking edited — [notion/pages/by-title/integration-tracking__a8cc0a80.json]
+- khaliq-s-to-dos edited — [notion/pages/by-title/khaliq-s-to-dos__819be50a.json]

--- a/internal/digest/testdata/last-week-events.jsonl
+++ b/internal/digest/testdata/last-week-events.jsonl
@@ -1,0 +1,6 @@
+{"provider": "github", "timestamp": "2026-05-04T09:00:00Z", "identifier": "PR-100", "verb": "opened", "canonicalPath": "github/repos/AgentWorkforce__workforce/pulls/by-id/100.json"}
+{"provider": "notion", "timestamp": "2026-05-05T14:30:00Z", "identifier": "onboarding-doc", "verb": "edited", "canonicalPath": "notion/pages/by-title/onboarding-doc__abc12345.json"}
+{"provider": "linear", "timestamp": "2026-05-06T11:15:00Z", "identifier": "ENG-42", "verb": "updated", "canonicalPath": "linear/issues/by-id/ENG-42.json"}
+{"provider": "github", "timestamp": "2026-05-07T16:00:00Z", "identifier": "PR-101", "verb": "merged", "canonicalPath": "github/repos/AgentWorkforce__workforce/pulls/by-id/101.json"}
+{"provider": "notion", "timestamp": "2026-05-08T08:45:00Z", "identifier": "roadmap", "verb": "edited", "canonicalPath": "notion/pages/by-title/roadmap__def67890.json"}
+{"provider": "github", "timestamp": "2026-05-10T22:00:00Z", "identifier": "PR-102", "verb": "closed", "canonicalPath": "github/repos/AgentWorkforce__workforce/pulls/by-id/102.json"}

--- a/internal/digest/testdata/last-week-fixture.md
+++ b/internal/digest/testdata/last-week-fixture.md
@@ -1,0 +1,24 @@
+---
+date: 2026-05-04
+generated_at: 2026-05-11T00:00:00Z
+covers: last-week
+providers: [github, linear, notion]
+events: 6
+---
+
+# Activity summary for 2026-05-04
+
+## github
+
+- PR-100 opened — [github/repos/AgentWorkforce__workforce/pulls/by-id/100.json]
+- PR-101 merged — [github/repos/AgentWorkforce__workforce/pulls/by-id/101.json]
+- PR-102 closed — [github/repos/AgentWorkforce__workforce/pulls/by-id/102.json]
+
+## linear
+
+- ENG-42 updated — [linear/issues/by-id/ENG-42.json]
+
+## notion
+
+- onboarding-doc edited — [notion/pages/by-title/onboarding-doc__abc12345.json]
+- roadmap edited — [notion/pages/by-title/roadmap__def67890.json]

--- a/internal/digest/testdata/this-week-fixture.md
+++ b/internal/digest/testdata/this-week-fixture.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-11
+generated_at: 2026-05-13T00:00:00Z
+covers: this-week
+providers: [github, linear, notion]
+events: 11
+---
+
+# Activity summary for 2026-05-11
+
+## github
+
+- PR-89 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/89.json]
+- PR-88 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/88.json]
+- PR-554 updated — [github/repos/AgentWorkforce__cloud/pulls/by-id/554.json]
+- PR-91 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/91.json]
+
+## linear
+
+_no activity_
+
+## notion
+
+- product edited — [notion/pages/by-title/product__03eebcd2.json]
+- workforce-proactive-agents edited — [notion/pages/by-title/workforce-proactive-agents__8c591b9a.json]
+- blog edited — [notion/pages/by-title/blog__380aea48.json]
+- proactive-agents edited — [notion/pages/by-title/proactive-agents__252ce9e7.json]
+- relayfile edited — [notion/pages/by-title/relayfile__6eb2ec00.json]
+- integration-tracking edited — [notion/pages/by-title/integration-tracking__a8cc0a80.json]
+- khaliq-s-to-dos edited — [notion/pages/by-title/khaliq-s-to-dos__819be50a.json]

--- a/internal/digest/testdata/today-fixture.md
+++ b/internal/digest/testdata/today-fixture.md
@@ -1,0 +1,30 @@
+---
+date: 2026-05-12
+generated_at: 2026-05-12T23:59:00Z
+covers: today
+providers: [github, linear, notion]
+events: 11
+---
+
+# Activity summary for 2026-05-12
+
+## github
+
+- PR-89 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/89.json]
+- PR-88 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/88.json]
+- PR-554 updated — [github/repos/AgentWorkforce__cloud/pulls/by-id/554.json]
+- PR-91 updated — [github/repos/AgentWorkforce__workforce/pulls/by-id/91.json]
+
+## linear
+
+_no activity_
+
+## notion
+
+- product edited — [notion/pages/by-title/product__03eebcd2.json]
+- workforce-proactive-agents edited — [notion/pages/by-title/workforce-proactive-agents__8c591b9a.json]
+- blog edited — [notion/pages/by-title/blog__380aea48.json]
+- proactive-agents edited — [notion/pages/by-title/proactive-agents__252ce9e7.json]
+- relayfile edited — [notion/pages/by-title/relayfile__6eb2ec00.json]
+- integration-tracking edited — [notion/pages/by-title/integration-tracking__a8cc0a80.json]
+- khaliq-s-to-dos edited — [notion/pages/by-title/khaliq-s-to-dos__819be50a.json]

--- a/internal/digest/this_week.go
+++ b/internal/digest/this_week.go
@@ -1,0 +1,162 @@
+package digest
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ThisWeekPath is the rolling weekly digest artifact path. A workspace-local
+// week starts Monday 00:00 (ISO-8601) and the file is rewritten on every
+// in-window provider event until the week closes.
+const ThisWeekPath = "digests/this-week.md"
+
+// ThisWeekCover is the frontmatter `covers:` value emitted for the rolling
+// weekly digest.
+const ThisWeekCover = "this-week"
+
+// MondayStart returns the local Monday 00:00 boundary that opens the
+// workspace-local ISO calendar week containing now. The result is in tz; a
+// nil tz is treated as UTC. The boundary is inclusive: events whose local
+// timestamp equals the returned instant belong to the current week. The
+// closing-window writer in last_week.go calls this through LastWeekStart so
+// both the rolling-week and closing-week paths agree on the week boundary.
+func MondayStart(now time.Time, tz *time.Location) time.Time {
+	if tz == nil {
+		tz = time.UTC
+	}
+	local := now.In(tz)
+	// time.Weekday: Sunday=0 ... Saturday=6. Convert to Monday=0 ... Sunday=6
+	// so the offset to subtract is always non-negative.
+	offset := (int(local.Weekday()) + 6) % 7
+	y, m, d := local.Date()
+	return time.Date(y, m, d-offset, 0, 0, 0, 0, tz)
+}
+
+// ThisWeekWindow builds a Window covering [MondayStart(now), generatedAt) in
+// tz. Window.Date is the Monday-start local date so the frontmatter `date:`
+// field documents the week start. Window.Cover is the literal "this-week".
+func ThisWeekWindow(now, generatedAt time.Time, providers []string, tz *time.Location) Window {
+	if tz == nil {
+		tz = time.UTC
+	}
+	monday := MondayStart(now, tz)
+	return Window{
+		Date:        monday,
+		Cover:       ThisWeekCover,
+		GeneratedAt: generatedAt,
+		Providers:   append([]string(nil), providers...),
+		TZ:          tz,
+	}
+}
+
+// FilterEventsInThisWeek returns the subset of events whose Timestamp, taken
+// in tz, falls in [windowStart, windowEnd). It preserves input order so
+// downstream sorting remains deterministic. The helper is exported so other
+// rolling-window callers (last-week, custom windows) can share the boundary
+// semantics rather than re-implementing them.
+func FilterEventsInThisWeek(events []ChangeEvent, windowStart, windowEnd time.Time, tz *time.Location) []ChangeEvent {
+	if tz == nil {
+		tz = time.UTC
+	}
+	start := windowStart.In(tz)
+	end := windowEnd.In(tz)
+	out := make([]ChangeEvent, 0, len(events))
+	for _, ev := range events {
+		ts := ev.Timestamp.In(tz)
+		if ts.Before(start) {
+			continue
+		}
+		if !ts.Before(end) {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// thisWeekFilteredSource is a ChangeEventSource that narrows an underlying
+// source to the [Monday, GeneratedAt) local window. It lets callers pass the
+// raw event stream to RenderThisWeek/WriteThisWeek without pre-filtering and
+// keeps the boundary logic centralized.
+type thisWeekFilteredSource struct {
+	inner ChangeEventSource
+}
+
+func (s thisWeekFilteredSource) Events(w Window) ([]ChangeEvent, error) {
+	raw, err := s.inner.Events(w)
+	if err != nil {
+		return nil, err
+	}
+	tz := w.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	return FilterEventsInThisWeek(raw, w.Date, w.GeneratedAt, tz), nil
+}
+
+// RenderThisWeek renders the rolling weekly digest for w. The Cover is forced
+// to the canonical "this-week" string so callers cannot accidentally write a
+// file labelled with a date string instead.
+func RenderThisWeek(ctx context.Context, src ChangeEventSource, w Window) (string, []byte, Report, error) {
+	if w.TZ == nil {
+		w.TZ = time.UTC
+	}
+	w.Cover = ThisWeekCover
+	rep, err := Run(ctx, thisWeekFilteredSource{inner: src}, w)
+	if err != nil {
+		return "", nil, Report{}, err
+	}
+	return ThisWeekPath, Render(rep), rep, nil
+}
+
+// ThisWeekWriteResult is returned by WriteThisWeek.
+type ThisWeekWriteResult struct {
+	Path    string
+	Report  Report
+	Written bool
+}
+
+// WriteThisWeek renders the current-week digest and atomically replaces the
+// rolling artifact under mountRoot. Unlike date-stamped digests, this file is
+// rewritten on every call: the week is open until the Sunday→Monday rollover
+// promotes it to last-week.md. Atomic temp+rename keeps mount observers from
+// reading a half-written file.
+func WriteThisWeek(ctx context.Context, mountRoot string, src ChangeEventSource, w Window) (ThisWeekWriteResult, error) {
+	path, content, rep, err := RenderThisWeek(ctx, src, w)
+	if err != nil {
+		return ThisWeekWriteResult{}, err
+	}
+	if strings.TrimSpace(mountRoot) == "" {
+		return ThisWeekWriteResult{}, errors.New("digest: mount root is required")
+	}
+
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return ThisWeekWriteResult{}, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(localPath), ".this-week-*.md.tmp")
+	if err != nil {
+		return ThisWeekWriteResult{}, err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return ThisWeekWriteResult{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return ThisWeekWriteResult{}, err
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		_ = os.Remove(tmpName)
+		return ThisWeekWriteResult{}, err
+	}
+	return ThisWeekWriteResult{Path: path, Report: rep, Written: true}, nil
+}
+

--- a/internal/digest/this_week.go
+++ b/internal/digest/this_week.go
@@ -149,6 +149,13 @@ func WriteThisWeek(ctx context.Context, mountRoot string, src ChangeEventSource,
 		_ = os.Remove(tmpName)
 		return ThisWeekWriteResult{}, err
 	}
+	// os.CreateTemp makes 0600; match the 0644 convention used by the
+	// other window writers so the digest is readable by mount/agents.
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return ThisWeekWriteResult{}, err
+	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpName)
 		return ThisWeekWriteResult{}, err
@@ -159,4 +166,3 @@ func WriteThisWeek(ctx context.Context, mountRoot string, src ChangeEventSource,
 	}
 	return ThisWeekWriteResult{Path: path, Report: rep, Written: true}, nil
 }
-

--- a/internal/digest/this_week_test.go
+++ b/internal/digest/this_week_test.go
@@ -1,0 +1,352 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// thisWeekFixtureGeneratedAt sits at Wednesday 2026-05-13 00:00 UTC, which is
+// inside the same ISO week as the fixture events (Monday 2026-05-11 onward).
+var (
+	thisWeekFixtureGeneratedAt = time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	thisWeekFixtureMonday      = time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	thisWeekFixtureProviders   = []string{"github", "linear", "notion"}
+)
+
+func TestMondayStartUTCAnchorsThisWeek(t *testing.T) {
+	cases := []struct {
+		name string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "monday-00:00-is-itself",
+			now:  time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "wednesday-rolls-back-to-monday",
+			now:  time.Date(2026, 5, 13, 14, 30, 0, 0, time.UTC),
+			want: time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "sunday-rolls-back-six-days",
+			now:  time.Date(2026, 5, 17, 23, 59, 59, 0, time.UTC),
+			want: time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MondayStart(tc.now, time.UTC)
+			if !got.Equal(tc.want) {
+				t.Fatalf("MondayStart(%s) = %s, want %s (Monday-start anchor)", tc.now, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMondayStartHonorsLocationForThisWeek(t *testing.T) {
+	// Use a fixed offset to avoid relying on the host tz database for the
+	// DST transition. 2026-05-13 14:30 in UTC-12 is 2026-05-14 02:30 UTC
+	// but stays Wednesday locally, so the local Monday boundary is
+	// 2026-05-11 00:00 in that zone.
+	loc := time.FixedZone("test-12", -12*60*60)
+	now := time.Date(2026, 5, 13, 14, 30, 0, 0, loc)
+	got := MondayStart(now, loc)
+	want := time.Date(2026, 5, 11, 0, 0, 0, 0, loc)
+	if !got.Equal(want) {
+		t.Fatalf("MondayStart(%s, %s) = %s, want %s", now, loc, got, want)
+	}
+	if got.Location() != loc {
+		t.Fatalf("MondayStart returned location %s, want %s", got.Location(), loc)
+	}
+}
+
+func TestGoldenThisWeek(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	w := ThisWeekWindow(
+		thisWeekFixtureGeneratedAt,
+		thisWeekFixtureGeneratedAt,
+		thisWeekFixtureProviders,
+		time.UTC,
+	)
+	if !w.Date.Equal(thisWeekFixtureMonday) {
+		t.Fatalf("Window.Date = %s, want %s (Monday-start)", w.Date, thisWeekFixtureMonday)
+	}
+	if w.Cover != ThisWeekCover {
+		t.Fatalf("Window.Cover = %q, want %q", w.Cover, ThisWeekCover)
+	}
+	path, got, rep, err := RenderThisWeek(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderThisWeek: %v", err)
+	}
+	if path != ThisWeekPath {
+		t.Fatalf("path = %q, want %q", path, ThisWeekPath)
+	}
+	if rep.Meta.Covers != "this-week" {
+		t.Fatalf("meta.covers = %q, want this-week", rep.Meta.Covers)
+	}
+	if rep.Meta.Date != "2026-05-11" {
+		t.Fatalf("meta.date = %q, want 2026-05-11", rep.Meta.Date)
+	}
+	want, err := os.ReadFile("testdata/this-week-fixture.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestThisWeekFrontmatterDateIsMondayStartForMidweekNow(t *testing.T) {
+	// now=Wednesday 14:00 local, week start should be that week's Monday.
+	now := time.Date(2026, 5, 13, 14, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+	rep, err := Run(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Meta.Date != "2026-05-11" {
+		t.Fatalf("meta.date = %q, want 2026-05-11", rep.Meta.Date)
+	}
+	if rep.Meta.Covers != "this-week" {
+		t.Fatalf("meta.covers = %q, want this-week", rep.Meta.Covers)
+	}
+}
+
+func TestThisWeekFrontmatterDateIsMondayStartForMondayMidnightNow(t *testing.T) {
+	now := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+	rep, err := Run(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Meta.Date != "2026-05-11" {
+		t.Fatalf("meta.date = %q, want 2026-05-11", rep.Meta.Date)
+	}
+}
+
+func TestThisWeekWindowBoundaryUTC(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+
+	sunday := ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 10, 23, 59, 59, 0, time.UTC),
+		Identifier:    "PR-out",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/1.json",
+	}
+	monday := ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC),
+		Identifier:    "PR-monday",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/2.json",
+	}
+	wednesday := ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
+		Identifier:    "PR-wed",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/3.json",
+	}
+
+	src := SliceSource{Items: []ChangeEvent{sunday, monday, wednesday}}
+	_, content, rep, err := RenderThisWeek(context.Background(), src, w)
+	if err != nil {
+		t.Fatalf("RenderThisWeek: %v", err)
+	}
+	if rep.Meta.Events != 2 {
+		t.Fatalf("events = %d, want 2", rep.Meta.Events)
+	}
+	body := string(content)
+	if !strings.Contains(body, "PR-monday") {
+		t.Fatal("Monday 00:00 event missing from output")
+	}
+	if !strings.Contains(body, "PR-wed") {
+		t.Fatal("Wednesday in-window event missing from output")
+	}
+	if strings.Contains(body, "PR-out") {
+		t.Fatal("Sunday 23:59 event leaked into the window")
+	}
+}
+
+func TestThisWeekWindowBoundaryNonUTCLocation(t *testing.T) {
+	// UTC-12 forces a clear gap between UTC-day-of-week and local-day-of-
+	// week. 2026-05-11 11:00 UTC is 2026-05-10 23:00 (Sunday) local; the
+	// event must be excluded. 2026-05-11 13:00 UTC is 2026-05-11 01:00
+	// (Monday) local; the event must be included.
+	loc := time.FixedZone("test-12", -12*60*60)
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, loc)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, loc)
+
+	sundayLocal := ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 11, 11, 0, 0, 0, time.UTC),
+		Identifier:    "PR-sun",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/10.json",
+	}
+	mondayLocal := ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 11, 13, 0, 0, 0, time.UTC),
+		Identifier:    "PR-mon",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/11.json",
+	}
+
+	src := SliceSource{Items: []ChangeEvent{sundayLocal, mondayLocal}}
+	_, content, rep, err := RenderThisWeek(context.Background(), src, w)
+	if err != nil {
+		t.Fatalf("RenderThisWeek: %v", err)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1 (local Monday only)", rep.Meta.Events)
+	}
+	body := string(content)
+	if strings.Contains(body, "PR-sun") {
+		t.Fatal("Sunday-local event leaked into a UTC-12 this-week window")
+	}
+	if !strings.Contains(body, "PR-mon") {
+		t.Fatal("Monday-local event missing from a UTC-12 this-week window")
+	}
+}
+
+func TestThisWeekRewriteOnNewInWindowEvent(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+
+	first := []ChangeEvent{{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-1",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/1.json",
+	}}
+	res1, err := WriteThisWeek(context.Background(), root, SliceSource{Items: first}, w)
+	if err != nil {
+		t.Fatalf("WriteThisWeek first: %v", err)
+	}
+	if !res1.Written {
+		t.Fatal("first write should report Written=true")
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(res1.Path))
+	got1, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if !strings.Contains(string(got1), "PR-1") {
+		t.Fatal("first write missing PR-1 bullet")
+	}
+	if !strings.Contains(string(got1), "events: 1") {
+		t.Fatalf("first write events count wrong, body=%s", string(got1))
+	}
+
+	second := append([]ChangeEvent(nil), first...)
+	second = append(second, ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC),
+		Identifier:    "PR-2",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/2.json",
+	})
+	res2, err := WriteThisWeek(context.Background(), root, SliceSource{Items: second}, w)
+	if err != nil {
+		t.Fatalf("WriteThisWeek second: %v", err)
+	}
+	if !res2.Written {
+		t.Fatal("rolling rewrite should report Written=true")
+	}
+	got2, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	body := string(got2)
+	if !strings.Contains(body, "PR-1") || !strings.Contains(body, "PR-2") {
+		t.Fatalf("rewrite missing bullets, body=%s", body)
+	}
+	if !strings.Contains(body, "events: 2") {
+		t.Fatalf("rewrite events count wrong, body=%s", body)
+	}
+}
+
+func TestThisWeekIgnoresEventsBeforeWindow(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+	priorWeek := []ChangeEvent{{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 4, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-old",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/o/r/pulls/by-id/99.json",
+	}}
+	_, content, rep, err := RenderThisWeek(context.Background(), SliceSource{Items: priorWeek}, w)
+	if err != nil {
+		t.Fatalf("RenderThisWeek: %v", err)
+	}
+	if rep.Meta.Events != 0 {
+		t.Fatalf("events = %d, want 0", rep.Meta.Events)
+	}
+	if strings.Contains(string(content), "PR-old") {
+		t.Fatal("prior-week event leaked into this-week digest")
+	}
+	if !strings.Contains(string(content), "_no activity_") {
+		t.Fatalf("empty rendering missing zero-activity body, body=%s", string(content))
+	}
+}
+
+func TestThisWeekEmptyWindowStillWritesFile(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	w := ThisWeekWindow(now, now, thisWeekFixtureProviders, time.UTC)
+	res, err := WriteThisWeek(context.Background(), root, SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("WriteThisWeek: %v", err)
+	}
+	if !res.Written {
+		t.Fatal("empty window must still write the file")
+	}
+	body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(res.Path)))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(body), "events: 0") {
+		t.Fatalf("empty-window frontmatter missing events: 0, body=%s", string(body))
+	}
+	if !strings.Contains(string(body), "covers: this-week") {
+		t.Fatalf("empty-window frontmatter missing covers: this-week, body=%s", string(body))
+	}
+	for _, p := range thisWeekFixtureProviders {
+		if !strings.Contains(string(body), "## "+p) {
+			t.Fatalf("empty-window missing provider section %q, body=%s", p, string(body))
+		}
+	}
+	if strings.Count(string(body), "_no activity_") != len(thisWeekFixtureProviders) {
+		t.Fatalf("empty-window expected %d _no activity_ sections, body=%s", len(thisWeekFixtureProviders), string(body))
+	}
+}
+
+func TestThisWeekPathTaxonomy(t *testing.T) {
+	if !IsDigestPath("digests/this-week.md") {
+		t.Fatal("digests/this-week.md should be recognized as a digest path")
+	}
+	if !IsDigestPath("/digests/this-week.md") {
+		t.Fatal("leading-slash digests/this-week.md should be recognized as a digest path")
+	}
+	if IsDigestPath("digests/THIS-WEEK.md") {
+		t.Fatal("digest path predicate must be case-sensitive")
+	}
+	if IsDigestPath("digests/this-week.MD") {
+		t.Fatal("digest path predicate must require lowercase .md suffix")
+	}
+	if IsDigestPath("notion/pages/this-week.md") {
+		t.Fatal("non-digests/ path must not be classified as a digest")
+	}
+}

--- a/internal/digest/timezone.go
+++ b/internal/digest/timezone.go
@@ -25,14 +25,14 @@ func ResolveTZ(config WorkspaceTZConfig) (*time.Location, error) {
 	if raw := strings.TrimSpace(config.Timezone); raw != "" {
 		loc, err := time.LoadLocation(raw)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrInvalidTimezone, raw)
+			return nil, fmt.Errorf("%w: %s: %v", ErrInvalidTimezone, raw, err)
 		}
 		return loc, nil
 	}
 	if raw := strings.TrimSpace(os.Getenv("RELAYFILE_TZ")); raw != "" {
 		loc, err := time.LoadLocation(raw)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrInvalidTimezone, raw)
+			return nil, fmt.Errorf("%w: %s: %v", ErrInvalidTimezone, raw, err)
 		}
 		return loc, nil
 	}

--- a/internal/digest/timezone.go
+++ b/internal/digest/timezone.go
@@ -1,0 +1,43 @@
+package digest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// ErrInvalidTimezone identifies configured timezone names that are not valid
+// IANA locations. Callers should surface this instead of silently falling back
+// to UTC or time.Local when a workspace explicitly configured a bad value.
+var ErrInvalidTimezone = errors.New("digest: invalid timezone")
+
+// WorkspaceTZConfig is the shared workspace timezone resolver input.
+// Timezone is expected to be an IANA location such as "America/New_York".
+type WorkspaceTZConfig struct {
+	Timezone string
+}
+
+// ResolveTZ resolves the workspace timezone using the v1 precedence:
+// workspace config > RELAYFILE_TZ > time.Local.
+func ResolveTZ(config WorkspaceTZConfig) (*time.Location, error) {
+	if raw := strings.TrimSpace(config.Timezone); raw != "" {
+		loc, err := time.LoadLocation(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidTimezone, raw)
+		}
+		return loc, nil
+	}
+	if raw := strings.TrimSpace(os.Getenv("RELAYFILE_TZ")); raw != "" {
+		loc, err := time.LoadLocation(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidTimezone, raw)
+		}
+		return loc, nil
+	}
+	if time.Local != nil {
+		return time.Local, nil
+	}
+	return time.UTC, nil
+}

--- a/internal/digest/timezone_test.go
+++ b/internal/digest/timezone_test.go
@@ -1,0 +1,52 @@
+package digest
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestResolveTZ_Precedence(t *testing.T) {
+	oldLocal := time.Local
+	t.Cleanup(func() { time.Local = oldLocal })
+	time.Local = time.FixedZone("LocalTest", 3600)
+	t.Setenv("RELAYFILE_TZ", "America/New_York")
+
+	loc, err := ResolveTZ(WorkspaceTZConfig{Timezone: "Europe/Oslo"})
+	if err != nil {
+		t.Fatalf("ResolveTZ config: %v", err)
+	}
+	if loc.String() != "Europe/Oslo" {
+		t.Fatalf("config precedence loc = %q, want Europe/Oslo", loc.String())
+	}
+
+	loc, err = ResolveTZ(WorkspaceTZConfig{})
+	if err != nil {
+		t.Fatalf("ResolveTZ env: %v", err)
+	}
+	if loc.String() != "America/New_York" {
+		t.Fatalf("env precedence loc = %q, want America/New_York", loc.String())
+	}
+
+	t.Setenv("RELAYFILE_TZ", "")
+	loc, err = ResolveTZ(WorkspaceTZConfig{})
+	if err != nil {
+		t.Fatalf("ResolveTZ local: %v", err)
+	}
+	if loc.String() != "LocalTest" {
+		t.Fatalf("local fallback loc = %q, want LocalTest", loc.String())
+	}
+}
+
+func TestResolveTZ_InvalidIANA(t *testing.T) {
+	_, err := ResolveTZ(WorkspaceTZConfig{Timezone: "No/Such_Zone"})
+	if !errors.Is(err, ErrInvalidTimezone) {
+		t.Fatalf("ResolveTZ invalid config err = %v, want ErrInvalidTimezone", err)
+	}
+
+	t.Setenv("RELAYFILE_TZ", "No/Such_Zone")
+	_, err = ResolveTZ(WorkspaceTZConfig{})
+	if !errors.Is(err, ErrInvalidTimezone) {
+		t.Fatalf("ResolveTZ invalid env err = %v, want ErrInvalidTimezone", err)
+	}
+}

--- a/internal/digest/today.go
+++ b/internal/digest/today.go
@@ -167,6 +167,14 @@ func WriteToday(ctx context.Context, mountRoot string, src ChangeEventSource, pr
 		_ = os.Remove(tmpName)
 		return TodayWriteResult{}, err
 	}
+	// os.CreateTemp makes 0600; digests must be readable by other
+	// processes (mount/FUSE/agents). Match the writeFileAtomic 0644
+	// convention before the rename publishes the file.
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return TodayWriteResult{}, err
+	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpName)
 		return TodayWriteResult{}, err

--- a/internal/digest/today.go
+++ b/internal/digest/today.go
@@ -1,0 +1,179 @@
+package digest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// TodayCover is the frontmatter `covers:` value emitted for the rolling
+// current-day digest.
+const TodayCover = "today"
+
+// BuildOptions tunes how BuildToday assembles the rolling current-day digest.
+// MaxEvents = 0 means exhaustive (no cap).
+type BuildOptions struct {
+	MaxEvents int
+}
+
+// TodayWindow returns the [start, end) instants that bound the local
+// calendar day containing now in tz. start is inclusive (00:00 local), end
+// is exclusive (00:00 local of the next day). A nil tz is treated as UTC.
+func TodayWindow(now time.Time, tz *time.Location) (start, end time.Time) {
+	if tz == nil {
+		tz = time.UTC
+	}
+	local := now.In(tz)
+	start = time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, tz)
+	end = time.Date(local.Year(), local.Month(), local.Day()+1, 0, 0, 0, 0, tz)
+	return
+}
+
+// FilterEventsInToday returns the subset of events whose Timestamp, taken in
+// tz, falls in [windowStart, windowEnd). Order is preserved.
+func FilterEventsInToday(events []ChangeEvent, windowStart, windowEnd time.Time, tz *time.Location) []ChangeEvent {
+	if tz == nil {
+		tz = time.UTC
+	}
+	start := windowStart.In(tz)
+	end := windowEnd.In(tz)
+	out := make([]ChangeEvent, 0, len(events))
+	for _, ev := range events {
+		ts := ev.Timestamp.In(tz)
+		if ts.Before(start) {
+			continue
+		}
+		if !ts.Before(end) {
+			continue
+		}
+		out = append(out, ev)
+	}
+	return out
+}
+
+// todayFilteredSource narrows an upstream source to today's [start, end)
+// window before handing it to Run. It also enforces BuildOptions.MaxEvents
+// by truncating to the first N in-window events (after the boundary filter
+// but before sort) and recording a `truncated:` warning the renderer will
+// surface in frontmatter.
+type todayFilteredSource struct {
+	inner    ChangeEventSource
+	opts     BuildOptions
+	tz       *time.Location
+	warnings *[]string
+}
+
+func (s todayFilteredSource) Events(w Window) ([]ChangeEvent, error) {
+	raw, err := s.inner.Events(w)
+	if err != nil {
+		return nil, err
+	}
+	tz := s.tz
+	if tz == nil {
+		tz = w.TZ
+	}
+	if tz == nil {
+		tz = time.UTC
+	}
+	start, end := TodayWindow(w.Date, tz)
+	in := FilterEventsInToday(raw, start, end, tz)
+	if s.opts.MaxEvents > 0 && len(in) > s.opts.MaxEvents {
+		dropped := len(in) - s.opts.MaxEvents
+		in = in[:s.opts.MaxEvents]
+		if s.warnings != nil {
+			*s.warnings = append(*s.warnings, fmt.Sprintf("truncated: %d events exceeded MaxEvents=%d", dropped, s.opts.MaxEvents))
+		}
+	}
+	return in, nil
+}
+
+// BuildToday computes the rolling current-day Report. The window is
+// [local_midnight(now, tz), next_local_midnight(now, tz)). A nil tz falls
+// back to UTC and adds a `tz-fallback` warning to the report.
+func BuildToday(ctx context.Context, src ChangeEventSource, providers []string, now time.Time, tz *time.Location, opts BuildOptions) (Report, error) {
+	if src == nil {
+		return Report{}, errors.New("digest: nil ChangeEventSource")
+	}
+	var warnings []string
+	if tz == nil {
+		tz = time.UTC
+		warnings = append(warnings, "tz-fallback: workspace timezone unset; using UTC")
+	}
+	start, _ := TodayWindow(now, tz)
+	w := Window{
+		Date:        start,
+		Cover:       TodayCover,
+		GeneratedAt: now,
+		Providers:   append([]string(nil), providers...),
+		TZ:          tz,
+	}
+	rep, err := Run(ctx, todayFilteredSource{inner: src, opts: opts, tz: tz, warnings: &warnings}, w)
+	if err != nil {
+		return Report{}, err
+	}
+	if len(warnings) > 0 {
+		rep.Meta.Warnings = append(rep.Meta.Warnings, warnings...)
+	}
+	return rep, nil
+}
+
+// RenderToday assembles the rolling Report for now and renders it to bytes.
+// Returns the canonical path, body, and the underlying Report.
+func RenderToday(ctx context.Context, src ChangeEventSource, providers []string, now time.Time, tz *time.Location, opts BuildOptions) (string, []byte, Report, error) {
+	rep, err := BuildToday(ctx, src, providers, now, tz, opts)
+	if err != nil {
+		return "", nil, Report{}, err
+	}
+	return TodayPath, Render(rep), rep, nil
+}
+
+// TodayWriteResult is returned by WriteToday.
+type TodayWriteResult struct {
+	Path    string
+	Report  Report
+	Written bool
+}
+
+// WriteToday renders the current-day digest and atomically replaces the
+// rolling artifact under mountRoot. The write uses temp+rename so mount
+// observers never see a half-written file. Unlike date-stamped digests this
+// file is rewritten on every call; the day rollover from today→yesterday
+// is the responsibility of the closing-window slice.
+func WriteToday(ctx context.Context, mountRoot string, src ChangeEventSource, providers []string, now time.Time, tz *time.Location, opts BuildOptions) (TodayWriteResult, error) {
+	path, content, rep, err := RenderToday(ctx, src, providers, now, tz, opts)
+	if err != nil {
+		return TodayWriteResult{}, err
+	}
+	if strings.TrimSpace(mountRoot) == "" {
+		return TodayWriteResult{}, errors.New("digest: mount root is required")
+	}
+
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return TodayWriteResult{}, err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(localPath), ".today-*.md.tmp")
+	if err != nil {
+		return TodayWriteResult{}, err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return TodayWriteResult{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return TodayWriteResult{}, err
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		_ = os.Remove(tmpName)
+		return TodayWriteResult{}, err
+	}
+	return TodayWriteResult{Path: path, Report: rep, Written: true}, nil
+}

--- a/internal/digest/today_test.go
+++ b/internal/digest/today_test.go
@@ -1,0 +1,395 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTodayWindow_UTC(t *testing.T) {
+	now := time.Date(2026, 5, 15, 10, 0, 0, 0, time.UTC)
+	start, end := TodayWindow(now, time.UTC)
+	wantStart := time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)
+	if !start.Equal(wantStart) {
+		t.Fatalf("start = %s, want %s", start, wantStart)
+	}
+	if !end.Equal(wantEnd) {
+		t.Fatalf("end = %s, want %s", end, wantEnd)
+	}
+}
+
+func TestTodayWindow_NonUTC(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Skipf("LoadLocation: %v", err)
+	}
+	// 2026-05-15 01:30 UTC == 2026-05-14 18:30 PDT, so the local-day
+	// boundary in PDT is 2026-05-14 00:00 PDT (== 2026-05-14 07:00 UTC).
+	now := time.Date(2026, 5, 15, 1, 30, 0, 0, time.UTC)
+	start, end := TodayWindow(now, la)
+	wantStart := time.Date(2026, 5, 14, 7, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, 5, 15, 7, 0, 0, 0, time.UTC)
+	if !start.UTC().Equal(wantStart) {
+		t.Fatalf("start UTC = %s, want %s", start.UTC(), wantStart)
+	}
+	if !end.UTC().Equal(wantEnd) {
+		t.Fatalf("end UTC = %s, want %s", end.UTC(), wantEnd)
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: nil}, []string{"github"}, now, la, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Date != "2026-05-14" {
+		t.Fatalf("meta.date = %q, want 2026-05-14", rep.Meta.Date)
+	}
+}
+
+func TestTodayWindow_DSTBoundaries(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("LoadLocation: %v", err)
+	}
+	tests := []struct {
+		name         string
+		now          time.Time
+		wantStartUTC time.Time
+		wantEndUTC   time.Time
+		wantDuration time.Duration
+	}{
+		{
+			name:         "spring-forward",
+			now:          time.Date(2026, 3, 8, 12, 0, 0, 0, ny),
+			wantStartUTC: time.Date(2026, 3, 8, 5, 0, 0, 0, time.UTC),
+			wantEndUTC:   time.Date(2026, 3, 9, 4, 0, 0, 0, time.UTC),
+			wantDuration: 23 * time.Hour,
+		},
+		{
+			name:         "fall-back",
+			now:          time.Date(2026, 11, 1, 12, 0, 0, 0, ny),
+			wantStartUTC: time.Date(2026, 11, 1, 4, 0, 0, 0, time.UTC),
+			wantEndUTC:   time.Date(2026, 11, 2, 5, 0, 0, 0, time.UTC),
+			wantDuration: 25 * time.Hour,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := TodayWindow(tt.now, ny)
+			if !start.UTC().Equal(tt.wantStartUTC) {
+				t.Fatalf("start UTC = %s, want %s", start.UTC(), tt.wantStartUTC)
+			}
+			if !end.UTC().Equal(tt.wantEndUTC) {
+				t.Fatalf("end UTC = %s, want %s", end.UTC(), tt.wantEndUTC)
+			}
+			if got := end.Sub(start); got != tt.wantDuration {
+				t.Fatalf("duration = %s, want %s", got, tt.wantDuration)
+			}
+			endLocal := end.In(ny)
+			if endLocal.Hour() != 0 || endLocal.Minute() != 0 || endLocal.Second() != 0 || endLocal.Nanosecond() != 0 {
+				t.Fatalf("end local = %s, want local midnight", endLocal)
+			}
+		})
+	}
+}
+
+func TestBuildToday_FiltersOutsideWindow(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	start, end := TodayWindow(now, time.UTC)
+	events := []ChangeEvent{
+		{Provider: "github", Timestamp: start.Add(-time.Nanosecond), Identifier: "before-start", Verb: "x", CanonicalPath: "github/a"},
+		{Provider: "github", Timestamp: start, Identifier: "at-start", Verb: "x", CanonicalPath: "github/b"},
+		{Provider: "github", Timestamp: end.Add(-time.Nanosecond), Identifier: "before-end", Verb: "x", CanonicalPath: "github/c"},
+		{Provider: "github", Timestamp: end, Identifier: "at-end", Verb: "x", CanonicalPath: "github/d"},
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: events}, []string{"github"}, now, time.UTC, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Events != 2 {
+		t.Fatalf("events = %d, want 2 (start..end-1ns)", rep.Meta.Events)
+	}
+	var got []string
+	for _, sec := range rep.Sections {
+		for _, b := range sec.Bullets {
+			got = append(got, b.Identifier)
+		}
+	}
+	if len(got) != 2 || got[0] != "at-start" || got[1] != "before-end" {
+		t.Fatalf("bullets = %v, want [at-start before-end]", got)
+	}
+}
+
+func TestBuildToday_DSTSpringForwardExcludesNextLocalDay(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("LoadLocation: %v", err)
+	}
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, ny)
+	_, end := TodayWindow(now, ny)
+	events := []ChangeEvent{
+		{Provider: "github", Timestamp: end.Add(-time.Nanosecond), Identifier: "last-same-day", Verb: "updated", CanonicalPath: "github/same"},
+		{Provider: "github", Timestamp: time.Date(2026, 3, 9, 0, 30, 0, 0, ny), Identifier: "next-local-day", Verb: "updated", CanonicalPath: "github/next"},
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: events}, []string{"github"}, now, ny, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1", rep.Meta.Events)
+	}
+	var got []string
+	for _, sec := range rep.Sections {
+		for _, b := range sec.Bullets {
+			got = append(got, b.Identifier)
+		}
+	}
+	if len(got) != 1 || got[0] != "last-same-day" {
+		t.Fatalf("bullets = %v, want [last-same-day]", got)
+	}
+}
+
+func TestBuildToday_DSTFallBackIncludesFullLocalDay(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("LoadLocation: %v", err)
+	}
+	now := time.Date(2026, 11, 1, 12, 0, 0, 0, ny)
+	events := []ChangeEvent{
+		{Provider: "github", Timestamp: time.Date(2026, 11, 1, 23, 30, 0, 0, ny), Identifier: "late-same-day", Verb: "updated", CanonicalPath: "github/late"},
+		{Provider: "github", Timestamp: time.Date(2026, 11, 2, 0, 0, 0, 0, ny), Identifier: "next-local-day", Verb: "updated", CanonicalPath: "github/next"},
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: events}, []string{"github"}, now, ny, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1", rep.Meta.Events)
+	}
+	var got []string
+	for _, sec := range rep.Sections {
+		for _, b := range sec.Bullets {
+			got = append(got, b.Identifier)
+		}
+	}
+	if len(got) != 1 || got[0] != "late-same-day" {
+		t.Fatalf("bullets = %v, want [late-same-day]", got)
+	}
+}
+
+func TestBuildToday_Exhaustive(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	start, _ := TodayWindow(now, time.UTC)
+	events := make([]ChangeEvent, 0, 750)
+	for i := 0; i < 750; i++ {
+		events = append(events, ChangeEvent{
+			Provider:      "github",
+			Timestamp:     start.Add(time.Duration(i) * time.Millisecond),
+			Identifier:    fmt.Sprintf("id-%d", i),
+			Verb:          "updated",
+			CanonicalPath: fmt.Sprintf("github/x/%d", i),
+		})
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: events}, []string{"github"}, now, time.UTC, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Events != 750 {
+		t.Fatalf("events = %d, want 750 (exhaustive default)", rep.Meta.Events)
+	}
+	for _, w := range rep.Meta.Warnings {
+		if strings.HasPrefix(w, "truncated:") {
+			t.Fatalf("unexpected truncation warning: %q", w)
+		}
+	}
+}
+
+func TestBuildToday_TruncationWarning(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	start, _ := TodayWindow(now, time.UTC)
+	events := make([]ChangeEvent, 0, 750)
+	for i := 0; i < 750; i++ {
+		events = append(events, ChangeEvent{
+			Provider:      "github",
+			Timestamp:     start.Add(time.Duration(i) * time.Millisecond),
+			Identifier:    fmt.Sprintf("id-%d", i),
+			Verb:          "updated",
+			CanonicalPath: fmt.Sprintf("github/x/%d", i),
+		})
+	}
+	rep, err := BuildToday(context.Background(), SliceSource{Items: events}, []string{"github"}, now, time.UTC, BuildOptions{MaxEvents: 500})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	if rep.Meta.Events != 500 {
+		t.Fatalf("events = %d, want 500", rep.Meta.Events)
+	}
+	var found bool
+	for _, w := range rep.Meta.Warnings {
+		if strings.HasPrefix(w, "truncated:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected truncated: warning, got %v", rep.Meta.Warnings)
+	}
+}
+
+func TestBuildToday_NoFallbackTZ_Warns(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	rep, err := BuildToday(context.Background(), SliceSource{Items: nil}, []string{"github"}, now, nil, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	var found bool
+	for _, w := range rep.Meta.Warnings {
+		if strings.HasPrefix(w, "tz-fallback:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected tz-fallback warning, got %v", rep.Meta.Warnings)
+	}
+}
+
+func TestRender_HeaderFieldsMatchContract(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	rep, err := BuildToday(context.Background(), SliceSource{Items: nil}, []string{"github", "linear"}, now, time.UTC, BuildOptions{})
+	if err != nil {
+		t.Fatalf("BuildToday: %v", err)
+	}
+	body := string(Render(rep))
+	for _, field := range []string{"date:", "generated_at:", "covers:", "providers:", "events:"} {
+		if !strings.Contains(body, field) {
+			t.Fatalf("header missing %q\n--- body ---\n%s", field, body)
+		}
+	}
+	if strings.Contains(body, "warnings:") {
+		t.Fatalf("unexpected warnings header for clean run\n--- body ---\n%s", body)
+	}
+	withWarn := rep
+	withWarn.Meta.Warnings = []string{"truncated: 1 events exceeded MaxEvents=0"}
+	bodyWithWarn := string(Render(withWarn))
+	if !strings.Contains(bodyWithWarn, "warnings:") {
+		t.Fatalf("expected warnings header when set\n--- body ---\n%s", bodyWithWarn)
+	}
+}
+
+func TestWriteToday_AtomicAndDeterministic(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	root := t.TempDir()
+	events := []ChangeEvent{
+		{Provider: "github", Timestamp: now, Identifier: "PR-1", Verb: "updated", CanonicalPath: "github/x/1"},
+	}
+	first, err := WriteToday(context.Background(), root, SliceSource{Items: events}, []string{"github"}, now, time.UTC, BuildOptions{})
+	if err != nil {
+		t.Fatalf("WriteToday first: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("first WriteToday reported not written")
+	}
+	if first.Path != TodayPath {
+		t.Fatalf("path = %q, want %q", first.Path, TodayPath)
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(first.Path))
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if _, err := WriteToday(context.Background(), root, SliceSource{Items: events}, []string{"github"}, now, time.UTC, BuildOptions{}); err != nil {
+		t.Fatalf("WriteToday second: %v", err)
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("rolling rewrite produced different bytes\n--- first ---\n%s\n--- second ---\n%s", firstBytes, secondBytes)
+	}
+	entries, err := os.ReadDir(filepath.Dir(localPath))
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("temp leftover after atomic rename: %s", e.Name())
+		}
+	}
+}
+
+func TestDayRollover_TodayRendersNewDay(t *testing.T) {
+	day1 := time.Date(2026, 5, 15, 23, 30, 0, 0, time.UTC)
+	day2 := time.Date(2026, 5, 16, 0, 30, 0, 0, time.UTC)
+	root := t.TempDir()
+
+	day1Events := []ChangeEvent{
+		{Provider: "github", Timestamp: day1, Identifier: "PR-A", Verb: "updated", CanonicalPath: "github/a"},
+	}
+	if _, err := WriteToday(context.Background(), root, SliceSource{Items: day1Events}, []string{"github"}, day1, time.UTC, BuildOptions{}); err != nil {
+		t.Fatalf("WriteToday day1: %v", err)
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(TodayPath))
+	day1Bytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read day1: %v", err)
+	}
+	if !strings.Contains(string(day1Bytes), "date: 2026-05-15") {
+		t.Fatalf("day1 frontmatter missing date 2026-05-15\n%s", day1Bytes)
+	}
+
+	// After local-midnight, the same event stream plus a day2 event must
+	// cause the next render to label the file with the new local date.
+	day2Events := append([]ChangeEvent(nil), day1Events...)
+	day2Events = append(day2Events, ChangeEvent{
+		Provider: "github", Timestamp: day2, Identifier: "PR-B", Verb: "updated", CanonicalPath: "github/b",
+	})
+	if _, err := WriteToday(context.Background(), root, SliceSource{Items: day2Events}, []string{"github"}, day2, time.UTC, BuildOptions{}); err != nil {
+		t.Fatalf("WriteToday day2: %v", err)
+	}
+	day2Bytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read day2: %v", err)
+	}
+	if !strings.Contains(string(day2Bytes), "date: 2026-05-16") {
+		t.Fatalf("day2 frontmatter missing date 2026-05-16\n%s", day2Bytes)
+	}
+	if strings.Contains(string(day2Bytes), "PR-A") {
+		t.Fatalf("day1 event leaked into day2 today.md\n%s", day2Bytes)
+	}
+}
+
+func TestGoldenToday(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	// Pick a now-instant inside the local-day containing the fixture's
+	// event stream so all 11 events fall in the rolling window.
+	now := time.Date(2026, 5, 12, 23, 59, 0, 0, time.UTC)
+	path, body, rep, err := RenderToday(context.Background(), SliceSource{Items: events}, []string{"github", "linear", "notion"}, now, time.UTC, BuildOptions{})
+	if err != nil {
+		t.Fatalf("RenderToday: %v", err)
+	}
+	if path != TodayPath {
+		t.Fatalf("path = %q, want %q", path, TodayPath)
+	}
+	if rep.Meta.Date != "2026-05-12" {
+		t.Fatalf("date = %q, want 2026-05-12", rep.Meta.Date)
+	}
+	if rep.Meta.Covers != TodayCover {
+		t.Fatalf("covers = %q, want %q", rep.Meta.Covers, TodayCover)
+	}
+	if rep.Meta.Events != 11 {
+		t.Fatalf("events = %d, want 11", rep.Meta.Events)
+	}
+	want, err := os.ReadFile("testdata/today-fixture.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !bytes.Equal(body, want) {
+		t.Fatalf("golden mismatch\n--- got ---\n%s\n--- want ---\n%s", body, want)
+	}
+}

--- a/internal/digest/types.go
+++ b/internal/digest/types.go
@@ -33,6 +33,10 @@ type Window struct {
 	GeneratedAt time.Time      // UTC; used for `generated_at`
 	Providers   []string       // connected providers (incl. zero-activity ones)
 	TZ          *time.Location // workspace timezone; used for the `date` field
+	// Closing marks this run as a close-window write (the produced report
+	// captures a fully-closed local day, e.g. `digests/yesterday.md`). It is
+	// metadata for callers; self-host relayfile rendering remains exhaustive.
+	Closing bool
 }
 
 // Meta is the frontmatter bundle attached to a rendered digest.

--- a/internal/digest/yesterday.go
+++ b/internal/digest/yesterday.go
@@ -152,16 +152,23 @@ func WriteYesterday(ctx context.Context, mountRoot string, src ChangeEventSource
 		// Close for this local day already happened; treat the artifact as
 		// immutable. Re-read so the caller still gets a populated result.
 		existing, readErr := os.ReadFile(localPath)
-		if readErr != nil {
+		switch {
+		case readErr == nil:
+			return YesterdayWriteResult{
+				Path:    path,
+				Report:  Report{Meta: Meta{Date: localDateStr, Covers: "yesterday"}, Sections: nil},
+				Written: false,
+				Skipped: true,
+				Bytes:   existing,
+			}, nil
+		case errors.Is(readErr, os.ErrNotExist):
+			// Stale marker: the close was recorded but the artifact is gone
+			// (manually deleted, lost on a partial filesystem, never
+			// persisted). Hard-failing here would wedge the close pipeline
+			// for this day forever. Fall through and regenerate.
+		default:
 			return YesterdayWriteResult{}, fmt.Errorf("digest: marker present but yesterday.md unreadable: %w", readErr)
 		}
-		return YesterdayWriteResult{
-			Path:    path,
-			Report:  Report{Meta: Meta{Date: localDateStr, Covers: "yesterday"}, Sections: nil},
-			Written: false,
-			Skipped: true,
-			Bytes:   existing,
-		}, nil
 	}
 
 	_, content, rep, err := RenderYesterday(ctx, src, w)

--- a/internal/digest/yesterday.go
+++ b/internal/digest/yesterday.go
@@ -1,0 +1,258 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// YesterdayWriteResult describes the outcome of a WriteYesterday call.
+type YesterdayWriteResult struct {
+	Path    string
+	Report  Report
+	Written bool
+	Skipped bool
+	// Bytes is the rendered (or pre-existing immutable) yesterday.md
+	// content. Surfaced so callers can hash the close-write output without
+	// re-reading the file.
+	Bytes []byte
+}
+
+// YesterdayMarkerPath is the per-workspace lock file that records the close
+// write for a given local day. Its existence (and matching `<date>` content)
+// instructs subsequent calls to short-circuit, guaranteeing that
+// `digests/yesterday.md` is byte-stable after the close write for that date,
+// even if later ingest events arrive (parent spec WI-B gate B). Stored under
+// `.relay/` because it is internal scheduler state rather than a mounted
+// digest artifact; the mount watcher already excludes `.relay/`, preventing
+// the marker from re-entering digest regeneration.
+const YesterdayMarkerPath = ".relay/digests/yesterday.lock"
+
+const yesterdayTempDir = ".relay/digests/tmp"
+
+// YesterdayWindow builds a Window targeting the closed local day for the
+// `digests/yesterday.md` artifact. The frontmatter `covers` value is the
+// literal string `yesterday` so the file is self-describing as a rolling
+// closed-day pointer (parent spec WI-B, child slice acceptance check #6).
+func YesterdayWindow(date, generatedAt time.Time, providers []string, tz *time.Location) Window {
+	if tz == nil {
+		// TODO(workspace-primitives pr39 — timezone slice): once the
+		// workspace config exposes a configured zone, callers should
+		// pass it here. UTC is the documented fallback per the parent
+		// spec until that slice lands.
+		tz = time.UTC
+	}
+	localDate := date.In(tz)
+	return Window{
+		Date:        localDate,
+		Cover:       "yesterday",
+		GeneratedAt: generatedAt,
+		Providers:   append([]string(nil), providers...),
+		TZ:          tz,
+	}
+}
+
+// RenderYesterday renders the closing-window artifact for the just-closed
+// local day. `Meta.Date` is stamped with the closed day and `Meta.Covers` is
+// the literal string `yesterday` (acceptance check #6). The renderer reuses
+// Run so bullet ordering is byte-identical to what `today.md` produced for
+// the same event set during the closed day (acceptance check #2 modulo
+// frontmatter). Closing is metadata only; self-host digests remain exhaustive.
+func RenderYesterday(ctx context.Context, src ChangeEventSource, w Window) (string, []byte, Report, error) {
+	if w.TZ == nil {
+		// TODO(workspace-primitives pr39 — timezone slice): see YesterdayWindow.
+		w.TZ = time.UTC
+	}
+	w.Cover = "yesterday"
+	w.Closing = true
+	rep, err := Run(ctx, closedDailyFilteredSource{inner: src}, w)
+	if err != nil {
+		return "", nil, Report{}, err
+	}
+	return YesterdayPath, Render(rep), rep, nil
+}
+
+// readYesterdayMarker returns the date string recorded by the most recent
+// close write, or "" if no marker exists.
+func readYesterdayMarker(mountRoot string) string {
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(YesterdayMarkerPath))
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// writeYesterdayMarker records `date` as the closed local day for the
+// current `yesterday.md`. Subsequent CloseLocalDay calls for the same date
+// short-circuit; calls for a later date overwrite the marker as part of
+// rotation. The marker lives under `.relay/`, so the mount watcher skips it
+// before it can be observed as a provider source event.
+func writeYesterdayMarker(mountRoot, date string) error {
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(YesterdayMarkerPath))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(localPath), ".yesterday-marker-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write([]byte(date + "\n")); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// WriteYesterday renders the closing-window digest and writes it to
+// `<mountRoot>/digests/yesterday.md`. The write is idempotent in two ways:
+//
+//  1. When `w.Closing` is true (the close-write path) and the per-workspace
+//     marker `.relay/digests/yesterday.lock` already records the same local
+//     `date`, the on-disk file is treated as immutable for the rest of the
+//     day: the existing bytes are returned and the marker re-stamped,
+//     guaranteeing byte-equality across subsequent ingest events (gate B).
+//  2. When the on-disk file already has byte-equal content, the file is left
+//     untouched (mtime preserved) and Skipped is set on the result.
+//
+// When content differs (rotation forward at local midnight, or first write of
+// the day), the writer performs an atomic temp-file + rename so the artifact
+// is replaced as a single visible filesystem event (gate E).
+func WriteYesterday(ctx context.Context, mountRoot string, src ChangeEventSource, w Window) (YesterdayWriteResult, error) {
+	if strings.TrimSpace(mountRoot) == "" {
+		return YesterdayWriteResult{}, errors.New("digest: mount root is required")
+	}
+	if w.TZ == nil {
+		w.TZ = time.UTC
+	}
+	localDateStr := w.Date.In(w.TZ).Format("2006-01-02")
+	path := YesterdayPath
+	localPath := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(path))
+
+	if w.Closing && readYesterdayMarker(mountRoot) == localDateStr {
+		// Close for this local day already happened; treat the artifact as
+		// immutable. Re-read so the caller still gets a populated result.
+		existing, readErr := os.ReadFile(localPath)
+		if readErr != nil {
+			return YesterdayWriteResult{}, fmt.Errorf("digest: marker present but yesterday.md unreadable: %w", readErr)
+		}
+		return YesterdayWriteResult{
+			Path:    path,
+			Report:  Report{Meta: Meta{Date: localDateStr, Covers: "yesterday"}, Sections: nil},
+			Written: false,
+			Skipped: true,
+			Bytes:   existing,
+		}, nil
+	}
+
+	_, content, rep, err := RenderYesterday(ctx, src, w)
+	if err != nil {
+		return YesterdayWriteResult{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return YesterdayWriteResult{}, err
+	}
+
+	if existing, err := os.ReadFile(localPath); err == nil {
+		if bytes.Equal(existing, content) {
+			if w.Closing {
+				if err := writeYesterdayMarker(mountRoot, localDateStr); err != nil {
+					return YesterdayWriteResult{}, err
+				}
+			}
+			return YesterdayWriteResult{Path: path, Report: rep, Written: false, Skipped: true, Bytes: existing}, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return YesterdayWriteResult{}, err
+	}
+
+	tmpDir := filepath.Join(filepath.Clean(mountRoot), filepath.FromSlash(yesterdayTempDir))
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return YesterdayWriteResult{}, err
+	}
+	tmp, err := os.CreateTemp(tmpDir, ".yesterday-*.md.tmp")
+	if err != nil {
+		return YesterdayWriteResult{}, err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return YesterdayWriteResult{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return YesterdayWriteResult{}, err
+	}
+	if err := os.Chmod(tmpName, 0o644); err != nil {
+		_ = os.Remove(tmpName)
+		return YesterdayWriteResult{}, err
+	}
+	if err := os.Rename(tmpName, localPath); err != nil {
+		_ = os.Remove(tmpName)
+		return YesterdayWriteResult{}, err
+	}
+	if w.Closing {
+		if err := writeYesterdayMarker(mountRoot, localDateStr); err != nil {
+			return YesterdayWriteResult{}, err
+		}
+	}
+	return YesterdayWriteResult{Path: path, Report: rep, Written: true, Bytes: content}, nil
+}
+
+// CloseLocalDay invokes the yesterday writer for the local day that just
+// closed (the calendar day preceding `now` in `tz`). It is the callable
+// trigger this slice exposes to the existing tick/sync loop; this slice
+// deliberately does not introduce a new scheduler (lead-plan §Code
+// Changes / Closing-window trigger).
+//
+// Concurrency: serialization is the caller's responsibility — pass the
+// existing digest write lock around CloseLocalDay so concurrent ticks
+// observe a single rotation per local midnight. WriteYesterday's idempotent
+// equal-bytes short-circuit means two losing ticks observe Skipped=true
+// rather than a duplicate write.
+func CloseLocalDay(ctx context.Context, mountRoot string, src ChangeEventSource, now time.Time, providers []string, tz *time.Location) (YesterdayWriteResult, error) {
+	if tz == nil {
+		// TODO(workspace-primitives pr39 — timezone slice): see YesterdayWindow.
+		tz = time.UTC
+	}
+	closedDay := now.In(tz).AddDate(0, 0, -1)
+	w := YesterdayWindow(closedDay, now, providers, tz)
+	w.Closing = true
+	return WriteYesterday(ctx, mountRoot, src, w)
+}
+
+// CloseLocalDayFor closes the specific local `closedDay`. It is the
+// scheduler-friendly entry point: catch-up across offline days walks
+// chronologically and invokes CloseLocalDayFor for each missing date. The
+// marker prevents a re-close from mutating `yesterday.md` for dates older
+// than the most recently closed one (only the latest catch-up date "wins"
+// the artifact, but every closed day still produces its date-stamped
+// archive via the sibling slice — out of scope here).
+func CloseLocalDayFor(ctx context.Context, mountRoot string, src ChangeEventSource, closedDay, generatedAt time.Time, providers []string, tz *time.Location) (YesterdayWriteResult, error) {
+	if tz == nil {
+		tz = time.UTC
+	}
+	w := YesterdayWindow(closedDay, generatedAt, providers, tz)
+	w.Closing = true
+	return WriteYesterday(ctx, mountRoot, src, w)
+}

--- a/internal/digest/yesterday_test.go
+++ b/internal/digest/yesterday_test.go
@@ -1,0 +1,496 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestRenderYesterdayFrontmatter covers F1: RenderYesterday must stamp
+// Meta.Date to the closed local day and Meta.Covers to the literal string
+// "yesterday", and produce bullets byte-equal (modulo frontmatter) to what
+// Run produces for the same event set with Cover: "today".
+func TestRenderYesterdayFrontmatter(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	closedDay := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	generatedAt := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	providers := []string{"github", "linear", "notion"}
+
+	w := YesterdayWindow(closedDay, generatedAt, providers, time.UTC)
+	path, content, rep, err := RenderYesterday(context.Background(), SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("RenderYesterday: %v", err)
+	}
+	if path != "digests/yesterday.md" {
+		t.Fatalf("path = %q, want digests/yesterday.md", path)
+	}
+	if rep.Meta.Date != "2026-05-12" {
+		t.Fatalf("meta.date = %q, want 2026-05-12", rep.Meta.Date)
+	}
+	if rep.Meta.Covers != "yesterday" {
+		t.Fatalf("meta.covers = %q, want yesterday", rep.Meta.Covers)
+	}
+
+	// Acceptance check #2 byte-equality modulo frontmatter: produce the
+	// last-today report for the same event set and compare bullet bodies.
+	todayWin := Window{
+		Date:        closedDay,
+		Cover:       "today",
+		GeneratedAt: generatedAt,
+		Providers:   providers,
+		TZ:          time.UTC,
+	}
+	todayRep, err := Run(context.Background(), SliceSource{Items: events}, todayWin)
+	if err != nil {
+		t.Fatalf("Run today: %v", err)
+	}
+	if len(todayRep.Sections) != len(rep.Sections) {
+		t.Fatalf("section count drift: today=%d yesterday=%d", len(todayRep.Sections), len(rep.Sections))
+	}
+	for i := range rep.Sections {
+		if rep.Sections[i].Provider != todayRep.Sections[i].Provider {
+			t.Fatalf("section %d provider drift: today=%s yesterday=%s",
+				i, todayRep.Sections[i].Provider, rep.Sections[i].Provider)
+		}
+		if len(rep.Sections[i].Bullets) != len(todayRep.Sections[i].Bullets) {
+			t.Fatalf("section %d bullets drift", i)
+		}
+		for j := range rep.Sections[i].Bullets {
+			if rep.Sections[i].Bullets[j] != todayRep.Sections[i].Bullets[j] {
+				t.Fatalf("section %d bullet %d drift: today=%+v yesterday=%+v",
+					i, j, todayRep.Sections[i].Bullets[j], rep.Sections[i].Bullets[j])
+			}
+		}
+	}
+
+	// Content must match the existing yesterday fixture used by TestGoldenYesterday.
+	want, err := os.ReadFile("testdata/yesterday-fixture.md")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	if !bytes.Equal(content, want) {
+		t.Fatalf("RenderYesterday output drifted from golden fixture\n--- got ---\n%s\n--- want ---\n%s", content, want)
+	}
+}
+
+func TestYesterdayFiltersClosedLocalDay(t *testing.T) {
+	events := []ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 11, 23, 59, 59, 0, time.UTC),
+			Identifier:    "before",
+			Verb:          "updated",
+			CanonicalPath: "github/before.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+			Identifier:    "inside",
+			Verb:          "updated",
+			CanonicalPath: "github/inside.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+			Identifier:    "after",
+			Verb:          "updated",
+			CanonicalPath: "github/after.json",
+		},
+	}
+
+	_, body, rep, err := RenderYesterday(context.Background(), SliceSource{Items: events}, YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 5, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	))
+	if err != nil {
+		t.Fatalf("RenderYesterday: %v", err)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1", rep.Meta.Events)
+	}
+	if !bytes.Contains(body, []byte("inside")) || bytes.Contains(body, []byte("before")) || bytes.Contains(body, []byte("after")) {
+		t.Fatalf("yesterday digest did not filter to the closed day:\n%s", body)
+	}
+}
+
+// TestWriteYesterdayIdempotentSameDay covers F2 / acceptance check #3:
+// repeat invocations with the same event set leave the on-disk file byte-
+// equal AND preserve mtime (the equal-bytes short-circuit path).
+func TestWriteYesterdayIdempotentSameDay(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+
+	first, err := WriteYesterday(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteYesterday first: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("first write reported not written")
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(first.Path))
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first digest: %v", err)
+	}
+	firstInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat first digest: %v", err)
+	}
+
+	// Backdate the file so mtime equality is a meaningful assertion: if
+	// the writer rewrites it, the new mtime will be "now" and != backdated.
+	backdated := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(localPath, backdated, backdated); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	firstInfo, err = os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("re-stat first digest: %v", err)
+	}
+
+	second, err := WriteYesterday(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteYesterday second: %v", err)
+	}
+	if second.Written {
+		t.Fatal("second write rewrote byte-equal yesterday digest (mtime would drift)")
+	}
+	if !second.Skipped {
+		t.Fatal("second write should report Skipped=true on byte-equal short-circuit")
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second digest: %v", err)
+	}
+	if !bytes.Equal(secondBytes, firstBytes) {
+		t.Fatalf("yesterday digest changed on no-op rerun")
+	}
+	secondInfo, err := os.Stat(localPath)
+	if err != nil {
+		t.Fatalf("stat second digest: %v", err)
+	}
+	if !secondInfo.ModTime().Equal(firstInfo.ModTime()) {
+		t.Fatalf("mtime drifted on no-op rerun: first=%s second=%s",
+			firstInfo.ModTime(), secondInfo.ModTime())
+	}
+}
+
+// TestWriteYesterdayRotatesOnNewDay covers F2 / acceptance check #2:
+// when the window advances to a new local day, the writer replaces the file
+// atomically and the new body covers the new closed day.
+func TestWriteYesterdayRotatesOnNewDay(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+
+	first, err := WriteYesterday(context.Background(), root, SliceSource{Items: events},
+		YesterdayWindow(
+			time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+			[]string{"github", "linear", "notion"},
+			time.UTC,
+		),
+	)
+	if err != nil {
+		t.Fatalf("WriteYesterday day1: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("day1 write reported not written")
+	}
+
+	// Day rolls forward: no events on 2026-05-13 in the fixture, so the
+	// rotated yesterday body should be empty (zero events across all
+	// configured providers) and the frontmatter date should be 2026-05-13.
+	second, err := WriteYesterday(context.Background(), root, SliceSource{Items: nil},
+		YesterdayWindow(
+			time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 14, 0, 0, 0, 0, time.UTC),
+			[]string{"github", "linear", "notion"},
+			time.UTC,
+		),
+	)
+	if err != nil {
+		t.Fatalf("WriteYesterday day2: %v", err)
+	}
+	if !second.Written {
+		t.Fatal("day2 write should have rotated, but Written=false")
+	}
+	if second.Report.Meta.Date != "2026-05-13" {
+		t.Fatalf("rotated date = %q, want 2026-05-13", second.Report.Meta.Date)
+	}
+	if second.Report.Meta.Events != 0 {
+		t.Fatalf("rotated events = %d, want 0", second.Report.Meta.Events)
+	}
+
+	localPath := filepath.Join(root, filepath.FromSlash(second.Path))
+	body, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read rotated digest: %v", err)
+	}
+	if !bytes.Contains(body, []byte("date: 2026-05-13")) {
+		t.Fatalf("rotated file does not contain new date frontmatter:\n%s", body)
+	}
+	if !bytes.Contains(body, []byte("covers: yesterday")) {
+		t.Fatalf("rotated file lost covers: yesterday:\n%s", body)
+	}
+}
+
+// TestWriteYesterdayImmutableAgainstLaterDayEvents covers acceptance check
+// #3: ingesting events from a later local day and re-running the digest
+// pipeline with the SAME closed-day window leaves yesterday.md untouched.
+func TestWriteYesterdayImmutableAgainstLaterDayEvents(t *testing.T) {
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+	w := YesterdayWindow(
+		time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC),
+		[]string{"github", "linear", "notion"},
+		time.UTC,
+	)
+
+	first, err := WriteYesterday(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteYesterday first: %v", err)
+	}
+	localPath := filepath.Join(root, filepath.FromSlash(first.Path))
+	firstBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+
+	// Add later-day events — yesterday must not pick them up because the
+	// closed-day window's date is still 2026-05-12. Per Run's contract,
+	// events with timestamps outside the day still flow through the source
+	// (Run does not filter by timestamp), but yesterday's *Meta.Date* and
+	// the closed-day immutability contract say once it's written for a
+	// given closed day, re-running with the same window+events-of-that-day
+	// must be a no-op.
+	laterEvents := append([]ChangeEvent(nil), events...)
+	laterEvents = append(laterEvents, ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC),
+		Identifier:    "PR-92",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/92.json",
+	})
+
+	// Caller re-runs the closing-day digest with the SAME closed-day window
+	// and the SAME 2026-05-12 event set (later-day events are partitioned
+	// out by the caller per the spec's window contract — they belong in
+	// today.md, not yesterday). The writer must skip the write.
+	second, err := WriteYesterday(context.Background(), root, SliceSource{Items: events}, w)
+	if err != nil {
+		t.Fatalf("WriteYesterday second: %v", err)
+	}
+	if second.Written {
+		t.Fatal("rerun with same closed-day set should not rewrite yesterday.md")
+	}
+	if !second.Skipped {
+		t.Fatal("rerun should report Skipped=true")
+	}
+	secondBytes, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if !bytes.Equal(firstBytes, secondBytes) {
+		t.Fatalf("yesterday.md mutated by later-day events")
+	}
+}
+
+// TestCloseLocalDayWritesYesterdayOncePerRollover covers F3: driving the
+// fake clock across local midnight in a non-UTC zone invokes CloseLocalDay
+// exactly once per rollover and the produced body is byte-equivalent to
+// the Run output for the closed local day.
+func TestCloseLocalDayWritesYesterdayOncePerRollover(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Skipf("America/Los_Angeles tz not available: %v", err)
+	}
+	events := loadEventsJSONL(t, "testdata/events.jsonl")
+	root := t.TempDir()
+
+	// First midnight crossing: now is 2026-05-13 00:05 PT; closed local
+	// day is 2026-05-12.
+	midnightCrossing := time.Date(2026, 5, 13, 0, 5, 0, 0, la)
+	res, err := CloseLocalDay(context.Background(), root, SliceSource{Items: events},
+		midnightCrossing, []string{"github", "linear", "notion"}, la)
+	if err != nil {
+		t.Fatalf("CloseLocalDay: %v", err)
+	}
+	if !res.Written {
+		t.Fatal("first close did not write")
+	}
+	if res.Report.Meta.Date != "2026-05-12" {
+		t.Fatalf("closed-day date = %q, want 2026-05-12", res.Report.Meta.Date)
+	}
+	if res.Report.Meta.Covers != "yesterday" {
+		t.Fatalf("covers = %q, want yesterday", res.Report.Meta.Covers)
+	}
+
+	// Second invocation on the same local day: no-op (Skipped).
+	res2, err := CloseLocalDay(context.Background(), root, SliceSource{Items: events},
+		midnightCrossing.Add(30*time.Minute),
+		[]string{"github", "linear", "notion"}, la)
+	if err != nil {
+		t.Fatalf("CloseLocalDay rerun: %v", err)
+	}
+	if res2.Written {
+		t.Fatal("second close on same closed-day rewrote yesterday")
+	}
+	if !res2.Skipped {
+		t.Fatal("second close should report Skipped=true")
+	}
+
+	// Read yesterday.md and assert it is byte-equal to RenderYesterday for
+	// the same closed day and event set (acceptance check #2).
+	localPath := filepath.Join(root, "digests", "yesterday.md")
+	onDisk, err := os.ReadFile(localPath)
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+	closedDay := time.Date(2026, 5, 12, 0, 0, 0, 0, la)
+	_, rendered, _, err := RenderYesterday(context.Background(), SliceSource{Items: events},
+		YesterdayWindow(closedDay, midnightCrossing, []string{"github", "linear", "notion"}, la))
+	if err != nil {
+		t.Fatalf("RenderYesterday: %v", err)
+	}
+	if !bytes.Equal(onDisk, rendered) {
+		t.Fatalf("on-disk yesterday != RenderYesterday output\n--- disk ---\n%s\n--- rendered ---\n%s",
+			onDisk, rendered)
+	}
+}
+
+// TestYesterdayWindowUsesNonUTCZone covers F6 / acceptance check #4:
+// when a non-UTC zone is configured, the window date is resolved in that
+// zone. With now = 2026-05-13 00:05 PT, the closed local day is
+// 2026-05-12 (PT), not 2026-05-13 (UTC).
+func TestYesterdayWindowUsesNonUTCZone(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Skipf("America/Los_Angeles tz not available: %v", err)
+	}
+	// Choose an instant where UTC and PT disagree on which calendar day
+	// "yesterday" refers to: 2026-05-12 18:00 PT = 2026-05-13 01:00 UTC.
+	// In PT, the previous local day is 2026-05-11; in UTC, the previous
+	// calendar day is 2026-05-12. Same wall-clock instant, different zone,
+	// different yesterday — proving the zone is what anchors the boundary.
+	now := time.Date(2026, 5, 12, 18, 0, 0, 0, la)
+	closedDayPT := now.In(la).AddDate(0, 0, -1)
+	w := YesterdayWindow(closedDayPT, now, []string{"github"}, la)
+	if w.TZ != la {
+		t.Fatalf("window TZ not preserved")
+	}
+	rep, err := Run(context.Background(), SliceSource{Items: nil}, w)
+	if err != nil {
+		t.Fatalf("Run PT: %v", err)
+	}
+	if rep.Meta.Date != "2026-05-11" {
+		t.Fatalf("non-UTC date resolution: got %q, want 2026-05-11 (PT yesterday for 2026-05-12 18:00 PT)", rep.Meta.Date)
+	}
+
+	closedDayUTC := now.In(time.UTC).AddDate(0, 0, -1)
+	utcWin := YesterdayWindow(closedDayUTC, now, []string{"github"}, time.UTC)
+	utcRep, err := Run(context.Background(), SliceSource{Items: nil}, utcWin)
+	if err != nil {
+		t.Fatalf("Run UTC: %v", err)
+	}
+	if utcRep.Meta.Date == rep.Meta.Date {
+		t.Fatalf("UTC and PT produced the same yesterday-date %q, expected zone divergence", rep.Meta.Date)
+	}
+	if utcRep.Meta.Date != "2026-05-12" {
+		t.Fatalf("UTC yesterday-date = %q, want 2026-05-12", utcRep.Meta.Date)
+	}
+}
+
+// TestYesterdayTimezoneBoundary covers F6 / acceptance check #4 boundary
+// case: an event at 23:30 local on day D lands in day-D yesterday.md after
+// midnight; an event at 00:30 local on D+1 does not.
+//
+// Note: Run does not filter events by timestamp itself — the upstream
+// ChangeEventSource is responsible for windowing. This test asserts the
+// integration contract by passing a source whose Events() method partitions
+// on the window date in the workspace zone, then verifies the produced
+// bullets cover the 23:30 event and exclude the 00:30 event.
+func TestYesterdayTimezoneBoundary(t *testing.T) {
+	la, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		t.Skipf("America/Los_Angeles tz not available: %v", err)
+	}
+	allEvents := []ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 23, 30, 0, 0, la), // 2026-05-12 23:30 PT
+			Identifier:    "PR-late",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/late.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 13, 0, 30, 0, 0, la), // 2026-05-13 00:30 PT
+			Identifier:    "PR-after",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/after.json",
+		},
+	}
+	now := time.Date(2026, 5, 13, 1, 0, 0, 0, la)
+	closedDay := now.AddDate(0, 0, -1)
+	w := YesterdayWindow(closedDay, now, []string{"github"}, la)
+
+	src := windowFilteredSource{items: allEvents, tz: la}
+	rep, err := Run(context.Background(), src, w)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rep.Meta.Date != "2026-05-12" {
+		t.Fatalf("date = %q, want 2026-05-12", rep.Meta.Date)
+	}
+	if rep.Meta.Events != 1 {
+		t.Fatalf("events = %d, want 1 (only the 23:30 PT event)", rep.Meta.Events)
+	}
+	var section *DigestSection
+	for i := range rep.Sections {
+		if rep.Sections[i].Provider == "github" {
+			section = &rep.Sections[i]
+			break
+		}
+	}
+	if section == nil || len(section.Bullets) != 1 {
+		t.Fatalf("expected exactly one github bullet, got %+v", section)
+	}
+	if section.Bullets[0].Identifier != "PR-late" {
+		t.Fatalf("expected PR-late, got %q (boundary event leaked)", section.Bullets[0].Identifier)
+	}
+}
+
+// windowFilteredSource mimics the production source that partitions events
+// by the window's local day. Tests use it to assert the boundary contract
+// without depending on the not-yet-present production event store.
+type windowFilteredSource struct {
+	items []ChangeEvent
+	tz    *time.Location
+}
+
+func (s windowFilteredSource) Events(w Window) ([]ChangeEvent, error) {
+	tz := s.tz
+	if tz == nil {
+		tz = time.UTC
+	}
+	dayKey := w.Date.In(tz).Format("2006-01-02")
+	out := make([]ChangeEvent, 0, len(s.items))
+	for _, ev := range s.items {
+		if ev.Timestamp.In(tz).Format("2006-01-02") == dayKey {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}

--- a/internal/digest/yesterday_test.go
+++ b/internal/digest/yesterday_test.go
@@ -284,11 +284,12 @@ func TestWriteYesterdayImmutableAgainstLaterDayEvents(t *testing.T) {
 		CanonicalPath: "github/repos/AgentWorkforce__workforce/pulls/by-id/92.json",
 	})
 
-	// Caller re-runs the closing-day digest with the SAME closed-day window
-	// and the SAME 2026-05-12 event set (later-day events are partitioned
-	// out by the caller per the spec's window contract — they belong in
-	// today.md, not yesterday). The writer must skip the write.
-	second, err := WriteYesterday(context.Background(), root, SliceSource{Items: events}, w)
+	// Re-run the closing-day digest with a source that now ALSO contains a
+	// later-day (2026-05-13) event. Immutability is pinned by the per-day
+	// marker, not by the caller pre-filtering the source: once yesterday.md
+	// is closed for 2026-05-12, a re-close for that date must skip the write
+	// even if the source is contaminated with out-of-window events.
+	second, err := WriteYesterday(context.Background(), root, SliceSource{Items: laterEvents}, w)
 	if err != nil {
 		t.Fatalf("WriteYesterday second: %v", err)
 	}

--- a/internal/mountfuse/dir.go
+++ b/internal/mountfuse/dir.go
@@ -104,6 +104,9 @@ func (n *DirNode) Mkdir(ctx context.Context, name string, mode uint32, out *fuse
 }
 
 func (n *DirNode) Create(ctx context.Context, name string, flags uint32, mode uint32, out *fuse.EntryOut) (*gofusefs.Inode, gofusefs.FileHandle, uint32, syscall.Errno) {
+	if isVirtualSkillsDirPath(n.state.remoteRoot, n.path) {
+		return nil, nil, 0, syscall.EACCES
+	}
 	remotePath := joinRemotePath(n.path, name)
 	meta := nodeMeta{
 		path:        remotePath,
@@ -143,6 +146,9 @@ func (n *DirNode) Unlink(ctx context.Context, name string) syscall.Errno {
 	}
 	if meta.isDir() {
 		return syscall.EISDIR
+	}
+	if isReadOnlyVirtualPath(n.state.remoteRoot, meta.path) {
+		return syscall.EACCES
 	}
 	baseRevision := meta.revision
 	if baseRevision == "" {

--- a/internal/mountfuse/fs.go
+++ b/internal/mountfuse/fs.go
@@ -321,6 +321,9 @@ func (s *fsState) listDirectory(ctx context.Context, remotePath string) (map[str
 	if err := s.ensureGithubRepoMaterialized(ctx, remotePath); err != nil {
 		return nil, err
 	}
+	if isVirtualSkillsDirPath(s.remoteRoot, remotePath) {
+		return virtualSkillsDirectory(s.remoteRoot), nil
+	}
 	if entries, ok := s.getDir(remotePath); ok {
 		return entries, nil
 	}
@@ -338,8 +341,8 @@ func (s *fsState) listDirectory(ctx context.Context, remotePath string) (map[str
 	}
 	if remotePath == s.remoteRoot {
 		// Alias directories such as by-title/by-id/by-state are adapter-owned
-		// remote entries; the only synthesized root entry here is the virtual layout.
-		entries[layoutFilename] = virtualLayoutMeta(s.remoteRoot)
+		// remote entries; root-level guidance files are synthesized here.
+		virtualRootDirectoryEntries(s.remoteRoot, entries)
 	}
 	if provider, ok := providerRootSegment(s.remoteRoot, remotePath); ok {
 		manifest := s.layoutManifest(provider)
@@ -387,6 +390,12 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 			modTime: time.Now(),
 		}, nil
 	}
+	if isVirtualSkillsDirPath(s.remoteRoot, remotePath) {
+		return virtualSkillsDirMeta(s.remoteRoot), nil
+	}
+	if isVirtualActivitySummaryPath(s.remoteRoot, remotePath) {
+		return virtualActivitySummaryMeta(s.remoteRoot), nil
+	}
 	if isVirtualLayoutPath(s.remoteRoot, remotePath) {
 		return virtualLayoutMeta(s.remoteRoot), nil
 	}
@@ -421,6 +430,9 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 
 func (s *fsState) readFile(ctx context.Context, remotePath string) (mountsync.RemoteFile, error) {
 	remotePath = normalizeRemotePath(remotePath)
+	if isVirtualActivitySummaryPath(s.remoteRoot, remotePath) {
+		return readVirtualActivitySummary(s.remoteRoot), nil
+	}
 	if isVirtualLayoutPath(s.remoteRoot, remotePath) {
 		return readVirtualLayout(s.remoteRoot), nil
 	}

--- a/internal/mountfuse/fs.go
+++ b/internal/mountfuse/fs.go
@@ -345,8 +345,9 @@ func (s *fsState) listDirectory(ctx context.Context, remotePath string) (map[str
 		virtualRootDirectoryEntries(s.remoteRoot, entries)
 	}
 	if provider, ok := providerRootSegment(s.remoteRoot, remotePath); ok {
-		manifest := s.layoutManifest(provider)
+		manifest := s.providerLayoutManifest(ctx, provider)
 		entries[providerLayoutFilename] = virtualProviderLayoutMeta(s.remoteRoot, manifest)
+		entries[legacyProviderLayoutFilename] = legacyVirtualProviderLayoutMeta(s.remoteRoot, manifest)
 	}
 	if provider, resource, ok := virtualSchemaForDirectory(s.remoteRoot, remotePath); ok {
 		if payload, present := loadResourceSchema(provider, resource); present {
@@ -400,7 +401,7 @@ func (s *fsState) lookupMetadata(ctx context.Context, remotePath string) (nodeMe
 		return virtualLayoutMeta(s.remoteRoot), nil
 	}
 	if provider, ok := isVirtualProviderLayoutPath(s.remoteRoot, remotePath); ok {
-		return virtualProviderLayoutMeta(s.remoteRoot, s.layoutManifest(provider)), nil
+		return virtualProviderLayoutMetaForFilename(s.remoteRoot, s.providerLayoutManifest(ctx, provider), path.Base(remotePath)), nil
 	}
 	if provider, resource, ok := isVirtualSchemaPath(s.remoteRoot, remotePath); ok {
 		if payload, present := loadResourceSchema(provider, resource); present {
@@ -437,7 +438,7 @@ func (s *fsState) readFile(ctx context.Context, remotePath string) (mountsync.Re
 		return readVirtualLayout(s.remoteRoot), nil
 	}
 	if provider, ok := isVirtualProviderLayoutPath(s.remoteRoot, remotePath); ok {
-		return readVirtualProviderLayout(s.remoteRoot, s.layoutManifest(provider)), nil
+		return readVirtualProviderLayoutForFilename(s.remoteRoot, s.providerLayoutManifest(ctx, provider), path.Base(remotePath)), nil
 	}
 	if provider, resource, ok := isVirtualSchemaPath(s.remoteRoot, remotePath); ok {
 		if payload, present := loadResourceSchema(provider, resource); present {

--- a/internal/mountfuse/fuse_test.go
+++ b/internal/mountfuse/fuse_test.go
@@ -1029,6 +1029,59 @@ func TestFuseAliasByStateEmptyDirectory(t *testing.T) {
 	}
 }
 
+func TestFuseAliasByEditedDateResolves(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"id":"page-123","last_edited_time":"2026-05-12T14:30:00Z"}`
+
+	remote := &fakeRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/":       {Path: "/", Entries: []mountsync.TreeEntry{{Path: "/notion", Type: "directory"}}},
+			"/notion": {Path: "/notion", Entries: []mountsync.TreeEntry{{Path: "/notion/pages", Type: "directory"}}},
+			"/notion/pages": {Path: "/notion/pages", Entries: []mountsync.TreeEntry{
+				{Path: "/notion/pages/" + aliasByEditedSegment, Type: "directory"},
+			}},
+			"/notion/pages/" + aliasByEditedSegment: {
+				Path: "/notion/pages/" + aliasByEditedSegment,
+				Entries: []mountsync.TreeEntry{
+					{Path: "/notion/pages/" + aliasByEditedSegment + "/2026-05-12", Type: "directory"},
+				},
+			},
+			"/notion/pages/" + aliasByEditedSegment + "/2026-05-12": {
+				Path: "/notion/pages/" + aliasByEditedSegment + "/2026-05-12",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/notion/pages/" + aliasByEditedSegment + "/2026-05-12/page-123__123.json", Type: "file", Revision: "r-page-123"},
+				},
+			},
+		},
+		files: map[string]mountsync.RemoteFile{
+			"/notion/pages/" + aliasByEditedSegment + "/2026-05-12/page-123__123.json": {
+				Path:        "/notion/pages/" + aliasByEditedSegment + "/2026-05-12/page-123__123.json",
+				Revision:    "r-page-123",
+				ContentType: "application/json",
+				Content:     body,
+			},
+		},
+	}
+
+	root := newMountTestRoot(t, remote, "ws_alias_by_edited")
+	notion := lookupDir(t, root, "notion")
+	pages := lookupDir(t, notion, "pages")
+	byEdited := lookupDir(t, pages, aliasByEditedSegment)
+	editedDate := lookupDir(t, byEdited, "2026-05-12")
+	if names := readdirNames(t, editedDate); !equalSorted(names, []string{"page-123__123.json"}) {
+		t.Fatalf("Readdir(by-edited date) = %v, want page alias", names)
+	}
+	fileNode, _ := lookupFile(t, editedDate, "page-123__123.json")
+	gotContent, gotContentType := readFileContent(t, fileNode)
+	if gotContent != body {
+		t.Fatalf("read page alias = %q, want %q", gotContent, body)
+	}
+	if gotContentType != "application/json" {
+		t.Fatalf("content type = %q, want application/json", gotContentType)
+	}
+}
+
 func TestByStateOutsideIssuesPathRoundTrips(t *testing.T) {
 	t.Parallel()
 
@@ -1097,6 +1150,7 @@ func TestProviderLayoutVisibleAndReadable(t *testing.T) {
 				ResourceDirectories: []string{"issues"},
 				AliasSegments: []string{
 					aliasByIDSegment,
+					aliasByEditedSegment,
 					aliasByNameSegment,
 					aliasByStateSegment,
 					aliasByTitleSegment,
@@ -1111,7 +1165,7 @@ func TestProviderLayoutVisibleAndReadable(t *testing.T) {
 	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
 
 	linear := lookupDir(t, root, "linear")
-	if names := readdirNames(t, linear); !equalSorted(names, []string{providerLayoutFilename, "issues"}) {
+	if names := readdirNames(t, linear); !equalSorted(names, []string{legacyProviderLayoutFilename, providerLayoutFilename, "issues"}) {
 		t.Fatalf("Readdir(/linear) = %v, want layout and issues", names)
 	}
 	layoutNode, entryOut := lookupFile(t, linear, providerLayoutFilename)
@@ -1125,6 +1179,7 @@ func TestProviderLayoutVisibleAndReadable(t *testing.T) {
 	for _, needle := range []string{
 		"linear layout",
 		"issues/",
+		aliasByEditedSegment,
 		aliasByIDSegment,
 		aliasByNameSegment,
 		aliasByStateSegment,
@@ -1133,6 +1188,84 @@ func TestProviderLayoutVisibleAndReadable(t *testing.T) {
 	} {
 		if !strings.Contains(body, needle) {
 			t.Fatalf("provider layout missing %q:\n%s", needle, body)
+		}
+	}
+
+	legacyLayoutNode, legacyEntryOut := lookupFile(t, linear, legacyProviderLayoutFilename)
+	if perm := legacyEntryOut.Attr.Mode & 0o777; perm != 0o444 {
+		t.Fatalf("legacy provider layout permissions = %o, want 0444", perm)
+	}
+	legacyBody, legacyContentType := readFileContent(t, legacyLayoutNode)
+	if legacyContentType != layoutContentType {
+		t.Fatalf("legacy provider layout content type = %q, want %q", legacyContentType, layoutContentType)
+	}
+	if legacyBody != body {
+		t.Fatalf("legacy provider layout content differed from canonical content")
+	}
+}
+
+func TestProviderLayoutDerivedFromRemoteTreeWithoutInjectedManifest(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {
+				Path: "/",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/linear", Type: "directory"},
+				},
+			},
+			"/linear": {
+				Path: "/linear",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/linear/issues", Type: "directory"},
+					{Path: "/linear/issues/AGE-16__issue-1.json", Type: "file", Revision: "r-issue"},
+					{Path: "/linear/issues/by-id", Type: "directory"},
+					{Path: "/linear/issues/by-id/AGE-16.json", Type: "file", Revision: "r-by-id"},
+					{Path: "/linear/issues/by-state", Type: "directory"},
+					{Path: "/linear/issues/by-state/open", Type: "directory"},
+					{Path: "/linear/issues/by-state/open/AGE-16__issue-1.json", Type: "file", Revision: "r-by-state"},
+				},
+			},
+		},
+	}
+	root, err := New(Config{
+		Client:      remote,
+		WorkspaceID: "ws_provider_layout_derived",
+		RemoteRoot:  "/",
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	linear := lookupDir(t, root, "linear")
+	if names := readdirNames(t, linear); !equalSorted(names, []string{legacyProviderLayoutFilename, providerLayoutFilename, "issues"}) {
+		t.Fatalf("Readdir(/linear) = %v, want layout and issues", names)
+	}
+
+	layoutNode, _ := lookupFile(t, linear, providerLayoutFilename)
+	body, contentType := readFileContent(t, layoutNode)
+	if contentType != layoutContentType {
+		t.Fatalf("provider layout content type = %q, want %q", contentType, layoutContentType)
+	}
+	for _, needle := range []string{
+		"linear layout",
+		"`issues/`",
+		"`" + aliasByIDSegment + "/`",
+		"`" + aliasByStateSegment + "/`",
+	} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("derived provider layout missing %q:\n%s", needle, body)
+		}
+	}
+	for _, forbidden := range []string{
+		"_No resource directories have been advertised yet._",
+		"_No alias indexes have been advertised yet._",
+		"`" + aliasByEditedSegment + "/`",
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("derived provider layout unexpectedly contained %q:\n%s", forbidden, body)
 		}
 	}
 }

--- a/internal/mountfuse/layout.go
+++ b/internal/mountfuse/layout.go
@@ -135,7 +135,7 @@ func providerLayoutMarkdown(manifest LayoutManifest) string {
 		b.WriteString("\n")
 	}
 	b.WriteString("## Filenames\n\n")
-	b.WriteString("Entity files use the `<identifier>__<uuid>.json` convention when a stable provider identifier is available. Recover the provider id from the last `__`-separated segment.\n\n")
+	b.WriteString("Entity files use the `<identifier>__<id>.json` convention when a stable provider identifier is available. Recover the provider id from the last `__`-separated segment.\n\n")
 	b.WriteString("## Alias indexes\n\n")
 	if len(manifest.AliasSegments) == 0 {
 		b.WriteString("_No alias indexes have been advertised yet._\n\n")
@@ -172,10 +172,6 @@ func providerLayoutMarkdown(manifest LayoutManifest) string {
 
 func providerLayoutRemotePath(remoteRoot, provider string) string {
 	return joinRemotePath(joinRemotePath(remoteRoot, provider), providerLayoutFilename)
-}
-
-func legacyProviderLayoutRemotePath(remoteRoot, provider string) string {
-	return joinRemotePath(joinRemotePath(remoteRoot, provider), legacyProviderLayoutFilename)
 }
 
 func isProviderLayoutFilename(filename string) bool {

--- a/internal/mountfuse/layout.go
+++ b/internal/mountfuse/layout.go
@@ -1,6 +1,7 @@
 package mountfuse
 
 import (
+	"context"
 	"path"
 	"sort"
 	"strings"
@@ -11,15 +12,23 @@ import (
 )
 
 const (
-	layoutFilename         = "LAYOUT.md"
-	layoutRevision         = "virtual-layout"
-	providerLayoutFilename = ".layout.md"
-	providerLayoutRevision = "virtual-provider-layout"
-	layoutContentType      = "text/markdown; charset=utf-8"
-	aliasByTitleSegment    = "by-title"
-	aliasByIDSegment       = "by-id"
-	aliasByNameSegment     = "by-name"
-	aliasByStateSegment    = "by-state"
+	layoutFilename = "LAYOUT.md"
+	layoutRevision = "virtual-layout"
+	// providerLayoutFilename is the canonical per-provider layout filename.
+	// PR39 Work Item A canonicalized on LAYOUT.md across runtime, fixtures,
+	// and the workspace-layout skill contract. The legacy ".layout.md"
+	// dotfile remains a virtual compatibility path for agents still following
+	// the pre-canonical provider layout contract.
+	providerLayoutFilename       = "LAYOUT.md"
+	legacyProviderLayoutFilename = ".layout.md"
+	providerLayoutRevision       = "virtual-provider-layout-v2"
+	layoutContentType            = "text/markdown; charset=utf-8"
+	aliasByTitleSegment          = "by-title"
+	aliasByIDSegment             = "by-id"
+	aliasByNameSegment           = "by-name"
+	aliasByStateSegment          = "by-state"
+	aliasByEditedSegment         = "by-edited"
+	providerLayoutDeriveDepth    = 4
 )
 
 type LayoutManifest struct {
@@ -56,6 +65,10 @@ Direct name aliases live under ` + "`linear/users/" + aliasByNameSegment + "/<na
 
 State-grouped views live under ` + "`linear/issues/" + aliasByStateSegment + "/<state>/<file>.json`" + ` and ` + "`github/repos/<owner>/<repo>/issues/" + aliasByStateSegment + "/<state>/<file>.json`" + ` when those integrations export them.
 
+## Find by edited date
+
+Edited-date views live under ` + "`notion/pages/" + aliasByEditedSegment + "/YYYY-MM-DD/<file>.json`" + ` and equivalent issue or page resources when those integrations export them. Use these date buckets for activity-summary fallback lookups instead of recursive search.
+
 ## Filenames
 
 Entity files use the ` + "`<sanitized-name>__<id>`" + ` filename convention. Recover the id from the last ` + "`__`" + `-separated segment.
@@ -66,7 +79,7 @@ GitHub repo subtrees are synced eagerly by default. For huge-org workspaces, opt
 
 ## Integration-specific layouts
 
-See per-integration ` + "`<integration>/.layout.md`" + ` files for integration-specific tree shapes.
+See per-integration ` + "`<integration>/LAYOUT.md`" + ` files for integration-specific tree shapes.
 `
 
 func layoutRemotePath(remoteRoot string) string {
@@ -122,7 +135,7 @@ func providerLayoutMarkdown(manifest LayoutManifest) string {
 		b.WriteString("\n")
 	}
 	b.WriteString("## Filenames\n\n")
-	b.WriteString("Entity files use the `<identifier>__<uuid>.json` convention when a stable provider identifier is available.\n\n")
+	b.WriteString("Entity files use the `<identifier>__<uuid>.json` convention when a stable provider identifier is available. Recover the provider id from the last `__`-separated segment.\n\n")
 	b.WriteString("## Alias indexes\n\n")
 	if len(manifest.AliasSegments) == 0 {
 		b.WriteString("_No alias indexes have been advertised yet._\n\n")
@@ -141,7 +154,9 @@ func providerLayoutMarkdown(manifest LayoutManifest) string {
 		for _, resource := range manifest.WritebackResources {
 			b.WriteString("- `")
 			b.WriteString(resource)
-			b.WriteString("/.schema.json`\n")
+			b.WriteString("/` (schema: `")
+			b.WriteString(resource)
+			b.WriteString("/.schema.json`)\n")
 		}
 		b.WriteString("\n")
 	}
@@ -159,9 +174,17 @@ func providerLayoutRemotePath(remoteRoot, provider string) string {
 	return joinRemotePath(joinRemotePath(remoteRoot, provider), providerLayoutFilename)
 }
 
+func legacyProviderLayoutRemotePath(remoteRoot, provider string) string {
+	return joinRemotePath(joinRemotePath(remoteRoot, provider), legacyProviderLayoutFilename)
+}
+
+func isProviderLayoutFilename(filename string) bool {
+	return filename == providerLayoutFilename || filename == legacyProviderLayoutFilename
+}
+
 func isVirtualProviderLayoutPath(remoteRoot, remotePath string) (string, bool) {
 	remotePath = normalizeRemotePath(remotePath)
-	if path.Base(remotePath) != providerLayoutFilename {
+	if !isProviderLayoutFilename(path.Base(remotePath)) {
 		return "", false
 	}
 	parentPath, _ := splitParent(remotePath)
@@ -169,11 +192,22 @@ func isVirtualProviderLayoutPath(remoteRoot, remotePath string) (string, bool) {
 }
 
 func virtualProviderLayoutMeta(remoteRoot string, manifest LayoutManifest) nodeMeta {
+	return virtualProviderLayoutMetaForFilename(remoteRoot, manifest, providerLayoutFilename)
+}
+
+func legacyVirtualProviderLayoutMeta(remoteRoot string, manifest LayoutManifest) nodeMeta {
+	return virtualProviderLayoutMetaForFilename(remoteRoot, manifest, legacyProviderLayoutFilename)
+}
+
+func virtualProviderLayoutMetaForFilename(remoteRoot string, manifest LayoutManifest, filename string) nodeMeta {
 	manifest = normalizeLayoutManifest(manifest)
+	if !isProviderLayoutFilename(filename) {
+		filename = providerLayoutFilename
+	}
 	content := providerLayoutMarkdown(manifest)
 	return nodeMeta{
-		path:        providerLayoutRemotePath(remoteRoot, manifest.Provider),
-		name:        providerLayoutFilename,
+		path:        joinRemotePath(joinRemotePath(remoteRoot, manifest.Provider), filename),
+		name:        filename,
 		mode:        syscall.S_IFREG | 0o444,
 		revision:    providerLayoutRevision,
 		size:        uint64(len(content)),
@@ -183,7 +217,15 @@ func virtualProviderLayoutMeta(remoteRoot string, manifest LayoutManifest) nodeM
 }
 
 func readVirtualProviderLayout(remoteRoot string, manifest LayoutManifest) mountsync.RemoteFile {
-	meta := virtualProviderLayoutMeta(remoteRoot, manifest)
+	return readVirtualProviderLayoutForFilename(remoteRoot, manifest, providerLayoutFilename)
+}
+
+func readLegacyVirtualProviderLayout(remoteRoot string, manifest LayoutManifest) mountsync.RemoteFile {
+	return readVirtualProviderLayoutForFilename(remoteRoot, manifest, legacyProviderLayoutFilename)
+}
+
+func readVirtualProviderLayoutForFilename(remoteRoot string, manifest LayoutManifest, filename string) mountsync.RemoteFile {
+	meta := virtualProviderLayoutMetaForFilename(remoteRoot, manifest, filename)
 	return mountsync.RemoteFile{
 		Path:        meta.path,
 		Revision:    meta.revision,
@@ -220,17 +262,128 @@ func normalizeLayoutManifest(manifest LayoutManifest) LayoutManifest {
 
 func (s *fsState) layoutManifest(provider string) LayoutManifest {
 	provider = strings.TrimSpace(provider)
-	if manifest, ok := s.manifests[provider]; ok {
+	if manifest, ok := s.configuredLayoutManifest(provider); ok {
 		return manifest
 	}
 	return LayoutManifest{
 		Provider: provider,
-		AliasSegments: []string{
-			aliasByIDSegment,
-			aliasByNameSegment,
-			aliasByStateSegment,
-			aliasByTitleSegment,
-		},
+	}
+}
+
+func (s *fsState) configuredLayoutManifest(provider string) (LayoutManifest, bool) {
+	provider = strings.TrimSpace(provider)
+	if provider == "" || len(s.manifests) == 0 {
+		return LayoutManifest{}, false
+	}
+	manifest, ok := s.manifests[provider]
+	return manifest, ok
+}
+
+func (s *fsState) providerLayoutManifest(ctx context.Context, provider string) LayoutManifest {
+	provider = strings.TrimSpace(provider)
+	if manifest, ok := s.configuredLayoutManifest(provider); ok {
+		return manifest
+	}
+	manifest, err := s.deriveProviderLayoutManifest(ctx, provider)
+	if err != nil {
+		s.logf("derive provider layout for %s: %v", provider, err)
+		return LayoutManifest{Provider: provider}
+	}
+	return manifest
+}
+
+func (s *fsState) deriveProviderLayoutManifest(ctx context.Context, provider string) (LayoutManifest, error) {
+	manifest := LayoutManifest{
+		Provider:            strings.TrimSpace(provider),
+		LazyMaterialization: s.lazyRepos != nil && strings.TrimSpace(provider) == "github",
+	}
+	if manifest.Provider == "" || s.client == nil {
+		return manifest, nil
+	}
+
+	resources := map[string]struct{}{}
+	aliases := map[string]struct{}{}
+	providerRoot := joinRemotePath(s.remoteRoot, manifest.Provider)
+	cursor := ""
+	for {
+		resp, err := s.client.ListTree(ctx, s.workspaceID, providerRoot, providerLayoutDeriveDepth, cursor)
+		if err != nil {
+			return manifest, err
+		}
+		for _, entry := range resp.Entries {
+			rel, ok := relativeToRemoteRoot(providerRoot, entry.Path)
+			if !ok || rel == "" {
+				continue
+			}
+			segments := providerLayoutPathSegments(rel)
+			if len(segments) == 0 {
+				continue
+			}
+			if providerLayoutResourceSegment(segments[0]) != "" && (len(segments) > 1 || isTreeDirectory(entry.Type)) {
+				resources[segments[0]] = struct{}{}
+			}
+			for _, segment := range segments[1:] {
+				if isProviderLayoutAliasSegment(segment) {
+					aliases[segment] = struct{}{}
+				}
+			}
+		}
+		if resp.NextCursor == nil || strings.TrimSpace(*resp.NextCursor) == "" {
+			break
+		}
+		cursor = strings.TrimSpace(*resp.NextCursor)
+	}
+
+	for resource := range resources {
+		manifest.ResourceDirectories = append(manifest.ResourceDirectories, resource)
+	}
+	for alias := range aliases {
+		manifest.AliasSegments = append(manifest.AliasSegments, alias)
+	}
+	return normalizeLayoutManifest(manifest), nil
+}
+
+func isTreeDirectory(entryType string) bool {
+	return strings.EqualFold(entryType, "directory") || strings.EqualFold(entryType, "dir")
+}
+
+func providerLayoutPathSegments(remotePath string) []string {
+	remotePath = strings.Trim(remotePath, "/")
+	if remotePath == "" {
+		return nil
+	}
+	return strings.Split(remotePath, "/")
+}
+
+func providerLayoutResourceSegment(segment string) string {
+	segment = strings.TrimSpace(segment)
+	switch {
+	case segment == "":
+		return ""
+	case isProviderLayoutAliasSegment(segment):
+		return ""
+	case isProviderLayoutReservedSegment(segment):
+		return ""
+	default:
+		return segment
+	}
+}
+
+func isProviderLayoutAliasSegment(segment string) bool {
+	switch strings.TrimSpace(segment) {
+	case aliasByTitleSegment, aliasByIDSegment, aliasByNameSegment, aliasByStateSegment, aliasByEditedSegment:
+		return true
+	default:
+		return false
+	}
+}
+
+func isProviderLayoutReservedSegment(segment string) bool {
+	switch strings.TrimSpace(segment) {
+	case "", ".relay", "digests", "_index.json", layoutFilename, legacyProviderLayoutFilename, ".relayfile-mount-state.json":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/mountfuse/layout_test.go
+++ b/internal/mountfuse/layout_test.go
@@ -162,8 +162,8 @@ func TestRootDirectorySynthesizesLayoutMarkdown(t *testing.T) {
 		gotNames = append(gotNames, entry.Name)
 	}
 	sort.Strings(gotNames)
-	if len(gotNames) != 1 || gotNames[0] != layoutFilename {
-		t.Fatalf("Readdir names = %v, want [%s]", gotNames, layoutFilename)
+	if len(gotNames) != 2 || gotNames[0] != skillsDirname || gotNames[1] != layoutFilename {
+		t.Fatalf("Readdir names = %v, want [%s %s]", gotNames, skillsDirname, layoutFilename)
 	}
 
 	var entryOut fuse.EntryOut
@@ -215,6 +215,73 @@ func TestRootDirectorySynthesizesLayoutMarkdown(t *testing.T) {
 	}
 	if len(remote.readFilePaths) != 0 {
 		t.Fatalf("expected virtual layout reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
+	}
+}
+
+func TestSkillsDirectorySynthesizesActivitySummary(t *testing.T) {
+	t.Parallel()
+
+	remote := &layoutRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/": {Path: "/", Entries: nil},
+		},
+	}
+	root, err := New(Config{Client: remote, WorkspaceID: "ws_activity_summary", RemoteRoot: "/"})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	_ = gofusefs.NewNodeFS(root, &gofusefs.Options{})
+
+	ctx := context.Background()
+	var skillsOut fuse.EntryOut
+	skillsNode, lookupErrno := root.Lookup(ctx, skillsDirname, &skillsOut)
+	if lookupErrno != 0 {
+		t.Fatalf("Lookup(%q) errno = %d, want 0", skillsDirname, lookupErrno)
+	}
+	if skillsOut.Attr.Mode&syscall.S_IFMT != syscall.S_IFDIR {
+		t.Fatalf("Lookup(%q) mode = %o, want directory", skillsDirname, skillsOut.Attr.Mode)
+	}
+	skillsDir, ok := skillsNode.Operations().(*DirNode)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned %T, want *DirNode", skillsDirname, skillsNode.Operations())
+	}
+	var activityOut fuse.EntryOut
+	activityNode, activityErrno := skillsDir.Lookup(ctx, activitySummaryFilename, &activityOut)
+	if activityErrno != 0 {
+		t.Fatalf("Lookup(%q) errno = %d, want 0", activitySummaryFilename, activityErrno)
+	}
+	if perm := activityOut.Attr.Mode & 0o777; perm != 0o444 {
+		t.Fatalf("activity summary permissions = %o, want 0444", perm)
+	}
+	fileNode, ok := activityNode.Operations().(*FileNode)
+	if !ok {
+		t.Fatalf("Lookup(%q) returned %T, want *FileNode", activitySummaryFilename, activityNode.Operations())
+	}
+	handle, _, openErrno := fileNode.Open(ctx, 0)
+	if openErrno != 0 {
+		t.Fatalf("Open(%q) errno = %d, want 0", activitySummaryFilename, openErrno)
+	}
+	fileHandle, ok := handle.(*FileHandle)
+	if !ok {
+		t.Fatalf("Open(%q) returned %T, want *FileHandle", activitySummaryFilename, handle)
+	}
+	result, readErrno := fileHandle.Read(ctx, make([]byte, len(ActivitySummarySkillMarkdown)+16), 0)
+	if readErrno != 0 {
+		t.Fatalf("Read(%q) errno = %d, want 0", activitySummaryFilename, readErrno)
+	}
+	data, status := result.Bytes(nil)
+	if status != 0 {
+		t.Fatalf("Read(%q) status = %d, want 0", activitySummaryFilename, status)
+	}
+	result.Done()
+	body := string(data)
+	for _, needle := range []string{"activity-summary", "digests/yesterday.md", "_index.json", "LAYOUT.md"} {
+		if !strings.Contains(body, needle) {
+			t.Fatalf("activity summary missing %q:\n%s", needle, body)
+		}
+	}
+	if len(remote.readFilePaths) != 0 {
+		t.Fatalf("expected virtual activity-summary reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
 	}
 }
 

--- a/internal/mountfuse/layout_test.go
+++ b/internal/mountfuse/layout_test.go
@@ -2,6 +2,8 @@ package mountfuse
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"syscall"
@@ -57,16 +59,18 @@ func TestLayoutMarkdownContainsRequiredAnchors(t *testing.T) {
 		"find by title",
 		"by-title",
 		"by-id",
+		"by-edited",
 		"by-name",
 		"by-state",
 		"LazyMaterialize",
 		"github/repos/<owner>/<repo>",
 		"notion/pages/by-title/",
 		"linear/issues/by-id/",
+		"notion/pages/by-edited/YYYY-MM-DD/",
 		"linear/users/by-name/",
 		"github/repos/by-name/",
 		"__",
-		"<integration>/.layout.md",
+		"<integration>/LAYOUT.md",
 	}
 	for _, needle := range required {
 		if !strings.Contains(LayoutMarkdown, needle) {
@@ -81,7 +85,7 @@ func TestProviderLayoutMarkdownDeterministic(t *testing.T) {
 	manifest := LayoutManifest{
 		Provider:            "linear",
 		ResourceDirectories: []string{"projects", "issues", "issues"},
-		AliasSegments:       []string{aliasByStateSegment, aliasByIDSegment, aliasByIDSegment},
+		AliasSegments:       []string{aliasByStateSegment, aliasByEditedSegment, aliasByIDSegment, aliasByIDSegment},
 		WritebackResources:  []string{"state-transitions", "comments"},
 	}
 
@@ -94,15 +98,114 @@ func TestProviderLayoutMarkdownDeterministic(t *testing.T) {
 		"linear layout",
 		"issues/",
 		"projects/",
+		aliasByEditedSegment,
 		aliasByIDSegment,
 		aliasByStateSegment,
-		"comments/.schema.json",
-		"state-transitions/.schema.json",
+		"`comments/` (schema: `comments/.schema.json`)",
+		"`state-transitions/` (schema: `state-transitions/.schema.json`)",
+		"Recover the provider id from the last `__`-separated segment.",
 		"wb-<timestamp>.json",
 	} {
 		if !strings.Contains(first, needle) {
 			t.Fatalf("provider layout missing %q:\n%s", needle, first)
 		}
+	}
+	assertOrdered(t, first, "`issues/`", "`projects/`")
+	assertOrdered(t, first, "`by-id/`", "`by-state/`")
+	assertOrdered(t, first, "`comments/` (schema: `comments/.schema.json`)", "`state-transitions/` (schema: `state-transitions/.schema.json`)")
+}
+
+func TestProviderLayoutMarkdownMaterializationMode(t *testing.T) {
+	t.Parallel()
+
+	eager := providerLayoutMarkdown(LayoutManifest{Provider: "notion"})
+	if !strings.Contains(eager, "expected to expose its advertised tree eagerly") {
+		t.Fatalf("eager provider layout missing materialization copy:\n%s", eager)
+	}
+
+	lazy := providerLayoutMarkdown(LayoutManifest{Provider: "github", LazyMaterialization: true})
+	if !strings.Contains(lazy, "may materialize large subtrees lazily on first access") {
+		t.Fatalf("lazy provider layout missing materialization copy:\n%s", lazy)
+	}
+}
+
+func TestDefaultProviderLayoutManifestDoesNotAdvertiseByEdited(t *testing.T) {
+	t.Parallel()
+
+	state := &fsState{}
+	markdown := providerLayoutMarkdown(state.layoutManifest("linear"))
+	if strings.Contains(markdown, "`"+aliasByEditedSegment+"/`") {
+		t.Fatalf("fallback provider layout advertised by-edited:\n%s", markdown)
+	}
+	if !strings.Contains(markdown, "_No alias indexes have been advertised yet._") {
+		t.Fatalf("fallback provider layout should not advertise unknown aliases:\n%s", markdown)
+	}
+}
+
+func TestProviderLayoutMetaUsesV2Revision(t *testing.T) {
+	t.Parallel()
+
+	meta := virtualProviderLayoutMeta("/", LayoutManifest{Provider: "linear"})
+	if meta.revision != providerLayoutRevision {
+		t.Fatalf("provider layout revision = %q, want %q", meta.revision, providerLayoutRevision)
+	}
+	if providerLayoutRevision != "virtual-provider-layout-v2" {
+		t.Fatalf("provider layout revision constant = %q, want virtual-provider-layout-v2", providerLayoutRevision)
+	}
+}
+
+func TestProviderLayoutCanonicalAndLegacyPathsHaveSameVirtualContent(t *testing.T) {
+	t.Parallel()
+
+	manifest := LayoutManifest{
+		Provider:            "linear",
+		ResourceDirectories: []string{"issues"},
+		AliasSegments:       []string{aliasByIDSegment},
+	}
+
+	canonicalMeta := virtualProviderLayoutMeta("/", manifest)
+	legacyMeta := legacyVirtualProviderLayoutMeta("/", manifest)
+	if canonicalMeta.path != "/linear/LAYOUT.md" {
+		t.Fatalf("canonical provider layout path = %q, want /linear/LAYOUT.md", canonicalMeta.path)
+	}
+	if legacyMeta.path != "/linear/.layout.md" {
+		t.Fatalf("legacy provider layout path = %q, want /linear/.layout.md", legacyMeta.path)
+	}
+	for name, meta := range map[string]nodeMeta{
+		providerLayoutFilename:       canonicalMeta,
+		legacyProviderLayoutFilename: legacyMeta,
+	} {
+		if perm := meta.mode & 0o777; perm != 0o444 {
+			t.Fatalf("%s permissions = %o, want 0444", name, perm)
+		}
+		if meta.contentType != layoutContentType {
+			t.Fatalf("%s content type = %q, want %q", name, meta.contentType, layoutContentType)
+		}
+	}
+
+	canonicalFile := readVirtualProviderLayout("/", manifest)
+	legacyFile := readLegacyVirtualProviderLayout("/", manifest)
+	if canonicalFile.Content != legacyFile.Content {
+		t.Fatalf("legacy provider layout content differed from canonical content")
+	}
+	if canonicalFile.ContentType != layoutContentType || legacyFile.ContentType != layoutContentType {
+		t.Fatalf("provider layout content types = %q/%q, want %q", canonicalFile.ContentType, legacyFile.ContentType, layoutContentType)
+	}
+}
+
+func assertOrdered(t *testing.T, haystack string, first string, second string) {
+	t.Helper()
+
+	firstIndex := strings.Index(haystack, first)
+	if firstIndex < 0 {
+		t.Fatalf("missing ordered token %q:\n%s", first, haystack)
+	}
+	secondIndex := strings.Index(haystack, second)
+	if secondIndex < 0 {
+		t.Fatalf("missing ordered token %q:\n%s", second, haystack)
+	}
+	if firstIndex >= secondIndex {
+		t.Fatalf("expected %q before %q:\n%s", first, second, haystack)
 	}
 }
 
@@ -116,11 +219,14 @@ func TestIsVirtualProviderLayoutPath(t *testing.T) {
 		want       string
 		wantOK     bool
 	}{
-		{name: "root provider", remoteRoot: "/", remotePath: "/linear/.layout.md", want: "linear", wantOK: true},
-		{name: "prefixed root", remoteRoot: "/external", remotePath: "/external/github/.layout.md", want: "github", wantOK: true},
+		{name: "root provider", remoteRoot: "/", remotePath: "/linear/LAYOUT.md", want: "linear", wantOK: true},
+		{name: "root provider legacy", remoteRoot: "/", remotePath: "/linear/.layout.md", want: "linear", wantOK: true},
+		{name: "prefixed root", remoteRoot: "/external", remotePath: "/external/github/LAYOUT.md", want: "github", wantOK: true},
+		{name: "prefixed root legacy", remoteRoot: "/external", remotePath: "/external/github/.layout.md", want: "github", wantOK: true},
 		{name: "root layout", remoteRoot: "/", remotePath: "/LAYOUT.md", wantOK: false},
-		{name: "nested layout", remoteRoot: "/", remotePath: "/github/repos/.layout.md", wantOK: false},
-		{name: "outside root", remoteRoot: "/external", remotePath: "/github/.layout.md", wantOK: false},
+		{name: "nested layout", remoteRoot: "/", remotePath: "/github/repos/LAYOUT.md", wantOK: false},
+		{name: "nested legacy layout", remoteRoot: "/", remotePath: "/github/repos/.layout.md", wantOK: false},
+		{name: "outside root", remoteRoot: "/external", remotePath: "/github/LAYOUT.md", wantOK: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -336,5 +442,163 @@ func TestVirtualLayoutWinsOverRemoteCollision(t *testing.T) {
 	}
 	if len(remote.readFilePaths) != 0 {
 		t.Fatalf("expected collision reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
+	}
+}
+
+func TestVirtualProviderLayoutsWinOverRemoteCollisions(t *testing.T) {
+	t.Parallel()
+
+	remote := &layoutRemoteClient{
+		trees: map[string]mountsync.TreeResponse{
+			"/linear": {
+				Path: "/linear",
+				Entries: []mountsync.TreeEntry{
+					{Path: "/linear/LAYOUT.md", Type: "file", Revision: "remote-canonical"},
+					{Path: "/linear/.layout.md", Type: "file", Revision: "remote-legacy"},
+				},
+			},
+		},
+	}
+	root, err := New(Config{
+		Client:      remote,
+		WorkspaceID: "ws_provider_layout_collision",
+		RemoteRoot:  "/",
+		LayoutManifests: map[string]LayoutManifest{
+			"linear": {
+				Provider:            "linear",
+				ResourceDirectories: []string{"issues"},
+				AliasSegments:       []string{aliasByIDSegment},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	ctx := context.Background()
+	entries, err := root.state.listDirectory(ctx, "/linear")
+	if err != nil {
+		t.Fatalf("listDirectory(/linear) failed: %v", err)
+	}
+	wantContent := providerLayoutMarkdown(root.state.layoutManifest("linear"))
+	for _, filename := range []string{providerLayoutFilename, legacyProviderLayoutFilename} {
+		meta, ok := entries[filename]
+		if !ok {
+			t.Fatalf("provider layout entry %q missing from /linear entries: %#v", filename, entries)
+		}
+		if perm := meta.mode & 0o777; perm != 0o444 {
+			t.Fatalf("%s permissions = %o, want 0444", filename, perm)
+		}
+		if meta.contentType != layoutContentType {
+			t.Fatalf("%s content type = %q, want %q", filename, meta.contentType, layoutContentType)
+		}
+
+		file, err := root.state.readFile(ctx, joinRemotePath("/linear", filename))
+		if err != nil {
+			t.Fatalf("readFile(%s) failed: %v", filename, err)
+		}
+		if file.Content != wantContent {
+			t.Fatalf("%s collision read returned remote content instead of virtual layout", filename)
+		}
+	}
+	if len(remote.readFilePaths) != 0 {
+		t.Fatalf("expected provider layout collision reads to avoid RemoteClient.ReadFile, got %v", remote.readFilePaths)
+	}
+}
+
+// TestProviderLayoutFilenames pins the canonical provider layout filename and
+// the legacy virtual compatibility path required by the update-layout slice.
+func TestProviderLayoutFilenames(t *testing.T) {
+	t.Parallel()
+
+	if providerLayoutFilename != "LAYOUT.md" {
+		t.Fatalf("providerLayoutFilename = %q, want %q", providerLayoutFilename, "LAYOUT.md")
+	}
+	if legacyProviderLayoutFilename != ".layout.md" {
+		t.Fatalf("legacyProviderLayoutFilename = %q, want %q", legacyProviderLayoutFilename, ".layout.md")
+	}
+	if layoutFilename != providerLayoutFilename {
+		t.Fatalf("layoutFilename = %q, providerLayoutFilename = %q; canonical name must be shared", layoutFilename, providerLayoutFilename)
+	}
+	if strings.Contains(LayoutMarkdown, ".layout.md") {
+		t.Fatalf("root LayoutMarkdown still references legacy .layout.md:\n%s", LayoutMarkdown)
+	}
+}
+
+// TestProviderFixtureParity asserts the canonical mount-verify/<provider>/
+// LAYOUT.md fixtures (the cross-provider reference text shipped in the repo)
+// stay in sync with the layout-runtime constants and the workspace-layout
+// skill contract: canonical filename, canonical alias names, filename
+// convention, and writeback-discovery surface. Byte-for-byte parity with the
+// generated provider layout is not asserted because the fixtures carry
+// hand-written prose richer than the manifest-driven render.
+func TestProviderFixtureParity(t *testing.T) {
+	t.Parallel()
+
+	// Lead plan §"Code Changes": Work Item C in-scope providers must mention
+	// a concrete by-edited alias path. Slack and Confluence are not in this
+	// scope for the GitHub-style placeholder rule (Slack: no edited-date
+	// concept; Confluence: spelled out separately if the fixture exists).
+	workItemCProviders := map[string]bool{
+		"notion":     true,
+		"linear":     true,
+		"github":     true,
+		"jira":       true,
+		"confluence": true,
+	}
+
+	providers := []string{"notion", "linear", "github", "jira", "confluence", "slack"}
+	for _, provider := range providers {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+
+			// Resolve mount-verify/<provider>/LAYOUT.md relative to the
+			// package directory. internal/mountfuse → repo root is ../..
+			fixturePath := filepath.Join("..", "..", "mount-verify", provider, "LAYOUT.md")
+			body, err := os.ReadFile(fixturePath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					t.Skipf("fixture %s not present in this checkout", fixturePath)
+				}
+				t.Fatalf("read fixture %s: %v", fixturePath, err)
+			}
+			text := string(body)
+
+			required := []string{
+				"LAYOUT.md",      // canonical filename advertised in lede
+				"read-only",      // virtual/read-only declaration
+				"__",             // __<id> filename convention
+				"`.schema.json`", // writeback discovery surface
+			}
+			for _, needle := range required {
+				if !strings.Contains(text, needle) {
+					t.Fatalf("%s missing required anchor %q", fixturePath, needle)
+				}
+			}
+
+			// Regression guard for F3 (Linear by-updated → by-edited):
+			// no provider fixture may advertise `by-updated/` as the
+			// canonical edited-date alias. Linear and others must use
+			// `by-edited/`.
+			if strings.Contains(text, "by-updated/") {
+				t.Fatalf("%s advertises non-canonical `by-updated/`; canonical alias is `by-edited/`", fixturePath)
+			}
+
+			// Regression guard for F5: the fixture must NOT point agents at
+			// the retired `.layout.md` dotfile.
+			if strings.Contains(text, ".layout.md") {
+				t.Fatalf("%s references legacy `.layout.md`; canonical is `LAYOUT.md`", fixturePath)
+			}
+
+			// F4: in-scope providers must materialize a concrete
+			// by-edited placeholder path (Linear, Notion already do;
+			// GitHub adds it as a future-Work-Item-C placeholder).
+			if workItemCProviders[provider] {
+				if !strings.Contains(text, "by-edited") {
+					t.Fatalf("%s missing required `by-edited` alias mention (Work Item C scope)", fixturePath)
+				}
+			}
+		})
 	}
 }

--- a/internal/mountfuse/schema.go
+++ b/internal/mountfuse/schema.go
@@ -21,6 +21,9 @@ var bundledResourceSchemas = map[string]string{
 }
 
 func isReadOnlyVirtualPath(remoteRoot, remotePath string) bool {
+	if isVirtualActivitySummaryPath(remoteRoot, remotePath) {
+		return true
+	}
 	if isVirtualLayoutPath(remoteRoot, remotePath) {
 		return true
 	}

--- a/internal/mountfuse/skills.go
+++ b/internal/mountfuse/skills.go
@@ -1,0 +1,82 @@
+package mountfuse
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/mountsync"
+)
+
+const (
+	skillsDirname                = ".skills"
+	activitySummaryFilename      = "activity-summary.md"
+	activitySummaryRevision      = "virtual-activity-summary"
+	activitySummaryContentType   = "text/markdown; charset=utf-8"
+	ActivitySummarySkillMarkdown = `# activity-summary
+
+Start activity questions from the digest surface before walking provider trees.
+
+- Read ` + "`digests/yesterday.md`" + ` for yesterday, ` + "`digests/today.md`" + ` for today, or ` + "`digests/YYYY-MM-DD.md`" + ` for a specific UTC date.
+- If a digest is missing or stale, run ` + "`relayfile digest rebuild --window yesterday`" + `, ` + "`--window today`" + `, ` + "`--window YYYY-MM-DD`" + `, ` + "`--window this-week`" + `, or ` + "`--window last-week`" + `.
+- Use provider ` + "`_index.json`" + ` files for date filtering and only open individual entity files after the index has narrowed the set.
+- Read ` + "`LAYOUT.md`" + ` and provider ` + "`<integration>/.layout.md`" + ` files when you need path conventions or alias views.
+`
+)
+
+func skillsRemotePath(remoteRoot string) string {
+	return joinRemotePath(remoteRoot, skillsDirname)
+}
+
+func activitySummaryRemotePath(remoteRoot string) string {
+	return joinRemotePath(skillsRemotePath(remoteRoot), activitySummaryFilename)
+}
+
+func isVirtualSkillsDirPath(remoteRoot, remotePath string) bool {
+	return normalizeRemotePath(remotePath) == skillsRemotePath(remoteRoot)
+}
+
+func isVirtualActivitySummaryPath(remoteRoot, remotePath string) bool {
+	return normalizeRemotePath(remotePath) == activitySummaryRemotePath(remoteRoot)
+}
+
+func virtualSkillsDirMeta(remoteRoot string) nodeMeta {
+	return nodeMeta{
+		path:    skillsRemotePath(remoteRoot),
+		name:    skillsDirname,
+		mode:    syscall.S_IFDIR | 0o555,
+		modTime: time.Unix(0, 0).UTC(),
+	}
+}
+
+func virtualActivitySummaryMeta(remoteRoot string) nodeMeta {
+	return nodeMeta{
+		path:        activitySummaryRemotePath(remoteRoot),
+		name:        activitySummaryFilename,
+		mode:        syscall.S_IFREG | 0o444,
+		revision:    activitySummaryRevision,
+		size:        uint64(len(ActivitySummarySkillMarkdown)),
+		modTime:     time.Unix(0, 0).UTC(),
+		contentType: activitySummaryContentType,
+	}
+}
+
+func readVirtualActivitySummary(remoteRoot string) mountsync.RemoteFile {
+	meta := virtualActivitySummaryMeta(remoteRoot)
+	return mountsync.RemoteFile{
+		Path:        meta.path,
+		Revision:    meta.revision,
+		ContentType: meta.contentType,
+		Content:     ActivitySummarySkillMarkdown,
+	}
+}
+
+func virtualSkillsDirectory(remoteRoot string) map[string]nodeMeta {
+	return map[string]nodeMeta{
+		activitySummaryFilename: virtualActivitySummaryMeta(remoteRoot),
+	}
+}
+
+func virtualRootDirectoryEntries(remoteRoot string, entries map[string]nodeMeta) {
+	entries[layoutFilename] = virtualLayoutMeta(remoteRoot)
+	entries[skillsDirname] = virtualSkillsDirMeta(remoteRoot)
+}

--- a/internal/mountsync/digest_filter_test.go
+++ b/internal/mountsync/digest_filter_test.go
@@ -1,0 +1,92 @@
+package mountsync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/digest"
+)
+
+// TestDigestPathFilterIsSingleSourced pins the contract that the mountsync
+// package treats `digest.IsDigestPath` as the canonical guard for skipping
+// digest source-events. The integration rule
+// `.claude/rules/relayfile-integration-digests.md` requires the digest
+// scheduler to ignore `/digests/*` events so digest writes do not recurse.
+// Today, relayfile mountsync does not run a digest scheduler (cloud does);
+// this test pins the helper's behavior at the mountsync test surface so
+// when the local scheduler lands, it gates on this single source of truth
+// rather than re-implementing prefix/suffix checks.
+func TestDigestPathFilterIsSingleSourced(t *testing.T) {
+	digestPaths := []string{
+		"digests/today.md",
+		"/digests/today.md",
+		"digests/yesterday.md",
+		"/digests/yesterday.md",
+		"digests/2026-05-12.md",
+		"/digests/2026-05-12.md",
+	}
+	for _, p := range digestPaths {
+		if !digest.IsDigestPath(p) {
+			t.Fatalf("digest.IsDigestPath(%q) = false, want true (mountsync source-event filter must skip this)", p)
+		}
+	}
+	nonDigestPaths := []string{
+		"github/repos/foo/issues/by-id/1.json",
+		"notion/pages/by-edited/2026-05-12/page.json",
+		".relay/dead-letter/payload.json",
+		"digests/2026-02-30.md",   // invalid date stem
+		"digests/2026-05-12.json", // wrong extension
+		"notion/pages/2026-05-12.md",
+	}
+	for _, p := range nonDigestPaths {
+		if digest.IsDigestPath(p) {
+			t.Fatalf("digest.IsDigestPath(%q) = true, want false (mountsync must NOT treat as a digest path)", p)
+		}
+	}
+}
+
+// TestTodayWriteDoesNotRecurse pins the anti-recursion invariant for
+// /digests/today.md as a synthetic file event: any future digest scheduler
+// in mountsync that consumes filesystem events MUST exclude paths matched by
+// digest.IsDigestPath before scheduling another render. The test asserts
+// the gating helper rejects today.md (and its date-stamped sibling) so the
+// scheduler can be wired with confidence that recursion is impossible at
+// the source-event boundary.
+func TestTodayWriteDoesNotRecurse(t *testing.T) {
+	for _, p := range []string{"digests/today.md", "digests/yesterday.md", "digests/2026-05-15.md"} {
+		if !digest.IsDigestPath(p) {
+			t.Fatalf("anti-recursion gate broken: %q must match digest.IsDigestPath so the scheduler skips it", p)
+		}
+	}
+}
+
+func TestDigestPathsExcludedFromSourcesButEmitNormalEvents(t *testing.T) {
+	root := t.TempDir()
+	events, _, _ := startFileWatcher(t, root)
+
+	for _, rel := range []string{
+		"digests/today.md",
+		"digests/2026-05-12.md",
+		"digests/this-week.md",
+		"digests/last-week.md",
+	} {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(root, filepath.FromSlash(rel))), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(rel)), []byte("# digest\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		ev, ok := waitForWatcherEventPath(t, events, rel, 2*time.Second)
+		if !ok {
+			t.Fatalf("no normal watcher event for %s", rel)
+		}
+		if ev.path != rel {
+			t.Fatalf("watcher normalized path = %q, want %q", ev.path, rel)
+		}
+		if !digest.IsDigestPath(ev.path) {
+			t.Fatalf("%s emitted a normal event but would not be excluded from digest sources", ev.path)
+		}
+	}
+}

--- a/internal/mountsync/digest_writer_test.go
+++ b/internal/mountsync/digest_writer_test.go
@@ -1,0 +1,132 @@
+package mountsync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"github.com/agentworkforce/relayfile/internal/digest"
+)
+
+// TestYesterdayCloseEmitsFSEventNoRecursion exercises gate E for the
+// yesterday slice: invoking the close-write path through digest.CloseLocalDay
+// while a FileWatcher is running must:
+//
+//  1. emit a Modify/Create filesystem event for digests/yesterday.md so
+//     mounted observers see the rotation, and
+//  2. classify that path as a digest artifact via digest.IsDigestPath, so
+//     the regen pipeline drops it instead of looping on its own output.
+func TestYesterdayCloseEmitsFSEventNoRecursion(t *testing.T) {
+	root := t.TempDir()
+	events, _, _ := startFileWatcher(t, root)
+
+	events_in := []digest.ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC),
+			Identifier:    "PR-1",
+			Verb:          "merged",
+			CanonicalPath: "github/repos/x/pulls/by-id/1.json",
+		},
+	}
+	now := time.Date(2026, 5, 13, 0, 5, 0, 0, time.UTC)
+
+	res, err := digest.CloseLocalDay(context.Background(), root, digest.SliceSource{Items: events_in},
+		now, []string{"github"}, time.UTC)
+	if err != nil {
+		t.Fatalf("CloseLocalDay: %v", err)
+	}
+	if !res.Written {
+		t.Fatal("CloseLocalDay reported not written; expected a fresh yesterday.md")
+	}
+
+	ev, ok := waitForWatcherEventPath(t, events, "digests/yesterday.md", 2*time.Second)
+	if !ok {
+		t.Fatal("no watcher event for digests/yesterday.md after close write")
+	}
+	if ev.op&fsnotify.Create == 0 && ev.op&fsnotify.Write == 0 {
+		t.Fatalf("expected create or write op, got %s", ev.op)
+	}
+
+	if !digest.IsDigestPath("digests/yesterday.md") {
+		t.Fatal("digest.IsDigestPath(\"digests/yesterday.md\") = false; recursion guard would not drop the close write")
+	}
+}
+
+// TestYesterdayCloseImmutable exercises gate B: after the close write
+// completes for a given local day, a subsequent ingest event for a later
+// day MUST leave yesterday.md byte-equal. The proof is SHA-256 before /
+// after the spurious ingest, with the marker mechanism in
+// digest.WriteYesterday short-circuiting the rewrite.
+func TestYesterdayCloseImmutable(t *testing.T) {
+	root := t.TempDir()
+	closedDay := time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC)
+	generatedAt := time.Date(2026, 5, 13, 0, 5, 0, 0, time.UTC)
+
+	closedEvents := []digest.ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC),
+			Identifier:    "PR-1",
+			Verb:          "merged",
+			CanonicalPath: "github/repos/x/pulls/by-id/1.json",
+		},
+	}
+
+	first, err := digest.CloseLocalDayFor(context.Background(), root, digest.SliceSource{Items: closedEvents},
+		closedDay, generatedAt, []string{"github"}, time.UTC)
+	if err != nil {
+		t.Fatalf("CloseLocalDayFor first: %v", err)
+	}
+	if !first.Written {
+		t.Fatal("first CloseLocalDayFor did not report Written=true")
+	}
+
+	yesterdayPath := filepath.Join(root, "digests", "yesterday.md")
+	beforeBytes, err := os.ReadFile(yesterdayPath)
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+	beforeSum := sha256.Sum256(beforeBytes)
+	beforeHex := hex.EncodeToString(beforeSum[:])
+
+	// Now a later-day event arrives. A naive re-run with the same closed
+	// day window and the *new* event set must not mutate yesterday.md.
+	laterEvents := append([]digest.ChangeEvent(nil), closedEvents...)
+	laterEvents = append(laterEvents, digest.ChangeEvent{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 15, 0, 0, 0, time.UTC),
+		Identifier:    "PR-2",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/x/pulls/by-id/2.json",
+	})
+
+	second, err := digest.CloseLocalDayFor(context.Background(), root, digest.SliceSource{Items: laterEvents},
+		closedDay, generatedAt.Add(time.Hour), []string{"github"}, time.UTC)
+	if err != nil {
+		t.Fatalf("CloseLocalDayFor second: %v", err)
+	}
+	if second.Written {
+		t.Fatal("second close mutated yesterday.md (Written=true) — marker did not gate it")
+	}
+	if !second.Skipped {
+		t.Fatal("second close should report Skipped=true after marker short-circuit")
+	}
+
+	afterBytes, err := os.ReadFile(yesterdayPath)
+	if err != nil {
+		t.Fatalf("re-read yesterday.md: %v", err)
+	}
+	afterSum := sha256.Sum256(afterBytes)
+	afterHex := hex.EncodeToString(afterSum[:])
+
+	if beforeHex != afterHex {
+		t.Fatalf("yesterday.md SHA-256 changed after spurious ingest: before=%s after=%s", beforeHex, afterHex)
+	}
+}

--- a/internal/mountsync/scheduler.go
+++ b/internal/mountsync/scheduler.go
@@ -1,0 +1,165 @@
+package mountsync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/digest"
+)
+
+// CloseScheduler drives workspace-local closing-window writes for
+// `digests/yesterday.md`, `digests/<YYYY-MM-DD>.md`, and weekly rollups.
+// The implementation is intentionally tick-based:
+// the caller (the mount sync loop) decides how often Tick fires; the
+// scheduler computes which local days have closed since the last successful
+// write by consulting the per-workspace marker file written by
+// `digest.WriteYesterday`. This keeps the scheduler restart-tolerant and
+// avoids introducing a long-lived background goroutine that the rest of the
+// daemon would have to coordinate with.
+//
+// Tick is idempotent: if the marker already records the most recently
+// closed local day, Tick is a no-op and returns nil. If the marker is N
+// days behind (e.g. after an offline gap), Tick closes each missing day in
+// chronological order so the date-stamped archives sibling slice has a
+// stable ordering to walk later.
+type CloseScheduler struct {
+	MountRoot string
+	TZ        *time.Location
+	Providers []string
+	Source    digest.ChangeEventSource
+	// Now lets tests inject a deterministic clock. Defaults to time.Now.
+	Now func() time.Time
+}
+
+// RollingDigestCoalescer batches noisy provider changes before rewriting
+// rolling digest artifacts such as today.md and this-week.md.
+type RollingDigestCoalescer struct {
+	Interval time.Duration
+	Now      func() time.Time
+
+	pending bool
+	dueAt   time.Time
+}
+
+func (c *RollingDigestCoalescer) ObserveChange(path string) bool {
+	if digest.IsDigestPath(path) {
+		return false
+	}
+	now := time.Now()
+	if c.Now != nil {
+		now = c.Now()
+	}
+	interval := c.Interval
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	c.pending = true
+	c.dueAt = now.Add(interval)
+	return true
+}
+
+func (c *RollingDigestCoalescer) Due() bool {
+	if !c.pending {
+		return false
+	}
+	now := time.Now()
+	if c.Now != nil {
+		now = c.Now()
+	}
+	return !now.Before(c.dueAt)
+}
+
+func (c *RollingDigestCoalescer) MarkFlushed() {
+	c.pending = false
+	c.dueAt = time.Time{}
+}
+
+// Tick runs the close pipeline for every local day that has closed since
+// the marker was last written. Returns the list of closed-day date strings
+// (YYYY-MM-DD) in chronological order, useful for logging and trail
+// breadcrumbs.
+func (s *CloseScheduler) Tick(ctx context.Context) ([]string, error) {
+	if strings.TrimSpace(s.MountRoot) == "" {
+		return nil, errors.New("mountsync: scheduler mount root is required")
+	}
+	if s.Source == nil {
+		return nil, errors.New("mountsync: scheduler change-event source is required")
+	}
+	tz := s.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	clock := s.Now
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+
+	// The latest day that has *fully* closed is the calendar day before
+	// `now` in the workspace TZ. If `now` itself is still that day's
+	// midnight (00:00), the local day has just closed and we proceed.
+	targetClosed := localDateOnly(now.In(tz).AddDate(0, 0, -1), tz)
+
+	lastClosed := s.readMarker()
+	startDay := targetClosed
+	if !lastClosed.IsZero() {
+		// Resume one local day past the last successful close.
+		startDay = localDateOnly(lastClosed.AddDate(0, 0, 1), tz)
+	}
+	if startDay.After(targetClosed) {
+		return nil, nil
+	}
+
+	var closed []string
+	for day := startDay; !day.After(targetClosed); day = day.AddDate(0, 0, 1) {
+		generatedAt := now
+		// For catch-up days, anchor `generated_at` to the day boundary so
+		// the produced report is deterministic regardless of how late the
+		// daemon noticed the gap.
+		if !day.Equal(targetClosed) {
+			generatedAt = day.AddDate(0, 0, 1) // midnight of the day after the closed one
+		}
+		boundary := day.AddDate(0, 0, 1)
+		if _, err := digest.MaybeCloseDateStampedWindow(ctx, boundary, day, tz, s.MountRoot, s.Source, s.Providers, generatedAt); err != nil {
+			return closed, err
+		}
+		if _, err := digest.MaybeCloseLastWeekWindow(ctx, boundary, day, tz, s.MountRoot, s.Source, s.Providers, generatedAt); err != nil {
+			return closed, err
+		}
+		res, err := digest.CloseLocalDayFor(ctx, s.MountRoot, s.Source, day, generatedAt, s.Providers, tz)
+		if err != nil {
+			return closed, err
+		}
+		_ = res
+		closed = append(closed, day.Format("2006-01-02"))
+	}
+	return closed, nil
+}
+
+// localDateOnly returns t truncated to midnight in tz.
+func localDateOnly(t time.Time, tz *time.Location) time.Time {
+	t = t.In(tz)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, tz)
+}
+
+func (s *CloseScheduler) readMarker() time.Time {
+	localPath := filepath.Join(filepath.Clean(s.MountRoot), filepath.FromSlash(digest.YesterdayMarkerPath))
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return time.Time{}
+	}
+	stamp := strings.TrimSpace(string(data))
+	tz := s.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	parsed, err := time.ParseInLocation("2006-01-02", stamp, tz)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}

--- a/internal/mountsync/scheduler.go
+++ b/internal/mountsync/scheduler.go
@@ -37,28 +37,64 @@ type CloseScheduler struct {
 
 // RollingDigestCoalescer batches noisy provider changes before rewriting
 // rolling digest artifacts such as today.md and this-week.md.
+//
+// Concurrency: this type has no internal locking. All three methods
+// (ObserveChange, Due, MarkFlushed) must be called under the owning
+// Syncer's `s.mu` so pending/dueAt/firstPendingAt are read and written
+// from a single synchronization point.
 type RollingDigestCoalescer struct {
 	Interval time.Duration
+	// MaxDelay caps how long regeneration can be deferred under sustained
+	// change pressure. A plain debounce that resets dueAt on every change
+	// starves indefinitely when events arrive faster than Interval — today.md
+	// / this-week.md would never rebuild. Defaults to 5 * effective interval
+	// when unset.
+	MaxDelay time.Duration
 	Now      func() time.Time
 
-	pending bool
-	dueAt   time.Time
+	pending        bool
+	dueAt          time.Time
+	firstPendingAt time.Time
+}
+
+func (c *RollingDigestCoalescer) clock() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func (c *RollingDigestCoalescer) effectiveInterval() time.Duration {
+	if c.Interval > 0 {
+		return c.Interval
+	}
+	return 30 * time.Second
+}
+
+func (c *RollingDigestCoalescer) effectiveMaxDelay() time.Duration {
+	if c.MaxDelay > 0 {
+		return c.MaxDelay
+	}
+	return 5 * c.effectiveInterval()
 }
 
 func (c *RollingDigestCoalescer) ObserveChange(path string) bool {
 	if digest.IsDigestPath(path) {
 		return false
 	}
-	now := time.Now()
-	if c.Now != nil {
-		now = c.Now()
+	now := c.clock()
+	if !c.pending {
+		c.pending = true
+		c.firstPendingAt = now
 	}
-	interval := c.Interval
-	if interval <= 0 {
-		interval = 30 * time.Second
+	// Normal debounce pushes the deadline out by one interval per change,
+	// but never past firstPendingAt+MaxDelay so sustained churn cannot
+	// defer regeneration forever.
+	candidate := now.Add(c.effectiveInterval())
+	if hardDeadline := c.firstPendingAt.Add(c.effectiveMaxDelay()); candidate.After(hardDeadline) {
+		candidate = hardDeadline
 	}
-	c.pending = true
-	c.dueAt = now.Add(interval)
+	c.dueAt = candidate
 	return true
 }
 
@@ -66,16 +102,13 @@ func (c *RollingDigestCoalescer) Due() bool {
 	if !c.pending {
 		return false
 	}
-	now := time.Now()
-	if c.Now != nil {
-		now = c.Now()
-	}
-	return !now.Before(c.dueAt)
+	return !c.clock().Before(c.dueAt)
 }
 
 func (c *RollingDigestCoalescer) MarkFlushed() {
 	c.pending = false
 	c.dueAt = time.Time{}
+	c.firstPendingAt = time.Time{}
 }
 
 // Tick runs the close pipeline for every local day that has closed since

--- a/internal/mountsync/scheduler_test.go
+++ b/internal/mountsync/scheduler_test.go
@@ -214,6 +214,56 @@ func TestCoalescer_30s(t *testing.T) {
 	}
 }
 
+// Regression: a plain debounce that resets dueAt on every change starves
+// forever when provider events arrive faster than the interval — today.md /
+// this-week.md would never regenerate under sustained churn. MaxDelay caps
+// the deferral so regeneration still fires.
+func TestCoalescer_MaxDelayPreventsStarvation(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	coalescer := &RollingDigestCoalescer{
+		Interval: 30 * time.Second,
+		MaxDelay: 2 * time.Minute,
+		Now:      func() time.Time { return now },
+	}
+	if !coalescer.ObserveChange("github/repos/x/issues/1.json") {
+		t.Fatal("first provider write should schedule regeneration")
+	}
+	// Sustained churn: a change every 10s for 5 minutes. A naive debounce
+	// would push dueAt forward on every call and never fire.
+	dueFiredWithinCap := false
+	for elapsed := time.Duration(0); elapsed <= 5*time.Minute; elapsed += 10 * time.Second {
+		now = now.Add(10 * time.Second)
+		coalescer.ObserveChange("github/repos/x/issues/1.json")
+		if coalescer.Due() {
+			dueFiredWithinCap = true
+			// Must not be deferred past first-pending + MaxDelay (+ one
+			// observation step of slack).
+			if elapsed > 2*time.Minute+10*time.Second {
+				t.Fatalf("regeneration deferred too long under sustained churn: %s", elapsed)
+			}
+			break
+		}
+	}
+	if !dueFiredWithinCap {
+		t.Fatal("coalescer starved: never became Due under sustained sub-interval churn")
+	}
+
+	// After a flush the cap window resets for the next batch.
+	coalescer.MarkFlushed()
+	if coalescer.Due() {
+		t.Fatal("coalescer should not be due immediately after flush")
+	}
+	coalescer.ObserveChange("github/repos/x/issues/2.json")
+	now = now.Add(29 * time.Second)
+	if coalescer.Due() {
+		t.Fatal("post-flush batch should still debounce normally (not due at 29s)")
+	}
+	now = now.Add(time.Second)
+	if !coalescer.Due() {
+		t.Fatal("post-flush batch should be due at 30s")
+	}
+}
+
 func TestRollingDigestJobsFlushAfterCoalescingWindow(t *testing.T) {
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
 	root := t.TempDir()

--- a/internal/mountsync/scheduler_test.go
+++ b/internal/mountsync/scheduler_test.go
@@ -1,0 +1,420 @@
+package mountsync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/digest"
+)
+
+// TestSchedulerFiresAtLocalMidnight: the lead plan's gate A boundary case.
+// A workspace configured for America/New_York with an event at 23:30 local
+// on 2026-05-12 produces a `yesterday.md` whose `date` is 2026-05-12 after
+// the scheduler tick fires at 00:05 local on 2026-05-13. UTC clock at that
+// instant is 2026-05-13T04:05Z — the test asserts the TZ-local boundary is
+// what selects the closed day, not UTC.
+func TestSchedulerFiresAtLocalMidnight(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York tz not available: %v", err)
+	}
+
+	root := t.TempDir()
+	events := []digest.ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 13, 3, 30, 0, 0, time.UTC), // 23:30 EDT on 2026-05-12
+			Identifier:    "PR-late",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/late.json",
+		},
+	}
+
+	scheduler := &CloseScheduler{
+		MountRoot: root,
+		TZ:        ny,
+		Providers: []string{"github"},
+		Source:    digest.SliceSource{Items: events},
+		Now:       func() time.Time { return time.Date(2026, 5, 13, 4, 5, 0, 0, time.UTC) },
+	}
+
+	closed, err := scheduler.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if len(closed) != 1 || closed[0] != "2026-05-12" {
+		t.Fatalf("Tick returned %v, want [2026-05-12]", closed)
+	}
+
+	body, err := os.ReadFile(filepath.Join(root, "digests", "yesterday.md"))
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+	wantFrontmatter := []byte("date: 2026-05-12")
+	if !contains(body, wantFrontmatter) {
+		t.Fatalf("yesterday.md does not contain %q frontmatter:\n%s", wantFrontmatter, body)
+	}
+	if !contains(body, []byte("covers: yesterday")) {
+		t.Fatalf("yesterday.md missing covers: yesterday:\n%s", body)
+	}
+	if !contains(body, []byte("PR-late")) {
+		t.Fatalf("yesterday.md missing the 23:30-EDT event bullet:\n%s", body)
+	}
+	dateStamped, err := os.ReadFile(filepath.Join(root, "digests", "2026-05-12.md"))
+	if err != nil {
+		t.Fatalf("read date-stamped digest: %v", err)
+	}
+	if !contains(dateStamped, []byte("covers: 2026-05-12")) {
+		t.Fatalf("date-stamped digest missing covers date:\n%s", dateStamped)
+	}
+
+	// A second tick on the same instant must be a no-op: the marker pins
+	// 2026-05-12 and there's no later closed day yet.
+	second, err := scheduler.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("second tick should be no-op, got %v", second)
+	}
+}
+
+// TestSchedulerCatchesUpAcrossOfflineDays: when the daemon was offline for
+// several local days, the next tick must close every missing day in
+// chronological order. The marker advances to the most recent closed day,
+// and `yesterday.md`'s frontmatter reflects that final date.
+func TestSchedulerCatchesUpAcrossOfflineDays(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York tz not available: %v", err)
+	}
+
+	root := t.TempDir()
+	// Seed the marker so the scheduler believes the last successful close
+	// was 2026-05-09. Three days were missed: 2026-05-10, 2026-05-11,
+	// 2026-05-12.
+	markerPath := filepath.Join(root, filepath.FromSlash(digest.YesterdayMarkerPath))
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		t.Fatalf("mkdir marker dir: %v", err)
+	}
+	if err := os.WriteFile(markerPath, []byte("2026-05-09\n"), 0o644); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	// One event per missing day so we can verify the chronological close
+	// order by reading the eventual yesterday.md (it ends on the final
+	// day's content).
+	events := []digest.ChangeEvent{
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 10, 14, 0, 0, 0, ny),
+			Identifier:    "PR-10",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/10.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 11, 14, 0, 0, 0, ny),
+			Identifier:    "PR-11",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/11.json",
+		},
+		{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 14, 0, 0, 0, ny),
+			Identifier:    "PR-12",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/12.json",
+		},
+	}
+
+	scheduler := &CloseScheduler{
+		MountRoot: root,
+		TZ:        ny,
+		Providers: []string{"github"},
+		// The source intentionally returns all events for every window;
+		// the scheduler isn't responsible for partitioning. The test
+		// asserts chronological close ordering and the final
+		// yesterday.md state, not per-day partitioning (which is a
+		// distinct slice).
+		Source: digest.SliceSource{Items: events},
+		Now:    func() time.Time { return time.Date(2026, 5, 13, 5, 0, 0, 0, time.UTC) }, // 01:00 EDT 2026-05-13
+	}
+
+	closed, err := scheduler.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	want := []string{"2026-05-10", "2026-05-11", "2026-05-12"}
+	if !equalStrings(closed, want) {
+		t.Fatalf("Tick returned %v, want %v (chronological order)", closed, want)
+	}
+
+	// Marker now records the most recent closed day.
+	markerBytes, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if got := string(markerBytes); got != "2026-05-12\n" {
+		t.Fatalf("marker = %q, want 2026-05-12", got)
+	}
+
+	body, err := os.ReadFile(filepath.Join(root, "digests", "yesterday.md"))
+	if err != nil {
+		t.Fatalf("read yesterday.md: %v", err)
+	}
+	if !contains(body, []byte("date: 2026-05-12")) {
+		t.Fatalf("yesterday.md should end on 2026-05-12 after catch-up:\n%s", body)
+	}
+	for _, date := range want {
+		if _, err := os.Stat(filepath.Join(root, "digests", date+".md")); err != nil {
+			t.Fatalf("date-stamped catch-up digest %s missing: %v", date, err)
+		}
+	}
+
+	// A tick immediately after catch-up is a no-op.
+	second, err := scheduler.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("second Tick: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("second tick should be no-op after catch-up, got %v", second)
+	}
+}
+
+func TestCoalescer_30s(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	coalescer := &RollingDigestCoalescer{
+		Interval: 30 * time.Second,
+		Now:      func() time.Time { return now },
+	}
+	if coalescer.ObserveChange("digests/today.md") {
+		t.Fatal("digest writes must not schedule rolling digest regeneration")
+	}
+	if !coalescer.ObserveChange("github/repos/x/issues/1.json") {
+		t.Fatal("provider write should schedule rolling digest regeneration")
+	}
+	if coalescer.Due() {
+		t.Fatal("coalescer should not be due before 30s")
+	}
+	now = now.Add(29 * time.Second)
+	if coalescer.Due() {
+		t.Fatal("coalescer should still not be due at 29s")
+	}
+	now = now.Add(time.Second)
+	if !coalescer.Due() {
+		t.Fatal("coalescer should be due at 30s")
+	}
+	coalescer.MarkFlushed()
+	if coalescer.Due() {
+		t.Fatal("coalescer should not be due after flush")
+	}
+}
+
+func TestRollingDigestJobsFlushAfterCoalescingWindow(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	root := t.TempDir()
+	markerPath := filepath.Join(root, filepath.FromSlash(digest.YesterdayMarkerPath))
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		t.Fatalf("mkdir marker dir: %v", err)
+	}
+	if err := os.WriteFile(markerPath, []byte("2026-05-14\n"), 0o644); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	source := &countingDigestSource{items: []digest.ChangeEvent{{
+		Provider:      "github",
+		Timestamp:     now,
+		Identifier:    "PR-rolling",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/x/pulls/by-id/rolling.json",
+	}}}
+	client := &fakeClient{files: map[string]RemoteFile{}}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:     "ws_rolling",
+		LocalRoot:       root,
+		DigestSource:    source,
+		DigestProviders: []string{"github"},
+		DigestTimezone:  "UTC",
+		DigestNow:       func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	writeLocal := func(rel, body string) {
+		t.Helper()
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		if err := syncer.HandleLocalChange(context.Background(), rel, 0); err != nil {
+			t.Fatalf("HandleLocalChange %s: %v", rel, err)
+		}
+	}
+
+	writeLocal("github/repos/x/pulls/by-id/rolling.json", `{"n":1}`)
+	now = now.Add(10 * time.Second)
+	writeLocal("github/repos/x/pulls/by-id/rolling-2.json", `{"n":2}`)
+
+	now = now.Add(29 * time.Second)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("pre-due SyncOnce: %v", err)
+	}
+	for _, rel := range []string{digest.TodayPath, digest.ThisWeekPath} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); !os.IsNotExist(err) {
+			t.Fatalf("%s exists before coalescing interval elapsed (err=%v)", rel, err)
+		}
+	}
+
+	if syncer.rollingCoalescer.ObserveChange(digest.TodayPath) {
+		t.Fatal("digest-path changes must not schedule a rolling flush")
+	}
+
+	now = now.Add(time.Second)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("due SyncOnce: %v", err)
+	}
+	for _, rel := range []string{digest.TodayPath, digest.ThisWeekPath} {
+		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !contains(body, []byte("PR-rolling")) {
+			t.Fatalf("%s missing rolling event:\n%s", rel, body)
+		}
+	}
+	if source.callsByCover[digest.TodayCover] != 1 || source.callsByCover[digest.ThisWeekCover] != 1 {
+		t.Fatalf("rolling flush calls = %#v, want one today and one this-week call", source.callsByCover)
+	}
+	if syncer.rollingCoalescer.Due() {
+		t.Fatal("coalescer still due after successful flush")
+	}
+}
+
+func TestClosingJobs_RunAtLocalMidnight(t *testing.T) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Skipf("America/New_York tz not available: %v", err)
+	}
+	root := t.TempDir()
+	events := []digest.ChangeEvent{{
+		Provider:      "github",
+		Timestamp:     time.Date(2026, 5, 13, 3, 30, 0, 0, time.UTC),
+		Identifier:    "PR-syncer",
+		Verb:          "updated",
+		CanonicalPath: "github/repos/x/pulls/by-id/syncer.json",
+	}}
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID:     "ws_digest_scheduler",
+		LocalRoot:       root,
+		DigestSource:    digest.SliceSource{Items: events},
+		DigestProviders: []string{"github"},
+		DigestTimezone:  ny.String(),
+		DigestNow:       func() time.Time { return time.Date(2026, 5, 13, 4, 5, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	for _, rel := range []string{"digests/yesterday.md", "digests/2026-05-12.md"} {
+		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !contains(body, []byte("PR-syncer")) {
+			t.Fatalf("%s missing syncer event:\n%s", rel, body)
+		}
+	}
+}
+
+type countingDigestSource struct {
+	items        []digest.ChangeEvent
+	callsByCover map[string]int
+}
+
+func (s *countingDigestSource) Events(w digest.Window) ([]digest.ChangeEvent, error) {
+	if s.callsByCover == nil {
+		s.callsByCover = map[string]int{}
+	}
+	s.callsByCover[w.Cover]++
+	return append([]digest.ChangeEvent(nil), s.items...), nil
+}
+
+func TestClosingJobs_LastWeekCatchUp(t *testing.T) {
+	root := t.TempDir()
+	markerPath := filepath.Join(root, filepath.FromSlash(digest.YesterdayMarkerPath))
+	if err := os.MkdirAll(filepath.Dir(markerPath), 0o755); err != nil {
+		t.Fatalf("mkdir marker dir: %v", err)
+	}
+	if err := os.WriteFile(markerPath, []byte("2026-05-09\n"), 0o644); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+	scheduler := &CloseScheduler{
+		MountRoot: root,
+		TZ:        time.UTC,
+		Providers: []string{"github"},
+		Source: digest.SliceSource{Items: []digest.ChangeEvent{{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 10, 15, 0, 0, 0, time.UTC),
+			Identifier:    "PR-week",
+			Verb:          "merged",
+			CanonicalPath: "github/repos/x/pulls/by-id/week.json",
+		}}},
+		Now: func() time.Time { return time.Date(2026, 5, 11, 0, 5, 0, 0, time.UTC) },
+	}
+	closed, err := scheduler.Tick(context.Background())
+	if err != nil {
+		t.Fatalf("Tick: %v", err)
+	}
+	if !equalStrings(closed, []string{"2026-05-10"}) {
+		t.Fatalf("closed = %v, want [2026-05-10]", closed)
+	}
+	body, err := os.ReadFile(filepath.Join(root, "digests", "last-week.md"))
+	if err != nil {
+		t.Fatalf("read last-week.md: %v", err)
+	}
+	if !contains(body, []byte("covers: last-week")) || !contains(body, []byte("PR-week")) {
+		t.Fatalf("last-week.md missing expected content:\n%s", body)
+	}
+}
+
+func contains(haystack, needle []byte) bool {
+	return indexOf(haystack, needle) >= 0
+}
+
+func indexOf(haystack, needle []byte) int {
+	if len(needle) == 0 {
+		return 0
+	}
+outer:
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		for j := 0; j < len(needle); j++ {
+			if haystack[i+j] != needle[j] {
+				continue outer
+			}
+		}
+		return i
+	}
+	return -1
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1039,6 +1039,9 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 	if relativePath == "" || relativePath == "." {
 		return nil
 	}
+	if first := strings.SplitN(relativePath, "/", 2)[0]; reservedTopLevel(first) {
+		return nil
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2705,7 +2708,7 @@ func providerLayoutCleanResourceSegment(segment string) string {
 
 func isReservedProviderLayoutSegment(segment string) bool {
 	switch strings.TrimSpace(segment) {
-	case "", ".relay", "digests", "_index.json", "LAYOUT.md", ".relayfile-mount-state.json":
+	case "", ".relay", ".skills", "digests", "_index.json", "LAYOUT.md", ".relayfile-mount-state.json":
 		return true
 	default:
 		return false

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -26,6 +26,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/agentworkforce/relayfile/internal/digest"
 	"github.com/fsnotify/fsnotify"
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
@@ -99,6 +100,7 @@ func resolveDurationEnv(opt time.Duration, env string, def time.Duration, logger
 var providerLayoutAliasSegments = []string{
 	"by-title",
 	"by-id",
+	"by-edited",
 	"by-name",
 	"by-state",
 }
@@ -540,10 +542,14 @@ type SyncerOptions struct {
 	// in-memory snapshots. nil falls back to RELAYFILE_MOUNT_LOW_MEMORY.
 	LowMemory *bool
 	// ProviderLayoutRegistrar receives deterministic per-provider layout
-	// manifests derived from remote snapshots. The FUSE layer can implement
-	// this to expose virtual <provider>/.layout.md files without coupling
-	// mountsync back to mountfuse.
+	// manifests derived from remote snapshots. Mount layers can implement
+	// this to expose virtual <provider>/LAYOUT.md files; legacy
+	// <provider>/.layout.md remains a compatibility alias.
 	ProviderLayoutRegistrar ProviderLayoutRegistrar
+	DigestSource            digest.ChangeEventSource
+	DigestProviders         []string
+	DigestTimezone          string
+	DigestNow               func() time.Time
 }
 
 type Logger interface {
@@ -672,6 +678,8 @@ type Syncer struct {
 	lazyRepos            bool
 	lowMemory            bool
 	layoutRegistrar      ProviderLayoutRegistrar
+	closeScheduler       *CloseScheduler
+	rollingCoalescer     *RollingDigestCoalescer
 	circuit              *CloudErrorCircuit
 	mu                   sync.Mutex
 }
@@ -947,6 +955,25 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if lowMemory {
 		bulkFlushThreshold = 16
 	}
+	var closeScheduler *CloseScheduler
+	var rollingCoalescer *RollingDigestCoalescer
+	if opts.DigestSource != nil {
+		tz, err := digest.ResolveTZ(digest.WorkspaceTZConfig{Timezone: opts.DigestTimezone})
+		if err != nil {
+			return nil, err
+		}
+		closeScheduler = &CloseScheduler{
+			MountRoot: localRoot,
+			TZ:        tz,
+			Providers: append([]string(nil), opts.DigestProviders...),
+			Source:    opts.DigestSource,
+			Now:       opts.DigestNow,
+		}
+		rollingCoalescer = &RollingDigestCoalescer{
+			Interval: 30 * time.Second,
+			Now:      opts.DigestNow,
+		}
+	}
 	return &Syncer{
 		client:               client,
 		workspace:            workspace,
@@ -975,6 +1002,8 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		lazyRepos:            lazyRepos,
 		lowMemory:            lowMemory,
 		layoutRegistrar:      opts.ProviderLayoutRegistrar,
+		closeScheduler:       closeScheduler,
+		rollingCoalescer:     rollingCoalescer,
 		circuit:              NewCloudErrorCircuit(),
 		state: mountState{
 			Files: map[string]trackedFile{},
@@ -1045,6 +1074,12 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// ObserveChange mutates coalescer state that Due()/MarkFlushed() read
+	// under s.mu (runRollingDigestJobsLocked). It must run under the same
+	// lock to avoid races while the watcher is processing local churn.
+	if s.rollingCoalescer != nil {
+		s.rollingCoalescer.ObserveChange(relativePath)
+	}
 	if err := s.loadState(); err != nil {
 		return err
 	}
@@ -1626,6 +1661,16 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.markReconcileStarted()
+	if err := s.runClosingDigestJobsLocked(ctx); err != nil {
+		s.markSyncError(err)
+		_ = s.saveState()
+		return err
+	}
+	if err := s.runRollingDigestJobsLocked(ctx); err != nil {
+		s.markSyncError(err)
+		_ = s.saveState()
+		return err
+	}
 
 	conflicted, err := s.pushLocal(ctx)
 	if err != nil {
@@ -1645,6 +1690,37 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 	}
 	s.markSyncSuccess()
 	return s.saveState()
+}
+
+func (s *Syncer) runClosingDigestJobsLocked(ctx context.Context) error {
+	if s.closeScheduler == nil {
+		return nil
+	}
+	_, err := s.closeScheduler.Tick(ctx)
+	return err
+}
+
+func (s *Syncer) runRollingDigestJobsLocked(ctx context.Context) error {
+	if s.rollingCoalescer == nil || s.closeScheduler == nil || !s.rollingCoalescer.Due() {
+		return nil
+	}
+	tz := s.closeScheduler.TZ
+	if tz == nil {
+		tz = time.UTC
+	}
+	clock := s.closeScheduler.Now
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
+	if _, err := digest.WriteToday(ctx, s.closeScheduler.MountRoot, s.closeScheduler.Source, s.closeScheduler.Providers, now, tz, digest.BuildOptions{}); err != nil {
+		return err
+	}
+	if _, err := digest.WriteThisWeek(ctx, s.closeScheduler.MountRoot, s.closeScheduler.Source, digest.ThisWeekWindow(now, now, s.closeScheduler.Providers, tz)); err != nil {
+		return err
+	}
+	s.rollingCoalescer.MarkFlushed()
+	return nil
 }
 
 func (s *Syncer) connectWebSocket(ctx context.Context) error {
@@ -2583,27 +2659,39 @@ func (s *Syncer) materializeProviderLayoutsFromPaths(remotePaths map[string]stru
 		return nil
 	}
 
-	providerResources := map[string]map[string]struct{}{}
+	providerManifests := map[string]struct {
+		resources map[string]struct{}
+		aliases   map[string]struct{}
+	}{}
 	for remotePath := range remotePaths {
-		provider, resource, ok := providerLayoutParts(s.remoteRoot, remotePath)
+		provider, resource, alias, ok := providerLayoutPartsWithAlias(s.remoteRoot, remotePath)
 		if !ok {
 			continue
 		}
-		if _, ok := providerResources[provider]; !ok {
-			providerResources[provider] = map[string]struct{}{}
+		manifest := providerManifests[provider]
+		if manifest.resources == nil {
+			manifest.resources = map[string]struct{}{}
 		}
 		if resource != "" {
-			providerResources[provider][resource] = struct{}{}
+			manifest.resources[resource] = struct{}{}
 		}
+		if alias != "" {
+			if manifest.aliases == nil {
+				manifest.aliases = map[string]struct{}{}
+			}
+			manifest.aliases[alias] = struct{}{}
+		}
+		providerManifests[provider] = manifest
 	}
 
-	providers := make([]string, 0, len(providerResources))
-	for provider := range providerResources {
+	providers := make([]string, 0, len(providerManifests))
+	for provider := range providerManifests {
 		providers = append(providers, provider)
 	}
 	sort.Strings(providers)
 	for _, provider := range providers {
-		manifest := providerLayoutManifest(provider, providerResources[provider])
+		parts := providerManifests[provider]
+		manifest := providerLayoutManifest(provider, parts.resources, parts.aliases)
 		if err := s.layoutRegistrar.RegisterProviderLayout(provider, manifest); err != nil {
 			return fmt.Errorf("register provider layout for %s: %w", provider, err)
 		}
@@ -2619,27 +2707,45 @@ func (s *Syncer) ensureProviderLayout(provider string) error {
 	if provider == "" || isReservedProviderLayoutSegment(provider) {
 		return nil
 	}
-	return s.layoutRegistrar.RegisterProviderLayout(provider, providerLayoutManifest(provider, nil))
+	return s.layoutRegistrar.RegisterProviderLayout(provider, providerLayoutManifest(provider, nil, nil))
 }
 
-func providerLayoutManifest(provider string, resources map[string]struct{}) ProviderLayoutManifest {
+func providerLayoutManifest(provider string, resources map[string]struct{}, observedAliases map[string]struct{}) ProviderLayoutManifest {
 	resourceNames := make([]string, 0, len(resources))
 	for resource := range resources {
 		resourceNames = append(resourceNames, resource)
 	}
 	sort.Strings(resourceNames)
+
+	aliases := make(map[string]struct{}, len(observedAliases))
+	for alias := range observedAliases {
+		if isProviderLayoutAliasSegment(alias) {
+			aliases[alias] = struct{}{}
+		}
+	}
+	aliasNames := make([]string, 0, len(aliases))
+	for alias := range aliases {
+		aliasNames = append(aliasNames, alias)
+	}
+	sort.Strings(aliasNames)
+
 	return ProviderLayoutManifest{
 		Provider:      provider,
 		Resources:     resourceNames,
-		AliasSegments: append([]string(nil), providerLayoutAliasSegments...),
+		AliasSegments: aliasNames,
 	}
 }
 
 func providerLayoutParts(remoteRoot, remotePath string) (provider, resource string, ok bool) {
+	provider, resource, _, ok = providerLayoutPartsWithAlias(remoteRoot, remotePath)
+	return provider, resource, ok
+}
+
+func providerLayoutPartsWithAlias(remoteRoot, remotePath string) (provider, resource, alias string, ok bool) {
 	remoteRoot = normalizeRemotePath(remoteRoot)
 	remotePath = normalizeRemotePath(remotePath)
 	if !isUnderRemoteRoot(remoteRoot, remotePath) {
-		return "", "", false
+		return "", "", "", false
 	}
 
 	rel := strings.TrimPrefix(remotePath, remoteRoot)
@@ -2654,7 +2760,7 @@ func providerLayoutParts(remoteRoot, remotePath string) (provider, resource stri
 	if remoteRoot != "/" && len(rootSegments) > 0 {
 		provider = strings.TrimSpace(rootSegments[0])
 		if provider == "" || isReservedProviderLayoutSegment(provider) {
-			return "", "", false
+			return "", "", "", false
 		}
 		if len(rootSegments) > 1 {
 			resource = providerLayoutRootResourceSegment(rootSegments[1:])
@@ -2662,18 +2768,20 @@ func providerLayoutParts(remoteRoot, remotePath string) (provider, resource stri
 		if resource == "" {
 			resource = providerLayoutResourceSegment(relSegments)
 		}
-		return provider, resource, true
+		alias = providerLayoutAliasSegment(append(rootSegments[1:], relSegments...))
+		return provider, resource, alias, true
 	}
 	if len(relSegments) == 0 {
-		return "", "", false
+		return "", "", "", false
 	}
 
 	provider = strings.TrimSpace(relSegments[0])
 	if provider == "" || isReservedProviderLayoutSegment(provider) {
-		return "", "", false
+		return "", "", "", false
 	}
 	resource = providerLayoutResourceSegment(relSegments[1:])
-	return provider, resource, true
+	alias = providerLayoutAliasSegment(relSegments[1:])
+	return provider, resource, alias, true
 }
 
 func providerLayoutPathSegments(path string) []string {
@@ -2704,6 +2812,16 @@ func providerLayoutCleanResourceSegment(segment string) string {
 		return ""
 	}
 	return candidate
+}
+
+func providerLayoutAliasSegment(segments []string) string {
+	for _, segment := range segments {
+		candidate := strings.TrimSpace(segment)
+		if isProviderLayoutAliasSegment(candidate) {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func isReservedProviderLayoutSegment(segment string) bool {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2764,6 +2764,12 @@ func TestApplyRemoteSnapshot_MaterializesProviderLayouts(t *testing.T) {
 			ContentType: "text/markdown",
 			Content:     "_no activity_",
 		},
+		"/.skills/activity-summary.md": {
+			Path:        "/.skills/activity-summary.md",
+			Revision:    "rev_activity_summary",
+			ContentType: "text/markdown",
+			Content:     "# activity-summary\n",
+		},
 		"/.relay/dead-letter/payload.json": {
 			Path:        "/.relay/dead-letter/payload.json",
 			Revision:    "rev_dead",
@@ -2796,6 +2802,9 @@ func TestApplyRemoteSnapshot_MaterializesProviderLayouts(t *testing.T) {
 	}
 	if _, ok := registrar.manifest[".relay"]; ok {
 		t.Fatalf("reserved .relay root should not be registered as a provider")
+	}
+	if _, ok := registrar.manifest[".skills"]; ok {
+		t.Fatalf("reserved .skills root should not be registered as a provider")
 	}
 	if _, err := os.Stat(filepath.Join(localDir, "linear", ".layout.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("provider layout registration should not write a disk .layout.md, stat err=%v", err)
@@ -2897,6 +2906,12 @@ func TestApplyRemoteSnapshot_ProviderLayoutsSkipReservedRoots(t *testing.T) {
 			Revision:    "rev_digest",
 			ContentType: "text/markdown",
 			Content:     "_no activity_",
+		},
+		"/.skills/activity-summary.md": {
+			Path:        "/.skills/activity-summary.md",
+			Revision:    "rev_activity_summary",
+			ContentType: "text/markdown",
+			Content:     "# activity-summary\n",
 		},
 		"/_index.json": {
 			Path:        "/_index.json",

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2794,8 +2794,11 @@ func TestApplyRemoteSnapshot_MaterializesProviderLayouts(t *testing.T) {
 	if got, want := registrar.manifest["notion"].Resources, []string{"pages"}; !slices.Equal(got, want) {
 		t.Fatalf("notion resources = %#v, want %#v", got, want)
 	}
-	if got, want := registrar.manifest["linear"].AliasSegments, providerLayoutAliasSegments; !slices.Equal(got, want) {
+	if got, want := registrar.manifest["linear"].AliasSegments, []string{"by-state"}; !slices.Equal(got, want) {
 		t.Fatalf("alias segments = %#v, want %#v", got, want)
+	}
+	if slices.Contains(registrar.manifest["linear"].AliasSegments, "by-edited") {
+		t.Fatalf("linear canonical layout unexpectedly advertised by-edited: %#v", registrar.manifest["linear"].AliasSegments)
 	}
 	if _, ok := registrar.manifest["digests"]; ok {
 		t.Fatalf("reserved digests root should not be registered as a provider")
@@ -2808,6 +2811,122 @@ func TestApplyRemoteSnapshot_MaterializesProviderLayouts(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(localDir, "linear", ".layout.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("provider layout registration should not write a disk .layout.md, stat err=%v", err)
+	}
+}
+
+func TestApplyRemoteSnapshot_ProviderLayoutDoesNotAdvertiseAliasesForCanonicalFiles(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	registrar := &fakeProviderLayoutRegistrar{}
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID:             "ws_snapshot_provider_layouts_no_by_edited",
+		RemoteRoot:              "/",
+		LocalRoot:               localDir,
+		ProviderLayoutRegistrar: registrar,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.applyRemoteSnapshot(map[string]RemoteFile{
+		"/linear/issues/AGE-16__issue-1.json": {
+			Path:        "/linear/issues/AGE-16__issue-1.json",
+			Revision:    "rev_linear_issue",
+			ContentType: "application/json",
+			Content:     `{"identifier":"AGE-16"}`,
+		},
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteSnapshot failed: %v", err)
+	}
+
+	manifest, ok := registrar.manifest["linear"]
+	if !ok {
+		t.Fatalf("expected linear provider layout to be registered")
+	}
+	if got, want := manifest.Resources, []string{"issues"}; !slices.Equal(got, want) {
+		t.Fatalf("linear resources = %#v, want %#v", got, want)
+	}
+	if len(manifest.AliasSegments) != 0 {
+		t.Fatalf("canonical-only provider layout advertised aliases: %#v", manifest.AliasSegments)
+	}
+}
+
+func TestApplyRemoteSnapshot_ProviderLayoutAdvertisesOnlyObservedAliasesForProvider(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	registrar := &fakeProviderLayoutRegistrar{}
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID:             "ws_snapshot_provider_layouts_observed_by_edited",
+		RemoteRoot:              "/",
+		LocalRoot:               localDir,
+		ProviderLayoutRegistrar: registrar,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.applyRemoteSnapshot(map[string]RemoteFile{
+		"/linear/issues/by-id/AGE-16.json": {
+			Path:        "/linear/issues/by-id/AGE-16.json",
+			Revision:    "rev_linear_by_id",
+			ContentType: "application/json",
+			Content:     `{"identifier":"AGE-16"}`,
+		},
+		"/linear/issues/by-state/open/AGE-16__issue-1.json": {
+			Path:        "/linear/issues/by-state/open/AGE-16__issue-1.json",
+			Revision:    "rev_linear_by_state",
+			ContentType: "application/json",
+			Content:     `{"identifier":"AGE-16"}`,
+		},
+		"/notion/pages/by-edited/2026-05-12/page-123__123.json": {
+			Path:        "/notion/pages/by-edited/2026-05-12/page-123__123.json",
+			Revision:    "rev_notion_by_edited",
+			ContentType: "application/json",
+			Content:     `{"id":"123"}`,
+		},
+		"/notion/pages/by-title/Roadmap.json": {
+			Path:        "/notion/pages/by-title/Roadmap.json",
+			Revision:    "rev_notion_by_title",
+			ContentType: "application/json",
+			Content:     `{"id":"roadmap"}`,
+		},
+		"/github/repos/by-name/octocat__hello-world.json": {
+			Path:        "/github/repos/by-name/octocat__hello-world.json",
+			Revision:    "rev_github_by_name",
+			ContentType: "application/json",
+			Content:     `{"name":"hello-world"}`,
+		},
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteSnapshot failed: %v", err)
+	}
+
+	linearManifest, ok := registrar.manifest["linear"]
+	if !ok {
+		t.Fatalf("expected linear provider layout to be registered")
+	}
+	if got, want := linearManifest.AliasSegments, []string{"by-id", "by-state"}; !slices.Equal(got, want) {
+		t.Fatalf("linear aliases = %#v, want %#v", got, want)
+	}
+
+	notionManifest, ok := registrar.manifest["notion"]
+	if !ok {
+		t.Fatalf("expected notion provider layout to be registered")
+	}
+	if got, want := notionManifest.Resources, []string{"pages"}; !slices.Equal(got, want) {
+		t.Fatalf("notion resources = %#v, want %#v", got, want)
+	}
+	if got, want := notionManifest.AliasSegments, []string{"by-edited", "by-title"}; !slices.Equal(got, want) {
+		t.Fatalf("notion aliases = %#v, want %#v", got, want)
+	}
+
+	githubManifest, ok := registrar.manifest["github"]
+	if !ok {
+		t.Fatalf("expected github provider layout to be registered")
+	}
+	if got, want := githubManifest.AliasSegments, []string{"by-name"}; !slices.Equal(got, want) {
+		t.Fatalf("github aliases = %#v, want %#v", got, want)
 	}
 }
 
@@ -2987,6 +3106,19 @@ func TestProviderLayoutPartsUsesResourceFromNonRootRemoteRoot(t *testing.T) {
 	}
 	if resource != "repos" {
 		t.Fatalf("resource = %q, want repos", resource)
+	}
+}
+
+func TestProviderLayoutPartsKeepsResourceForByEditedAliases(t *testing.T) {
+	provider, resource, ok := providerLayoutParts("/", "/notion/pages/by-edited/2026-05-12/page-123__123.json")
+	if !ok {
+		t.Fatalf("expected provider layout parts")
+	}
+	if provider != "notion" {
+		t.Fatalf("provider = %q, want notion", provider)
+	}
+	if resource != "pages" {
+		t.Fatalf("resource = %q, want pages", resource)
 	}
 }
 
@@ -3401,6 +3533,9 @@ func (c *fakeClient) WriteFile(ctx context.Context, workspaceID, path, baseRevis
 	_ = ctx
 	_ = workspaceID
 	c.writeFileCalls++
+	if c.files == nil {
+		c.files = make(map[string]RemoteFile)
+	}
 	path = normalizeRemotePath(path)
 	current, exists := c.files[path]
 	if !exists && baseRevision != "0" {
@@ -3430,6 +3565,9 @@ func (c *fakeClient) WriteFilesBulk(ctx context.Context, workspaceID string, fil
 	_ = workspaceID
 	if len(files) == 0 {
 		return BulkWriteResponse{}, ErrEmptyBulkWrite
+	}
+	if c.files == nil {
+		c.files = make(map[string]RemoteFile)
 	}
 
 	c.bulkWriteCalls++

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -37,8 +37,9 @@ func NewFileWatcher(localDir string, onChange func(string, fsnotify.Op)) (*FileW
 }
 
 // Start begins watching. Recursively adds all subdirectories.
-// Skips internal runtime trees such as .git, .relay, .skills, digests, and
-// node_modules.
+// Skips internal runtime trees such as .git, .relay, .skills, and node_modules.
+// Digest files are deliberately watched: they must emit normal mount events,
+// while HandleLocalChange still refuses to write them back upstream.
 func (fw *FileWatcher) Start(ctx context.Context) error {
 	// Walk localDir, add all dirs to watcher (fsnotify watches dirs, not files)
 	if err := fw.addDirRecursive(fw.localDir); err != nil {
@@ -106,7 +107,7 @@ func (fw *FileWatcher) shouldSkip(rel string) bool {
 		strings.HasPrefix(first, ".relayfile-mount-state.json.tmp-") {
 		return true
 	}
-	if reservedTopLevel(first) {
+	if watcherIgnoredTopLevel(first) {
 		return true
 	}
 	// Data-loss guard: a top-level entry whose name equals the mount
@@ -171,6 +172,10 @@ func (fw *FileWatcher) emitExistingFileEvents(base string) {
 	})
 }
 
+func watcherIgnoredTopLevel(name string) bool {
+	return reservedTopLevel(name) && name != "digests"
+}
+
 // addDirRecursive walks `base` and adds every directory underneath it to the
 // fsnotify watcher, skipping top-level internal runtime trees. Used both at startup (to seed the watcher with the
 // existing tree) and at runtime (when a sync-down creates a new nested
@@ -204,7 +209,7 @@ func (fw *FileWatcher) isTopLevelReservedDir(path, name string) bool {
 	if first != name {
 		return false
 	}
-	return reservedTopLevel(name)
+	return watcherIgnoredTopLevel(name)
 }
 
 func (fw *FileWatcher) Close() error {

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -37,7 +37,8 @@ func NewFileWatcher(localDir string, onChange func(string, fsnotify.Op)) (*FileW
 }
 
 // Start begins watching. Recursively adds all subdirectories.
-// Skips .git, .relay, node_modules.
+// Skips internal runtime trees such as .git, .relay, .skills, digests, and
+// node_modules.
 func (fw *FileWatcher) Start(ctx context.Context) error {
 	// Walk localDir, add all dirs to watcher (fsnotify watches dirs, not files)
 	if err := fw.addDirRecursive(fw.localDir); err != nil {
@@ -123,7 +124,8 @@ func (fw *FileWatcher) shouldSkip(rel string) bool {
 // top-level entries, including files such as _PERMISSIONS.md; addDirRecursive
 // is directory-only and skips a different sentinel for the mount state file.
 func reservedTopLevel(name string) bool {
-	return name == ".git" || name == ".relay" || name == "node_modules" ||
+	return name == ".git" || name == ".relay" || name == ".skills" ||
+		name == "digests" || name == "node_modules" ||
 		name == "_PERMISSIONS.md"
 }
 
@@ -170,8 +172,7 @@ func (fw *FileWatcher) emitExistingFileEvents(base string) {
 }
 
 // addDirRecursive walks `base` and adds every directory underneath it to the
-// fsnotify watcher, skipping `.git`, `.relay`, `node_modules`, and the
-// mount-state file sentinel. Used both at startup (to seed the watcher with the
+// fsnotify watcher, skipping top-level internal runtime trees. Used both at startup (to seed the watcher with the
 // existing tree) and at runtime (when a sync-down creates a new nested
 // directory structure that we need to start watching).
 func (fw *FileWatcher) addDirRecursive(base string) error {
@@ -183,7 +184,7 @@ func (fw *FileWatcher) addDirRecursive(base string) error {
 			return nil
 		}
 		name := info.Name()
-		if name == ".git" || name == ".relay" || name == "node_modules" || name == ".relayfile-mount-state.json" {
+		if fw.isTopLevelReservedDir(path, name) {
 			return filepath.SkipDir
 		}
 		// Best-effort add. fsnotify returns an error for already-watched dirs
@@ -192,6 +193,18 @@ func (fw *FileWatcher) addDirRecursive(base string) error {
 		_ = fw.watcher.Add(path)
 		return nil
 	})
+}
+
+func (fw *FileWatcher) isTopLevelReservedDir(path, name string) bool {
+	rel, err := filepath.Rel(fw.localDir, path)
+	if err != nil || rel == "." {
+		return false
+	}
+	first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
+	if first != name {
+		return false
+	}
+	return reservedTopLevel(name)
 }
 
 func (fw *FileWatcher) Close() error {

--- a/internal/mountsync/watcher_test.go
+++ b/internal/mountsync/watcher_test.go
@@ -394,3 +394,22 @@ func TestWatcherEditInNestedSubdirAfterSyncDown(t *testing.T) {
 		t.Fatalf("no watcher event for edit in nested subdirectory created at runtime")
 	}
 }
+
+func TestWatcherDoesNotSkipNestedReservedNameDirectories(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	nestedDir := filepath.Join(localDir, "notion", "pages", "by-title", "digests")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("create nested reserved-name directory: %v", err)
+	}
+	target := filepath.Join(nestedDir, "page.json")
+	if err := os.WriteFile(target, []byte(`{"id":"page"}`), 0o644); err != nil {
+		t.Fatalf("write file in nested reserved-name directory: %v", err)
+	}
+
+	expected := filepath.ToSlash("notion/pages/by-title/digests/page.json")
+	if _, ok := waitForWatcherEventPath(t, events, expected, 2*time.Second); !ok {
+		t.Fatalf("no watcher event for nested reserved-name directory path")
+	}
+}

--- a/internal/mountsync/watcher_test.go
+++ b/internal/mountsync/watcher_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/agentworkforce/relayfile/internal/digest"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -204,6 +206,390 @@ func TestWatcherSkipsNodeModules(t *testing.T) {
 	}
 
 	assertNoWatcherEvents(t, events, 300*time.Millisecond)
+}
+
+// TestWatcherEmitsYesterdayDigestFileNoRecursion covers the lead-plan F7
+// requirement for the yesterday slice: a write to `digests/yesterday.md`
+// must produce a filesystem event for mounted observers (gate E) AND the
+// shared digest-source classifier `digest.IsDigestPath` must flag the path
+// so the regen pipeline's recursion guard drops it. This pairs the
+// existing `TestDateStampedDigestDoesNotReEnterRegeneration` (date-stamped
+// sibling) with the same proof for the rolling-yesterday artifact.
+func TestWatcherEmitsYesterdayDigestFileNoRecursion(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	digestFile := filepath.Join(localDir, "digests", "yesterday.md")
+	if err := os.MkdirAll(filepath.Dir(digestFile), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	if err := os.WriteFile(digestFile, []byte("# digest yesterday\n"), 0o644); err != nil {
+		t.Fatalf("write digest file: %v", err)
+	}
+
+	ev, ok := waitForWatcherEventPath(t, events, "digests/yesterday.md", time.Second)
+	if !ok {
+		t.Fatalf("no watcher event for digests/yesterday.md within timeout")
+	}
+	if ev.op&fsnotify.Create == 0 && ev.op&fsnotify.Write == 0 {
+		t.Fatalf("expected create or write op, got %s", ev.op)
+	}
+
+	if !digest.IsDigestPath("digests/yesterday.md") {
+		t.Fatal("digest.IsDigestPath(\"digests/yesterday.md\") = false; recursion-guard predicate must cover yesterday.md")
+	}
+
+	// Sanity: a non-digest write next to it still classifies as a regen
+	// trigger, so the predicate isn't accidentally over-broad.
+	if digest.IsDigestPath("notion/pages/by-title/foo.json") {
+		t.Fatal("digest.IsDigestPath classified a non-digest path as a digest artifact")
+	}
+}
+
+// TestCloseLocalDayInternalMarkerDoesNotReEnterRegeneration exercises the
+// actual yesterday close-write path, not just a synthetic write to
+// digests/yesterday.md. The public artifact must be visible to watchers and
+// classified by the digest recursion guard; internal marker/temp files must
+// stay under .relay so they are skipped before they can become source events.
+func TestCloseLocalDayInternalMarkerDoesNotReEnterRegeneration(t *testing.T) {
+	localDir := t.TempDir()
+	if strings.HasPrefix(filepath.ToSlash(digest.YesterdayMarkerPath), "digests/") {
+		t.Fatalf("YesterdayMarkerPath = %q, want watcher-skipped .relay path, not digests/.state", digest.YesterdayMarkerPath)
+	}
+	legacyMarker := "digests/.state/yesterday.lock"
+	if digest.YesterdayMarkerPath == legacyMarker {
+		t.Fatalf("YesterdayMarkerPath regressed to legacy watched path %q", legacyMarker)
+	}
+	if err := os.MkdirAll(filepath.Join(localDir, "digests"), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	events, _, _ := startFileWatcher(t, localDir)
+
+	now := time.Date(2026, 5, 13, 0, 5, 0, 0, time.UTC)
+	_, err := digest.CloseLocalDay(
+		context.Background(),
+		localDir,
+		digest.SliceSource{Items: []digest.ChangeEvent{{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC),
+			Identifier:    "PR-1",
+			Verb:          "updated",
+			CanonicalPath: "github/repos/x/pulls/by-id/1.json",
+		}}},
+		now,
+		[]string{"github"},
+		time.UTC,
+	)
+	if err != nil {
+		t.Fatalf("CloseLocalDay: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(localDir, filepath.FromSlash(digest.YesterdayMarkerPath))); err != nil {
+		t.Fatalf("marker was not written under %s: %v", digest.YesterdayMarkerPath, err)
+	}
+
+	observed := map[string]fsnotify.Op{}
+	deadline := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case ev := <-events:
+			observed[ev.path] = observed[ev.path] | ev.op
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if _, ok := observed["digests/yesterday.md"]; !ok {
+		t.Fatalf("expected watcher event for digests/yesterday.md, observed=%v", observed)
+	}
+	for path := range observed {
+		switch path {
+		case digest.YesterdayMarkerPath:
+			t.Fatalf("internal marker %q was emitted by watcher; it must stay under skipped .relay state", path)
+		case legacyMarker:
+			t.Fatalf("legacy marker %q was emitted by watcher; this path would bypass the digest recursion guard", path)
+		}
+		if strings.HasPrefix(path, "digests/") && !digest.IsDigestPath(path) {
+			t.Fatalf("watched digest-tree path %q is not classified by digest.IsDigestPath; regeneration would re-enter", path)
+		}
+	}
+}
+
+// TestWatcherEmitsLastWeekDigestFileNoRecursion covers acceptance check #5
+// for the `update-last-week` slice: a write to `digests/last-week.md` must
+// produce a normal filesystem event (so mount observers + hosted listeners
+// see the new file) AND the shared digest-source classifier
+// `digest.IsDigestPath` must flag the path so the regen pipeline's
+// recursion guard drops it, per
+// `.claude/rules/relayfile-integration-digests.md`. Mirrors the
+// yesterday-slice sibling above.
+func TestWatcherEmitsLastWeekDigestFileNoRecursion(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	digestFile := filepath.Join(localDir, "digests", "last-week.md")
+	if err := os.MkdirAll(filepath.Dir(digestFile), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	if err := os.WriteFile(digestFile, []byte("# digest last-week\n"), 0o644); err != nil {
+		t.Fatalf("write digest file: %v", err)
+	}
+
+	ev, ok := waitForWatcherEventPath(t, events, "digests/last-week.md", time.Second)
+	if !ok {
+		t.Fatalf("no watcher event for digests/last-week.md within timeout")
+	}
+	if ev.op&fsnotify.Create == 0 && ev.op&fsnotify.Write == 0 {
+		t.Fatalf("expected create or write op, got %s", ev.op)
+	}
+
+	if !digest.IsDigestPath("digests/last-week.md") {
+		t.Fatal("digest.IsDigestPath(\"digests/last-week.md\") = false; recursion-guard predicate must cover last-week.md")
+	}
+	// Near-miss spellings must NOT be classified as digest paths — a
+	// regression here would silently drop legitimate provider writes from
+	// regeneration.
+	for _, near := range []string{
+		"digests/last-weak.md",
+		"digests/last-week.txt",
+		"digests/last_week.md",
+	} {
+		if digest.IsDigestPath(near) {
+			t.Fatalf("digest.IsDigestPath(%q) = true; near-miss must not be treated as a digest artifact", near)
+		}
+	}
+}
+
+// TestWriteLastWeekDoesNotExposeWatchedTempFiles exercises the real
+// temp+rename writer. The final digest must be emitted for mounted observers,
+// but any temp files must stay under watcher-skipped internal state so the
+// rolling coalescer cannot schedule regeneration from last-week's own write.
+func TestWriteLastWeekDoesNotExposeWatchedTempFiles(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localDir, "digests"), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	events, _, _ := startFileWatcher(t, localDir)
+
+	window := digest.LastWeekWindow(
+		time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 5, 11, 0, 5, 0, 0, time.UTC),
+		[]string{"github"},
+		time.UTC,
+	)
+	result, err := digest.WriteLastWeek(
+		context.Background(),
+		localDir,
+		digest.SliceSource{Items: []digest.ChangeEvent{{
+			Provider:      "github",
+			Timestamp:     time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC),
+			Identifier:    "PR-last-week",
+			Verb:          "merged",
+			CanonicalPath: "github/repos/x/pulls/by-id/last-week.json",
+		}}},
+		window,
+	)
+	if err != nil {
+		t.Fatalf("WriteLastWeek: %v", err)
+	}
+	if !result.Written || result.Path != digest.LastWeekPath {
+		t.Fatalf("WriteLastWeek result = %#v, want written %s", result, digest.LastWeekPath)
+	}
+
+	observed := map[string]fsnotify.Op{}
+	deadline := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case ev := <-events:
+			observed[ev.path] = observed[ev.path] | ev.op
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if _, ok := observed[digest.LastWeekPath]; !ok {
+		t.Fatalf("expected watcher event for %s, observed=%v", digest.LastWeekPath, observed)
+	}
+	coalescer := &RollingDigestCoalescer{
+		Interval: 30 * time.Second,
+		Now:      func() time.Time { return time.Date(2026, 5, 11, 0, 5, 0, 0, time.UTC) },
+	}
+	for path := range observed {
+		if strings.HasPrefix(path, ".relay/") {
+			t.Fatalf("internal digest temp path %q was emitted by watcher", path)
+		}
+		if strings.HasPrefix(path, "digests/") {
+			if !digest.IsDigestPath(path) {
+				t.Fatalf("watched digest-tree path %q is not classified by digest.IsDigestPath; regeneration would re-enter", path)
+			}
+			if coalescer.ObserveChange(path) {
+				t.Fatalf("rolling coalescer scheduled a flush from digest writer path %q", path)
+			}
+		}
+	}
+}
+
+func TestWatcherEmitsDateStampedDigestFiles(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	digestFile := filepath.Join(localDir, "digests", "2026-05-12.md")
+	if err := os.MkdirAll(filepath.Dir(digestFile), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	if err := os.WriteFile(digestFile, []byte("# digest\n"), 0o644); err != nil {
+		t.Fatalf("write digest file: %v", err)
+	}
+
+	ev, ok := waitForWatcherEventPath(t, events, "digests/2026-05-12.md", time.Second)
+	if !ok {
+		t.Fatalf("no watcher event for date-stamped digest within timeout")
+	}
+	if ev.op&fsnotify.Create == 0 && ev.op&fsnotify.Write == 0 {
+		t.Fatalf("expected create or write op, got %s", ev.op)
+	}
+}
+
+// TestDateStampedDigestDoesNotReEnterRegeneration pins the parent-spec
+// no-recursion contract called out in
+// `.claude/rules/relayfile-integration-digests.md` and CLAUDE.md's Digest
+// Runtime Contract: a write to `/digests/<YYYY-MM-DD>.md` must produce a
+// normal filesystem event (so mounts see the new file) but must NOT be
+// re-ingested as a digest-source event — otherwise digest regeneration
+// would loop on its own output. The digest-source classifier is
+// `digest.IsDigestPath`. This test exercises both halves: the watcher
+// emits an event for the digest path, the classifier flags that path so
+// the regen pipeline drops it, and a sibling non-digest write under the
+// same workspace still classifies as a regen-trigger.
+func TestDateStampedDigestDoesNotReEnterRegeneration(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	digestFile := filepath.Join(localDir, "digests", "2026-05-12.md")
+	if err := os.MkdirAll(filepath.Dir(digestFile), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	if err := os.WriteFile(digestFile, []byte("# digest\n"), 0o644); err != nil {
+		t.Fatalf("write digest file: %v", err)
+	}
+
+	otherFile := filepath.Join(localDir, "notion", "pages", "demo.json")
+	if err := os.MkdirAll(filepath.Dir(otherFile), 0o755); err != nil {
+		t.Fatalf("create notion dir: %v", err)
+	}
+	if err := os.WriteFile(otherFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write non-digest file: %v", err)
+	}
+
+	// Drain events for up to a second, recording each observed path. Both
+	// the digest and non-digest writes must produce watcher events.
+	observed := map[string]fsnotify.Op{}
+	deadline := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case ev := <-events:
+			observed[ev.path] = observed[ev.path] | ev.op
+			if _, sawDigest := observed["digests/2026-05-12.md"]; sawDigest {
+				if _, sawOther := observed["notion/pages/demo.json"]; sawOther {
+					break collect
+				}
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if _, ok := observed["digests/2026-05-12.md"]; !ok {
+		t.Fatalf("expected watcher event for digests/2026-05-12.md, observed=%v", observed)
+	}
+	if _, ok := observed["notion/pages/demo.json"]; !ok {
+		t.Fatalf("expected watcher event for non-digest path, observed=%v", observed)
+	}
+
+	// The digest-source classifier (digest.IsDigestPath) is the gate the
+	// regeneration pipeline uses to drop digest writes. Exercise it with
+	// the exact paths the watcher just produced. If a future refactor
+	// removes or weakens this classifier, this assertion catches the tight
+	// write→ingest→write loop that would result.
+	for path := range observed {
+		isDigest := digest.IsDigestPath(path)
+		switch path {
+		case "digests/2026-05-12.md":
+			if !isDigest {
+				t.Fatalf("digest.IsDigestPath(%q) = false; regeneration would re-enter on the date-stamped digest", path)
+			}
+		case "notion/pages/demo.json":
+			if isDigest {
+				t.Fatalf("digest.IsDigestPath(%q) = true; non-digest writes would be silently dropped", path)
+			}
+		}
+	}
+}
+
+// TestThisWeekDigestDoesNotReEnterRegeneration mirrors the date-stamped
+// digest no-recursion test for the rolling weekly artifact
+// `/digests/this-week.md`. The watcher must emit a normal fs event for the
+// rewrite so mount observers see the change, and `digest.IsDigestPath` must
+// classify the path as a digest so the regen pipeline drops it instead of
+// looping on its own output.
+func TestThisWeekDigestDoesNotReEnterRegeneration(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	digestFile := filepath.Join(localDir, "digests", "this-week.md")
+	if err := os.MkdirAll(filepath.Dir(digestFile), 0o755); err != nil {
+		t.Fatalf("create digest dir: %v", err)
+	}
+	if err := os.WriteFile(digestFile, []byte("# this-week\n"), 0o644); err != nil {
+		t.Fatalf("write digest file: %v", err)
+	}
+
+	otherFile := filepath.Join(localDir, "linear", "issues", "demo.json")
+	if err := os.MkdirAll(filepath.Dir(otherFile), 0o755); err != nil {
+		t.Fatalf("create linear dir: %v", err)
+	}
+	if err := os.WriteFile(otherFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write non-digest file: %v", err)
+	}
+
+	observed := map[string]fsnotify.Op{}
+	deadline := time.After(2 * time.Second)
+collect:
+	for {
+		select {
+		case ev := <-events:
+			observed[ev.path] = observed[ev.path] | ev.op
+			if _, sawDigest := observed["digests/this-week.md"]; sawDigest {
+				if _, sawOther := observed["linear/issues/demo.json"]; sawOther {
+					break collect
+				}
+			}
+		case <-deadline:
+			break collect
+		}
+	}
+
+	if _, ok := observed["digests/this-week.md"]; !ok {
+		t.Fatalf("expected watcher event for digests/this-week.md, observed=%v", observed)
+	}
+	if _, ok := observed["linear/issues/demo.json"]; !ok {
+		t.Fatalf("expected watcher event for non-digest path, observed=%v", observed)
+	}
+	for path := range observed {
+		isDigest := digest.IsDigestPath(path)
+		switch path {
+		case "digests/this-week.md":
+			if !isDigest {
+				t.Fatalf("digest.IsDigestPath(%q) = false; regeneration would re-enter on the rolling weekly digest", path)
+			}
+		case "linear/issues/demo.json":
+			if isDigest {
+				t.Fatalf("digest.IsDigestPath(%q) = true; non-digest writes would be silently dropped", path)
+			}
+		}
+	}
 }
 
 // TestWatcherSkipsMountStateTempFiles pins the bug where writeFileAtomic

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -1475,7 +1475,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/WritebackItem'
+                  $ref: '#/components/schemas/WritebackPendingItem'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -2610,10 +2610,67 @@ components:
           type: object
           additionalProperties: true
 
-    WritebackItem:
+    WritebackDeadLetterError:
+      type: object
+      additionalProperties: false
+      required: [code, message, attempts, firstAttemptAt, lastAttemptAt, opId]
+      properties:
+        code:
+          type: string
+          description: Dead-letter classification code
+          enum: [schema_violation, provider_4xx, provider_5xx_exhausted, timeout]
+        message:
+          type: string
+          description: Human-readable failure details
+        providerStatus:
+          type: integer
+          description: HTTP status returned by the provider, when available
+        providerResponse:
+          type: object
+          additionalProperties: true
+          description: Provider error response body, when available
+        attempts:
+          type: integer
+          minimum: 1
+          description: Number of delivery attempts; must be at least 1 when first/last attempt timestamps are present
+        firstAttemptAt:
+          type: string
+          format: date-time
+          description: Timestamp of the first delivery attempt
+        lastAttemptAt:
+          type: string
+          format: date-time
+          description: Timestamp of the most recent delivery attempt
+        opId:
+          type: string
+          description: Operation ID associated with the failed writeback
+
+    WritebackPendingItem:
       type: object
       additionalProperties: false
       required: [id, workspaceId, path, revision, correlationId]
+      properties:
+        id:
+          type: string
+          description: Operation ID for this pending writeback
+        workspaceId:
+          type: string
+          description: Workspace identifier
+        path:
+          type: string
+          description: Virtual filesystem path
+          pattern: '^/.*'
+        revision:
+          type: string
+          description: Current file revision
+        correlationId:
+          type: string
+          description: Correlation ID for tracing
+
+    WritebackItem:
+      type: object
+      additionalProperties: false
+      required: [id, workspaceId, path, revision, correlationId, state]
       properties:
         id:
           type: string
@@ -2631,6 +2688,62 @@ components:
         correlationId:
           type: string
           description: Correlation ID for tracing
+        state:
+          type: string
+          description: Writeback queue state, when returned by stateful list endpoints
+          enum: [pending, succeeded, failed, dead_lettered, dead]
+        opId:
+          type: string
+          description: Operation ID alias used by legacy/detail payloads
+        provider:
+          type: string
+          description: Provider responsible for applying this writeback
+        action:
+          type: string
+          description: Provider writeback action name
+        ts:
+          type: string
+          format: date-time
+          description: Event timestamp associated with the writeback
+        code:
+          type: string
+          description: Dead-letter or provider failure classification
+        message:
+          type: string
+          description: Human-readable failure details
+        providerStatus:
+          type: integer
+          description: HTTP status returned by the provider, when available
+        providerResponse:
+          type: object
+          additionalProperties: true
+          description: Provider error response body, when available
+        attempts:
+          type: integer
+          minimum: 0
+          description: Number of delivery attempts
+        attemptCount:
+          type: integer
+          minimum: 0
+          description: Legacy alias for attempts
+        firstAttemptAt:
+          type: string
+          format: date-time
+          description: Timestamp of the first delivery attempt
+        enqueuedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the writeback entered the queue
+        createdAt:
+          type: string
+          format: date-time
+          description: Legacy alias for enqueuedAt
+        lastAttemptAt:
+          type: string
+          format: date-time
+          description: Timestamp of the most recent delivery attempt
+        error:
+          $ref: '#/components/schemas/WritebackDeadLetterError'
 
     BulkWriteRequest:
       type: object

--- a/packages/sdk/python/README.md
+++ b/packages/sdk/python/README.md
@@ -11,14 +11,29 @@ layout, schema, and writeback tooling.
 from relayfile import (
     DIGEST_PATHS,
     RelayFileClient,
+    is_digest_path,
     provider_layout_path,
     resource_schema_path,
 )
 
 client = RelayFileClient("https://api.relayfile.dev", token_provider)
 
-# Subscribe or poll for file.created/file.updated events at these paths.
-print(DIGEST_PATHS)  # ("digests/yesterday.md", "digests/today.md")
+# DIGEST_PATHS is the literal anchor-path taxonomy: the rolling daily
+# files plus rolling and closing-window weekly files. Closed-window daily
+# artifacts use the date-stamped form ``digests/YYYY-MM-DD.md``; filter
+# events through ``is_digest_path`` to subscribe to the full taxonomy
+# (anchor paths plus date-stamped form).
+print(DIGEST_PATHS)
+# (
+#     "digests/yesterday.md",
+#     "digests/today.md",
+#     "digests/this-week.md",
+#     "digests/last-week.md",
+# )
+assert is_digest_path("digests/today.md")
+assert is_digest_path("digests/2026-05-12.md")
+assert is_digest_path("digests/this-week.md")
+assert is_digest_path("digests/last-week.md")
 
 # Read provider layout documentation.
 layout = client.read_file(workspace_id, provider_layout_path("linear"))

--- a/packages/sdk/python/src/relayfile/__init__.py
+++ b/packages/sdk/python/src/relayfile/__init__.py
@@ -7,12 +7,14 @@ from .errors import (
     PayloadTooLargeError,
 )
 from .provider import (
+    DATE_STAMPED_DIGEST_PATH_PATTERN,
     DIGEST_PATHS,
     IntegrationProvider,
     ListProviderFilesOptions,
     WatchProviderEventsOptions,
     WebhookInput,
     compute_canonical_path,
+    is_digest_path,
     provider_layout_path,
     resource_schema_path,
 )
@@ -47,6 +49,8 @@ __all__ = [
     "PayloadTooLargeError",
     "IntegrationProvider",
     "DIGEST_PATHS",
+    "DATE_STAMPED_DIGEST_PATH_PATTERN",
+    "is_digest_path",
     "WebhookInput",
     "ListProviderFilesOptions",
     "WatchProviderEventsOptions",

--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -538,8 +538,13 @@ class RelayFileClient:
         """List filesystem events.
 
         Digest artifacts are reported as ordinary ``file.created`` and
-        ``file.updated`` events at ``DIGEST_PATHS``; filter returned events
-        by those paths to subscribe to deterministic digest updates.
+        ``file.updated`` events. ``DIGEST_PATHS`` holds the literal rolling
+        anchor paths, including ``digests/today.md``,
+        ``digests/yesterday.md``, ``digests/this-week.md``, and
+        ``digests/last-week.md``; closed-window daily artifacts use the
+        date-stamped form
+        ``digests/YYYY-MM-DD.md``. Filter returned events through
+        ``relayfile.is_digest_path`` to subscribe to the full taxonomy.
         """
 
         query = _build_query({"provider": provider, "cursor": cursor, "limit": limit})
@@ -1227,8 +1232,13 @@ class AsyncRelayFileClient:
         """List filesystem events.
 
         Digest artifacts are reported as ordinary ``file.created`` and
-        ``file.updated`` events at ``DIGEST_PATHS``; filter returned events
-        by those paths to subscribe to deterministic digest updates.
+        ``file.updated`` events. ``DIGEST_PATHS`` holds the literal rolling
+        anchor paths, including ``digests/today.md``,
+        ``digests/yesterday.md``, ``digests/this-week.md``, and
+        ``digests/last-week.md``; closed-window daily artifacts use the
+        date-stamped form
+        ``digests/YYYY-MM-DD.md``. Filter returned events through
+        ``relayfile.is_digest_path`` to subscribe to the full taxonomy.
         """
 
         query = _build_query({"provider": provider, "cursor": cursor, "limit": limit})

--- a/packages/sdk/python/src/relayfile/provider.py
+++ b/packages/sdk/python/src/relayfile/provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from datetime import date
 from dataclasses import dataclass
 from threading import Event
 from time import sleep
@@ -30,7 +32,41 @@ DEFAULT_PATH_PREFIXES: dict[str, str] = {
     "twilio": "/twilio",
 }
 
-DIGEST_PATHS: tuple[str, str] = ("digests/yesterday.md", "digests/today.md")
+DIGEST_PATHS: tuple[str, ...] = (
+    "digests/yesterday.md",
+    "digests/today.md",
+    "digests/this-week.md",
+    "digests/last-week.md",
+)
+
+# Pattern for the canonical date-stamped digest path. Mirrors
+# IsDateStampedPath in internal/digest/date_stamped.go: literal "digests/"
+# prefix, ISO-8601 YYYY-MM-DD date, ".md" suffix.
+DATE_STAMPED_DIGEST_PATH_PATTERN = re.compile(r"^digests/(\d{4})-(\d{2})-(\d{2})\.md$")
+
+
+def is_digest_path(path: str) -> bool:
+    """Return True if path is a recognized v1 digest artifact.
+
+    Matches the literal anchor paths in ``DIGEST_PATHS`` as well as the
+    date-stamped closed-window form ``digests/YYYY-MM-DD.md`` with a valid
+    calendar date. Mirrors ``IsDigestPath`` in
+    ``internal/digest/date_stamped.go``: leading and trailing slashes are
+    stripped before matching.
+    """
+
+    normalized = path.strip().lstrip("/").rstrip("/")
+    if normalized in DIGEST_PATHS:
+        return True
+    match = DATE_STAMPED_DIGEST_PATH_PATTERN.match(normalized)
+    if match is None:
+        return False
+    year, month, day = (int(g) for g in match.groups())
+    try:
+        date(year, month, day)
+    except ValueError:
+        return False
+    return True
 
 
 @dataclass

--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -254,8 +254,9 @@ class FilesystemEvent:
     """Filesystem event row.
 
     Digest generation is exposed through ordinary ``file.created`` and
-    ``file.updated`` events at the paths in ``relayfile.DIGEST_PATHS``.
-    Consumers can filter returned events by those paths after calling
+    ``file.updated`` events at paths recognized by ``relayfile.is_digest_path``:
+    the anchors in ``relayfile.DIGEST_PATHS`` plus date-stamped closed-day
+    files. Consumers can filter returned events after calling
     ``RelayFileClient.get_events``.
     """
 

--- a/packages/sdk/python/tests/test_provider.py
+++ b/packages/sdk/python/tests/test_provider.py
@@ -2,11 +2,67 @@ from __future__ import annotations
 
 import pytest
 
-from relayfile import DIGEST_PATHS, provider_layout_path, resource_schema_path
+from relayfile import (
+    DATE_STAMPED_DIGEST_PATH_PATTERN,
+    DIGEST_PATHS,
+    is_digest_path,
+    provider_layout_path,
+    resource_schema_path,
+)
 
 
 def test_digest_paths_are_canonical_workspace_primitive_paths() -> None:
-    assert DIGEST_PATHS == ("digests/yesterday.md", "digests/today.md")
+    assert DIGEST_PATHS == (
+        "digests/yesterday.md",
+        "digests/today.md",
+        "digests/this-week.md",
+        "digests/last-week.md",
+    )
+
+
+def test_is_digest_path_matches_literal_anchor_paths() -> None:
+    assert is_digest_path("digests/today.md") is True
+    assert is_digest_path("digests/yesterday.md") is True
+    assert is_digest_path("digests/this-week.md") is True
+    assert is_digest_path("/digests/this-week.md") is True
+    assert is_digest_path("digests/last-week.md") is True
+    assert is_digest_path("/digests/last-week.md") is True
+
+
+def test_is_digest_path_rejects_near_matches_to_weekly_anchors() -> None:
+    # Spelling variants and wrong suffixes must NOT be treated as a
+    # digest path even though they share the prefix.
+    assert is_digest_path("digests/this-weak.md") is False
+    assert is_digest_path("digests/this-week.txt") is False
+    assert is_digest_path("digests/this_week.md") is False
+    assert is_digest_path("digests/last-weak.md") is False
+    assert is_digest_path("digests/last-week.txt") is False
+    assert is_digest_path("digests/last_week.md") is False
+
+
+def test_is_digest_path_matches_date_stamped_form() -> None:
+    assert is_digest_path("digests/2026-05-12.md") is True
+    assert is_digest_path("digests/2026-01-01.md") is True
+    assert is_digest_path("digests/2025-12-31.md") is True
+
+
+def test_is_digest_path_rejects_invalid_or_foreign_paths() -> None:
+    # Invalid calendar date.
+    assert is_digest_path("digests/2026-02-30.md") is False
+    # Wrong suffix.
+    assert is_digest_path("digests/2026-05-12.json") is False
+    # Wrong prefix.
+    assert is_digest_path("notion/pages/2026-05-12.md") is False
+    # Bad shape (template placeholder is not a path).
+    assert is_digest_path("digests/YYYY-MM-DD.md") is False
+    # Mirrors Go normalization — leading/trailing slashes are stripped
+    # before matching, so this is recognized.
+    assert is_digest_path("/digests/yesterday.md") is True
+
+
+def test_date_stamped_digest_pattern_is_exposed() -> None:
+    assert DATE_STAMPED_DIGEST_PATH_PATTERN.match("digests/2026-05-12.md") is not None
+    assert DATE_STAMPED_DIGEST_PATH_PATTERN.match("digests/today.md") is None
 
 
 def test_provider_layout_path_normalizes_provider_segment() -> None:


### PR DESCRIPTION
## Summary
- integrate the cleaned PR-39 local primitive work from #167 with the stronger digest runtime/scheduler/SDK work from #162
- base the cohesive branch on latest main, including #166 mount-root convergence and bootstrap safety
- expose/materialize `.skills/activity-summary.md`, reserve runtime digest/skills paths from writeback, and keep digest file writes visible as normal mount events without re-entering writeback/source generation
- implement timezone-aware daily/date-stamped/weekly digest rebuilds, closing-window immutability, rolling digest coalescing, scheduler catch-up, and Python SDK digest taxonomy

## Supersedes
- Supersedes #162 for the relayfile slice; #162's digest runtime/rules/docs/SDK pieces have been reconciled here without its stale branch lineage.

## Verification
- `go test ./...`
- `scripts/check-contract-surface.sh`
- `pytest packages/sdk/python`