### PR TITLE
Use one-shot latest-event lookup to seed mount cursor

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1832,7 +1832,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request, workspaceI
 		}
 		writeJSON(w, http.StatusOK, feed)
 	case "desc":
-		feed, err := s.store.GetEventsTail(workspaceID, provider, limit)
+		feed, err := s.store.GetEventsTail(workspaceID, provider, r.URL.Query().Get("cursor"), limit)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", err.Error(), correlationID)
 			return

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1821,12 +1821,26 @@ func (s *Server) handleDeleteFile(w http.ResponseWriter, r *http.Request, worksp
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request, workspaceID, correlationID string) {
 	limit := parseBoundedInt(r.URL.Query().Get("limit"), 200, 1, 1000)
-	feed, err := s.store.GetEvents(workspaceID, r.URL.Query().Get("provider"), r.URL.Query().Get("cursor"), limit)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", err.Error(), correlationID)
-		return
+	provider := r.URL.Query().Get("provider")
+	direction := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("direction")))
+	switch direction {
+	case "", "asc":
+		feed, err := s.store.GetEvents(workspaceID, provider, r.URL.Query().Get("cursor"), limit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error(), correlationID)
+			return
+		}
+		writeJSON(w, http.StatusOK, feed)
+	case "desc":
+		feed, err := s.store.GetEventsTail(workspaceID, provider, limit)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error(), correlationID)
+			return
+		}
+		writeJSON(w, http.StatusOK, feed)
+	default:
+		writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("unsupported direction %q (must be asc or desc)", direction), correlationID)
 	}
