### PR TITLE
Fix stuck mount daemon stop recovery

### DIFF
--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -60,8 +60,12 @@ func TestA14BackgroundModeWritesPidAndStopSignalsCleanly(t *testing.T) {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		_, _ = cmd.Process.Wait()
 	})
+	exited := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		exited <- err
+	}()
 
 	pidFile := mountPIDFile(localDir)
 	logFile := mountLogFile(localDir)
@@ -97,11 +101,6 @@ func TestA14BackgroundModeWritesPidAndStopSignalsCleanly(t *testing.T) {
 	}
 
 	deadline := time.Now().Add(5 * time.Second)
-	exited := make(chan error, 1)
-	go func() {
-		_, err := cmd.Process.Wait()
-		exited <- err
-	}()
 	select {
 	case err := <-exited:
 		if err == nil {
@@ -118,6 +117,119 @@ func TestA14BackgroundModeWritesPidAndStopSignalsCleanly(t *testing.T) {
 		t.Fatalf("subprocess exited with unexpected error: %v", err)
 	case <-time.After(time.Until(deadline)):
 		t.Fatalf("subprocess did not exit within 5s of SIGTERM")
+	}
+}
+
+func TestStopEscalatesToKillWhenDaemonIgnoresTerm(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	oldGracefulTimeout := daemonGracefulStopTimeout
+	oldForceTimeout := daemonForceStopTimeout
+	daemonGracefulStopTimeout = 100 * time.Millisecond
+	daemonForceStopTimeout = 2 * time.Second
+	t.Cleanup(func() {
+		daemonGracefulStopTimeout = oldGracefulTimeout
+		daemonForceStopTimeout = oldForceTimeout
+	})
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	cmd := exec.Command("sh", "-c", "trap '' TERM; exec sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start TERM-ignoring subprocess failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	exited := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		exited <- cmd.Wait()
+		close(done)
+	}()
+	waited := false
+	t.Cleanup(func() {
+		if waited {
+			return
+		}
+		select {
+		case <-done:
+			<-exited
+		default:
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			<-done
+			<-exited
+		}
+	})
+
+	daemonExe, lerr := exec.LookPath("sleep")
+	if lerr != nil {
+		t.Fatalf("look up sleep executable failed: %v", lerr)
+	}
+	if resolved, rerr := filepath.EvalSymlinks(daemonExe); rerr == nil {
+		daemonExe = resolved
+	}
+	if err := writeDaemonPIDState(mountPIDFile(localDir), daemonPIDState{
+		PID:         cmd.Process.Pid,
+		WorkspaceID: "ws_demo",
+		LocalDir:    localDir,
+		Executable:  daemonExe,
+	}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+
+	oldList := listProcessCommands
+	listProcessCommands = func() ([]processCommandSnapshot, error) {
+		select {
+		case <-done:
+			return nil, nil
+		default:
+			return []processCommandSnapshot{{
+				PID:     cmd.Process.Pid,
+				Command: "relayfile mount demo " + localDir + " --daemonized",
+			}}, nil
+		}
+	}
+	t.Cleanup(func() { listProcessCommands = oldList })
+
+	var stdout bytes.Buffer
+	if err := run([]string{"stop", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run stop failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "did not exit after SIGTERM; sending SIGKILL") ||
+		!strings.Contains(got, "Stopped background mount for demo") {
+		t.Fatalf("expected force-stop output, got %q", got)
+	}
+	if _, err := os.Stat(mountPIDFile(localDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected pid file to be removed after force stop, got %v", err)
+	}
+
+	select {
+	case err := <-exited:
+		waited = true
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("expected signal exit after force stop, got %v", err)
+		}
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); !ok || !status.Signaled() || status.Signal() != syscall.SIGKILL {
+			t.Fatalf("expected SIGKILL exit after force stop, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("subprocess did not exit after force stop")
 	}
 }
 
@@ -173,11 +285,20 @@ func TestStopDiscoversOrphanDaemonWithoutPIDFile(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start sleep subprocess failed: %v", err)
 	}
+	exited := make(chan error, 1)
+	go func() {
+		_, err := cmd.Process.Wait()
+		exited <- err
+	}()
+	waited := false
 	t.Cleanup(func() {
+		if waited {
+			return
+		}
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		_, _ = cmd.Process.Wait()
+		<-exited
 	})
 
 	oldList := listProcessCommands
@@ -203,13 +324,9 @@ func TestStopDiscoversOrphanDaemonWithoutPIDFile(t *testing.T) {
 		t.Fatalf("unexpected stop output: %q", got)
 	}
 
-	exited := make(chan error, 1)
-	go func() {
-		_, err := cmd.Process.Wait()
-		exited <- err
-	}()
 	select {
 	case err := <-exited:
+		waited = true
 		var exitErr *exec.ExitError
 		if err != nil && !errors.As(err, &exitErr) {
 			t.Fatalf("subprocess exited with unexpected error: %v", err)
@@ -310,6 +427,67 @@ func TestMountBackgroundRefusesExistingDaemonFromProcessScan(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), "Mirror started in background") {
 		t.Fatalf("mount should not have spawned a background daemon: %q", stdout.String())
+	}
+}
+
+func TestMountBackgroundClearsDeadStructuredPIDBeforeStart(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if err := saveCredentials(credentials{
+		Server: defaultServerURL,
+		Token:  testJWTWithWorkspace("ws_demo"),
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+	if err := writeDaemonPIDState(mountPIDFile(localDir), daemonPIDState{
+		PID:         1 << 30,
+		WorkspaceID: "ws_demo",
+		LocalDir:    localDir,
+	}); err != nil {
+		t.Fatalf("writeDaemonPIDState failed: %v", err)
+	}
+
+	oldList := listProcessCommands
+	listProcessCommands = func() ([]processCommandSnapshot, error) { return nil, nil }
+	t.Cleanup(func() { listProcessCommands = oldList })
+
+	oldSpawn := spawnBackgroundMountProcessFn
+	spawned := false
+	spawnBackgroundMountProcessFn = func(originalArgs []string, absLocalDir, pidFile, logFile string) error {
+		spawned = true
+		if absLocalDir != localDir {
+			t.Fatalf("spawn localDir = %q, want %q", absLocalDir, localDir)
+		}
+		if _, err := os.Stat(pidFile); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected stale pid file to be cleared before spawn, got %v", err)
+		}
+		return nil
+	}
+	t.Cleanup(func() { spawnBackgroundMountProcessFn = oldSpawn })
+
+	var stdout bytes.Buffer
+	if err := run([]string{"mount", "demo", "--background"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run mount failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if !spawned {
+		t.Fatalf("expected mount to proceed after clearing stale pid file")
+	}
+	if _, err := os.Stat(mountPIDFile(localDir)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale pid file to remain cleared, got %v", err)
 	}
 }
 

--- a/cmd/relayfile-cli/daemon_unix.go
+++ b/cmd/relayfile-cli/daemon_unix.go
@@ -34,3 +34,8 @@ func processExecutablePath(pid int) (path string, known bool) {
 func signalDaemonStop(process *os.Process) error {
 	return process.Signal(syscall.SIGTERM)
 }
+
+// forceDaemonStop terminates a daemon that ignored the graceful stop signal.
+func forceDaemonStop(process *os.Process) error {
+	return process.Kill()
+}

--- a/cmd/relayfile-cli/daemon_windows.go
+++ b/cmd/relayfile-cli/daemon_windows.go
@@ -26,6 +26,12 @@ func signalDaemonStop(process *os.Process) error {
 	return process.Kill()
 }
 
+// forceDaemonStop terminates a daemon that did not exit after the first stop
+// request. Windows has no stronger portable signal than TerminateProcess.
+func forceDaemonStop(process *os.Process) error {
+	return process.Kill()
+}
+
 // processExecutablePath is a no-op on Windows: resolving another
 // process's image path needs OpenProcess/QueryFullProcessImageName and
 // the extra privileges/handling are not worth it for this guard. Callers

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3893,9 +3893,14 @@ func runMount(args []string) error {
 	}
 
 	if shouldRefuseCompetingMount(*daemonized, *once) {
-		running, _, derr := runningMountDaemons(absLocalDir, workspaceID, workspaceNameForStart(workspaceID))
+		running, stalePID, derr := runningMountDaemons(absLocalDir, workspaceID, workspaceNameForStart(workspaceID))
 		if derr != nil {
 			return fmt.Errorf("check for existing mount daemon: %w", derr)
+		}
+		if stalePID != 0 {
+			if rerr := os.Remove(mountPIDFile(absLocalDir)); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+				return fmt.Errorf("failed to clear stale background mount state for %s: %w", workspaceID, rerr)
+			}
 		}
 		if len(running) > 0 {
 			return fmt.Errorf(
@@ -3908,7 +3913,7 @@ func runMount(args []string) error {
 	}
 
 	if *background && !*daemonized {
-		return spawnBackgroundMountProcess(args, absLocalDir, pidFile, logFile)
+		return spawnBackgroundMountProcessFn(args, absLocalDir, pidFile, logFile)
 	}
 	registerPID := shouldRegisterMountPID(*daemonized, *once)
 	if *daemonized {
@@ -4695,6 +4700,18 @@ func runRestart(args []string, stdout io.Writer) error {
 // modern Go check) and `syscall.ESRCH` (raw signal failure) as "gone".
 func isProcessAlreadyGone(err error) bool {
 	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, syscall.ESRCH)
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || !isProcessAlreadyGone(err)
 }
 
 // waitForDaemonExit polls the pid file and the process itself, returning
@@ -6138,6 +6155,8 @@ func runningMountDaemons(localDir, workspaceID, workspaceName string) ([]mountDa
 	if pid, verified, strong := verifyDaemonProcessForDiscovery(localDir, workspaceID); pid != 0 {
 		_, foundByScan := seen[pid]
 		switch {
+		case !processAlive(pid):
+			stalePID = pid
 		case verified && strong && !foundByScan:
 			processes = append(processes, mountDaemonProcess{PID: pid, Source: "pidfile"})
 			seen[pid] = struct{}{}
@@ -6367,6 +6386,9 @@ func daemonStatusLine(record workspaceRecord) string {
 		return "daemon: not running"
 	}
 	if len(running) == 0 {
+		if pid := readDaemonPID(record.LocalDir); pid != 0 {
+			return fmt.Sprintf("daemon: running (pid %d)", pid)
+		}
 		return "daemon: not running"
 	}
 	if hasPIDFileDaemon(running) {
@@ -6422,6 +6444,11 @@ func formatDaemonPIDs(processes []mountDaemonProcess) string {
 	return strings.Join(parts, ", ")
 }
 
+var (
+	daemonGracefulStopTimeout = 5 * time.Second
+	daemonForceStopTimeout    = 2 * time.Second
+)
+
 func stopWorkspaceMountDaemons(record workspaceRecord, stdout io.Writer, tolerateMissing bool) error {
 	running, stalePID, err := runningMountDaemons(record.LocalDir, record.ID, record.Name)
 	if err != nil {
@@ -6463,12 +6490,37 @@ func stopWorkspaceMountDaemons(record workspaceRecord, stdout io.Writer, tolerat
 	if len(stopped) == 0 {
 		return nil
 	}
-	if werr := waitForDaemonDiscoveryClear(record.LocalDir, record.ID, record.Name, stopped, 5*time.Second); werr != nil {
-		return werr
+	if werr := waitForDaemonDiscoveryClear(record.LocalDir, record.ID, record.Name, stopped, daemonGracefulStopTimeout); werr != nil {
+		var aliveErr daemonStillAliveError
+		if !errors.As(werr, &aliveErr) {
+			return werr
+		}
+		fmt.Fprintf(stdout, "Background mount for %s did not exit after SIGTERM; sending SIGKILL (%s)\n", record.Name, formatDaemonPIDs(stopped))
+		for _, daemon := range stopped {
+			process, perr := os.FindProcess(daemon.PID)
+			if perr != nil {
+				return fmt.Errorf("failed to find background mount for %s (pid %d) for force stop: %w", record.Name, daemon.PID, perr)
+			}
+			if kerr := forceDaemonStop(process); kerr != nil && !isProcessAlreadyGone(kerr) {
+				return fmt.Errorf("failed to force stop background mount for %s (pid %d): %w", record.Name, daemon.PID, kerr)
+			}
+		}
+		if werr := waitForDaemonDiscoveryClear(record.LocalDir, record.ID, record.Name, stopped, daemonForceStopTimeout); werr != nil {
+			return werr
+		}
 	}
 	_ = os.Remove(mountPIDFile(record.LocalDir))
 	fmt.Fprintf(stdout, "Stopped background mount for %s (%s)\n", record.Name, formatDaemonPIDs(stopped))
 	return nil
+}
+
+type daemonStillAliveError struct {
+	timeout time.Duration
+	running []mountDaemonProcess
+}
+
+func (e daemonStillAliveError) Error() string {
+	return fmt.Sprintf("daemon still alive after %s (%s)", e.timeout, formatDaemonPIDs(e.running))
 }
 
 func waitForDaemonDiscoveryClear(localDir, workspaceID, workspaceName string, signaled []mountDaemonProcess, timeout time.Duration) error {
@@ -6482,30 +6534,46 @@ func waitForDaemonDiscoveryClear(localDir, workspaceID, workspaceName string, si
 		if err != nil {
 			return fmt.Errorf("confirm daemon stop: %w", err)
 		}
-		if !daemonIntersection(signaled, running) {
+		stillAlive := signaledDaemonsStillAlive(signaled, running)
+		if len(stillAlive) == 0 {
 			return nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("daemon still alive after %s (%s)", timeout, formatDaemonPIDs(running))
+			return daemonStillAliveError{timeout: timeout, running: stillAlive}
 		}
 		time.Sleep(pollInterval)
 	}
 }
 
-func daemonIntersection(left, right []mountDaemonProcess) bool {
-	if len(left) == 0 || len(right) == 0 {
-		return false
+func signaledDaemonsStillAlive(signaled, discovered []mountDaemonProcess) []mountDaemonProcess {
+	if len(signaled) == 0 {
+		return nil
 	}
-	seen := map[int]struct{}{}
-	for _, process := range left {
-		seen[process.PID] = struct{}{}
-	}
-	for _, process := range right {
-		if _, ok := seen[process.PID]; ok {
-			return true
+	discoveredByPID := map[int]mountDaemonProcess{}
+	for _, daemon := range discovered {
+		if daemon.PID > 0 {
+			discoveredByPID[daemon.PID] = daemon
 		}
 	}
-	return false
+	stillAlive := make([]mountDaemonProcess, 0, len(signaled))
+	seen := map[int]struct{}{}
+	for _, daemon := range signaled {
+		if daemon.PID <= 0 {
+			continue
+		}
+		if _, ok := seen[daemon.PID]; ok {
+			continue
+		}
+		seen[daemon.PID] = struct{}{}
+		if discoveredDaemon, ok := discoveredByPID[daemon.PID]; ok {
+			stillAlive = append(stillAlive, discoveredDaemon)
+			continue
+		}
+		if processAlive(daemon.PID) {
+			stillAlive = append(stillAlive, daemon)
+		}
+	}
+	return stillAlive
 }
 
 func rotateLogFile(path string) error {
@@ -7372,6 +7440,8 @@ func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64)
 	}
 	return delay
 }
+
+var spawnBackgroundMountProcessFn = spawnBackgroundMountProcess
 
 func spawnBackgroundMountProcess(originalArgs []string, localDir, pidFile, logFile string) error {
 	if err := ensureMirrorLayout(localDir); err != nil {


### PR DESCRIPTION
## Summary
- escalate `relayfile stop` from SIGTERM to force kill when a mount daemon remains discoverable after the graceful timeout
- clear dead structured mount pidfiles during `relayfile mount --background` startup so manual SIGKILL recovery does not require `rm .relay/mount.pid`
- tighten stop confirmation to also poll verified pidfile-only daemons, and add regression coverage for force-stop and stale-pid startup recovery

Fixes #202

## Review / validation
- reviewed the stop path for pidfile-only daemon discovery; adjusted the wait loop so verified pidfile daemons cannot be reported stopped while still alive
- `git diff --check`
- `go test ./cmd/relayfile-cli`
- `go test ./cmd/...`

## Notes
The original working tree had unrelated dirty mountsync/SDK changes. This PR was built from a clean worktree based on current `origin/main` and includes only the CLI stop/start recovery changes.