### PR TITLE
fix: speed up mount bootstrap fallback

### DIFF
--- a/internal/httpapi/websocket.go
+++ b/internal/httpapi/websocket.go
@@ -13,10 +13,11 @@ import (
 )
 
 type fileEventMessage struct {
-	Type      string `json:"type"`
-	Path      string `json:"path,omitempty"`
-	Revision  string `json:"revision,omitempty"`
-	Timestamp string `json:"timestamp,omitempty"`
+	Type        string `json:"type"`
+	Path        string `json:"path,omitempty"`
+	Revision    string `json:"revision,omitempty"`
+	ContentHash string `json:"contentHash,omitempty"`
+	Timestamp   string `json:"timestamp,omitempty"`
 }
 
 type websocketClientMessage struct {
@@ -132,9 +133,10 @@ func (s *Server) readWebSocketMessages(ctx context.Context, conn *websocket.Conn
 
 func (s *Server) writeWebSocketEvent(ctx context.Context, conn *websocket.Conn, event relayfile.Event) error {
 	return wsjson.Write(ctx, conn, fileEventMessage{
-		Type:      event.Type,
-		Path:      event.Path,
-		Revision:  event.Revision,
-		Timestamp: event.Timestamp,
+		Type:        event.Type,
+		Path:        event.Path,
+		Revision:    event.Revision,
+		ContentHash: event.ContentHash,
+		Timestamp:   event.Timestamp,
 	})
 }

--- a/internal/mountsync/bootstrap_test.go
+++ b/internal/mountsync/bootstrap_test.go
@@ -38,6 +38,8 @@ type bootstrapClient struct {
 
 	listTreeCalls atomic.Int64
 	readFileCalls atomic.Int64
+	activeReads   atomic.Int64
+	maxActiveRead atomic.Int64
 }
 
 func newBootstrapClient(fileCount, pageSize int) *bootstrapClient {
@@ -104,7 +106,7 @@ func (c *bootstrapClient) ListTree(ctx context.Context, workspaceID, path string
 	entries := make([]TreeEntry, 0, end-start)
 	for _, p := range paths[start:end] {
 		f := c.files[p]
-		entries = append(entries, TreeEntry{Path: p, Type: "file", Revision: f.Revision})
+		entries = append(entries, TreeEntry{Path: p, Type: "file", Revision: f.Revision, ContentHash: f.ContentHash})
 	}
 	resp := TreeResponse{Path: normalizeRemotePath(path), Entries: entries}
 	if end < len(paths) {
@@ -130,6 +132,14 @@ func (c *bootstrapClient) ListEvents(ctx context.Context, workspaceID, provider,
 
 func (c *bootstrapClient) ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error) {
 	c.readFileCalls.Add(1)
+	active := c.activeReads.Add(1)
+	for {
+		currentMax := c.maxActiveRead.Load()
+		if active <= currentMax || c.maxActiveRead.CompareAndSwap(currentMax, active) {
+			break
+		}
+	}
+	defer c.activeReads.Add(-1)
 	if c.readFileSleep > 0 {
 		select {
 		case <-time.After(c.readFileSleep):
@@ -191,6 +201,27 @@ func defaultIf(v, def string) string {
 		return def
 	}
 	return v
+}
+
+func TestBootstrapReadsFilesWithBoundedParallelism(t *testing.T) {
+	t.Setenv("RELAYFILE_BOOTSTRAP_READ_CONCURRENCY", "4")
+	client := newBootstrapClient(12, 12)
+	client.readFileSleep = 25 * time.Millisecond
+	localDir := t.TempDir()
+	s := newBootstrapSyncer(t, client, localDir, SyncerOptions{
+		RootCtx: context.Background(),
+	})
+
+	if err := s.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if got := client.maxActiveRead.Load(); got < 2 || got > 4 {
+		t.Fatalf("expected bounded parallel reads between 2 and 4, got %d", got)
+	}
+	if got, want := client.readFileCalls.Load(), int64(12); got != want {
+		t.Fatalf("expected %d ReadFile calls, got %d", want, got)
+	}
 }
 
 // TestBootstrapTimeoutDecoupledFromCycleTimeout: a tiny inbound per-cycle

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -78,6 +78,7 @@ const (
 	defaultBootstrapTimeout     = 0 * time.Second
 	defaultBootstrapIdleTimeout = 90 * time.Second
 	defaultCursorTimeout        = 20 * time.Second
+	defaultBootstrapReadWorkers = 16
 )
 
 // resolveDurationEnv returns the option value if non-zero, else parses the
@@ -1682,6 +1683,18 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 		return err
 	}
 
+	conflicted := map[string]struct{}{}
+	didPoll := false
+	if !s.state.BootstrapComplete || s.forceFullReconcile {
+		if err := s.pullRemote(ctx, conflicted); err != nil {
+			s.markSyncError(err)
+			_ = s.saveState()
+			return err
+		}
+		s.bootstrapped = true
+		didPoll = true
+	}
+
 	conflicted, err := s.pushLocal(ctx)
 	if err != nil {
 		s.markSyncError(err)
@@ -1689,7 +1702,7 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 		return err
 	}
 
-	shouldPoll := forcePoll || !s.bootstrapped || s.wsConn == nil
+	shouldPoll := !didPoll && (forcePoll || !s.bootstrapped || s.wsConn == nil)
 	if shouldPoll {
 		if err := s.pullRemote(ctx, conflicted); err != nil {
 			s.markSyncError(err)
@@ -2279,6 +2292,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		s.recordCloudSuccess()
 		prog.touch()
 		filesThisPage := 0
+		readJobs := make([]bootstrapReadJob, 0, len(page.Entries))
 		for _, entry := range page.Entries {
 			if entry.Type != "file" {
 				continue
@@ -2312,23 +2326,38 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 					s.logf("tree revision %s reused for %s with divergent content hash (tracked=%s remote=%s); refetching", entry.Revision, remotePath, tracked.Hash, entry.ContentHash)
 				}
 			}
-			file, err := s.client.ReadFile(ctx, s.workspace, remotePath)
+			skipped, err := s.trySkipBootstrapRead(remotePath, entry)
 			if err != nil {
+				return err
+			}
+			if skipped {
+				prog.touch()
+				remotePaths[remotePath] = struct{}{}
+				filesThisPage++
+				continue
+			}
+			readJobs = append(readJobs, bootstrapReadJob{
+				Index:      len(readJobs),
+				RemotePath: remotePath,
+			})
+		}
+		for _, result := range s.readBootstrapFiles(ctx, readJobs, prog) {
+			if result.Err != nil {
 				var httpErr *HTTPError
-				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
-					s.logf("skipping denied file: %s", remotePath)
-					if markErr := s.markReadDenied(remotePath); markErr != nil {
+				if errors.As(result.Err, &httpErr) && httpErr.StatusCode == http.StatusForbidden {
+					s.logf("skipping denied file: %s", result.RemotePath)
+					if markErr := s.markReadDenied(result.RemotePath); markErr != nil {
 						return markErr
 					}
 					continue
 				}
-				return err
+				return result.Err
 			}
-			if err := s.applyRemoteFile(remotePath, file, conflicted); err != nil {
+			if err := s.applyRemoteFile(result.RemotePath, result.File, conflicted); err != nil {
 				return err
 			}
 			prog.touch()
-			remotePaths[remotePath] = struct{}{}
+			remotePaths[result.RemotePath] = struct{}{}
 			filesThisPage++
 		}
 		if page.NextCursor == nil || *page.NextCursor == "" {
@@ -2381,6 +2410,123 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 	}
 	s.markBootstrapComplete()
 	return nil
+}
+
+type bootstrapReadJob struct {
+	Index      int
+	RemotePath string
+}
+
+type bootstrapReadResult struct {
+	Index      int
+	RemotePath string
+	File       RemoteFile
+	Err        error
+}
+
+func (s *Syncer) trySkipBootstrapRead(remotePath string, entry TreeEntry) (bool, error) {
+	if strings.TrimSpace(entry.ContentHash) == "" {
+		return false, nil
+	}
+	if tracked, ok := s.state.Files[remotePath]; ok {
+		if tracked.Dirty || tracked.Denied {
+			return false, nil
+		}
+	}
+	localPath, err := remoteToLocalPath(s.localRoot, s.remoteRoot, remotePath)
+	if err != nil {
+		return false, nil
+	}
+	if err := s.assertNotMountRoot(localPath); err != nil {
+		s.logf("skipping local hash probe for %s: %v", remotePath, err)
+		return false, nil
+	}
+	snapshot, err := readLocalSnapshot(localPath, false)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, nil
+	}
+	if snapshot.Hash != entry.ContentHash {
+		return false, nil
+	}
+	canWrite := s.canWritePath(remotePath)
+	if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
+		return false, err
+	}
+	s.state.Files[remotePath] = trackedFile{
+		Revision:    entry.Revision,
+		ContentType: snapshot.ContentType,
+		Hash:        snapshot.Hash,
+		Dirty:       false,
+		Denied:      false,
+		ReadOnly:    !canWrite,
+	}
+	return true, nil
+}
+
+func (s *Syncer) readBootstrapFiles(ctx context.Context, jobs []bootstrapReadJob, prog bootstrapProgress) []bootstrapReadResult {
+	if len(jobs) == 0 {
+		return nil
+	}
+	workers := bootstrapReadWorkers()
+	if workers > len(jobs) {
+		workers = len(jobs)
+	}
+	readCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobCh := make(chan bootstrapReadJob, len(jobs))
+	for _, job := range jobs {
+		jobCh <- job
+	}
+	close(jobCh)
+
+	resultCh := make(chan bootstrapReadResult, len(jobs))
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobCh {
+				file, err := s.client.ReadFile(readCtx, s.workspace, job.RemotePath)
+				if err == nil {
+					prog.touch()
+				}
+				resultCh <- bootstrapReadResult{
+					Index:      job.Index,
+					RemotePath: job.RemotePath,
+					File:       file,
+					Err:        err,
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(resultCh)
+
+	results := make([]bootstrapReadResult, 0, len(jobs))
+	for result := range resultCh {
+		results = append(results, result)
+	}
+	sort.Slice(results, func(i, j int) bool { return results[i].Index < results[j].Index })
+	return results
+}
+
+func bootstrapReadWorkers() int {
+	raw := strings.TrimSpace(os.Getenv("RELAYFILE_BOOTSTRAP_READ_CONCURRENCY"))
+	if raw == "" {
+		return defaultBootstrapReadWorkers
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return defaultBootstrapReadWorkers
+	}
+	if v > 64 {
+		return 64
+	}
+	return v
 }
 
 // markBootstrapComplete records that a full-tree (or export) pull has

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -646,6 +646,102 @@ func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	}
 }
 
+func TestPullRemoteFullTreeSkipsReadFileWhenLocalHashMatchesContentHash(t *testing.T) {
+	content := "# A"
+	remotePath := "/notion/Docs/A.md"
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			remotePath: {
+				Path:        remotePath,
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     content,
+				ContentHash: hashString(content),
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local dir failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed local file failed: %v", err)
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_skip_hash",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("pull full tree failed: %v", err)
+	}
+
+	if got := client.requestedReadCalls(); got != 0 {
+		t.Fatalf("expected matching contentHash to skip ReadFile, got %d read(s)", got)
+	}
+	tracked := syncer.state.Files[remotePath]
+	if tracked.Revision != "rev_1" || tracked.Hash != hashString(content) || tracked.Dirty {
+		t.Fatalf("unexpected tracked state after skip: %+v", tracked)
+	}
+	assertLocalFileContent(t, localPath, content)
+}
+
+func TestReconcileBootstrapSkipsMatchingKeptMirrorBeforePushLocal(t *testing.T) {
+	content := "# A"
+	remotePath := "/notion/Docs/A.md"
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			remotePath: {
+				Path:        remotePath,
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     content,
+				ContentHash: hashString(content),
+			},
+		},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local dir failed: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed kept mirror failed: %v", err)
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_mount_kept_mirror",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		WebSocket:   boolPtr(false),
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	if got := client.requestedReadCalls(); got != 0 {
+		t.Fatalf("expected matching kept mirror to skip ReadFile, got %d read(s)", got)
+	}
+	if client.bulkWriteCalls != 0 {
+		t.Fatalf("expected bootstrap to track kept mirror before pushLocal, got %d bulk write(s)", client.bulkWriteCalls)
+	}
+	tracked := syncer.state.Files[remotePath]
+	if tracked.Revision != "rev_1" || tracked.Hash != hashString(content) || tracked.Dirty {
+		t.Fatalf("unexpected tracked state after reconcile: %+v", tracked)
+	}
+	assertLocalFileContent(t, localPath, content)
+}
+
 func TestSyncOnceWritesPublicStateFile(t *testing.T) {
 	client := &fakeClient{
 		files: map[string]RemoteFile{
@@ -3439,6 +3535,7 @@ func TestAtomicTempPatternHidesTempForDotPrefixedTarget(t *testing.T) {
 }
 
 type fakeClient struct {
+	mu                    sync.Mutex
 	files                 map[string]RemoteFile
 	events                []FilesystemEvent
 	revisionCounter       int
@@ -3464,6 +3561,8 @@ type fakeClient struct {
 // against this fake client. Used by tests asserting that quiet reconcile
 // cycles do not perform per-file remote reads.
 func (c *fakeClient) requestedReadCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.readFileCalls
 }
 
@@ -3512,9 +3611,10 @@ func (c *fakeClient) ListTree(ctx context.Context, workspaceID, path string, dep
 			continue
 		}
 		entries = append(entries, TreeEntry{
-			Path:     remotePath,
-			Type:     "file",
-			Revision: file.Revision,
+			Path:        remotePath,
+			Type:        "file",
+			Revision:    file.Revision,
+			ContentHash: file.ContentHash,
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
@@ -3570,6 +3670,8 @@ func (c *fakeClient) ListEvents(ctx context.Context, workspaceID, provider, curs
 func (c *fakeClient) ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error) {
 	_ = ctx
 	_ = workspaceID
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.readFileCalls++
 	path = normalizeRemotePath(path)
 	if c.readFileCallsByPath == nil {

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -3,7 +3,9 @@ package relayfile
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -64,6 +66,7 @@ type TreeEntry struct {
 	Path             string `json:"path"`
 	Type             string `json:"type"`
 	Revision         string `json:"revision"`
+	ContentHash      string `json:"contentHash,omitempty"`
 	Provider         string `json:"provider,omitempty"`
 	ProviderObjectID string `json:"providerObjectId,omitempty"`
 	Size             int64  `json:"size,omitempty"`
@@ -144,6 +147,7 @@ type Event struct {
 	Type          string `json:"type"`
 	Path          string `json:"path"`
 	Revision      string `json:"revision"`
+	ContentHash   string `json:"contentHash,omitempty"`
 	Origin        string `json:"origin"`
 	Provider      string `json:"provider,omitempty"`
 	CorrelationID string `json:"correlationId"`
@@ -1072,6 +1076,7 @@ func (s *Store) ListTree(workspaceID, path string, depth int, cursor string) (Tr
 					Path:             child,
 					Type:             "file",
 					Revision:         file.Revision,
+					ContentHash:      contentHashForFile(file),
 					Provider:         file.Provider,
 					ProviderObjectID: file.ProviderObjectID,
 					Size:             int64(len(file.Content)),
@@ -3267,6 +3272,7 @@ func (s *Store) recordWriteLocked(ws *workspaceState, path, revision, eventType,
 		Type:          eventType,
 		Path:          path,
 		Revision:      revision,
+		ContentHash:   contentHashForFile(ws.Files[path]),
 		Origin:        "agent_write",
 		Provider:      provider,
 		CorrelationID: correlationID,
@@ -3832,6 +3838,7 @@ func (s *Store) applyProviderUpsertLocked(ws *workspaceState, provider string, a
 		Type:          fsEvent,
 		Path:          path,
 		Revision:      revision,
+		ContentHash:   contentHashForFile(file),
 		Origin:        "provider_sync",
 		Provider:      provider,
 		CorrelationID: correlationID,
@@ -4227,6 +4234,7 @@ func listTreeFromFiles(files map[string]File, path string, depth int, cursor str
 					Path:             child,
 					Type:             "file",
 					Revision:         file.Revision,
+					ContentHash:      contentHashForFile(file),
 					Provider:         file.Provider,
 					ProviderObjectID: file.ProviderObjectID,
 					Size:             int64(len(file.Content)),
@@ -4761,6 +4769,28 @@ func validateEncodedContent(content, encoding string) error {
 		return nil
 	}
 	return ErrInvalidInput
+}
+
+func contentHashForFile(file File) string {
+	data := []byte(file.Content)
+	if normalizeEncodingForHash(file.Encoding) == "base64" {
+		if decoded, err := base64.StdEncoding.DecodeString(file.Content); err == nil {
+			data = decoded
+		} else if decoded, err := base64.RawStdEncoding.DecodeString(file.Content); err == nil {
+			data = decoded
+		}
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeEncodingForHash(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "base64":
+		return "base64"
+	default:
+		return ""
+	}
 }
 
 func providerWatermarkKey(provider string, action ApplyAction) string {

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -3267,12 +3267,16 @@ func (s *Store) recordWriteLocked(ws *workspaceState, path, revision, eventType,
 	}
 	ws.Ops[opID] = op
 
+	contentHash := ""
+	if eventType != "file.deleted" {
+		contentHash = contentHashForFile(ws.Files[path])
+	}
 	event := Event{
 		EventID:       s.nextEventIDLocked(),
 		Type:          eventType,
 		Path:          path,
 		Revision:      revision,
-		ContentHash:   contentHashForFile(ws.Files[path]),
+		ContentHash:   contentHash,
 		Origin:        "agent_write",
 		Provider:      provider,
 		CorrelationID: correlationID,

--- a/internal/relayfile/store_test.go
+++ b/internal/relayfile/store_test.go
@@ -1058,6 +1058,12 @@ func TestListTreeHonorsDepth(t *testing.T) {
 		if expectedType != entry.Type {
 			t.Fatalf("expected %s to be %s, got %s", entry.Path, expectedType, entry.Type)
 		}
+		if entry.Type == "file" && entry.ContentHash == "" {
+			t.Fatalf("expected contentHash on file tree entry: %+v", entry)
+		}
+		if entry.Type == "dir" && entry.ContentHash != "" {
+			t.Fatalf("expected no contentHash on dir tree entry: %+v", entry)
+		}
 	}
 }
 
@@ -1308,6 +1314,9 @@ func TestStoreEventsAndOps(t *testing.T) {
 	}
 	if len(feed.Events) == 0 {
 		t.Fatalf("expected at least one event")
+	}
+	if feed.Events[0].ContentHash == "" {
+		t.Fatalf("expected contentHash on file event: %+v", feed.Events[0])
 	}
 
 	op, err := store.GetOperation("ws_2", write.OpID)

--- a/internal/relayfile/store_test.go
+++ b/internal/relayfile/store_test.go
@@ -1319,6 +1319,31 @@ func TestStoreEventsAndOps(t *testing.T) {
 		t.Fatalf("expected contentHash on file event: %+v", feed.Events[0])
 	}
 
+	if _, err := store.DeleteFile(DeleteRequest{
+		WorkspaceID:   "ws_2",
+		Path:          "/external/Product/Roadmap.md",
+		IfMatch:       write.TargetRevision,
+		CorrelationID: "corr_evt_delete",
+	}); err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	feed, err = store.GetEvents("ws_2", "", "", 100)
+	if err != nil {
+		t.Fatalf("events after delete failed: %v", err)
+	}
+	foundDelete := false
+	for _, event := range feed.Events {
+		if event.Type == "file.deleted" && event.Path == "/external/Product/Roadmap.md" {
+			foundDelete = true
+			if event.ContentHash != "" {
+				t.Fatalf("expected delete event to omit contentHash, got %+v", event)
+			}
+		}
+	}
+	if !foundDelete {
+		t.Fatalf("expected delete event in feed: %+v", feed.Events)
+	}
+
 	op, err := store.GetOperation("ws_2", write.OpID)
 	if err != nil {
 		t.Fatalf("op lookup failed: %v", err)

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -198,6 +198,13 @@ paths:
             type: string
             enum: [json, tar, patch]
             default: json
+        - name: path
+          in: query
+          required: false
+          description: Export only files under this workspace path prefix
+          schema:
+            type: string
+            default: /
       responses:
         '200':
           description: Export data in requested format
@@ -1695,6 +1702,9 @@ components:
           enum: [file, dir]
         revision:
           type: string
+        contentHash:
+          type: string
+          description: SHA-256 hash of the decoded file bytes; omitted for directories
         provider:
           type: string
         providerObjectId:
@@ -1901,6 +1911,9 @@ components:
           type: string
         revision:
           type: string
+        contentHash:
+          type: string
+          description: SHA-256 hash of the decoded file bytes for create/update events
         origin:
           type: string
           enum: [provider_sync, agent_write, system]


### PR DESCRIPTION
## Summary
- add decoded-byte `contentHash` to tree entries and filesystem events, including websocket forwarding and OpenAPI coverage
- make incomplete bootstrap pull before local writeback scanning so a kept mirror after state loss is tracked before `pushLocal` can echo it back
- skip fallback `ReadFile` calls when local bytes already match tree `contentHash`, and fetch remaining tree files through bounded parallelism (`RELAYFILE_BOOTSTRAP_READ_CONCURRENCY`, default 16, max 64)

## Review Notes
- Verified the current client already uses in-process Go HTTP with an HTTP/2-capable shared transport; the stale subprocess-per-file behavior from the issue is not present on `main`.
- During review, found and fixed a recovery ordering bug: state-wipe + kept files would still run `pushLocal` before bootstrap, defeating skip-on-hash and risking noisy writeback. Added a regression for that exact shape.
- Kept this PR based directly on `origin/main` so it does not include the older issue-182/lifecycle branch work.

## Tests
- `go test ./...`
- `scripts/check-contract-surface.sh`

Fixes #183