-	writeJSON(w, http.StatusOK, feed)
 }
 
 func (s *Server) handleQueryFiles(w http.ResponseWriter, r *http.Request, workspaceID, correlationID string, claims tokenClaims) {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -2046,6 +2046,52 @@ func TestEventsAndSyncStatus(t *testing.T) {
 		t.Fatalf("expected 400 on unknown direction, got %d (%s)", badDirResp.Code, badDirResp.Body.String())
 	}
 
+	// Descending pagination must respect cursor: a follow-up call using
+	// the previous page's NextCursor walks one page older, never repeats
+	// the newest page. CodeRabbit caught the original GetEventsTail
+	// signature omitting cursor entirely — guard against regressing back
+	// to that.
+	descPage1 := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_2/fs/events?direction=desc&limit=1",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_evt_desc_p1",
+		},
+	})
+	if descPage1.Code != http.StatusOK {
+		t.Fatalf("desc page1: expected 200, got %d (%s)", descPage1.Code, descPage1.Body.String())
+	}
+	var descPage1Feed relayfile.EventFeed
+	if err := json.NewDecoder(descPage1.Body).Decode(&descPage1Feed); err != nil {
+		t.Fatalf("decode desc page1: %v", err)
+	}
+	if len(descPage1Feed.Events) != 1 || descPage1Feed.NextCursor == nil || *descPage1Feed.NextCursor == "" {
+		t.Fatalf("desc page1: expected 1 event + a non-empty NextCursor, got events=%d nextCursor=%v",
+			len(descPage1Feed.Events), descPage1Feed.NextCursor)
+	}
+	descPage2 := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_2/fs/events?direction=desc&limit=1&cursor=" + *descPage1Feed.NextCursor,
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_evt_desc_p2",
+		},
+	})
+	if descPage2.Code != http.StatusOK {
+		t.Fatalf("desc page2: expected 200, got %d (%s)", descPage2.Code, descPage2.Body.String())
+	}
+	var descPage2Feed relayfile.EventFeed
+	if err := json.NewDecoder(descPage2.Body).Decode(&descPage2Feed); err != nil {
+		t.Fatalf("decode desc page2: %v", err)
+	}
+	if len(descPage2Feed.Events) != 1 {
+		t.Fatalf("desc page2: expected 1 event, got %d", len(descPage2Feed.Events))
+	}
+	if descPage2Feed.Events[0].EventID == descPage1Feed.Events[0].EventID {
+		t.Fatalf("desc page2: must advance past page1; both returned %q", descPage2Feed.Events[0].EventID)
+	}
+
 	syncResp := doRequest(t, server, request{
 		method: http.MethodGet,
 		path:   "/v1/workspaces/ws_2/sync/status",

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -2006,6 +2006,46 @@ func TestEventsAndSyncStatus(t *testing.T) {
 		}
 	}
 
+	// direction=desc&limit=1 must return the NEWEST event, not the oldest
+	// (and crucially must not silently ignore the direction param — see
+	// review feedback on PR #196 / cloud#926).
+	descResp := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_2/fs/events?direction=desc&limit=1",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_evt_desc",
+		},
+	})
+	if descResp.Code != http.StatusOK {
+		t.Fatalf("expected 200 on direction=desc, got %d (%s)", descResp.Code, descResp.Body.String())
+	}
+	var descFeed relayfile.EventFeed
+	if err := json.NewDecoder(descResp.Body).Decode(&descFeed); err != nil {
+		t.Fatalf("decode desc events response: %v", err)
+	}
+	if len(descFeed.Events) != 1 {
+		t.Fatalf("expected 1 event for desc&limit=1, got %d", len(descFeed.Events))
+	}
+	if len(feed.Events) > 0 {
+		newest := feed.Events[len(feed.Events)-1]
+		if descFeed.Events[0].EventID != newest.EventID {
+			t.Fatalf("desc&limit=1 must return newest event (%q), got %q", newest.EventID, descFeed.Events[0].EventID)
+		}
+	}
+
+	badDirResp := doRequest(t, server, request{
+		method: http.MethodGet,
+		path:   "/v1/workspaces/ws_2/fs/events?direction=sideways&limit=1",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_evt_bad_dir",
+		},
+	})
+	if badDirResp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on unknown direction, got %d (%s)", badDirResp.Code, badDirResp.Body.String())
+	}
+
 	syncResp := doRequest(t, server, request{
 		method: http.MethodGet,
 		path:   "/v1/workspaces/ws_2/sync/status",

--- a/internal/mountfuse/fuse_test.go
+++ b/internal/mountfuse/fuse_test.go
@@ -49,6 +49,10 @@ func (f *fakeRemoteClient) ListEvents(_ context.Context, _, _, _ string, _ int) 
 	return mountsync.EventFeed{}, nil
 }
 
+func (f *fakeRemoteClient) LatestEventID(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
 func (f *fakeRemoteClient) ReadFile(_ context.Context, _, path string) (mountsync.RemoteFile, error) {
 	if f.readFileErr != nil {
 		return mountsync.RemoteFile{}, f.readFileErr

--- a/internal/mountfuse/layout_test.go
+++ b/internal/mountfuse/layout_test.go
@@ -30,6 +30,10 @@ func (c *layoutRemoteClient) ListEvents(_ context.Context, _, _, _ string, _ int
 	return mountsync.EventFeed{}, nil
 }
 
+func (c *layoutRemoteClient) LatestEventID(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
 func (c *layoutRemoteClient) ReadFile(_ context.Context, _, path string) (mountsync.RemoteFile, error) {
 	c.readFilePaths = append(c.readFilePaths, path)
 	return mountsync.RemoteFile{}, &mountsync.HTTPError{StatusCode: 404, Code: "not_found", Message: "file not found"}

--- a/internal/mountsync/bootstrap_test.go
+++ b/internal/mountsync/bootstrap_test.go
@@ -116,6 +116,20 @@ func (c *bootstrapClient) ListTree(ctx context.Context, workspaceID, path string
 	return resp, nil
 }
 
+func (c *bootstrapClient) LatestEventID(ctx context.Context, workspaceID, provider string) (string, error) {
+	if c.listEventsSleep > 0 {
+		select {
+		case <-time.After(c.listEventsSleep):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	if len(c.events) == 0 {
+		return "", nil
+	}
+	return c.events[len(c.events)-1].EventID, nil
+}
+
 func (c *bootstrapClient) ListEvents(ctx context.Context, workspaceID, provider, cursor string, limit int) (EventFeed, error) {
 	if c.listEventsSleep > 0 {
 		select {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -178,6 +178,14 @@ type WriteResult struct {
 type RemoteClient interface {
 	ListTree(ctx context.Context, workspaceID, path string, depth int, cursor string) (TreeResponse, error)
 	ListEvents(ctx context.Context, workspaceID, provider, cursor string, limit int) (EventFeed, error)
+	// LatestEventID returns the most recent event id for the workspace
+	// (optionally filtered by provider) in a single round trip, using the
+	// `direction=desc&limit=1` shape on /fs/events. Returns "" when the
+	// workspace has no events. Implementations may return an HTTPError with
+	// status 400 or 404 to signal that the server does not support the
+	// descending-direction query; callers should treat that as a fallthrough
+	// to the legacy page-walk.
+	LatestEventID(ctx context.Context, workspaceID, provider string) (string, error)
 	ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error)
 	WriteFile(ctx context.Context, workspaceID, path, baseRevision, contentType, content string) (WriteResult, error)
 	WriteFilesBulk(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error)
@@ -304,6 +312,25 @@ func (c *HTTPClient) ListEvents(ctx context.Context, workspaceID, provider, curs
 	var out EventFeed
 	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/v1/workspaces/%s/fs/events?%s", url.PathEscape(workspaceID), q.Encode()), nil, nil, &out)
 	return out, err
+}
+
+func (c *HTTPClient) LatestEventID(ctx context.Context, workspaceID, provider string) (string, error) {
+	q := url.Values{}
+	if strings.TrimSpace(provider) != "" {
+		q.Set("provider", strings.TrimSpace(provider))
+	}
+	q.Set("direction", "desc")
+	q.Set("limit", "1")
+	var out EventFeed
+	if err := c.doJSON(ctx, http.MethodGet,
+		fmt.Sprintf("/v1/workspaces/%s/fs/events?%s", url.PathEscape(workspaceID), q.Encode()),
+		nil, nil, &out); err != nil {
+		return "", err
+	}
+	if len(out.Events) == 0 {
+		return "", nil
+	}
+	return strings.TrimSpace(out.Events[0].EventID), nil
 }
 
 func (c *HTTPClient) ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error) {
@@ -3341,6 +3368,22 @@ func (s *Syncer) resolveLatestEventCursor(ctx context.Context) (string, error) {
 	// only for cancellation via rootCtx propagation.
 	cctx, cancel := context.WithTimeout(s.rootCtx, s.cursorTimeout)
 	defer cancel()
+
+	// Preferred path (post cloud#927): /fs/events?direction=desc&limit=1
+	// returns the latest event id in one round trip. Walking the whole feed
+	// to the tail is O(N) pages and reliably exceeded cursorTimeout on
+	// workspaces with >~50k events.
+	if latest, err := s.client.LatestEventID(cctx, s.workspace, s.eventProvider); err == nil {
+		return latest, nil
+	} else {
+		var httpErr *HTTPError
+		if !errors.As(err, &httpErr) || (httpErr.StatusCode != http.StatusBadRequest && httpErr.StatusCode != http.StatusNotFound) {
+			return "", err
+		}
+		// Fall through: older self-host cloud may not yet support
+		// direction=desc; degrade to the legacy page-walk.
+	}
+
 	cursor := ""
 	latest := ""
 	for {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -776,6 +776,75 @@ func TestReconcileFallsBackToTreeWhenExportPayloadTooLarge(t *testing.T) {
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
 }
 
+// TestResolveLatestEventCursorPrefersLatestEventID guards against regressing
+// from the one-shot /fs/events?direction=desc&limit=1 lookup back to the
+// O(N) page-walk. resolveLatestEventCursor must call LatestEventID first and
+// MUST NOT issue any ListEvents calls when LatestEventID succeeds, because
+// the page-walk reliably exceeds cursorTimeout on workspaces with large
+// event histories (cloud#926).
+func TestResolveLatestEventCursorPrefersLatestEventID(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		events: []FilesystemEvent{
+			{EventID: "evt_1"}, {EventID: "evt_2"}, {EventID: "evt_3"},
+		},
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_latest",
+		LocalRoot:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	cursor, err := syncer.resolveLatestEventCursor(context.Background())
+	if err != nil {
+		t.Fatalf("resolveLatestEventCursor failed: %v", err)
+	}
+	if cursor != "evt_3" {
+		t.Fatalf("expected latest cursor evt_3, got %q", cursor)
+	}
+	if client.latestEventIDCalls != 1 {
+		t.Fatalf("expected exactly 1 LatestEventID call, got %d", client.latestEventIDCalls)
+	}
+	if client.listEventsCalls != 0 {
+		t.Fatalf("expected zero ListEvents calls (one-shot path), got %d", client.listEventsCalls)
+	}
+}
+
+// TestResolveLatestEventCursorFallsBackOnUnsupported covers older self-host
+// cloud deployments that don't implement direction=desc. A 400 bad_request
+// from LatestEventID must transparently fall through to the legacy
+// page-walk, not surface as a cycle failure.
+func TestResolveLatestEventCursorFallsBackOnUnsupported(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		events: []FilesystemEvent{
+			{EventID: "evt_1"}, {EventID: "evt_2"}, {EventID: "evt_3"},
+		},
+		latestEventIDUnsupported: true,
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_legacy",
+		LocalRoot:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	cursor, err := syncer.resolveLatestEventCursor(context.Background())
+	if err != nil {
+		t.Fatalf("resolveLatestEventCursor failed: %v", err)
+	}
+	if cursor != "evt_3" {
+		t.Fatalf("expected legacy fallback to return latest evt_3, got %q", cursor)
+	}
+	if client.latestEventIDCalls != 1 {
+		t.Fatalf("expected one LatestEventID attempt before fallback, got %d", client.latestEventIDCalls)
+	}
+	if client.listEventsCalls == 0 {
+		t.Fatalf("expected fallback to use ListEvents page-walk, got 0 calls")
+	}
+}
+
 func TestSyncOnceCreatesAndDeletesRemoteFiles(t *testing.T) {
 	client := &fakeClient{
 		files:           map[string]RemoteFile{},
@@ -3904,6 +3973,9 @@ type fakeClient struct {
 	eventCounter          int
 	listTreeCalls         int
 	listEventsCalls       int
+	latestEventIDCalls    int
+	latestEventIDErr      error
+	latestEventIDUnsupported bool
 	readFileCalls         int
 	readFileCallsByPath   map[string]int
 	writeFileCalls        int
@@ -3989,6 +4061,28 @@ func (c *fakeClient) ListTree(ctx context.Context, workspaceID, path string, dep
 		Entries:    entries,
 		NextCursor: nil,
 	}, nil
+}
+
+func (c *fakeClient) LatestEventID(ctx context.Context, workspaceID, provider string) (string, error) {
+	_ = ctx
+	_ = workspaceID
+	_ = provider
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.latestEventIDCalls++
+	if c.latestEventIDUnsupported {
+		return "", &HTTPError{StatusCode: http.StatusBadRequest, Code: "bad_request", Message: "direction=desc unsupported"}
+	}
+	if c.latestEventIDErr != nil {
+		return "", c.latestEventIDErr
+	}
+	if c.eventsUnsupported {
+		return "", &HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+	}
+	if len(c.events) == 0 {
+		return "", nil
+	}
+	return c.events[len(c.events)-1].EventID, nil
 }
 
 func (c *fakeClient) ListEvents(ctx context.Context, workspaceID, provider, cursor string, limit int) (EventFeed, error) {

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -1956,12 +1956,18 @@ func (s *Store) GetEvents(workspaceID, provider, cursor string, limit int) (Even
 	return EventFeed{Events: chunk, NextCursor: nextCursor}, nil
 }
 
-// GetEventsTail returns the last `limit` events for the workspace in
-// reverse chronological order (newest first), optionally filtered by
-// provider. Mirrors the cloud's /fs/events?direction=desc semantics so
-// daemon clients can resolve the latest event id in one round trip
-// instead of paginating the whole feed.
-func (s *Store) GetEventsTail(workspaceID, provider string, limit int) (EventFeed, error) {
+// GetEventsTail returns up to `limit` events for the workspace in reverse
+// chronological order (newest first), optionally filtered by provider.
+// Mirrors the cloud's /fs/events?direction=desc semantics so daemon
+// clients can resolve the latest event id in one round trip instead of
+// paginating the whole feed.
+//
+// `cursor` is treated as an exclusive upper bound: only events older than
+// (occurring before) the cursored event are returned. Pass "" to start
+// from the newest event. When more older events remain, the returned
+// NextCursor points to the oldest event in the returned page so a
+// follow-up call with that cursor advances to the next older page.
+func (s *Store) GetEventsTail(workspaceID, provider, cursor string, limit int) (EventFeed, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -1986,11 +1992,24 @@ func (s *Store) GetEventsTail(workspaceID, provider string, limit int) (EventFee
 	if len(events) == 0 {
 		return EventFeed{Events: []Event{}, NextCursor: nil}, nil
 	}
-	start := len(events) - limit
+	end := len(events)
+	if cursor != "" {
+		end = 0
+		for i := range events {
+			if events[i].EventID == cursor {
+				end = i
+				break
+			}
+		}
+	}
+	if end <= 0 {
+		return EventFeed{Events: []Event{}, NextCursor: nil}, nil
+	}
+	start := end - limit
 	if start < 0 {
 		start = 0
 	}
-	tail := events[start:]
+	tail := events[start:end]
 	chunk := make([]Event, len(tail))
 	for i := range tail {
 		chunk[i] = tail[len(tail)-1-i]

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -1956,6 +1956,53 @@ func (s *Store) GetEvents(workspaceID, provider, cursor string, limit int) (Even
 	return EventFeed{Events: chunk, NextCursor: nextCursor}, nil
 }
 
+// GetEventsTail returns the last `limit` events for the workspace in
+// reverse chronological order (newest first), optionally filtered by
+// provider. Mirrors the cloud's /fs/events?direction=desc semantics so
+// daemon clients can resolve the latest event id in one round trip
+// instead of paginating the whole feed.
+func (s *Store) GetEventsTail(workspaceID, provider string, limit int) (EventFeed, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ws, ok := s.workspaces[workspaceID]
+	if !ok || len(ws.Events) == 0 {
+		return EventFeed{Events: []Event{}, NextCursor: nil}, nil
+	}
+	if limit <= 0 {
+		limit = 200
+	}
+	events := ws.Events
+	normalizedProvider := normalizeProvider(provider)
+	if normalizedProvider != "" {
+		filtered := make([]Event, 0, len(ws.Events))
+		for _, event := range ws.Events {
+			if eventProvider(event) == normalizedProvider {
+				filtered = append(filtered, event)
+			}
+		}
+		events = filtered
+	}
+	if len(events) == 0 {
+		return EventFeed{Events: []Event{}, NextCursor: nil}, nil
+	}
+	start := len(events) - limit
+	if start < 0 {
+		start = 0
+	}
+	tail := events[start:]
+	chunk := make([]Event, len(tail))
+	for i := range tail {
+		chunk[i] = tail[len(tail)-1-i]
+	}
+	var nextCursor *string
+	if start > 0 {
+		next := events[start].EventID
+		nextCursor = &next
+	}
+	return EventFeed{Events: chunk, NextCursor: nextCursor}, nil
+}
+
 func (s *Store) GetRecentEvents(workspaceID string, limit int) ([]Event, error) {
 	if workspaceID == "" {
 		return []Event{}, ErrInvalidInput

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -400,6 +400,19 @@ paths:
             minimum: 1
             maximum: 1000
             default: 200
+        - name: direction
+          in: query
+          required: false
+          description: |
+            Iteration direction. `asc` (default) walks events newer than
+            `cursor` oldest-first — the normal incremental sync path.
+            `desc` walks newest-first and is intended for callers that just
+            need the tail of the feed (e.g. `direction=desc&limit=1` to
+            seed an events cursor without paginating the whole history).
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
       responses:
         '200':
           description: Event feed page
@@ -407,6 +420,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EventFeedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':


### PR DESCRIPTION
## Summary

\`resolveLatestEventCursor\` walks \`/fs/events\` page by page (limit=1000) just to find the workspace's tail event id. At ~437 ms per page, the 20 s \`cursorTimeout\` (default) buys ~50 pages = ~50 k events; workspaces past that threshold time out on every cycle. The post-bootstrap fast path therefore never engages on busy workspaces and the daemon stays stuck in degraded periodic-full-reconcile mode.

Live evidence on \`rw_fc7b534b\`:
- Events feed: **132,972 events**
- Pre-fix: \`eventsCursor: None\` for 6+ hours despite \`bootstrap: True\`; each cycle logged \`restart fast-path: cursor resolution failed (context deadline exceeded); falling through to full pull\`.
- Post-fix (this PR, freshly built binary): \`eventsCursor: evt_132972\` populated in ~milliseconds on daemon startup.

## Change

- Add \`LatestEventID(ctx, workspaceID, provider)\` to \`RemoteClient\`. Implemented by \`HTTPClient\` via \`/fs/events?direction=desc&limit=1\` (the endpoint shape that landed in AgentWorkforce/cloud#927), plus matching fakes in \`fakeClient\` and \`bootstrapClient\`.
- \`resolveLatestEventCursor\` calls \`LatestEventID\` first. On \`400 bad_request\` / \`404 not_found\` (older self-host cloud without \`direction=desc\`), it transparently falls through to the existing page-walk so the change is strictly additive against any backend.

## Test plan

- [x] \`go test ./internal/mountsync/... -count=1\` — full package green.
- [x] New tests:
  - \`TestResolveLatestEventCursorPrefersLatestEventID\` — asserts the one-shot is called and ListEvents is **not** invoked when supported.
  - \`TestResolveLatestEventCursorFallsBackOnUnsupported\` — asserts a 400 from LatestEventID transparently engages the legacy page-walk and returns the same cursor.
  - Existing \`TestResolveLatestEventCursorIndependentTimeout\` still passes — no regression.
- [x] **Live-verified on \`rw_fc7b534b\`** (see Summary): cursor seeded in ms after binary swap; previously stuck at \`None\` for hours.

## Related

- Closes AgentWorkforce/cloud#926.
- Consumes AgentWorkforce/cloud#927 (\`fix(relayfile): support latest fs event lookup\` — adds \`?direction=desc\` to \`/fs/events\`, merged 21:58Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)