### PR TITLE
Fix mount fallback for truncated export JSON

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2314,6 +2314,9 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 }
 
 func exportSnapshotUnsupported(err error) bool {
+	if exportSnapshotTruncated(err) {
+		return true
+	}
 	var httpErr *HTTPError
 	if !errors.As(err, &httpErr) {
 		return false
@@ -2322,6 +2325,20 @@ func exportSnapshotUnsupported(err error) bool {
 		return true
 	}
 	return httpErr.StatusCode == http.StatusBadRequest && strings.EqualFold(httpErr.Code, "bad_request")
+}
+
+func exportSnapshotTruncated(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var syntaxErr *json.SyntaxError
+	if errors.As(err, &syntaxErr) {
+		return true
+	}
+	return strings.Contains(err.Error(), "unexpected end of JSON input")
 }
 
 func isUnderLazyGithubRepoSubtree(remoteRoot, remotePath string) bool {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -620,6 +620,47 @@ func TestReconcileUsesExportSnapshotForInitialPull(t *testing.T) {
 	}
 }
 
+func TestReconcileFallsBackToTreeWhenExportJSONTruncated(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{
+		fakeClient: base,
+		exportErr:  errors.New("unexpected end of JSON input"),
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_truncated_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree after truncated export: %v", err)
+	}
+
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected truncated export to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	if client.readFileCalls != 1 {
+		t.Fatalf("expected tree fallback to read one file, got %d calls", client.readFileCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+}
+
 func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	client := &fakeClient{
 		files:           map[string]RemoteFile{},
@@ -3781,11 +3822,16 @@ type fakeExportClient struct {
 	*fakeClient
 	exportCalls   int
 	readFileCalls int
+	exportErr     error
 }
 
 func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {
 	_ = ctx
 	_ = workspaceID
+	c.exportCalls++
+	if c.exportErr != nil {
+		return nil, c.exportErr
+	}
 	base := normalizeRemotePath(path)
 	files := make([]RemoteFile, 0, len(c.files))
 	for remotePath, file := range c.files {
@@ -3795,7 +3841,6 @@ func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path st
 		files = append(files, file)
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	c.exportCalls++
 	return files, nil
 }
 


### PR DESCRIPTION
## Summary
- treat truncated /fs/export JSON responses as an unreliable export snapshot
- fall back to the existing full-tree pull instead of failing the sync cycle
- add regression coverage for the issue #192 failure signature

## Tests
- go test ./internal/mountsync
- go test ./...

Closes #192