### PR TITLE
Harden mount daemon recovery follow-ups

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3792,8 +3792,8 @@ func runMount(args []string) error {
 			}
 			if pid != 0 && !verified {
 				return fmt.Errorf(
-					"workspace %s has unverified background mount state at %s (pid %d); "+
-						"stop the existing daemon or remove %s after confirming it is stale before re-homing to %s",
+					"workspace %s has unverified mount state at %s (pid %d); "+
+						"stop the existing mount or remove %s after confirming it is stale before re-homing to %s",
 					workspaceID, absRecorded, pid, mountPIDFile(recordedLocalDir), absLocalDir,
 				)
 			}
@@ -3834,10 +3834,13 @@ func runMount(args []string) error {
 	if *background && !*daemonized {
 		return spawnBackgroundMountProcess(args, absLocalDir, pidFile, logFile)
 	}
+	registerPID := shouldRegisterMountPID(*daemonized, *once)
 	if *daemonized {
 		if err := rotateLogFile(logFile); err != nil {
 			return err
 		}
+	}
+	if registerPID {
 		if err := writeDaemonPIDState(pidFile, daemonPIDState{
 			PID:         os.Getpid(),
 			WorkspaceID: workspaceID,
@@ -3902,6 +3905,10 @@ func runMount(args []string) error {
 	_, _ = upsertWorkspaceDetails(record)
 
 	return runMountLoop(rootCtx, syncer, absLocalDir, workspaceID, strings.TrimRight(strings.TrimSpace(*server), "/"), *timeout, *interval, *intervalJitter, *websocketEnabled, *once, *daemonized, pidFile, logFile)
+}
+
+func shouldRegisterMountPID(daemonized, once bool) bool {
+	return daemonized || !once
 }
 
 // mountStartBanner formats the user-facing line printed when the mount loop

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1213,6 +1213,27 @@ func TestMountUsesLegacyRecordedLocalDirWhenOmitted(t *testing.T) {
 	}
 }
 
+func TestShouldRegisterMountPID(t *testing.T) {
+	tests := []struct {
+		name       string
+		daemonized bool
+		once       bool
+		want       bool
+	}{
+		{name: "background child", daemonized: true, once: false, want: true},
+		{name: "foreground loop", daemonized: false, once: false, want: true},
+		{name: "one shot", daemonized: false, once: true, want: false},
+		{name: "daemonized one shot still visible", daemonized: true, once: true, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldRegisterMountPID(tt.daemonized, tt.once); got != tt.want {
+				t.Fatalf("shouldRegisterMountPID(%v, %v) = %v, want %v", tt.daemonized, tt.once, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMountRefusesExplicitLocalDirThatRehomesRecordedMirror(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -1333,9 +1354,9 @@ func TestMountRehomeRefusesUnverifiedRecordedDaemon(t *testing.T) {
 
 	err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
-		t.Fatalf("expected rehome to refuse unverified background mount state")
+		t.Fatalf("expected rehome to refuse unverified mount state")
 	}
-	if !strings.Contains(err.Error(), "unverified background mount state") {
+	if !strings.Contains(err.Error(), "unverified mount state") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if _, statErr := os.Stat(mountPIDFile(localDir)); statErr != nil {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -675,6 +675,7 @@ type Syncer struct {
 	bootstrapIdleTimeout time.Duration
 	forceFullReconcile   bool
 	incrementalCycles    int
+	oversizedLogged      map[string]struct{}
 	lazyRepos            bool
 	lowMemory            bool
 	layoutRegistrar      ProviderLayoutRegistrar
@@ -999,6 +1000,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		bootstrapTimeout:     bootstrapTimeout,
 		bootstrapIdleTimeout: bootstrapIdleTimeout,
 		forceFullReconcile:   forceFullReconcile,
+		oversizedLogged:      map[string]struct{}{},
 		lazyRepos:            lazyRepos,
 		lowMemory:            lowMemory,
 		layoutRegistrar:      opts.ProviderLayoutRegistrar,
@@ -2037,6 +2039,9 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 			s.state.EventsCursor = nextCursor
 			return nil
 		}
+		if strings.TrimSpace(nextCursor) != "" && nextCursor != s.state.EventsCursor {
+			s.state.EventsCursor = nextCursor
+		}
 		var httpErr *HTTPError
 		if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
 			return err
@@ -2846,22 +2851,25 @@ func isProviderLayoutAliasSegment(segment string) bool {
 }
 
 func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[string]struct{}, cursor string) (string, error) {
-	changed := map[string]struct{}{}
-	deleted := map[string]struct{}{}
 	currentCursor := strings.TrimSpace(cursor)
+	safeCursor := currentCursor
 
 	for {
 		feed, err := s.client.ListEvents(ctx, s.workspace, s.eventProvider, currentCursor, 500)
 		if err != nil {
-			return cursor, err
+			return safeCursor, err
 		}
+		changed := map[string]struct{}{}
+		deleted := map[string]struct{}{}
+		pageCursor := currentCursor
+		pageLastEventAt := ""
 		for _, event := range feed.Events {
 			eventID := strings.TrimSpace(event.EventID)
 			if eventID != "" {
-				currentCursor = eventID
+				pageCursor = eventID
 			}
 			if ts := strings.TrimSpace(event.Timestamp); ts != "" {
-				s.state.LastEventAt = ts
+				pageLastEventAt = ts
 			}
 			remotePath := normalizeRemotePath(event.Path)
 			if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
@@ -2901,12 +2909,32 @@ func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[strin
 				delete(changed, remotePath)
 			}
 		}
+		if err := s.applyIncrementalChanges(ctx, changed, deleted, conflicted); err != nil {
+			return safeCursor, err
+		}
+		if pageLastEventAt != "" {
+			s.state.LastEventAt = pageLastEventAt
+		}
+		if strings.TrimSpace(pageCursor) != "" {
+			currentCursor = strings.TrimSpace(pageCursor)
+			safeCursor = currentCursor
+		}
 		if feed.NextCursor == nil || *feed.NextCursor == "" {
 			break
 		}
-		currentCursor = *feed.NextCursor
+		currentCursor = strings.TrimSpace(*feed.NextCursor)
+		if currentCursor != "" {
+			safeCursor = currentCursor
+		}
 	}
 
+	if safeCursor == "" {
+		safeCursor = cursor
+	}
+	return safeCursor, nil
+}
+
+func (s *Syncer) applyIncrementalChanges(ctx context.Context, changed, deleted map[string]struct{}, conflicted map[string]struct{}) error {
 	changedPaths := make([]string, 0, len(changed))
 	for remotePath := range changed {
 		changedPaths = append(changedPaths, remotePath)
@@ -2923,14 +2951,14 @@ func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[strin
 			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
 				s.logf("skipping denied file: %s", remotePath)
 				if markErr := s.markReadDenied(remotePath); markErr != nil {
-					return cursor, markErr
+					return markErr
 				}
 				continue
 			}
-			return cursor, err
+			return err
 		}
 		if err := s.applyRemoteFile(remotePath, file, conflicted); err != nil {
-			return cursor, err
+			return err
 		}
 	}
 
@@ -2941,14 +2969,10 @@ func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[strin
 	sort.Strings(deletedPaths)
 	for _, remotePath := range deletedPaths {
 		if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
-			return cursor, err
+			return err
 		}
 	}
-
-	if currentCursor == "" {
-		currentCursor = cursor
-	}
-	return currentCursor, nil
+	return nil
 }
 
 func (s *Syncer) resolveLatestEventCursor(ctx context.Context) (string, error) {
@@ -3403,16 +3427,23 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 		// enqueued for writeback (it both stresses the cloud and was part
 		// of the clobber pathology). Surface it and skip.
 		if max := maxWritebackBytes(); max > 0 && info.Size() > max {
-			s.logf("skipping oversized local file %s (%d bytes > %d byte writeback cap); not enqueued", path, info.Size(), max)
+			remotePath, err := localToRemotePath(s.localRoot, s.remoteRoot, path)
+			if err != nil {
+				return nil
+			}
+			logKey := fmt.Sprintf("%s:%d:%d", remotePath, info.Size(), max)
+			if s.oversizedLogged == nil {
+				s.oversizedLogged = map[string]struct{}{}
+			}
+			if _, seen := s.oversizedLogged[logKey]; !seen {
+				s.logf("skipping oversized local file %s (%d bytes > %d byte writeback cap); not enqueued", path, info.Size(), max)
+				s.oversizedLogged[logKey] = struct{}{}
+			}
 			snapshot, err := readLocalSnapshot(path, false)
 			if err != nil {
 				return err
 			}
 			snapshot.SkipWriteback = true
-			remotePath, err := localToRemotePath(s.localRoot, s.remoteRoot, path)
-			if err != nil {
-				return nil
-			}
 			results[remotePath] = snapshot
 			s.state.Counters.SkippedOversizeWriteback++
 			return nil

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3454,6 +3454,8 @@ type fakeClient struct {
 	bulkWriteResponseFunc func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error)
 	deleteCalls           []deleteCall
 	eventsUnsupported     bool
+	listEventsErrAfter    int
+	listEventsErr         error
 }
 
 // requestedReadCalls returns the cumulative number of ReadFile calls made
@@ -3528,6 +3530,9 @@ func (c *fakeClient) ListEvents(ctx context.Context, workspaceID, provider, curs
 	c.listEventsCalls++
 	if c.eventsUnsupported {
 		return EventFeed{}, &HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+	}
+	if c.listEventsErr != nil && c.listEventsCalls > c.listEventsErrAfter {
+		return EventFeed{}, c.listEventsErr
 	}
 	if limit <= 0 {
 		limit = 200
@@ -4541,6 +4546,123 @@ func TestPullShortCircuitsWhenNoNewEvents(t *testing.T) {
 	}
 	if string(data) != "# A v2" {
 		t.Fatalf("expected mirrored file to update after event; got %q", string(data))
+	}
+}
+
+func TestPullRemoteIncrementalPersistsAppliedPageCursorOnListEventsError(t *testing.T) {
+	files := map[string]RemoteFile{}
+	events := make([]FilesystemEvent, 0, 501)
+	for i := 1; i <= 501; i++ {
+		remotePath := fmt.Sprintf("/notion/Docs/%03d.md", i)
+		revision := fmt.Sprintf("rev_%03d", i)
+		files[remotePath] = RemoteFile{
+			Path:        remotePath,
+			Revision:    revision,
+			ContentType: "text/markdown",
+			Content:     fmt.Sprintf("# %03d", i),
+		}
+		events = append(events, FilesystemEvent{
+			EventID:  fmt.Sprintf("evt_%03d", i),
+			Type:     "file.created",
+			Path:     remotePath,
+			Revision: revision,
+		})
+	}
+	client := &fakeClient{
+		files:              files,
+		events:             events,
+		revisionCounter:    501,
+		eventCounter:       501,
+		listEventsErrAfter: 2,
+		listEventsErr:      context.DeadlineExceeded,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:      "ws_backlog",
+		RemoteRoot:       "/notion",
+		LocalRoot:        localDir,
+		FullPullEvery:    -1,
+		WebSocket:        boolPtr(false),
+		CursorTimeout:    time.Second,
+		BootstrapTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	syncer.loaded = true
+	syncer.state = mountState{
+		Files:             map[string]trackedFile{},
+		EventsCursor:      "evt_000",
+		BootstrapComplete: true,
+	}
+
+	err = syncer.Reconcile(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected list-events deadline after first applied page, got %v", err)
+	}
+	if got := syncer.state.EventsCursor; got != "evt_500" {
+		t.Fatalf("EventsCursor = %q, want first applied page cursor evt_500", got)
+	}
+	if _, err := os.ReadFile(filepath.Join(localDir, "Docs", "500.md")); err != nil {
+		t.Fatalf("expected page-one file to be applied before cursor advance: %v", err)
+	}
+	if _, err := os.ReadFile(filepath.Join(localDir, "Docs", "501.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("event after failed page should not be applied yet; stat err=%v", err)
+	}
+
+	client.listEventsErr = nil
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile after backlog error failed: %v", err)
+	}
+	if got := syncer.state.EventsCursor; got != "evt_501" {
+		t.Fatalf("EventsCursor = %q, want final cursor evt_501", got)
+	}
+	data, err := os.ReadFile(filepath.Join(localDir, "Docs", "501.md"))
+	if err != nil {
+		t.Fatalf("expected remaining event to apply on retry: %v", err)
+	}
+	if string(data) != "# 501" {
+		t.Fatalf("unexpected remaining file content: %q", data)
+	}
+}
+
+func TestScanLocalFilesLogsOversizedFileOncePerSize(t *testing.T) {
+	t.Setenv("RELAYFILE_MAX_WRITEBACK_BYTES", "4")
+
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "big.md"), []byte("too large"), 0o644); err != nil {
+		t.Fatalf("write oversized file: %v", err)
+	}
+	logger := &captureLogger{}
+	syncer, err := NewSyncer(&fakeClient{files: map[string]RemoteFile{}}, SyncerOptions{
+		WorkspaceID:   "ws_oversized",
+		RemoteRoot:    "/",
+		LocalRoot:     localDir,
+		Logger:        logger,
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		files, err := syncer.scanLocalFiles()
+		if err != nil {
+			t.Fatalf("scan %d failed: %v", i, err)
+		}
+		if snapshot, ok := files["/big.md"]; !ok || !snapshot.SkipWriteback {
+			t.Fatalf("scan %d did not mark oversized file as skipped: %#v", i, files["/big.md"])
+		}
+	}
+
+	oversizedLogs := 0
+	for _, line := range logger.lines {
+		if strings.Contains(line, "skipping oversized local file") {
+			oversizedLogs++
+		}
+	}
+	if oversizedLogs != 1 {
+		t.Fatalf("expected one oversized-file log across repeated scans, got %d lines: %#v", oversizedLogs, logger.lines)
 	}
 }
 


### PR DESCRIPTION
## Summary
- register foreground mount loops in the same PID state used by background daemons so `relayfile status`/`stop` can see active foreground mounts
- refuse re-home on unverified mount PID state without deleting the evidence, while preserving the PR #174 legacy localDir fallback
- dedupe oversized local-file skip logs per path/size/cap and persist incremental event progress only after each applied page so large backlogs can converge after mid-pull errors

## Issue coverage
Refs #175. This covers the remaining relayfile-side follow-ups C/E/F after #174 covered A/B/D. Cloud-side G/H remain out of scope for this repo.

## Review
- Codex subagent review: no findings after follow-up coverage was added
- Claude review via agent-relay: no blockers; noted foreground PID cleanup, which is covered by the existing deferred pid-file removal

## Verification
- `go test ./cmd/relayfile-cli -run 'TestMount(UsesLegacyRecordedLocalDirWhenOmitted|RefusesExplicitLocalDirThatRehomesRecordedMirror|RehomeRefusesRunningRecordedDaemon|RehomeRefusesUnverifiedRecordedDaemon|RehomeAllowsExplicitMoveAndPersistsLocalDir)|TestShouldRegisterMountPID|TestStatusIncludesLocalMirrorAndDaemonCounts' -count=3`\n- `go test ./internal/mountsync -run 'TestPullRemoteIncrementalPersistsAppliedPageCursorOnListEventsError|TestScanLocalFilesLogsOversizedFileOncePerSize|TestPullShortCircuitsWhenNoNewEvents|TestQuietEventCyclesEventuallyRunPeriodicFullPull|TestForceFullReconcile' -count=3`\n- `go test -count=1 ./...`\n- `scripts/check-contract-surface.sh`\n- `git diff --check --cached`