### PR TITLE
Fix mount daemon cloud refresh token rotation race

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -970,6 +970,37 @@ func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
 	if strings.TrimSpace(creds.RefreshToken) == "" {
 		return creds, ErrCloudRefreshExpired
 	}
+	refreshed, err := refreshCloudCredentialsOnce(creds)
+	if err == nil {
+		return refreshed, nil
+	}
+	if !isCloudRefreshAuthRejection(err) {
+		return creds, fmt.Errorf("refresh cloud session: %w", err)
+	}
+
+	diskCreds, diskErr := loadCloudCredentials()
+	if diskErr == nil {
+		if strings.TrimSpace(diskCreds.APIURL) == "" {
+			diskCreds.APIURL = creds.APIURL
+		}
+		diskChanged := !sameCloudRefreshMaterial(creds, diskCreds)
+		if diskChanged && !cloudAccessTokenExpiredSoon(diskCreds) {
+			return diskCreds, nil
+		}
+		if diskChanged {
+			refreshed, retryErr := refreshCloudCredentialsOnce(diskCreds)
+			if retryErr == nil {
+				return refreshed, nil
+			}
+			if !isCloudRefreshAuthRejection(retryErr) {
+				return diskCreds, fmt.Errorf("refresh cloud session: %w", retryErr)
+			}
+		}
+	}
+	return creds, ErrCloudRefreshExpired
+}
+
+func refreshCloudCredentialsOnce(creds cloudCredentials) (cloudCredentials, error) {
 	client, err := newAPIClient(creds.APIURL, creds.AccessToken)
 	if err != nil {
 		return creds, err
@@ -979,14 +1010,7 @@ func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
 		RefreshToken: creds.RefreshToken,
 	}, &refreshed)
 	if err != nil {
-		var httpErr *apiError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden && strings.EqualFold(strings.TrimSpace(httpErr.Code), "invalid_grant") {
-			return creds, ErrCloudRefreshExpired
-		}
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
-			return creds, ErrCloudRefreshExpired
-		}
-		return creds, fmt.Errorf("refresh cloud session: %w", err)
+		return creds, err
 	}
 	if strings.TrimSpace(refreshed.APIURL) == "" {
 		refreshed.APIURL = creds.APIURL
@@ -1002,6 +1026,22 @@ func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
 		return creds, err
 	}
 	return refreshed, nil
+}
+
+func isCloudRefreshAuthRejection(err error) bool {
+	var httpErr *apiError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	return httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden
+}
+
+func sameCloudRefreshMaterial(a, b cloudCredentials) bool {
+	return strings.TrimSpace(a.APIURL) == strings.TrimSpace(b.APIURL) &&
+		strings.TrimSpace(a.AccessToken) == strings.TrimSpace(b.AccessToken) &&
+		strings.TrimSpace(a.AccessTokenExpiresAt) == strings.TrimSpace(b.AccessTokenExpiresAt) &&
+		strings.TrimSpace(a.RefreshToken) == strings.TrimSpace(b.RefreshToken) &&
+		strings.TrimSpace(a.RefreshTokenExpiresAt) == strings.TrimSpace(b.RefreshTokenExpiresAt)
 }
 
 func providerPromptText(entries []integrationCatalogEntry) string {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1600,6 +1600,68 @@ func TestRefreshCloudCredentialsReturnsSentinelOnInvalidGrant(t *testing.T) {
 	}
 }
 
+func TestRefreshCloudCredentialsRetriesWithReloadedDiskTokenOnAuthRejection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var refreshTokens []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/token/refresh" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		var body cloudTokenRefreshRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode refresh body failed: %v", err)
+		}
+		refreshTokens = append(refreshTokens, body.RefreshToken)
+		switch body.RefreshToken {
+		case "rt_stale":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"code":"invalid_grant","message":"Invalid or expired refresh token"}`))
+		case "rt_disk":
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"rt_new","accessTokenExpiresAt":"2030-05-01T00:00:00Z","refreshTokenExpiresAt":"2030-06-01T00:00:00Z"}`))
+		default:
+			t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
+		}
+	}))
+	defer server.Close()
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:               server.URL,
+		AccessToken:          "cld_disk_old",
+		RefreshToken:         "rt_disk",
+		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+
+	refreshed, err := refreshCloudCredentials(cloudCredentials{
+		APIURL:               server.URL,
+		AccessToken:          "cld_stale",
+		RefreshToken:         "rt_stale",
+		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("refreshCloudCredentials failed: %v", err)
+	}
+	if refreshed.AccessToken != "cld_new" || refreshed.RefreshToken != "rt_new" {
+		t.Fatalf("unexpected refreshed credentials: %#v", refreshed)
+	}
+	if got := strings.Join(refreshTokens, ","); got != "rt_stale,rt_disk" {
+		t.Fatalf("unexpected refresh token attempts: %s", got)
+	}
+
+	diskCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	if diskCreds.AccessToken != "cld_new" || diskCreds.RefreshToken != "rt_new" {
+		t.Fatalf("expected refreshed credentials on disk, got: %#v", diskCreds)
+	}
+}
+
 func TestRefreshCloudCredentialsReturnsSentinelOnUnauthorized(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)


### PR DESCRIPTION
## Summary
- Retry cloud session refresh once with freshly reloaded disk credentials after refresh-token auth rejection.
- Reuse a fresh on-disk cloud access token when another CLI already rotated credentials.
- Treat unrecovered refresh endpoint 401/403 as the existing re-login/degraded sentinel instead of a non-fatal refresh blip.
- Add regression coverage for stale in-memory refresh tokens racing with rotated disk credentials.

## Tests
- go test ./cmd/relayfile-cli -run 'TestRefreshCloudCredentials|TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized|TestStatusSurfacesDegradedStallReason'
- go test ./cmd/relayfile-cli

Closes #178