### PR TITLE
Preserve workspace credentials when skipping login refresh

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1863,10 +1863,12 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		}
 	}
 
-	if err := removeCredentialFile(credentialsPath()); err != nil {
-		fmt.Fprintf(stdout, "warning: could not clear stale server credentials: %v\n", err)
+	if !*skipWorkspace {
+		if err := removeCredentialFile(credentialsPath()); err != nil {
+			fmt.Fprintf(stdout, "warning: could not clear stale server credentials: %v\n", err)
+		}
+		fmt.Fprintln(stdout, "Run 'relayfile setup' to create or join a workspace, or 'relayfile mount WORKSPACE' if you already have one.")
 	}
-	fmt.Fprintln(stdout, "Run 'relayfile setup' to create or join a workspace, or 'relayfile mount WORKSPACE' if you already have one.")
 	return nil
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2882,10 +2882,16 @@ func TestLoginRefreshesWorkspaceTokenForDefaultWorkspace(t *testing.T) {
 
 // TestLoginSkipsWorkspaceRefreshWhenFlagSet covers --skip-workspace-refresh:
 // even with a workspace registered, no /join call should fire and
-// credentials.json must remain absent.
+// existing credentials.json must be preserved.
 func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	if err := saveCredentials(credentials{
+		Server: "https://relayfile-old.test",
+		Token:  "stale_server_token",
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -2909,8 +2915,18 @@ func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
 		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
 	}
 
-	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
-		t.Fatalf("expected no server credentials written with --skip-workspace-refresh, got err=%v", err)
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	if creds.Server != "https://relayfile-old.test" {
+		t.Fatalf("expected existing server credentials preserved, got server %q", creds.Server)
+	}
+	if creds.Token != "stale_server_token" {
+		t.Fatalf("expected existing server token preserved, got %q", creds.Token)
+	}
+	if strings.Contains(stdout.String(), "Run 'relayfile setup'") {
+		t.Fatalf("expected no workspace setup hint with --skip-workspace-refresh, got %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep existing workspace credentials when `relayfile login --skip-workspace-refresh` refreshes only cloud auth
- suppress the workspace setup hint in skip-workspace mode
- update the skip-workspace test to pre-save server credentials and assert they survive

## Verification
- `go test ./cmd/relayfile-cli`

Follow-up to Devin review on #191: https://github.com/AgentWorkforce/relayfile/pull/191#discussion_r3281512673