### PR TITLE
Split SDK CLI utilities into explicit subpaths

### DIFF
--- a/docs/agent-workspace-golden-path.md
+++ b/docs/agent-workspace-golden-path.md
@@ -69,7 +69,7 @@ The target user experience is:
 The TypeScript path should feel like this:
 
 ```ts
-import { RelayfileSetup } from '@relayfile/sdk'
+import { RelayfileSetup } from '@relayfile/sdk/cli'
 
 const setup = await RelayfileSetup.login({
   onLoginUrl: (url) => {

--- a/docs/guides/post-auth-mount-session.md
+++ b/docs/guides/post-auth-mount-session.md
@@ -118,7 +118,7 @@ npm install @relayfile/sdk
 Use when you already have a `WorkspaceHandle` or a bare `workspaceId`. No provider check is performed — the caller is responsible for knowing the provider is ready.
 
 ```ts
-import { RelayfileSetup } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 
 const setup = await RelayfileSetup.login();
 const workspace = await setup.joinWorkspace("ws_abc123");
@@ -176,7 +176,8 @@ Exactly one of `workspace` / `workspaceId` must be provided. Passing both or nei
 Use when the workspace has an integration provider that must be connected before mounting. This is the standard entry point for sandbox integrators.
 
 ```ts
-import { RelayfileSetup, ProviderNotConnectedError, ProviderNotReadyError } from "@relayfile/sdk";
+import { ProviderNotConnectedError, ProviderNotReadyError } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 
 const setup = await RelayfileSetup.login();
 const workspace = await setup.joinWorkspace("ws_abc123");
@@ -275,7 +276,8 @@ When `verifyProvider: true` and no `provider` is supplied, the SDK throws `Mount
 ## Daytona Example
 
 ```ts
-import { RelayfileSetup, ProviderNotConnectedError } from "@relayfile/sdk";
+import { ProviderNotConnectedError } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 import Daytona from "@daytonaio/sdk";
 
 const daytona = new Daytona();
@@ -317,7 +319,7 @@ await daytona.delete(sandbox);
 ## E2B Example
 
 ```ts
-import { RelayfileSetup } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 import { Sandbox } from "e2b";
 
 const setup = await RelayfileSetup.login();
@@ -344,7 +346,8 @@ await sandbox.kill();
 ## Local / CI Example
 
 ```ts
-import { RelayfileSetup, MountReadyTimeoutError } from "@relayfile/sdk";
+import { MountReadyTimeoutError } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 import { execFile } from "node:child_process";
 import path from "node:path";
 
@@ -393,7 +396,7 @@ console.log("Probe ready:", handle.ready);
 Production code uses the bundled launcher (which runs `relayfile-mount`). Tests inject the in-process `startMountHarness` harness from `@relayfile/sdk/mount-harness` to avoid spawning a real process:
 
 ```ts
