### PR TITLE
fix(cli): skip post-connect sync poll in setup

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -865,11 +865,10 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 				return err
 			}
 		}
-		if !*skipMount {
-			if err := waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, selectedProvider, absLocalDir, *connectTimeout, stdout); err != nil {
-				return err
-			}
-		}
+		// We used to poll /sync/status here until the provider reported
+		// `ready`. That hung forever for providers without a sync handler
+		// (e.g. docker_hub) and was redundant for providers that do sync —
+		// the mount daemon below polls /sync/status on its own cadence.
 	} else {
 		fmt.Fprintln(stdout, "Integration connection skipped")
 	}
@@ -1652,7 +1651,7 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 					UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
 				})
 			}
-			fmt.Fprintf(stdout, "%s connected. Relayfile is preparing files in the background; keep this command running while initial sync finishes. Files will appear under %s/%s.\n", provider, localDir, providerRootDir(provider))
+			fmt.Fprintf(stdout, "%s connected. Files will appear under %s/%s as Relayfile syncs in the background; keep this command running while the mount is active.\n", provider, localDir, providerRootDir(provider))
 			pollErr = nil
 			return pollResult{done: true}
 		}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -918,7 +918,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	if !strings.Contains(got, "notion connected") {
 		t.Fatalf("unexpected integration connect output: %q", got)
 	}
-	if !strings.Contains(got, "keep this command running while initial sync finishes") {
+	if !strings.Contains(got, "keep this command running while the mount is active") {
 		t.Fatalf("expected connected-but-still-working guidance, got %q", got)
 	}
 	if !strings.Contains(got, "Waiting for notion initial sync. Leave this command running") {


### PR DESCRIPTION
## Summary
- `relayfile setup --provider docker_hub --backend composio` printed "Waiting for docker_hub sync status..." forever. The provider has no sync handler, so it never appeared in `/sync/status`, and the pre-mount poll spun until the operator killed it.
- Drop `waitForInitialSync` from `runSetup`. After a successful connect, jump straight to `runMount` — the mount daemon polls `/sync/status` on its own cadence, so the pre-mount poll was redundant for providers that do sync.
- Reword the connect-success message so it no longer promises an "initial sync" will finish before mount starts.

## Repro (before this PR)
```
$ relayfile setup --provider docker_hub --backend composio
...
docker_hub connected. Relayfile is preparing files in the background; keep this command running while initial sync finishes.
Waiting for docker_hub initial sync. Leave this command running; Relayfile is preparing files in the background.
Waiting for docker_hub sync status...
Waiting for docker_hub sync status...
Waiting for docker_hub sync status...
  (forever)
```

## Notes
- `runIntegrationConnect` still calls `waitForInitialSync` — that flow is opt-in and out of scope here.
- `docs/productized-cloud-mount-contract.md §7.2` still documents the old "CLI polls /sync after connect" behavior. Worth a follow-up to align the contract with the new flow.
- The hosted Composio callback (`https://agentrelay.com/cloud/api/v1/webhooks/composio/connect/callback?...&status=success`) returns raw JSON when there is no `returnTo` — tracked separately in a `cloud` issue.

## Test plan
- [x] `go test ./cmd/relayfile-cli -count=1`
- [ ] Manual: `relayfile setup --provider docker_hub --backend composio` exits the polling loop and proceeds to mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)