### PR TITLE
Fix mount reconcile drift and local-dir footguns

### DIFF
--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-18T19:14:56.208Z",
+  "lastUpdated": "2026-05-21T09:02:24.648Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -256,6 +256,20 @@
       "startedAt": "2026-05-18T18:45:52.924Z",
       "completedAt": "2026-05-18T19:14:56.067Z",
       "path": ".trajectories/completed/2026-05/traj_onpf37fwj1mj.json"
+    },
+    "traj_wzwo03w1kb1x": {
+      "title": "autofix-swarm-Agentworkforce-relayfile-workflow",
+      "status": "completed",
+      "startedAt": "2026-05-21T08:52:34.142Z",
+      "completedAt": "2026-05-21T09:02:24.642Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/.msd-autofix-b09c607b/.trajectories/completed/2026-05/traj_wzwo03w1kb1x.json"
+    },
+    "traj_5310ok4zat2n": {
+      "title": "Fix relayfile CLI rehome legacy LocalDir and pid verification",
+      "status": "completed",
+      "startedAt": "2026-05-21T08:54:30.035Z",
+      "completedAt": "2026-05-21T08:54:30.166Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/.msd-autofix-b09c607b/.trajectories/completed/2026-05/traj_5310ok4zat2n.json"
     }
   }
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3754,6 +3754,8 @@ func runMount(args []string) error {
 	recordedLocalDir := ""
 	if record, ok := workspaceRecordByID(workspaceID); ok {
 		recordedLocalDir = strings.TrimSpace(record.LocalDir)
+	} else if record, ok := workspaceRecordByName(workspaceID); ok && strings.TrimSpace(record.ID) == "" {
+		recordedLocalDir = strings.TrimSpace(record.LocalDir)
 	}
 	if localDir == "" {
 		localDir = recordedLocalDir
@@ -3789,9 +3791,11 @@ func runMount(args []string) error {
 				)
 			}
 			if pid != 0 && !verified {
-				if rerr := os.Remove(mountPIDFile(recordedLocalDir)); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
-					return fmt.Errorf("failed to clear stale background mount state for %s: %w", workspaceID, rerr)
-				}
+				return fmt.Errorf(
+					"workspace %s has unverified background mount state at %s (pid %d); "+
+						"stop the existing daemon or remove %s after confirming it is stale before re-homing to %s",
+					workspaceID, absRecorded, pid, mountPIDFile(recordedLocalDir), absLocalDir,
+				)
 			}
 		}
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -464,8 +464,7 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runPull(args[1:], stdout)
 	case "mount", "start":
 		// `start` is the friendlier alias for `mount`. Same flags, same
-		// behavior — `mount` retains the historical name; `start` pairs
-		// naturally with `stop` and `restart`.
+		// foreground/background behavior; pass --background to detach.
 		return runMount(args[1:])
 	case "restart":
 		return runRestart(args[1:], stdout)
@@ -679,7 +678,7 @@ Usage:
   relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME] [--json]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
   relayfile mount [WORKSPACE] [LOCAL_DIR]
-  relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount)
+  relayfile start [WORKSPACE] [LOCAL_DIR]            (alias for mount; pass --background to detach)
   relayfile stop [WORKSPACE]
   relayfile restart [WORKSPACE] [--foreground]
   relayfile tree [WORKSPACE] [PATH] [--depth N]
@@ -708,7 +707,7 @@ Subcommands:
               Regenerate daily, weekly, or date-stamped digest artifacts
   pull        Trigger an immediate sync refresh for one or all providers
   mount       Mirror a remote workspace to a local directory; add --background to detach
-  start       Alias for mount; pairs naturally with stop and restart
+  start       Alias for mount; pass --background to detach
   stop        Stop a background mount
   restart     Stop and start a workspace's mount in one step (--foreground to attach)
   tree        List a remote workspace path