-import { RelayfileSetup } from "@relayfile/sdk";
+import { RelayfileSetup } from "@relayfile/sdk/cli";
 import { startMountHarness } from "@relayfile/sdk/mount-harness";
 
 const harnessLauncher = {

--- a/packages/sdk/typescript/README.md
+++ b/packages/sdk/typescript/README.md
@@ -15,7 +15,7 @@ The recommended way to use `@relayfile/sdk` in an agent workflow is through
 environment variable generation for `relayfile-mount`, and agent invites.
 
 ```ts
-import { RelayfileSetup } from '@relayfile/sdk'
+import { RelayfileSetup } from '@relayfile/sdk/cli'
 
 const setup = await RelayfileSetup.login({
   onLoginUrl: (url) => console.log(`Sign in to Relayfile Cloud: ${url}`),
@@ -71,6 +71,12 @@ You can still pass `accessToken` directly to `new RelayfileSetup()` in CI or
 advanced hosts that already provide a valid Cloud bearer token. After Cloud auth,
 complete the Notion OAuth flow as described in
 [`docs/agent-workspace-golden-path.md`](../../../docs/agent-workspace-golden-path.md).
+
+The default `@relayfile/sdk` entry point is safe for Worker-style bundles and
+does not statically import the CLI-only mount launcher or local browser login
+helpers. Import interactive login and local mount launcher utilities from
+`@relayfile/sdk/cli`, `@relayfile/sdk/cloud-login`, or
+`@relayfile/sdk/mount-launcher`.
 
 ---
 

--- a/packages/sdk/typescript/package.json
+++ b/packages/sdk/typescript/package.json
@@ -5,6 +5,31 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./cli": {
+      "types": "./dist/cli/index.d.ts",
+      "default": "./dist/cli/index.js"
+    },
+    "./cloud-login": {
+      "types": "./dist/cloud-login.d.ts",
+      "default": "./dist/cloud-login.js"
+    },
+    "./mount-launcher": {
+      "types": "./dist/mount-launcher.d.ts",
+      "default": "./dist/mount-launcher.js"
+    },
+    "./mount-harness": {
+      "types": "./dist/mount-harness.d.ts",
+      "default": "./dist/mount-harness.js"
+    },
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/packages/sdk/typescript/src/cli/index.ts
+++ b/packages/sdk/typescript/src/cli/index.ts
@@ -1,0 +1,22 @@
+export * from "../index.js"
+export { RelayfileSetup } from "./setup.js"
+export {
+  createDefaultMountLauncher,
+  defaultMountLauncher,
+  readMountedWorkspaceStatus
+} from "../mount-launcher.js"
+export {
+  runRelayfileCloudLogin,
+  type RelayfileCloudLoginOptions,
+  type RelayfileCloudTokenSet,
+  type RelayfileCloudTokenSetupOptions
+} from "../cloud-login.js"
+export { createRelayfileCloudAccessTokenProvider } from "../cloud-token-provider.js"
+export type {
+  MountLauncher,
+  MountLauncherEvent,
+  MountLauncherInstance,
+  MountLauncherStart,
+  MountedWorkspaceStatus,
+  ReadMountedWorkspaceStatusInput
+} from "../setup-types.js"

--- a/packages/sdk/typescript/src/cli/setup.ts
+++ b/packages/sdk/typescript/src/cli/setup.ts
@@ -1,0 +1,69 @@
+import { createRelayfileCloudAccessTokenProvider } from "../cloud-token-provider.js"
+import {
+  runRelayfileCloudLogin,
+  type RelayfileCloudLoginOptions,
+  type RelayfileCloudTokenSet,
+  type RelayfileCloudTokenSetupOptions
+} from "../cloud-login.js"
+import {
+  defaultMountLauncher,
+  readMountedWorkspaceStatus
+} from "../mount-launcher.js"
+import {
+  RelayfileSetup as BaseRelayfileSetup
+} from "../setup.js"
+import type {
+  MountLauncher,
+  MountedWorkspaceStatus,
+  ReadMountedWorkspaceStatusInput
+} from "../setup-types.js"
+
+const DEFAULT_CLOUD_API_URL = "https://agentrelay.com/cloud"
+
+export class RelayfileSetup extends BaseRelayfileSetup {
+  static override async login(
+    options: RelayfileCloudLoginOptions = {}
+  ): Promise<RelayfileSetup> {
+    const cloudApiUrl = options.cloudApiUrl ?? DEFAULT_CLOUD_API_URL
+    const tokens = await runRelayfileCloudLogin({
+      ...options,
+      cloudApiUrl
+    })
+    await options.onTokens?.({ ...tokens })
+    return RelayfileSetup.fromCloudTokens(tokens, {
+      ...options,
+      cloudApiUrl: tokens.apiUrl ?? cloudApiUrl
+    })
+  }
+
+  static override fromCloudTokens(
+    tokens: RelayfileCloudTokenSet,
+    options: RelayfileCloudTokenSetupOptions = {}
+  ): RelayfileSetup {
+    const cloudApiUrl = options.cloudApiUrl ?? tokens.apiUrl ?? DEFAULT_CLOUD_API_URL
+    return new RelayfileSetup({
+      ...options,
+      cloudApiUrl,
+      accessToken: createRelayfileCloudAccessTokenProvider(
+        {
+          ...tokens,
+          apiUrl: tokens.apiUrl ?? cloudApiUrl
+        },
+        {
+          ...options,
+          cloudApiUrl
+        }
+      )
+    })
+  }
+
+  protected override getDefaultMountLauncher(): MountLauncher {
+    return defaultMountLauncher
+  }
+
+  protected override readMountedWorkspaceStatus(
+    input: ReadMountedWorkspaceStatusInput
+  ): Promise<MountedWorkspaceStatus> {
+    return readMountedWorkspaceStatus(input)
+  }
+}

--- a/packages/sdk/typescript/src/cloud-login.ts
+++ b/packages/sdk/typescript/src/cloud-login.ts
@@ -1,34 +1,17 @@
-import type { AccessTokenProvider } from "./client.js"
 import {
   CloudAbortError,
-  CloudApiError,
   CloudTimeoutError,
   MalformedCloudResponseError
 } from "./setup-errors.js"
-import type { RelayfileSetupOptions } from "./setup-types.js"
-import { RELAYFILE_SDK_VERSION } from "./version.js"
+import type { RelayfileCloudTokenSetupOptions, RelayfileCloudTokenSet } from "./cloud-token-provider.js"
 
 const DEFAULT_CLOUD_API_URL = "https://agentrelay.com/cloud"
 const DEFAULT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000
 const DEFAULT_REDIRECT_HOST = "127.0.0.1"
 const DEFAULT_REDIRECT_PATH = "/callback"
-const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
-const DEFAULT_REFRESH_WINDOW_MS = 60_000
 
-export interface RelayfileCloudTokenSet {
-  apiUrl?: string
-  accessToken: string
-  refreshToken: string
-  accessTokenExpiresAt: string
-  refreshTokenExpiresAt?: string
-}
-
-export interface RelayfileCloudTokenSetupOptions
-  extends Omit<RelayfileSetupOptions, "accessToken" | "cloudApiUrl"> {
-  cloudApiUrl?: string
-  refreshWindowMs?: number
-  onTokens?: (tokens: RelayfileCloudTokenSet) => void | Promise<void>
-}
+export type { RelayfileCloudTokenSetupOptions, RelayfileCloudTokenSet } from "./cloud-token-provider.js"
+export { createRelayfileCloudAccessTokenProvider } from "./cloud-token-provider.js"
 
 export interface RelayfileCloudLoginOptions
   extends RelayfileCloudTokenSetupOptions {
@@ -168,94 +151,6 @@ export async function runRelayfileCloudLogin(
   })
 }
 
-export function createRelayfileCloudAccessTokenProvider(
-  initialTokens: RelayfileCloudTokenSet,
-  options: RelayfileCloudTokenSetupOptions = {}
-): AccessTokenProvider {
-  const cloudApiUrl =
-    normalizeNonEmptyString(options.cloudApiUrl) ??
-    normalizeNonEmptyString(initialTokens.apiUrl) ??
-    DEFAULT_CLOUD_API_URL
-  const requestTimeoutMs = Math.max(
-    1,
-    Math.floor(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
-  )
-  const refreshWindowMs = Math.max(
-    0,
-    Math.floor(options.refreshWindowMs ?? DEFAULT_REFRESH_WINDOW_MS)
-  )
-  let tokens: RelayfileCloudTokenSet = {
-    ...initialTokens,
-    apiUrl: normalizeNonEmptyString(initialTokens.apiUrl) ?? cloudApiUrl
-  }
-  let refreshPromise: Promise<void> | undefined
-
-  return async () => {
-    if (shouldRefresh(tokens, refreshWindowMs)) {
-      if (!refreshPromise) {
-        refreshPromise = refresh()
-      }
-      try {
-        await refreshPromise
-      } finally {
-        refreshPromise = undefined
-      }
-    }
-    return tokens.accessToken
-  }
-
-  async function refresh(): Promise<void> {
-    const response = await fetchWithTimeout(
-      buildCloudUrl(cloudApiUrl, "api/v1/auth/token/refresh").toString(),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-Relayfile-SDK-Version": RELAYFILE_SDK_VERSION
-        },
-        body: JSON.stringify({ refreshToken: tokens.refreshToken })
-      },
-      requestTimeoutMs
-    )
-    const payload = await readResponseBody(response)
-    if (!response.ok) {
-      throw new CloudApiError(response.status, payload)
-    }
-    tokens = readTokenSetFromPayload(payload, cloudApiUrl)
-    await options.onTokens?.({ ...tokens })
-  }
-}
-
-function shouldRefresh(
-  tokens: RelayfileCloudTokenSet,
-  refreshWindowMs: number
-): boolean {
-  const expiresAt = Date.parse(tokens.accessTokenExpiresAt)
-  if (Number.isNaN(expiresAt)) {
-    return true
-  }
-  return expiresAt - Date.now() <= refreshWindowMs
-}
-
-async function fetchWithTimeout(
-  url: string,
-  init: RequestInit,
-  timeoutMs: number
-): Promise<Response> {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
-  try {
-    return await fetch(url, { ...init, signal: controller.signal })
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new CloudTimeoutError("refreshCloudAccessToken", timeoutMs)
-    }
-    throw error
-  } finally {
-    clearTimeout(timer)
-  }
-}
-
 function readTokenSetFromSearchParams(
   params: URLSearchParams,
   fallbackApiUrl: string
@@ -271,41 +166,12 @@ function readTokenSetFromSearchParams(
   }
 }
 
-function readTokenSetFromPayload(
-  payload: unknown,
-  fallbackApiUrl: string
-): RelayfileCloudTokenSet {
-  return {
-    apiUrl: readOptionalStringField(payload, "apiUrl") ?? fallbackApiUrl,
-    accessToken: requireStringField(payload, "accessToken"),
-    refreshToken: requireStringField(payload, "refreshToken"),
-    accessTokenExpiresAt: requireStringField(payload, "accessTokenExpiresAt"),
-    refreshTokenExpiresAt: readOptionalStringField(payload, "refreshTokenExpiresAt")
-  }
-}
-
 function requireSearchParam(params: URLSearchParams, field: string): string {
   const value = normalizeNonEmptyString(params.get(field) ?? undefined)
   if (!value) {
     throw new MalformedCloudResponseError(field, Object.fromEntries(params))
   }
   return value
-}
-
-async function readResponseBody(response: Response): Promise<unknown> {
-  const text = await response.text()
-  if (text === "") {
-    return null
-  }
-  const contentType = response.headers.get("content-type") ?? ""
-  if (contentType.includes("application/json")) {
-    try {
-      return JSON.parse(text)
-    } catch {
-      return text
-    }
-  }
-  return text
 }
 
 function requireStringField(payload: unknown, field: string): string {

--- a/packages/sdk/typescript/src/cloud-token-provider.ts
+++ b/packages/sdk/typescript/src/cloud-token-provider.ts
@@ -1,0 +1,183 @@
+import type { AccessTokenProvider } from "./client.js"
+import {
+  CloudApiError,
+  CloudTimeoutError,
+  MalformedCloudResponseError
+} from "./setup-errors.js"
+import type { RelayfileSetupOptions } from "./setup-types.js"
+import { RELAYFILE_SDK_VERSION } from "./version.js"
+
+const DEFAULT_CLOUD_API_URL = "https://agentrelay.com/cloud"
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_REFRESH_WINDOW_MS = 60_000
+
+export interface RelayfileCloudTokenSet {
+  apiUrl?: string
+  accessToken: string
+  refreshToken: string
+  accessTokenExpiresAt: string
+  refreshTokenExpiresAt?: string
+}
+
+export interface RelayfileCloudTokenSetupOptions
+  extends Omit<RelayfileSetupOptions, "accessToken" | "cloudApiUrl"> {
+  cloudApiUrl?: string
+  refreshWindowMs?: number
+  onTokens?: (tokens: RelayfileCloudTokenSet) => void | Promise<void>
+}
+
+export function createRelayfileCloudAccessTokenProvider(
+  initialTokens: RelayfileCloudTokenSet,
+  options: RelayfileCloudTokenSetupOptions = {}
+): AccessTokenProvider {
+  const cloudApiUrl =
+    normalizeNonEmptyString(options.cloudApiUrl) ??
+    normalizeNonEmptyString(initialTokens.apiUrl) ??
+    DEFAULT_CLOUD_API_URL
+  const requestTimeoutMs = Math.max(
+    1,
+    Math.floor(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+  )
+  const refreshWindowMs = Math.max(
+    0,
+    Math.floor(options.refreshWindowMs ?? DEFAULT_REFRESH_WINDOW_MS)
+  )
+  let tokens: RelayfileCloudTokenSet = {
+    ...initialTokens,
+    apiUrl: normalizeNonEmptyString(initialTokens.apiUrl) ?? cloudApiUrl
+  }
+  let refreshPromise: Promise<void> | undefined
+
+  return async () => {
+    if (shouldRefresh(tokens, refreshWindowMs)) {
+      if (!refreshPromise) {
+        refreshPromise = refresh()
+      }
+      try {
+        await refreshPromise
+      } finally {
+        refreshPromise = undefined
+      }
+    }
+    return tokens.accessToken
+  }
+
+  async function refresh(): Promise<void> {
+    const response = await fetchWithTimeout(
+      buildCloudUrl(cloudApiUrl, "api/v1/auth/token/refresh").toString(),
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Relayfile-SDK-Version": RELAYFILE_SDK_VERSION
+        },
+        body: JSON.stringify({ refreshToken: tokens.refreshToken })
+      },
+      requestTimeoutMs
+    )
+    const payload = await readResponseBody(response)
+    if (!response.ok) {
+      throw new CloudApiError(response.status, payload)
+    }
+    tokens = readTokenSetFromPayload(payload, cloudApiUrl)
+    await options.onTokens?.({ ...tokens })
+  }
+}
+
+function shouldRefresh(
+  tokens: RelayfileCloudTokenSet,
+  refreshWindowMs: number
+): boolean {
+  const expiresAt = Date.parse(tokens.accessTokenExpiresAt)
+  if (Number.isNaN(expiresAt)) {
+    return true
+  }
+  return expiresAt - Date.now() <= refreshWindowMs
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new CloudTimeoutError("refreshCloudAccessToken", timeoutMs)
+    }
+    throw error
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function readTokenSetFromPayload(
+  payload: unknown,
+  fallbackApiUrl: string
+): RelayfileCloudTokenSet {
+  return {
+    apiUrl: readOptionalStringField(payload, "apiUrl") ?? fallbackApiUrl,
+    accessToken: requireStringField(payload, "accessToken"),
+    refreshToken: requireStringField(payload, "refreshToken"),
+    accessTokenExpiresAt: requireStringField(payload, "accessTokenExpiresAt"),
+    refreshTokenExpiresAt: readOptionalStringField(payload, "refreshTokenExpiresAt")
+  }
+}
+
+async function readResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (text === "") {
+    return null
+  }
+  const contentType = response.headers.get("content-type") ?? ""
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  }
+  return text
+}
+
+function requireStringField(payload: unknown, field: string): string {
+  const value = readField(payload, field)
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new MalformedCloudResponseError(field, payload)
+  }
+  return value
+}
+
+function readOptionalStringField(payload: unknown, field: string): string | undefined {
+  const value = readField(payload, field)
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new MalformedCloudResponseError(field, payload)
+  }
+  return value
+}
+
+function readField(payload: unknown, field: string): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined
+  }
+  return (payload as Record<string, unknown>)[field]
+}
+
+function buildCloudUrl(baseUrl: string, path: string): URL {
+  const base = new URL(baseUrl)
+  if (!base.pathname.endsWith("/")) {
+    base.pathname = `${base.pathname}/`
+  }
+  return new URL(path.replace(/^\/+/, ""), base)
+}
+
+function normalizeNonEmptyString(value?: string): string | undefined {
+  const normalized = value?.trim()
+  return normalized ? normalized : undefined
+}

--- a/packages/sdk/typescript/src/import-safety.test.ts
+++ b/packages/sdk/typescript/src/import-safety.test.ts
@@ -1,0 +1,108 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import * as ts from "typescript"
+import { describe, expect, it } from "vitest"
+
+const SDK_SRC_ROOT = path.resolve(import.meta.dirname)
+const FORBIDDEN_DEFAULT_ENTRY_IMPORTS = new Set([
+  "node:child_process",
+  "node:fs",
+  "node:fs/promises",
+  "node:http",
+  "node:path",
+  "node:process",
+  "node:url"
+])
+
+describe("default entry import safety", () => {
+  it("does not statically pull CLI-only Node modules into @relayfile/sdk", async () => {
+    const graph = await collectStaticImportGraph(path.join(SDK_SRC_ROOT, "index.ts"))
+
+    expect([...graph.files].sort()).not.toContain(
+      path.join(SDK_SRC_ROOT, "mount-launcher.ts")
+    )
+    expect([...graph.files].sort()).not.toContain(
+      path.join(SDK_SRC_ROOT, "cloud-login.ts")
+    )
+    expect([...graph.nodeSpecifiers].sort()).toEqual([])
+  })
+})
+
+async function collectStaticImportGraph(entry: string): Promise<{
+  files: Set<string>
+  nodeSpecifiers: Set<string>
+}> {
+  const files = new Set<string>()
+  const nodeSpecifiers = new Set<string>()
+  const pending = [entry]
+
+  while (pending.length > 0) {
+    const file = pending.pop()!
+    if (files.has(file)) {
+      continue
+    }
+    files.add(file)
+
+    const source = await readFile(file, "utf8")
+    const sourceFile = ts.createSourceFile(
+      file,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    )
+
+    for (const specifier of readRuntimeModuleSpecifiers(sourceFile)) {
+      if (FORBIDDEN_DEFAULT_ENTRY_IMPORTS.has(specifier)) {
+        nodeSpecifiers.add(specifier)
+      }
+      if (specifier.startsWith(".")) {
+        pending.push(resolveTypeScriptSource(file, specifier))
+      }
+    }
+  }
+
+  return { files, nodeSpecifiers }
+}
+
+function readRuntimeModuleSpecifiers(sourceFile: ts.SourceFile): string[] {
+  const specifiers: string[] = []
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      if (statement.importClause?.isTypeOnly) {
+        continue
+      }
+      specifiers.push(readModuleSpecifier(statement.moduleSpecifier))
+      continue
+    }
+    if (ts.isExportDeclaration(statement) && statement.moduleSpecifier) {
+      if (statement.isTypeOnly || exportClauseIsTypeOnly(statement.exportClause)) {
+        continue
+      }
+      specifiers.push(readModuleSpecifier(statement.moduleSpecifier))
+    }
+  }
+  return specifiers
+}
+
+function exportClauseIsTypeOnly(exportClause: ts.NamedExportBindings | undefined): boolean {
+  if (!exportClause || !ts.isNamedExports(exportClause)) {
+    return false
+  }
+  return exportClause.elements.every((element) => element.isTypeOnly)
+}
+
+function readModuleSpecifier(specifier: ts.Expression): string {
+  if (!ts.isStringLiteral(specifier)) {
+    throw new Error(`Unsupported non-literal module specifier in ${specifier.getText()}`)
+  }
+  return specifier.text
+}
+
+function resolveTypeScriptSource(fromFile: string, specifier: string): string {
+  const resolved = path.resolve(path.dirname(fromFile), specifier)
+  if (resolved.endsWith(".js")) {
+    return `${resolved.slice(0, -3)}.ts`
+  }
+  return `${resolved}.ts`
+}

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -57,6 +57,7 @@ export {
   type MountedWorkspaceHandle,
   type MountedWorkspaceStatus,
   type MountWorkspaceInput,
+  type ReadMountedWorkspaceStatusInput,
   type RelayfileSetupOptions,
   type RelayfileSetupRetryOptions,
   type WaitForConnectionOptions,
@@ -66,11 +67,6 @@ export {
   type WorkspaceMountEnvOptions,
   type WorkspacePermissions
 } from "./setup-types.js";
-export {
-  createDefaultMountLauncher,
-  defaultMountLauncher,
-  readMountedWorkspaceStatus
-} from "./mount-launcher.js";
 export {
   RelayFileSync,
   type RelayFileSyncOptions,

--- a/packages/sdk/typescript/src/mount-launcher.ts
+++ b/packages/sdk/typescript/src/mount-launcher.ts
@@ -24,7 +24,8 @@ import type {
   MountLauncherInstance,
   MountLauncherStart,
   MountMode,
-  MountedWorkspaceStatus
+  MountedWorkspaceStatus,
+  ReadMountedWorkspaceStatusInput
 } from "./setup-types.js"
 
 const DEFAULT_READY_POLL_INTERVAL_MS = 250
@@ -37,18 +38,6 @@ interface DefaultMountLauncherOptions {
   spawnImpl?: typeof spawn
   now?: () => number
   readyPollIntervalMs?: number
-}
-
-interface ReadMountedWorkspaceStatusInput {
-  localDir: string
-  workspaceId: string
-  remotePath: string
-  mode: MountMode
-  relayfileBaseUrl: string
-  relayfileToken: string
-  expiresAt: string | null
-  suggestedRefreshAt: string | null
-  pid?: number
 }
 
 interface MountStateFile {

--- a/packages/sdk/typescript/src/setup-types.ts
+++ b/packages/sdk/typescript/src/setup-types.ts
@@ -144,6 +144,18 @@ export interface MountedWorkspaceStatus {
   pendingConflicts?: number
 }
 
+export interface ReadMountedWorkspaceStatusInput {
+  localDir: string
+  workspaceId: string
+  remotePath: string
+  mode: MountMode
+  relayfileBaseUrl: string
+  relayfileToken: string
+  expiresAt: string | null
+  suggestedRefreshAt: string | null
+  pid?: number
+}
+
 export interface MountedWorkspaceHandle {
   readonly workspaceId: string
   readonly localDir: string

--- a/packages/sdk/typescript/src/setup.test.ts
+++ b/packages/sdk/typescript/src/setup.test.ts
@@ -15,6 +15,7 @@ import {
   MalformedCloudResponseError
 } from "./setup-errors.js"
 import { RelayfileSetup } from "./setup.js"
+import { RelayfileSetup as RelayfileCliSetup } from "./cli/setup.js"
 import {
   type MountLauncher,
   type MountWorkspaceInput,
@@ -178,7 +179,7 @@ describe("RelayfileSetup", () => {
   it("logs in through the cloud callback URL and returns an authenticated setup", async () => {
     const loginUrls: string[] = []
     const onTokens = vi.fn()
-    const loginPromise = RelayfileSetup.login({
+    const loginPromise = RelayfileCliSetup.login({
       cloudApiUrl: "https://cloud.test/base",
       state: "state_test",
       timeoutMs: 5_000,
@@ -224,9 +225,15 @@ describe("RelayfileSetup", () => {
     })
   })
 
+  it("keeps interactive cloud login out of the default Worker-safe entry", async () => {
+    await expect(RelayfileSetup.login()).rejects.toMatchObject({
+      code: "node_only_sdk_feature"
+    })
+  })
+
   it("prints the cloud login URL by default", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
-    const loginPromise = RelayfileSetup.login({
+    const loginPromise = RelayfileCliSetup.login({
       cloudApiUrl: "https://cloud.test/base",
       state: "state_console",
       timeoutMs: 5_000
@@ -249,7 +256,7 @@ describe("RelayfileSetup", () => {
     )
 
     await fetch(callbackUrl)
-    await expect(loginPromise).resolves.toBeInstanceOf(RelayfileSetup)
+    await expect(loginPromise).resolves.toBeInstanceOf(RelayfileCliSetup)
   })
 
   it("creates a setup from cloud tokens and refreshes before requests", async () => {
@@ -1532,11 +1539,12 @@ describe("RelayfileSetup", () => {
         "utf8"
       )
 
-      const setup = new RelayfileSetup()
+      const setup = new RelayfileCliSetup()
       const handlePromise = setup.mountWorkspace({
         workspaceId: "ws_123",
         localDir,
-        launcher
+        launcher,
+        background: false
       })
 
       readyControl.resolve()
@@ -1573,11 +1581,12 @@ describe("RelayfileSetup", () => {
     const { launcher, readyControl } = createLauncherStub()
 
     try {
-      const setup = new RelayfileSetup()
+      const setup = new RelayfileCliSetup()
       const handlePromise = setup.mountWorkspace({
         workspaceId: "ws_123",
         localDir,
-        launcher
+        launcher,
+        background: false
       })
 
       readyControl.resolve()

--- a/packages/sdk/typescript/src/setup.ts
+++ b/packages/sdk/typescript/src/setup.ts
@@ -1,15 +1,13 @@
-import path from "node:path"
 import {
   RelayFileClient,
   type AccessTokenProvider
 } from "./client.js"
 import {
   createRelayfileCloudAccessTokenProvider,
-  runRelayfileCloudLogin,
-  type RelayfileCloudLoginOptions,
   type RelayfileCloudTokenSet,
   type RelayfileCloudTokenSetupOptions
-} from "./cloud-login.js"
+} from "./cloud-token-provider.js"
+import type { RelayfileCloudLoginOptions } from "./cloud-login.js"
 import {
   CloudAbortError,
   CloudApiError,
@@ -23,6 +21,7 @@ import {
   MountSessionInputError,
   ProviderNotConnectedError,
   ProviderNotReadyError,
+  RelayfileSetupError,
   UnknownProviderError
 } from "./setup-errors.js"
 import {
@@ -36,6 +35,7 @@ import {
   type CreateWorkspaceOptions,
   type JoinWorkspaceOptions,
   type MountLauncher,
+  type MountLauncherInstance,
   type MountMode,
   type MountSessionRequest,
   type MountSessionResponse,
@@ -43,6 +43,7 @@ import {
   type MountedWorkspaceHandle,
   type MountedWorkspaceStatus,
   type MountWorkspaceInput,
+  type ReadMountedWorkspaceStatusInput,
   type RelayfileSetupOptions,
   type WaitForConnectionOptions,
   type WorkspaceMountEnv,
@@ -52,10 +53,6 @@ import {
   type WorkspacePermissions
 } from "./setup-types.js"
 import { RELAYFILE_SDK_VERSION } from "./version.js"
-import {
-  defaultMountLauncher,
-  readMountedWorkspaceStatus
-} from "./mount-launcher.js"
 
 export { RELAYFILE_SDK_VERSION } from "./version.js"
 
@@ -72,6 +69,15 @@ const DEFAULT_WAIT_TIMEOUT_MS = 300_000
 const DEFAULT_MOUNT_READY_TIMEOUT_MS = 60_000
 const DEFAULT_MOUNT_AGENT_NAME = "relayfile-mount"
 const TOKEN_REFRESH_AGE_MS = 55 * 60 * 1000
+
+const nodeOnlyMountLauncher: MountLauncher = {
+  async start(): Promise<MountLauncherInstance> {
+    throw new RelayfileSetupError(
+      "The default relayfile-mount launcher is only available from @relayfile/sdk/cli. Import RelayfileSetup from @relayfile/sdk/cli or pass a custom launcher to mountWorkspace().",
+      "node_only_sdk_feature"
+    )
+  }
+}
 
 interface CreateWorkspaceResponse {
   workspaceId?: string
@@ -135,7 +141,7 @@ interface NormalizedMountWorkspaceInput {
   agentName?: string
   scopes?: string[]
   signal?: AbortSignal
-  launcher: MountLauncher
+  launcher?: MountLauncher
   readyTimeoutMs: number
 }
 
@@ -177,16 +183,11 @@ export class RelayfileSetup {
   static async login(
     options: RelayfileCloudLoginOptions = {}
   ): Promise<RelayfileSetup> {
-    const cloudApiUrl = options.cloudApiUrl ?? DEFAULT_CLOUD_API_URL
-    const tokens = await runRelayfileCloudLogin({
-      ...options,
-      cloudApiUrl
-    })
-    await options.onTokens?.({ ...tokens })
-    return RelayfileSetup.fromCloudTokens(tokens, {
-      ...options,
-      cloudApiUrl: tokens.apiUrl ?? cloudApiUrl
-    })
+    void options
+    throw new RelayfileSetupError(
+      "RelayfileSetup.login() starts a local HTTP callback server and is only available from @relayfile/sdk/cli. Import RelayfileSetup from @relayfile/sdk/cli for interactive Cloud login.",
+      "node_only_sdk_feature"
+    )
   }
 
   static fromCloudTokens(
@@ -287,7 +288,7 @@ export class RelayfileSetup {
     const normalized = normalizeMountWorkspaceInput(input)
     const workspace = await this.resolveWorkspaceForMount(normalized)
     const mountSession = await this.createMountSession(workspace, normalized)
-    const launcher = normalized.launcher
+    const launcher = normalized.launcher ?? this.getDefaultMountLauncher()
     const launcherInstance = await launcher.start({
       env: buildMountLauncherEnv(mountSession),
       signal: normalized.signal,
@@ -310,7 +311,8 @@ export class RelayfileSetup {
     return new MountedWorkspaceHandleImpl({
       mountSession,
       launcherInstance: normalized.background ? launcherInstance : undefined,
-      probeOnly: !normalized.background
+      probeOnly: !normalized.background,
+      readStatus: (statusInput) => this.readMountedWorkspaceStatus(statusInput)
     })
   }
 
@@ -440,6 +442,22 @@ export class RelayfileSetup {
 
   getCloudApiUrl(): string {
     return this.cloudApiUrl
+  }
+
+  protected getDefaultMountLauncher(): MountLauncher {
+    return nodeOnlyMountLauncher
+  }
+
+  protected async readMountedWorkspaceStatus(
+    input: ReadMountedWorkspaceStatusInput
+  ): Promise<MountedWorkspaceStatus> {
+    return {
+      ready: true,
+      mode: input.mode,
+      pid: input.pid,
+      expiresAt: input.expiresAt,
+      suggestedRefreshAt: input.suggestedRefreshAt
+    }
   }
 
   private async resolveWorkspaceForMount(
@@ -1058,6 +1076,9 @@ class MountedWorkspaceHandleImpl implements MountedWorkspaceHandle {
   private readonly mountSession: MountSessionResult
   private readonly launcherInstance?: Awaited<ReturnType<MountLauncher["start"]>>
   private readonly probeOnly: boolean
+  private readonly readStatus: (
+    input: ReadMountedWorkspaceStatusInput
+  ) => Promise<MountedWorkspaceStatus>
 
   private readySnapshot = true
   private stopPromise?: Promise<void>
@@ -1066,6 +1087,9 @@ class MountedWorkspaceHandleImpl implements MountedWorkspaceHandle {
     mountSession: MountSessionResult
     launcherInstance?: Awaited<ReturnType<MountLauncher["start"]>>
     probeOnly: boolean
+    readStatus: (
+      input: ReadMountedWorkspaceStatusInput
+    ) => Promise<MountedWorkspaceStatus>
   }) {
     this.mountSession = input.mountSession
     this.workspaceId = input.mountSession.workspaceId
@@ -1076,6 +1100,7 @@ class MountedWorkspaceHandleImpl implements MountedWorkspaceHandle {
     this.suggestedRefreshAt = input.mountSession.suggestedRefreshAt
     this.launcherInstance = input.launcherInstance
     this.probeOnly = input.probeOnly
+    this.readStatus = input.readStatus
   }
 
   get ready(): boolean {
@@ -1087,7 +1112,18 @@ class MountedWorkspaceHandleImpl implements MountedWorkspaceHandle {
   }
 
   async status(): Promise<MountedWorkspaceStatus> {
-    const status = await readMountedWorkspaceStatus({
+    if (this.launcherInstance) {
+      const status = await this.launcherInstance.status()
+      const mergedStatus = {
+        ...status,
+        expiresAt: this.expiresAt,
+        suggestedRefreshAt: this.suggestedRefreshAt
+      }
+      this.readySnapshot = mergedStatus.ready
+      return mergedStatus
+    }
+
+    const status = await this.readStatus({
       localDir: this.localDir,
       workspaceId: this.workspaceId,
       remotePath: this.remotePath,
@@ -1348,7 +1384,7 @@ function normalizeMountWorkspaceInput(
   return {
     workspace: input.workspace,
     workspaceId: normalizeNonEmptyString(input.workspaceId),
-    localDir: path.resolve(localDir),
+    localDir: resolveLocalDir(localDir),
     remotePath: normalizeMountRemotePath(input.remotePath),
     mode: normalizeMountModeInput(input.mode),
     background: input.background !== false,
@@ -1356,7 +1392,7 @@ function normalizeMountWorkspaceInput(
     scopes:
       input.scopes && input.scopes.length > 0 ? [...input.scopes] : undefined,
     signal: input.signal,
-    launcher: input.launcher ?? defaultMountLauncher,
+    launcher: input.launcher,
     readyTimeoutMs: Math.max(
       1,
       Math.floor(input.readyTimeoutMs ?? DEFAULT_MOUNT_READY_TIMEOUT_MS)
@@ -1396,13 +1432,69 @@ function normalizeMountRemotePath(remotePath?: string): string {
   if (segments.some((segment) => segment === "..")) {
     throw new InvalidRemotePathError(normalized)
   }
-  const resolved = path.posix.normalize(
+  const resolved = normalizePosixPath(
     normalized.startsWith("/") ? normalized : `/${normalized}`
   )
   if (!resolved.startsWith("/")) {
     throw new InvalidRemotePathError(normalized)
   }
   return resolved === "/" ? "/" : resolved.replace(/\/+$/, "")
+}
+
+function resolveLocalDir(localDir: string): string {
+  const normalized = localDir.replace(/\\/g, "/")
+  if (isAbsolutePathLike(normalized)) {
+    return normalizePosixPath(normalized)
+  }
+  const cwd = readProcessCwd()
+  if (!cwd) {
+    return normalized
+  }
+  return normalizePosixPath(`${cwd.replace(/\\/g, "/")}/${normalized}`)
+}
+
+function isAbsolutePathLike(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:\//.test(value)
+}
+
+function readProcessCwd(): string | undefined {
+  const maybeProcess = (globalThis as {
+    process?: { cwd?: () => string }
+  }).process
+  try {
+    return maybeProcess?.cwd?.()
+  } catch {
+    return undefined
+  }
+}
+
+function normalizePosixPath(value: string): string {
+  const isDrivePath = /^[A-Za-z]:\//.test(value)
+  const prefix = isDrivePath
+    ? value.slice(0, 3)
+    : value.startsWith("/")
+      ? "/"
+      : ""
+  const rest = isDrivePath ? value.slice(3) : value
+  const segments: string[] = []
+  for (const segment of rest.split("/")) {
+    if (!segment || segment === ".") {
+      continue
+    }
+    if (segment === "..") {
+      segments.pop()
+      continue
+    }
+    segments.push(segment)
+  }
+  const joined = segments.join("/")
+  if (prefix === "/") {
+    return joined ? `/${joined}` : "/"
+  }
+  if (prefix) {
+    return joined ? `${prefix}${joined}` : prefix
+  }
+  return joined || "."
 }
 
 function normalizeNonEmptyString(value?: string): string | undefined {


### PR DESCRIPTION
## Summary
- keep the default `@relayfile/sdk` entry Worker-safe by removing static imports/exports of CLI-only mount and login modules
- add explicit `@relayfile/sdk/cli`, `@relayfile/sdk/mount-launcher`, and `@relayfile/sdk/cloud-login` package exports
- split Worker-safe cloud token refresh into its own module and add an import-graph regression test
- update SDK docs/examples that use interactive login or the default mount launcher to import from `@relayfile/sdk/cli`

Closes #170.

## Self-review notes
- Reviewed the default entry graph after the first pass and tightened `@relayfile/sdk/cli` so it re-exports the main SDK surface plus CLI-specific overrides.
- Left unrelated local changes out of the commit (`package-lock.json`, `.trajectories/index.json`, and `docs/canonical-identity-spec.md`).

## Verification
- `npm run typecheck --workspace=packages/sdk/typescript`
- `npm run build --workspace=packages/sdk/typescript`
- `npm run test --workspace=packages/sdk/typescript`
- `npm pack --workspace=packages/sdk/typescript --dry-run --json`
- Browser-platform esbuild smoke test importing `@relayfile/sdk`; bundle/metafile contained no `node:child_process`, `node:http`, `node:fs`, `node:path`, `node:process`, `node:url`, `mount-launcher`, or `cloud-login`
- Node import smoke test for `@relayfile/sdk`, `@relayfile/sdk/cli`, and `@relayfile/sdk/mount-launcher`
