### PR TITLE
fix: guard mount writebacks from remote drift

### DIFF
--- a/internal/mountsync/mount_root_clobber_test.go
+++ b/internal/mountsync/mount_root_clobber_test.go
@@ -480,7 +480,7 @@ func TestOversizedTrackedFileDoesNotBecomeRemoteDelete(t *testing.T) {
 	}
 
 	state := readPublicState(t, localDir)
-	if state.PendingWriteback != 0 || state.Files[remotePath].Status != "writeback-skipped" {
-		t.Fatalf("oversized tracked file should be skipped, not pending: %+v", state)
+	if state.PendingWriteback != 0 || state.Files[remotePath].Status != "ready" {
+		t.Fatalf("oversized tracked drift should settle without writeback: %+v", state)
 	}
 }

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1350,7 +1350,7 @@ func chunkPendingBulkWrites(pending []pendingBulkWrite, maxBytes int64) [][]pend
 	for _, item := range pending {
 		candidate := append(append([]pendingBulkWrite(nil), current...), item)
 		if len(current) > 0 && bulkWriteRequestSize(bulkWriteFilesForPending(candidate)) > maxBytes {
-			chunks = append(chunks, current)
+			chunks = append(chunks, append([]pendingBulkWrite(nil), current...))
 			current = current[:0]
 		}
 		current = append(current, item)

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -739,6 +739,9 @@ type trackedFile struct {
 	Encoding    string `json:"encoding,omitempty"`
 	Hash        string `json:"hash"`
 	Dirty       bool   `json:"dirty,omitempty"`
+	// DeletePending is set only by an observed local delete. A missing file
+	// during a scan is not enough evidence to delete cloud state.
+	DeletePending bool `json:"deletePending,omitempty"`
 	// Denied — the server denied reading this path. The local copy (if any)
 	// has been removed and future syncs ignore it.
 	Denied bool `json:"denied,omitempty"`
@@ -1231,6 +1234,17 @@ func (s *Syncer) preparePendingBulkWrite(
 		}
 	}
 
+	tracked.ContentType = snapshot.ContentType
+	tracked.Encoding = normalizeEncoding(snapshot.Encoding)
+	tracked.Hash = snapshot.Hash
+	tracked.Dirty = true
+	tracked.DeletePending = false
+	tracked.Denied = false
+	tracked.WriteDenied = false
+	tracked.DeniedHash = ""
+	tracked.ReadOnly = false
+	s.state.Files[remotePath] = tracked
+
 	return &pendingBulkWrite{
 		remotePath: remotePath,
 		localPath:  localPath,
@@ -1251,6 +1265,15 @@ func (s *Syncer) flushPendingBulkWrites(ctx context.Context, pending []pendingBu
 		s.logf("writeback flush refused: cloud-error circuit breaker is open; %d file(s) remain pending", len(pending))
 		return nil
 	}
+	for _, chunk := range chunkPendingBulkWrites(pending, maxWritebackBatchBytes()) {
+		if err := s.flushPendingBulkWriteChunk(ctx, chunk, conflicted); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Syncer) flushPendingBulkWriteChunk(ctx context.Context, pending []pendingBulkWrite, conflicted map[string]struct{}) error {
 	files := make([]BulkWriteFile, 0, len(pending))
 	for _, pendingWrite := range pending {
 		files = append(files, BulkWriteFile{
@@ -1300,6 +1323,53 @@ func (s *Syncer) flushPendingBulkWrites(ctx context.Context, pending []pendingBu
 		}
 	}
 	return firstErr
+}
+
+func bulkWriteFilesForPending(pending []pendingBulkWrite) []BulkWriteFile {
+	files := make([]BulkWriteFile, 0, len(pending))
+	for _, pendingWrite := range pending {
+		files = append(files, BulkWriteFile{
+			Path:        pendingWrite.remotePath,
+			ContentType: pendingWrite.snapshot.ContentType,
+			Content:     pendingWrite.snapshot.WireContent,
+			Encoding:    pendingWrite.snapshot.Encoding,
+		})
+	}
+	return files
+}
+
+func chunkPendingBulkWrites(pending []pendingBulkWrite, maxBytes int64) [][]pendingBulkWrite {
+	if len(pending) == 0 {
+		return nil
+	}
+	if maxBytes <= 0 {
+		return [][]pendingBulkWrite{pending}
+	}
+	chunks := make([][]pendingBulkWrite, 0, 1)
+	current := make([]pendingBulkWrite, 0, len(pending))
+	for _, item := range pending {
+		candidate := append(append([]pendingBulkWrite(nil), current...), item)
+		if len(current) > 0 && bulkWriteRequestSize(bulkWriteFilesForPending(candidate)) > maxBytes {
+			chunks = append(chunks, current)
+			current = current[:0]
+		}
+		current = append(current, item)
+	}
+	if len(current) > 0 {
+		chunks = append(chunks, current)
+	}
+	return chunks
+}
+
+func bulkWriteRequestSize(files []BulkWriteFile) int64 {
+	body := struct {
+		Files []BulkWriteFile `json:"files"`
+	}{Files: files}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return 0
+	}
+	return int64(len(data))
 }
 
 func (s *Syncer) reconcileBulkWrite(ctx context.Context, pendingWrite pendingBulkWrite, revision string) error {
@@ -1617,6 +1687,10 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 		return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, "")
 	}
 
+	tracked.DeletePending = true
+	tracked.Dirty = false
+	s.state.Files[remotePath] = tracked
+
 	err := s.client.DeleteFile(ctx, s.workspace, remotePath, tracked.Revision)
 	if err != nil {
 		var httpErr *HTTPError
@@ -1625,6 +1699,8 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 			return nil
 		}
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
+			tracked.DeletePending = false
+			s.state.Files[remotePath] = tracked
 			return s.revertReadonlyFile(ctx, remotePath, localPath, tracked, "")
 		}
 		if errors.Is(err, ErrConflict) {
@@ -2341,9 +2417,11 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		if !s.state.BootstrapComplete {
 			s.state.BootstrapCursor = cursor
 			s.state.BootstrapFilesSynced += filesThisPage
+			prog.touch()
 			if err := s.saveState(); err != nil {
 				return err
 			}
+			prog.touch()
 		}
 	}
 
@@ -2492,6 +2570,11 @@ func (s *Syncer) recordCloudSuccess() {
 // pathological payloads out of the sync pipeline by default.
 const defaultMaxWritebackBytes int64 = 8 << 20
 
+// defaultMaxWritebackBatchBytes caps the serialized /fs/bulk request body.
+// The cloud rejects requests above roughly 10 MiB; 8 MiB leaves room for
+// transport and schema overhead while still batching normal writebacks.
+const defaultMaxWritebackBatchBytes int64 = 8 << 20
+
 // maxWritebackBytes returns the writeback body size cap in bytes.
 // Configurable via RELAYFILE_MAX_WRITEBACK_BYTES (positive integer).
 // A value of 0 or a negative override disables the cap.
@@ -2503,6 +2586,21 @@ func maxWritebackBytes() int64 {
 	v, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return defaultMaxWritebackBytes
+	}
+	if v <= 0 {
+		return 0
+	}
+	return v
+}
+
+func maxWritebackBatchBytes() int64 {
+	raw := strings.TrimSpace(os.Getenv("RELAYFILE_MAX_WRITEBACK_BATCH_BYTES"))
+	if raw == "" {
+		return defaultMaxWritebackBatchBytes
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return defaultMaxWritebackBatchBytes
 	}
 	if v <= 0 {
 		return 0
@@ -3122,17 +3220,6 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		localHash := hashBytes(current)
 		if localHash == remoteHash {
 			shouldWrite = false
-		} else if tracked, ok := s.state.Files[remotePath]; ok && localHash != tracked.Hash {
-			// Local file was modified since last sync — mark dirty and preserve the local edit
-			tracked.Revision = file.Revision
-			tracked.ContentType = file.ContentType
-			tracked.Hash = localHash
-			tracked.Dirty = true
-			if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
-				return err
-			}
-			s.state.Files[remotePath] = tracked
-			return nil
 		}
 	}
 	if shouldWrite {
@@ -3353,6 +3440,13 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 		if snapshot.SkipWriteback {
 			continue
 		}
+		if exists && !tracked.Dirty {
+			tracked.ContentType = snapshot.ContentType
+			tracked.Encoding = normalizeEncoding(snapshot.Encoding)
+			tracked.ReadOnly = false
+			s.state.Files[remotePath] = tracked
+			continue
+		}
 		fullSnapshot, err := readLocalSnapshot(localPath, true)
 		if err != nil {
 			return nil, err
@@ -3395,6 +3489,10 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 			continue
 		}
 		if _, ok := localFiles[remotePath]; ok {
+			continue
+		}
+		if !tracked.DeletePending {
+			s.state.Files[remotePath] = tracked
 			continue
 		}
 		err := s.client.DeleteFile(ctx, s.workspace, remotePath, tracked.Revision)
@@ -3616,17 +3714,15 @@ func (s *Syncer) savePublicState() error {
 			fileStatus = "write-denied"
 		case tracked.Denied:
 			fileStatus = "read-denied"
-		case tracked.Dirty:
+		case tracked.Dirty || tracked.DeletePending:
 			fileStatus = "writeback-pending"
 		}
 		if !s.lowMemory {
 			if snapshot, ok := currentFiles[remotePath]; ok {
 				if snapshot.SkipWriteback && !tracked.Denied && !tracked.WriteDenied {
 					fileStatus = "writeback-skipped"
-				} else if tracked.Hash != snapshot.Hash && fileStatus == "ready" {
-					fileStatus = "writeback-pending"
 				}
-			} else if !tracked.Denied && !tracked.WriteDenied && tracked.Hash != "" && fileStatus == "ready" {
+			} else if tracked.DeletePending && !tracked.Denied && !tracked.WriteDenied && fileStatus == "ready" {
 				fileStatus = "writeback-pending"
 			}
 		}

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -35,6 +35,21 @@ func boolPtr(value bool) *bool {
 	return &value
 }
 
+func markLocalDirtyForTest(t *testing.T, syncer *Syncer, remotePath, localPath string) {
+	t.Helper()
+	snapshot, err := readLocalSnapshot(localPath, true)
+	if err != nil {
+		t.Fatalf("read dirty snapshot for %s: %v", remotePath, err)
+	}
+	tracked := syncer.state.Files[normalizeRemotePath(remotePath)]
+	tracked.ContentType = snapshot.ContentType
+	tracked.Encoding = normalizeEncoding(snapshot.Encoding)
+	tracked.Hash = snapshot.Hash
+	tracked.Dirty = true
+	tracked.DeletePending = false
+	syncer.state.Files[normalizeRemotePath(remotePath)] = tracked
+}
+
 type fakeProviderLayoutRegistrar struct {
 	calls    []string
 	manifest map[string]ProviderLayoutManifest
@@ -87,8 +102,8 @@ func TestSyncOncePullsRemoteAndPushesLocalEdits(t *testing.T) {
 	if err := os.WriteFile(localFile, []byte("# A edited"), 0o644); err != nil {
 		t.Fatalf("write local edit failed: %v", err)
 	}
-	if err := syncer.SyncOnce(context.Background()); err != nil {
-		t.Fatalf("sync after edit failed: %v", err)
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/A.md", fsnotify.Write); err != nil {
+		t.Fatalf("handle local edit failed: %v", err)
 	}
 
 	remote := client.files["/notion/Docs/A.md"]
@@ -638,8 +653,8 @@ func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	if err := os.Remove(localFile); err != nil {
 		t.Fatalf("remove local file failed: %v", err)
 	}
-	if err := syncer.SyncOnce(context.Background()); err != nil {
-		t.Fatalf("sync delete failed: %v", err)
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/New.md", fsnotify.Remove); err != nil {
+		t.Fatalf("handle delete failed: %v", err)
 	}
 	if _, ok := client.files["/notion/Docs/New.md"]; ok {
 		t.Fatalf("expected remote file to be deleted")
@@ -727,8 +742,8 @@ func TestBinaryFileRoundTripsThroughMirror(t *testing.T) {
 	if err := os.WriteFile(localPath, updated, 0o644); err != nil {
 		t.Fatalf("write binary local edit failed: %v", err)
 	}
-	if err := syncer.SyncOnce(context.Background()); err != nil {
-		t.Fatalf("binary roundtrip sync failed: %v", err)
+	if err := syncer.HandleLocalChange(context.Background(), "blob.bin", fsnotify.Write); err != nil {
+		t.Fatalf("binary local change failed: %v", err)
 	}
 
 	remote := client.files["/external/blob.bin"]
@@ -869,12 +884,14 @@ func TestBulkWrite_MixedCreateAndUpdateBatch(t *testing.T) {
 		t.Fatalf("initial sync failed: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(localDir, "Docs", "A.md"), []byte("# A updated"), 0o644); err != nil {
+	localA := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.WriteFile(localA, []byte("# A updated"), 0o644); err != nil {
 		t.Fatalf("update local file failed: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(localDir, "Docs", "B.md"), []byte("# B"), 0o644); err != nil {
 		t.Fatalf("create local file failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/notion/Docs/A.md", localA)
 
 	client.bulkWriteCalls = 0
 	client.bulkWriteBatches = nil
@@ -934,6 +951,7 @@ func TestBulkWrite_OverwritesRemoteChangeInSingleCycle(t *testing.T) {
 	if err := os.WriteFile(localFile, []byte("# local"), 0o644); err != nil {
 		t.Fatalf("write local edit failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/notion/Docs/A.md", localFile)
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatalf("bulk write sync failed: %v", err)
 	}
@@ -1410,6 +1428,190 @@ func TestBulkWrite_ChunkAtThreshold(t *testing.T) {
 	}
 }
 
+func TestBulkWrite_ChunksBySerializedRequestSize(t *testing.T) {
+	t.Setenv("RELAYFILE_MAX_WRITEBACK_BATCH_BYTES", "650")
+
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+	}
+	localDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localDir, "Docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs failed: %v", err)
+	}
+	for idx := 0; idx < 4; idx++ {
+		name := fmt.Sprintf("Chunk%02d.md", idx+1)
+		path := filepath.Join(localDir, "Docs", name)
+		if err := os.WriteFile(path, []byte(strings.Repeat(name, 20)), 0o644); err != nil {
+			t.Fatalf("seed file %s failed: %v", name, err)
+		}
+	}
+
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_chunked_bulk_bytes",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("chunked sync failed: %v", err)
+	}
+
+	if client.bulkWriteCalls < 2 {
+		t.Fatalf("expected serialized-size chunking to split bulk writes, got %d call(s)", client.bulkWriteCalls)
+	}
+	for idx, batch := range client.bulkWriteBatches {
+		if size := bulkWriteRequestSize(batch); size > maxWritebackBatchBytes() {
+			t.Fatalf("batch %d serialized to %d bytes, over cap %d", idx, size, maxWritebackBatchBytes())
+		}
+	}
+}
+
+func TestPushLocalRequiresDirtyForTrackedHashDrift(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_hash_drift_no_push",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.WriteFile(localFile, []byte("# local drift"), 0o644); err != nil {
+		t.Fatalf("write local drift failed: %v", err)
+	}
+	client.bulkWriteCalls = 0
+	client.bulkWriteBatches = nil
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync after local drift failed: %v", err)
+	}
+
+	if client.bulkWriteCalls != 0 {
+		t.Fatalf("expected tracked hash drift without Dirty state not to write back, got %d bulk calls", client.bulkWriteCalls)
+	}
+	if got := client.files["/notion/Docs/A.md"].Content; got != "# A" {
+		t.Fatalf("expected remote content to remain unchanged, got %q", got)
+	}
+}
+
+func TestRemotePullOverwritesUnmarkedLocalDrift(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		events: []FilesystemEvent{{
+			EventID:  "evt_1",
+			Type:     "file.created",
+			Path:     "/notion/Docs/A.md",
+			Revision: "rev_1",
+		}},
+		revisionCounter: 1,
+		eventCounter:    1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_remote_overwrites_unmarked_drift",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.WriteFile(localFile, []byte("# local drift"), 0o644); err != nil {
+		t.Fatalf("write local drift failed: %v", err)
+	}
+	client.files["/notion/Docs/A.md"] = RemoteFile{
+		Path:        "/notion/Docs/A.md",
+		Revision:    "rev_2",
+		ContentType: "text/markdown",
+		Content:     "# remote v2",
+	}
+	client.appendEvent("file.updated", "/notion/Docs/A.md", "rev_2")
+	client.bulkWriteCalls = 0
+	client.bulkWriteBatches = nil
+
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync after remote update failed: %v", err)
+	}
+
+	if client.bulkWriteCalls != 0 {
+		t.Fatalf("expected remote pull not to write back unmarked local drift, got %d bulk calls", client.bulkWriteCalls)
+	}
+	assertLocalFileContent(t, localFile, "# remote v2")
+	if syncer.state.Files["/notion/Docs/A.md"].Dirty {
+		t.Fatalf("expected remote pull to keep tracked file clean")
+	}
+}
+
+func TestMissingTrackedFileRequiresDeletePending(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_missing_without_delete_event",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial sync failed: %v", err)
+	}
+
+	localFile := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.Remove(localFile); err != nil {
+		t.Fatalf("remove local file failed: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync after unmarked local removal failed: %v", err)
+	}
+
+	if len(client.deleteCalls) != 0 {
+		t.Fatalf("expected no remote delete without deletePending, got %+v", client.deleteCalls)
+	}
+	if _, exists := client.files["/notion/Docs/A.md"]; !exists {
+		t.Fatalf("expected remote file to remain after unmarked local removal")
+	}
+}
+
 func TestBulkWrite_PartialErrors(t *testing.T) {
 	client := &fakeClient{
 		files: map[string]RemoteFile{},
@@ -1522,6 +1724,7 @@ func TestBulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote(t *testing.T
 	if err := os.WriteFile(localA, []byte("# local A"), 0o644); err != nil {
 		t.Fatalf("write local A failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/notion/Docs/A.md", localA)
 	localB := filepath.Join(localDir, "Docs", "B.md")
 	if err := os.WriteFile(localB, []byte("# local B"), 0o644); err != nil {
 		t.Fatalf("write local B failed: %v", err)
@@ -1566,6 +1769,7 @@ func TestBulkWrite_PerFileConflictCreatesArtifactAndRefreshesRemote(t *testing.T
 	if err := os.WriteFile(localA, []byte("# local A resolved"), 0o644); err != nil {
 		t.Fatalf("write resolved local A failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/notion/Docs/A.md", localA)
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatalf("resolved retry sync failed: %v", err)
 	}
@@ -1626,6 +1830,7 @@ func TestBulkWrite_SchemaValidationQuarantinesLocalAndRestoresRemote(t *testing.
 	if err := os.WriteFile(localPath, []byte(`{"event":"PLEASE_APPROVE"}`), 0o644); err != nil {
 		t.Fatalf("write local draft failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/github/repos/acme/api/pulls/42/reviews/draft.json", localPath)
 
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatalf("sync with schema validation failure failed: %v", err)
@@ -1748,8 +1953,8 @@ func TestBulkWrite_DeletesStayPerFile(t *testing.T) {
 	if err := os.Remove(localPath); err != nil {
 		t.Fatalf("remove local file failed: %v", err)
 	}
-	if err := syncer.SyncOnce(context.Background()); err != nil {
-		t.Fatalf("delete sync failed: %v", err)
+	if err := syncer.HandleLocalChange(context.Background(), "Docs/A.md", fsnotify.Remove); err != nil {
+		t.Fatalf("delete local change failed: %v", err)
 	}
 
 	if client.bulkWriteCalls != 0 {
@@ -1796,6 +2001,7 @@ func TestBulkWrite_ReconcileUsesResponseRevision(t *testing.T) {
 	if err := os.WriteFile(localPath, []byte("# A updated"), 0o644); err != nil {
 		t.Fatalf("write local file failed: %v", err)
 	}
+	markLocalDirtyForTest(t, syncer, "/notion/Docs/A.md", localPath)
 	if err := syncer.SyncOnce(context.Background()); err != nil {
 		t.Fatalf("bulk write sync failed: %v", err)
 	}


### PR DESCRIPTION
## Summary
- chunk mount bulk writeback batches by serialized request size before calling `/fs/bulk`
- require explicit dirty/delete-pending state for tracked local writebacks instead of treating hash drift as local intent
- let authoritative remote pulls overwrite unmarked local drift and add regression coverage for drift, deletes, chunking, and pending status

Closes #182

## Tests
- `go test ./cmd/relayfile-cli ./cmd/relayfile-mount ./internal/mountsync/... -count=1 -timeout 240s`