@@ -3683,6 +3682,7 @@ func runMount(args []string) error {
 	daemonized := fs.Bool("daemonized", false, "internal flag used by relayfile mount --background")
 	once := fs.Bool("once", false, "run one sync cycle and exit")
 	resetAfterClobber := fs.Bool("reset-after-clobber", boolEnv("RELAYFILE_RESET_AFTER_CLOBBER", false), "acknowledge a mount-root clobber and authorize daemon to recreate the directory")
+	rehome := fs.Bool("rehome", false, "allow re-homing an already-registered workspace mirror to a different LOCAL_DIR")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"server":              true,
 		"token":               true,
@@ -3706,6 +3706,7 @@ func runMount(args []string) error {
 		"daemonized":          false,
 		"once":                false,
 		"reset-after-clobber": false,
+		"rehome":              false,
 		"local-dir":           true,
 	})); err != nil {
 		// `--help` / `-h` come back from flag.ContinueOnError as
@@ -3723,7 +3724,8 @@ func runMount(args []string) error {
 	}
 
 	workspaceID := ""
-	localDir := "."
+	localDir := ""
+	localDirExplicit := false
 	tokenValue := strings.TrimSpace(*token)
 	if tokenValue == "" {
 		return errors.New("token is required; run relayfile login or pass --token")
@@ -3733,25 +3735,65 @@ func runMount(args []string) error {
 	case 0:
 		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
 		localDir = strings.TrimSpace(*localDirFlag)
+		localDirExplicit = localDir != ""
 	case 1:
 		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
 		localDir = strings.TrimSpace(*localDirFlag)
+		localDirExplicit = localDir != ""
 	case 2:
 		if strings.TrimSpace(*localDirFlag) != "" {
 			return errors.New("local directory specified twice")
 		}
 		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
 		localDir = fs.Arg(1)
+		localDirExplicit = true
 	}
 	if err != nil {
 		return err
 	}
+	recordedLocalDir := ""
+	if record, ok := workspaceRecordByID(workspaceID); ok {
+		recordedLocalDir = strings.TrimSpace(record.LocalDir)
+	}
 	if localDir == "" {
-		localDir = "."
+		localDir = recordedLocalDir
+	}
+	if localDir == "" {
+		return fmt.Errorf(
+			"workspace %s has no recorded local mirror directory; pass LOCAL_DIR or --local-dir to choose one",
+			workspaceID,
+		)
 	}
 	absLocalDir, err := filepath.Abs(localDir)
 	if err != nil {
 		return err
+	}
+	if localDirExplicit && recordedLocalDir != "" {
+		absRecorded, aerr := filepath.Abs(recordedLocalDir)
+		if aerr != nil {
+			absRecorded = recordedLocalDir
+		}
+		if absRecorded != absLocalDir && !*rehome {
+			return fmt.Errorf(
+				"workspace %s is already mirrored at %s; refusing to silently re-home it to %s.\n"+
+					"Pass --rehome to move the mirror there, or omit LOCAL_DIR to use the registered directory",
+				workspaceID, absRecorded, absLocalDir,
+			)
+		}
+		if absRecorded != absLocalDir && *rehome {
+			pid, verified := verifyDaemonProcess(recordedLocalDir, workspaceID)
+			if pid != 0 && verified {
+				return fmt.Errorf(
+					"workspace %s has a running mount at %s (pid %d); stop it before re-homing to %s",
+					workspaceID, absRecorded, pid, absLocalDir,
+				)
+			}
+			if pid != 0 && !verified {
+				if rerr := os.Remove(mountPIDFile(recordedLocalDir)); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+					return fmt.Errorf("failed to clear stale background mount state for %s: %w", workspaceID, rerr)
+				}
+			}
+		}
 	}
 	// Recovery-mode precheck: refuse to (re)create a mount root if a prior
 	// run's directory was clobbered (replaced by a file, or missing in a
@@ -3843,7 +3885,9 @@ func runMount(args []string) error {
 	if record.Name == "" {
 		record.Name = workspaceID
 	}
-	record.LocalDir = absLocalDir
+	if localDirExplicit || strings.TrimSpace(record.LocalDir) == "" {
+		record.LocalDir = absLocalDir
+	}
 	record.Server = strings.TrimRight(strings.TrimSpace(*server), "/")
 	if record.AgentName == "" {
 		record.AgentName = "relayfile-cli"
@@ -3893,7 +3937,7 @@ Synced-mirror limitations (§3.6 of the productized cloud-mount contract):
 
 Common flags:
   --workspace NAME     workspace name or id (defaults to the active workspace)
-  --local-dir DIR      local mirror directory (defaults to a relay-... folder)
+  --local-dir DIR      local mirror directory (defaults to the recorded mirror)
   --mode poll|fuse     poll (synced mirror, default) or fuse
   --interval 30s       sync interval (default 30s)
   --background         detach and keep syncing in the background
@@ -3903,6 +3947,7 @@ Common flags:
                        hard cap for initial/full-tree bootstrap (0 = progress-based)
   --cursor-timeout 20s timeout for events-cursor resolution
   --full-reconcile     force one full reconcile regardless of bootstrap state
+  --rehome             allow moving an already-registered mirror to a new LOCAL_DIR
   --no-websocket       disable websocket event streaming
   --low-memory         skip detailed per-file public state and defer content reads
   --pprof-addr ADDR    expose pprof diagnostics, e.g. 127.0.0.1:6060
@@ -3950,9 +3995,9 @@ func runTree(args []string, stdout io.Writer) error {
 		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
 	case 1:
 		arg := strings.TrimSpace(fs.Arg(0))
-		if strings.HasPrefix(arg, "/") {
+		if looksLikeRemotePathArg(arg) {
 			workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
-			remotePath = arg
+			remotePath = normalizeCLIPathArg(arg)
 		} else {
 			workspaceID, err = resolveWorkspaceIDWithToken(arg, tokenValue)
 		}
@@ -4017,6 +4062,58 @@ func runTree(args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "next cursor: %s\n", strings.TrimSpace(*tree.NextCursor))
 	}
 	return nil
+}
+
+func looksLikeRemotePathArg(arg string) bool {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return false
+	}
+	if strings.HasPrefix(arg, "/") {
+		return true
+	}
+	if _, ok := catalogWorkspaceID(arg); ok {
+		return false
+	}
+	first, _, ok := strings.Cut(arg, "/")
+	if !ok {
+		return false
+	}
+	return knownRemoteRootSegment(first)
+}
+
+func normalizeCLIPathArg(arg string) string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" || strings.HasPrefix(arg, "/") {
+		return arg
+	}
+	return "/" + arg
+}
+
+func knownRemoteRootSegment(segment string) bool {
+	segment = strings.Trim(strings.TrimSpace(segment), "/")
+	if segment == "" {
+		return false
+	}
+	switch segment {
+	case "digests", ".skills", ".relay":
+		return true
+	}
+	for _, entry := range fallbackIntegrationCatalog() {
+		root := strings.Trim(strings.TrimSpace(entry.VFSRoot), "/")
+		if root != "" && segment == root {
+			return true
+		}
+		if dir := providerRootDir(entry.ID); dir != "" && segment == dir {
+			return true
+		}
+	}
+	switch segment {
+	case "google-mail", "google-calendar", "jira", "confluence":
+		return true
+	default:
+		return false
+	}
 }
 
 func runRead(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -362,6 +363,71 @@ func TestTreeUsesEnvWorkspaceWhenWorkspaceArgOmitted(t *testing.T) {
 	}
 
 	if got := stdout.String(); !strings.Contains(got, "Tree /github") {
+		t.Fatalf("expected tree header, got %q", got)
+	}
+}
+
+func TestTreeTreatsPathLikeSingleArgAsRemotePath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	t.Setenv("RELAYFILE_WORKSPACE", "ws_env")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws_env/fs/tree" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("path"); got != "/linear/projects" {
+			t.Fatalf("expected path /linear/projects, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/linear/projects","entries":[],"nextCursor":null}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"tree", "linear/projects"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run tree failed: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Tree /linear/projects") {
+		t.Fatalf("expected tree header, got %q", got)
+	}
+}
+
+func TestTreePreservesUncatalogedSlashWorkspaceWhenRootIsUnknown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); got != "/v1/workspaces/team%2Fproject/fs/tree" {
+			t.Fatalf("unexpected escaped path: %s", got)
+		}
+		if got := r.URL.Query().Get("path"); got != "/" {
+			t.Fatalf("expected root path, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/","entries":[],"nextCursor":null}`))
+	}))
+	defer server.Close()
+
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  "token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"tree", "team/project"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run tree failed: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Tree /") {
 		t.Fatalf("expected tree header, got %q", got)
 	}
 }
@@ -1009,6 +1075,233 @@ func TestRestartRequiresRecordedLocalMirror(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no recorded local mirror directory") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMountRequiresLocalDirWhenWorkspaceHasNoRecordedMirror(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected mount without LOCAL_DIR to fail when no localDir is recorded")
+	}
+	if !strings.Contains(err.Error(), "no recorded local mirror directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMountUsesRecordedLocalDirWhenOmitted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/fs/export":
+			_, _ = w.Write([]byte(`[{"path":"/notion/Docs/A.md","revision":"rev_1","contentType":"text/markdown","content":"# A"}]`))
+		case "/v1/workspaces/ws_demo/fs/events":
+			_, _ = w.Write([]byte(`{"events":[{"eventId":"evt_1","type":"file.created","path":"/notion/Docs/A.md","revision":"rev_1"}]}`))
+		case "/v1/workspaces/ws_demo/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	if err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run mount failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(localDir, "notion", "Docs", "A.md"))
+	if err != nil {
+		t.Fatalf("expected file under recorded localDir: %v", err)
+	}
+	if string(data) != "# A" {
+		t.Fatalf("unexpected mirrored content: %q", data)
+	}
+}
+
+func TestMountRefusesExplicitLocalDirThatRehomesRecordedMirror(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	otherDir := filepath.Join(t.TempDir(), "other-mirror")
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	err := run([]string{"mount", "demo", otherDir, "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected mount to refuse re-homing a recorded mirror")
+	}
+	if !strings.Contains(err.Error(), "refusing to silently re-home") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(otherDir, ".relay")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused re-home should not initialize other mirror dir; stat err=%v", statErr)
+	}
+}
+
+func TestMountRehomeRefusesRunningRecordedDaemon(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	otherDir := filepath.Join(t.TempDir(), "other-mirror")
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := os.WriteFile(mountPIDFile(localDir), []byte(strconv.Itoa(os.Getpid())+"\n"), 0o644); err != nil {
+		t.Fatalf("write legacy pid failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected rehome to refuse while old mirror has a running daemon")
+	}
+	if !strings.Contains(err.Error(), "has a running mount") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(otherDir, ".relay")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused rehome should not initialize other mirror dir; stat err=%v", statErr)
+	}
+}
+
+func TestMountRehomeAllowsExplicitMoveAndPersistsLocalDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	otherDir := t.TempDir()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/fs/export":
+			_, _ = w.Write([]byte(`[{"path":"/notion/Docs/Rehomed.md","revision":"rev_1","contentType":"text/markdown","content":"# Rehomed"}]`))
+		case "/v1/workspaces/ws_demo/fs/events":
+			_, _ = w.Write([]byte(`{"events":[{"eventId":"evt_1","type":"file.created","path":"/notion/Docs/Rehomed.md","revision":"rev_1"}]}`))
+		case "/v1/workspaces/ws_demo/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","providers":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	if err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run mount --rehome failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(otherDir, "notion", "Docs", "Rehomed.md"))
+	if err != nil {
+		t.Fatalf("expected file under rehomed localDir: %v", err)
+	}
+	if string(data) != "# Rehomed" {
+		t.Fatalf("unexpected mirrored content: %q", data)
+	}
+	record, ok := workspaceRecordByID("ws_demo")
+	if !ok {
+		t.Fatalf("expected workspace record")
+	}
+	wantLocalDir, _ := filepath.Abs(otherDir)
+	if record.LocalDir != wantLocalDir {
+		t.Fatalf("LocalDir = %q, want %q", record.LocalDir, wantLocalDir)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1162,6 +1162,57 @@ func TestMountUsesRecordedLocalDirWhenOmitted(t *testing.T) {
 	}
 }
 
+func TestMountUsesLegacyRecordedLocalDirWhenOmitted(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/demo/fs/export":
+			_, _ = w.Write([]byte(`[{"path":"/notion/Docs/Legacy.md","revision":"rev_1","contentType":"text/markdown","content":"# Legacy"}]`))
+		case "/v1/workspaces/demo/fs/events":
+			_, _ = w.Write([]byte(`{"events":[{"eventId":"evt_1","type":"file.created","path":"/notion/Docs/Legacy.md","revision":"rev_1"}]}`))
+		case "/v1/workspaces/demo/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"demo","providers":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	if err := saveCredentials(credentials{
+		Server: server.URL,
+		Token:  testJWTWithWorkspace("demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	if err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run mount failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(localDir, "notion", "Docs", "Legacy.md"))
+	if err != nil {
+		t.Fatalf("expected file under legacy recorded localDir: %v", err)
+	}
+	if string(data) != "# Legacy" {
+		t.Fatalf("unexpected mirrored content: %q", data)
+	}
+}
+
 func TestMountRefusesExplicitLocalDirThatRehomesRecordedMirror(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -1238,6 +1289,57 @@ func TestMountRehomeRefusesRunningRecordedDaemon(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "has a running mount") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(otherDir, ".relay")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("refused rehome should not initialize other mirror dir; stat err=%v", statErr)
+	}
+}
+
+func TestMountRehomeRefusesUnverifiedRecordedDaemon(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	otherDir := filepath.Join(t.TempDir(), "other-mirror")
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "demo",
+		Workspaces: []workspaceRecord{{
+			Name:       "demo",
+			ID:         "ws_demo",
+			LocalDir:   localDir,
+			CreatedAt:  now,
+			LastUsedAt: now,
+		}},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := writeDaemonPIDState(mountPIDFile(localDir), daemonPIDState{
+		PID:         os.Getpid(),
+		WorkspaceID: "ws_other",
+		LocalDir:    localDir,
+	}); err != nil {
+		t.Fatalf("write daemon pid state failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+
+	err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected rehome to refuse unverified background mount state")
+	}
+	if !strings.Contains(err.Error(), "unverified background mount state") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(mountPIDFile(localDir)); statErr != nil {
+		t.Fatalf("unverified pid file should remain in place: %v", statErr)
 	}
 	if _, statErr := os.Stat(filepath.Join(otherDir, ".relay")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("refused rehome should not initialize other mirror dir; stat err=%v", statErr)

--- a/internal/mountsync/bootstrap_test.go
+++ b/internal/mountsync/bootstrap_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -391,6 +392,59 @@ func TestForceFullReconcileEnvOverridesCompleteFlag(t *testing.T) {
 	}
 	if client.listTreeCalls.Load() != callsAfterForce {
 		t.Fatalf("expected fast-path to engage after force cleared; ListTree calls went %d -> %d", callsAfterForce, client.listTreeCalls.Load())
+	}
+}
+
+func TestForceFullReconcileBypassesEventsShortCircuit(t *testing.T) {
+	t.Setenv("RELAYFILE_FORCE_FULL_RECONCILE", "1")
+	client := newBootstrapClient(5, 10)
+	newPath := "/linear/projects/779cbfda.json"
+	client.files[newPath] = RemoteFile{
+		Path:        newPath,
+		Revision:    "rev_46580",
+		ContentType: "application/json",
+		Content:     `{"id":"779cbfda"}`,
+	}
+	localDir := t.TempDir()
+
+	seed := mountState{
+		Files:             map[string]trackedFile{},
+		BootstrapComplete: true,
+		EventsCursor:      "evt_stale",
+		LastEventAt:       time.Now().UTC().Add(-13 * time.Hour).Format(time.RFC3339Nano),
+	}
+	for p, f := range client.files {
+		if p == newPath {
+			continue
+		}
+		seed.Files[p] = trackedFile{Revision: f.Revision, ContentType: f.ContentType, Hash: hashBytes([]byte(f.Content))}
+		onDisk := filepath.Join(localDir, filepath.FromSlash(strings.TrimPrefix(p, "/")))
+		if err := os.MkdirAll(filepath.Dir(onDisk), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(onDisk, []byte(f.Content), 0o644); err != nil {
+			t.Fatalf("seed disk file: %v", err)
+		}
+	}
+	if err := writeMountState(filepath.Join(localDir, ".relayfile-mount-state.json"), seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	client.events = nil
+	s := newBootstrapSyncer(t, client, localDir, SyncerOptions{RootCtx: context.Background()})
+	if !s.forceFullReconcile {
+		t.Fatalf("expected forceFullReconcile resolved true from env")
+	}
+
+	if err := s.Reconcile(context.Background()); err != nil {
+		t.Fatalf("forced reconcile: %v", err)
+	}
+	if client.listTreeCalls.Load() == 0 {
+		t.Fatalf("forced reconcile must run a full tree pull despite a non-empty EventsCursor + quiet feed")
+	}
+	newOnDisk := filepath.Join(localDir, filepath.FromSlash(strings.TrimPrefix(newPath, "/")))
+	if _, err := os.Stat(newOnDisk); err != nil {
+		t.Fatalf("forced reconcile did not pull newer remote record %s into the mirror: %v", newPath, err)
 	}
 }
 

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1966,31 +1966,21 @@ func (s *Syncer) bootstrapContext(parent context.Context) (context.Context, cont
 }
 
 func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{}) error {
-	if s.state.EventsCursor != "" {
+	if s.state.EventsCursor != "" && !s.forceFullReconcile {
 		// Skip-if-no-events short-circuit. Most reconcile cycles on a
 		// quiet workspace have nothing to pull; turning that into a
 		// single cheap ListEvents probe avoids the worst-case full-tree
 		// fetch (sequential ReadFile per entry) that times out on
 		// workspaces with hundreds of files. If the events feed reports
-		// no new events since our last cursor, the local mirror is
-		// already up-to-date and we can return immediately. The caller
-		// (sync) then bumps LastSuccessfulReconcileAt so the stall
-		// detector stays clear.
+		// no new events since our last cursor, we can usually return
+		// immediately. The low-frequency periodic full-pull cadence still
+		// bypasses the short-circuit so records written without fs events
+		// eventually self-heal.
 		//
 		// If the events feed itself is unavailable (404) we fall through
 		// to the existing incremental/full-pull path, which will hit the
 		// 404 again and degrade to the full-tree fetch. That preserves
 		// pre-fix behaviour for backends without an events feed.
-		feed, err := s.client.ListEvents(ctx, s.workspace, s.eventProvider, s.state.EventsCursor, 1)
-		if err == nil && len(feed.Events) == 0 {
-			// Quiet cycle. Periodic full-pull cadence is still tracked
-			// against incrementalCycles below to keep the trust-but-verify
-			// safety net intact, but only when there is actually work to
-			// do. Counting empty cycles toward the threshold would race
-			// the periodic full pull against the very condition the
-			// short-circuit is designed to avoid.
-			return nil
-		}
 		// "Trust but verify": every Nth incremental cycle, force a full
 		// tree pull regardless of cursor health. This self-heals any stale
 		// state caused by cloud-side revision reuse — applyRemoteFile
@@ -1999,10 +1989,9 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 		// Tracks production failure mode where rev counter rolled back
 		// mid-envelope, leaving the daemon and cloud both calling distinct
 		// content "rev_96".
-		s.incrementalCycles++
-		if s.fullPullEvery > 0 && s.incrementalCycles >= s.fullPullEvery {
+		forceFullPull := func(reason string) error {
 			s.incrementalCycles = 0
-			s.logf("forcing periodic full tree pull (every %d incremental cycles) as defense against cloud-side revision reuse", s.fullPullEvery)
+			s.logf("%s", reason)
 			// Periodic full pull is the same heavy op as bootstrap — give
 			// it the rootCtx-derived bootstrap deadline, not the tiny
 			// per-cycle one. The surrounding ListEvents probe above stays
@@ -2027,6 +2016,20 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 			// applyRemoteFile is idempotent and will no-op when on-disk
 			// content already matches.
 			return nil
+		}
+		feed, err := s.client.ListEvents(ctx, s.workspace, s.eventProvider, s.state.EventsCursor, 1)
+		if err == nil && len(feed.Events) == 0 {
+			if s.fullPullEvery > 0 {
+				s.incrementalCycles++
+				if s.incrementalCycles >= s.fullPullEvery {
+					return forceFullPull(fmt.Sprintf("forcing periodic full tree pull (every %d quiet/incremental cycles) as defense against cloud-side revision reuse and missing events", s.fullPullEvery))
+				}
+			}
+			return nil
+		}
+		s.incrementalCycles++
+		if s.fullPullEvery > 0 && s.incrementalCycles >= s.fullPullEvery {
+			return forceFullPull(fmt.Sprintf("forcing periodic full tree pull (every %d quiet/incremental cycles) as defense against cloud-side revision reuse and missing events", s.fullPullEvery))
 		}
 
 		nextCursor, err := s.pullRemoteIncremental(ctx, conflicted, s.state.EventsCursor)

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -1107,6 +1107,53 @@ func TestSyncOnceFallsBackToFullPullWhenEventsUnavailable(t *testing.T) {
 	}
 }
 
+func TestFullReconcileBypassesQuietEventsShortCircuit(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_1",
+				Type:     "file.created",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_1",
+			},
+		},
+		revisionCounter: 1,
+		eventCounter:    1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_force_full_quiet",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	client.files["/notion/Docs/B.md"] = RemoteFile{
+		Path:        "/notion/Docs/B.md",
+		Revision:    "rev_2",
+		ContentType: "text/markdown",
+		Content:     "# B",
+	}
+	syncer.forceFullReconcile = true
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("forced reconcile failed: %v", err)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "B.md"), "# B")
+}
+
 func TestBulkSeedThenSync(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
 	t.Cleanup(store.Close)
@@ -4418,11 +4465,9 @@ func TestPullShortCircuitsWhenNoNewEvents(t *testing.T) {
 		WorkspaceID: "ws_short_circuit",
 		RemoteRoot:  "/notion",
 		LocalRoot:   localDir,
-		// Use a very small cadence so that, absent the short-circuit,
-		// the test would deterministically trigger a full-tree pull on
-		// the second post-bootstrap cycle. With the short-circuit, no
-		// full pull should fire because no new events ever arrive.
-		FullPullEvery: 2,
+		// Disable the periodic full-pull cadence so this test isolates
+		// the quiet-cycle short-circuit itself.
+		FullPullEvery: -1,
 	})
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
@@ -4440,15 +4485,14 @@ func TestPullShortCircuitsWhenNoNewEvents(t *testing.T) {
 	// short-circuit calls in isolation.
 	client.listEventsCalls = 0
 
-	// Run several quiet reconcile cycles. With no new events on the
+	// Run several quiet reconcile cycles with periodic full pulls disabled.
+	// With no new events on the
 	// feed, each cycle should:
 	//   1. Issue exactly one ListEvents probe.
 	//   2. NOT issue a ListTree call (would block reconcile on huge
 	//      workspaces).
 	//   3. NOT issue any ReadFile calls.
-	//   4. NOT increment the periodic-full-pull counter past the
-	//      threshold — even though we set FullPullEvery=2, the
-	//      short-circuit returns before the cadence counter advances.
+	//   4. Mark the cycle successful so status does not report a stall.
 	const quietCycles = 5
 	for i := 0; i < quietCycles; i++ {
 		if err := syncer.Reconcile(context.Background()); err != nil {
@@ -4498,6 +4542,59 @@ func TestPullShortCircuitsWhenNoNewEvents(t *testing.T) {
 	if string(data) != "# A v2" {
 		t.Fatalf("expected mirrored file to update after event; got %q", string(data))
 	}
+}
+
+func TestQuietEventCyclesEventuallyRunPeriodicFullPull(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_1",
+				Type:     "file.created",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_1",
+			},
+		},
+		revisionCounter: 1,
+		eventCounter:    1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   "ws_quiet_periodic_full",
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		FullPullEvery: 2,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("bootstrap sync: %v", err)
+	}
+
+	client.files["/notion/Docs/B.md"] = RemoteFile{
+		Path:        "/notion/Docs/B.md",
+		Revision:    "rev_2",
+		ContentType: "text/markdown",
+		Content:     "# B",
+	}
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("first quiet reconcile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(localDir, "Docs", "B.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("quiet cycle before cadence should not pull B.md yet; stat err=%v", err)
+	}
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("second quiet reconcile: %v", err)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "B.md"), "# B")
 }
 
 // TestPullRestartFastPathSkipsFullPull pins the daemon-restart half of


### PR DESCRIPTION
## Summary
- make forced full reconcile bypass quiet event-feed short-circuits and let quiet cycles reach the periodic full-pull safety net
- make mount/start fall back to the recorded local mirror instead of CWD, with explicit --rehome required for intentional moves
- guard --rehome against orphaning an already-running old daemon
- treat path-like tree args for known mirror roots while preserving slash-containing workspace IDs

Fixes #173

## Verification
- go test ./cmd/relayfile-cli -run 'TestMountRequiresLocalDirWhenWorkspaceHasNoRecordedMirror|TestMountUsesRecordedLocalDirWhenOmitted|TestMountRefusesExplicitLocalDirThatRehomesRecordedMirror|TestMountRehomeRefusesRunningRecordedDaemon|TestMountRehomeAllowsExplicitMoveAndPersistsLocalDir|TestTreeTreatsPathLikeSingleArgAsRemotePath|TestTreePreservesUncatalogedSlashWorkspaceWhenRootIsUnknown|TestRestartRequiresRecordedLocalMirror' -count=3\n- go test ./internal/mountsync -run 'TestForceFullReconcileBypassesEventsShortCircuit|TestFullReconcileBypassesQuietEventsShortCircuit|TestQuietEventCyclesEventuallyRunPeriodicFullPull|TestPullShortCircuitsWhenNoNewEvents' -count=3\n- go test -count=1 ./...\n- scripts/check-contract-surface.sh\n- git diff --check\n\n## Review Notes\n- reviewed with subagents for mountsync correctness and CLI guardrails\n- patched follow-up findings around --rehome and slash-containing workspace IDs before opening this PR\n