### PR TITLE
Fall back to tree pull when export exceeds cap or DO overloads (#192)

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2314,7 +2314,7 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 }
 
 func exportSnapshotUnsupported(err error) bool {
-	if exportSnapshotTruncated(err) {
+	if exportSnapshotTruncated(err) || exportSnapshotOverloaded(err) {
 		return true
 	}
 	var httpErr *HTTPError
@@ -2324,7 +2324,37 @@ func exportSnapshotUnsupported(err error) bool {
 	if httpErr.StatusCode == http.StatusNotFound {
 		return true
 	}
+	// The full-tree export serializes the entire workspace into one body.
+	// Large workspaces exceed the cloud export cap, which responds 413 and
+	// explicitly directs clients to the paginated tree/read APIs. Fall
+	// through to pullRemoteFullTree rather than retrying an export that can
+	// never fit.
+	if httpErr.StatusCode == http.StatusRequestEntityTooLarge {
+		return true
+	}
 	return httpErr.StatusCode == http.StatusBadRequest && strings.EqualFold(httpErr.Code, "bad_request")
+}
+
+// exportSnapshotOverloaded reports whether err is a cloud Durable Object
+// overload (HTTP 5xx with an "overloaded" signal). The single full-tree
+// export forces the DO to serialize the entire workspace in one invocation;
+// on large workspaces that reliably trips the DO's request-queue/memory
+// limits and the cycle spins on the export forever. Treating it as
+// "unsupported" lets pullRemoteFull fall through to pullRemoteFullTree, whose
+// paginated ListTree + per-file reads are individually bounded and resume
+// from the persisted cursor. A bare 5xx without the overload signal is left
+// alone so genuinely transient server errors still retry the export.
+func exportSnapshotOverloaded(err error) bool {
+	if err == nil {
+		return false
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		if httpErr.StatusCode >= 500 && strings.Contains(strings.ToLower(httpErr.Message), "overloaded") {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "durable object is overloaded")
 }
 
 func exportSnapshotTruncated(err error) bool {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -661,6 +661,121 @@ func TestReconcileFallsBackToTreeWhenExportJSONTruncated(t *testing.T) {
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
 }
 
+func TestReconcileFallsBackToTreeWhenExportDurableObjectOverloaded(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{
+		fakeClient: base,
+		exportErr: &HTTPError{
+			StatusCode: 500,
+			Code:       "internal_error",
+			Message:    "Durable Object is overloaded. Requests queued for too long.",
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_overloaded_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree after DO overload: %v", err)
+	}
+
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected DO overload to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	if client.readFileCalls != 1 {
+		t.Fatalf("expected tree fallback to read one file, got %d calls", client.readFileCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+}
+
+func TestExportSnapshotOverloadedClassification(t *testing.T) {
+	unsupported := []error{
+		&HTTPError{StatusCode: 500, Code: "internal_error", Message: "Durable Object is overloaded. Requests queued for too long."},
+		&HTTPError{StatusCode: 503, Message: "Worker overloaded"},
+		errors.New("http 500 internal_error: Durable Object is overloaded. Requests queued for too long."),
+		&HTTPError{StatusCode: 413, Code: "payload_too_large", Message: "workspace export body is 3524788058 bytes, which exceeds the export body limit of 134217728; use paginated tree/read APIs instead"},
+	}
+	for _, err := range unsupported {
+		if !exportSnapshotUnsupported(err) {
+			t.Fatalf("expected error to be classified as unsupported: %v", err)
+		}
+	}
+
+	supported := []error{
+		&HTTPError{StatusCode: 500, Code: "internal_error", Message: "boom"},
+		&HTTPError{StatusCode: 502, Message: "bad gateway"},
+		errors.New("http2: server sent GOAWAY and closed the connection"),
+	}
+	for _, err := range supported {
+		if exportSnapshotUnsupported(err) {
+			t.Fatalf("expected transient error to retry export, not fall back: %v", err)
+		}
+	}
+}
+
+func TestReconcileFallsBackToTreeWhenExportPayloadTooLarge(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{
+		fakeClient: base,
+		exportErr: &HTTPError{
+			StatusCode: 413,
+			Code:       "payload_too_large",
+			Message:    "workspace export body is 3524788058 bytes, which exceeds the export body limit of 134217728; use paginated tree/read APIs instead",
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_oversized_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree after 413: %v", err)
+	}
+
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected 413 to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	if client.readFileCalls != 1 {
+		t.Fatalf("expected tree fallback to read one file, got %d calls", client.readFileCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+}
+
 func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	client := &fakeClient{
 		files:           map[string]RemoteFile{},


### PR DESCRIPTION
## Summary

Extends the truncated-export fallback (PR that landed `451ff91`) to two further failure modes that wedge bootstrap on large workspaces.

On `rw_fc7b534b` (~29k files, ~3.5 GB export body), bootstrap was wedging because the full-tree export endpoint can't fit the workspace into one response:

- **`http 413 payload_too_large`** — the cloud caps the export body at 128 MB and responds: `workspace export body is N bytes, which exceeds the export body limit of 134217728; use paginated tree/read APIs instead`. This is the persistent, deterministic blocker.
- **`http 500 internal_error: Durable Object is overloaded`** — under load the export also intermittently fails this way (it's the secondary symptom of the same problem: the export forces the DO to serialize the entire workspace in one invocation).

`exportSnapshotUnsupported` recognized neither, so `pullRemoteFullExport` retried the doomed export every cycle and bootstrap never progressed past where the DO began to fail (observed wedging at ~14k files).

Classify both `413 payload_too_large` and `5xx-with-"overloaded"` as unsupported so `pullRemoteFull` falls through to `pullRemoteFullTree`, whose paginated `ListTree` + per-file reads are individually bounded and resume from the persisted cursor — exactly what the 413 body instructs. Bare `5xx` without the overload signal still retries the export so genuinely transient server errors are unaffected.

## Test plan

- [x] `go test ./internal/mountsync/... -count=1` — full package green, including:
  - `TestReconcileFallsBackToTreeWhenExportJSONTruncated` (existing, unaffected)
  - `TestReconcileFallsBackToTreeWhenExportDurableObjectOverloaded` (new)
  - `TestReconcileFallsBackToTreeWhenExportPayloadTooLarge` (new)
  - `TestExportSnapshotOverloadedClassification` (new — positive cases for 413/overload, negative cases asserting transient 5xx still retries)
- [x] **Live verified on `rw_fc7b534b`**: pre-fix the daemon wedged at ~14.3k files retrying the failing export. Post-fix the daemon broke past the wall (14,317 → 15,095 → 16,095 → … → **25,013 BOOTSTRAP COMPLETE**, then grew to 29,282 via incremental sync). No `cycle failed: 413` lines appeared after the fix took over — the fallback swallows the error cleanly.

## Related

- Closes #192 (the original `unexpected end of JSON input` symptom is one of three blockers on this code path; this PR completes the export-fallback story `451ff91` started).
- Coordinates with #175 H (cloud DO stall on large workspaces). Doesn't fix the cloud-side issue but routes the daemon around it via the per-file API the cloud already recommends in the 413 body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)