### PR TITLE
fix(httpapi): strip relayauth token-class prefix before parsing bearer as JWT

### DIFF
--- a/internal/httpapi/auth.go
+++ b/internal/httpapi/auth.go
@@ -115,6 +115,44 @@ func authorizeBearer(authHeader string, verifier *bearerVerifier, workspaceID, r
 	return claims, nil
 }
 
+// relayauthTokenPrefixes are the token-class prefixes that relayauth's
+// `/v1/tokens/*` endpoints attach to the access tokens they issue. The
+// prefix encodes the token class for clients that route by token type
+// (path-scoped vs workspace-scoped vs identity), but it is NOT part of
+// the RS256 JWT — the actual JWS string sits AFTER the prefix.
+//
+// Before this list existed, `parseBearer` split the prefixed bearer on
+// `.`, ended up with `relay_pa_<header_b64>` as `parts[0]`, and either
+// got an unparseable JSON header or a base64-decode error. Both paths
+// returned a 401 "invalid jwt header" / "invalid jwt format" even
+// though the underlying JWT was perfectly valid. The relayfile-mount
+// daemon (which uses these tokens as Bearer creds) sat in an infinite
+// 401 retry loop, which silently broke every proactive-runtime fire
+// that depended on it for writeback flushing.
+//
+// Keep this in sync with the prefixes minted by relayauth's
+// `packages/server/src/routes/tokens.ts` (`relay_pa_*` for path-access,
+// `relay_ws_*` for workspace, `relay_id_*` for identity).
+var relayauthTokenPrefixes = []string{
+	"relay_pa_",
+	"relay_ws_",
+	"relay_id_",
+}
+
+// stripRelayauthTokenPrefix removes the leading `relay_<class>_` prefix
+// emitted by relayauth's token-mint endpoints so the remainder can be
+// parsed as a standard RS256 JWT. Returns the raw input unchanged if no
+// known prefix is present (so plain JWTs minted directly via
+// `/v1/tokens` with no token-class wrapper still work).
+func stripRelayauthTokenPrefix(raw string) string {
+	for _, prefix := range relayauthTokenPrefixes {
+		if strings.HasPrefix(raw, prefix) {
+			return strings.TrimPrefix(raw, prefix)
+		}
+	}
+	return raw
+}
+
 func parseBearer(authHeader string, verifier *bearerVerifier, now time.Time) (tokenClaims, *authError) {
 	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return tokenClaims{}, &authError{
@@ -124,6 +162,7 @@ func parseBearer(authHeader string, verifier *bearerVerifier, now time.Time) (to
 		}
 	}
 	raw := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+	raw = stripRelayauthTokenPrefix(raw)
 	parts := strings.Split(raw, ".")
 	if len(parts) != 3 {
 		return tokenClaims{}, &authError{

--- a/internal/httpapi/auth_test.go
+++ b/internal/httpapi/auth_test.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -214,6 +215,83 @@ func TestParseBearerRS256HappyPath(t *testing.T) {
 	}
 	if hits.Load() != 1 {
 		t.Fatalf("expected one JWKS fetch, got %d", hits.Load())
+	}
+}
+
+// Regression coverage for the relayauth token-prefix bug: tokens minted
+// via relayauth's `/v1/tokens/path` come back wrapped as
+// `relay_pa_<jwt>`. Pre-fix, `parseBearer` would split on `.`, end up
+// with `relay_pa_<header_b64>` as `parts[0]`, and fail the JSON
+// unmarshal with a 401 "invalid jwt header" — silently breaking every
+// caller that authenticated with a relayauth-wrapped token. Pin that
+// the strip happens BEFORE the dot-split so the underlying JWT verifies
+// just like a bare token.
+func TestParseBearerStripsRelayauthTokenPrefixes(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	privateKey := mustRSATestKey(t)
+
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwksDocument{
+			Keys: []jwkKey{mustRSATestJWK("kid-1", &privateKey.PublicKey)},
+		})
+	}))
+	defer jwksServer.Close()
+
+	rawJWT := mustTestRS256JWT(t, privateKey, "kid-1", map[string]any{
+		"wks":    "ws-rs",
+		"sub":    "RelayfileGoWorker",
+		"scopes": []string{"fs:read"},
+		"exp":    now.Add(time.Hour).Unix(),
+		"aud":    "relayfile",
+	})
+
+	prefixes := []string{
+		"relay_pa_",
+		"relay_ws_",
+		"relay_id_",
+	}
+	for _, prefix := range prefixes {
+		prefix := prefix // capture
+		t.Run(strings.TrimSuffix(prefix, "_"), func(t *testing.T) {
+			claims, authErr := parseBearer("Bearer "+prefix+rawJWT, newBearerVerifier(ServerConfig{
+				JWKSURL:          jwksServer.URL,
+				JWKSFetchTimeout: time.Second,
+			}), now)
+			if authErr != nil {
+				t.Fatalf("parseBearer with %q prefix returned auth error: %+v", prefix, authErr)
+			}
+			if claims.WorkspaceID != "ws-rs" {
+				t.Fatalf("expected workspace ws-rs, got %q", claims.WorkspaceID)
+			}
+			if claims.AgentName != "RelayfileGoWorker" {
+				t.Fatalf("expected subject RelayfileGoWorker, got %q", claims.AgentName)
+			}
+		})
+	}
+
+	// Sanity: a bare JWT (no prefix) still parses correctly so we didn't
+	// break the direct `/v1/tokens` mint path that doesn't wrap.
+	claims, authErr := parseBearer("Bearer "+rawJWT, newBearerVerifier(ServerConfig{
+		JWKSURL:          jwksServer.URL,
+		JWKSFetchTimeout: time.Second,
+	}), now)
+	if authErr != nil {
+		t.Fatalf("parseBearer with bare JWT returned auth error: %+v", authErr)
+	}
+	if claims.WorkspaceID != "ws-rs" {
+		t.Fatalf("expected workspace ws-rs from bare JWT, got %q", claims.WorkspaceID)
+	}
+
+	// And: garbage that happens to start with `relay_pa_` but isn't a JWT
+	// still rejects cleanly (header decode fails AFTER the strip).
+	_, authErr = parseBearer("Bearer relay_pa_not.a.jwt", newBearerVerifier(ServerConfig{
+		JWKSURL:          jwksServer.URL,
+		JWKSFetchTimeout: time.Second,
+	}), now)
+	if authErr == nil {
+		t.Fatal("expected auth error for non-JWT after prefix strip")
 	}
 }
 


### PR DESCRIPTION
## Summary

Relayauth's `/v1/tokens/path` and `/v1/tokens/workspace` mint endpoints wrap the access token they issue with a class prefix: `relay_pa_<jwt>`, `relay_ws_<jwt>`, `relay_id_<jwt>`. The prefix encodes the token class for clients that route by type; it is NOT part of the RS256 JWS that follows.

`parseBearer` in `internal/httpapi/auth.go` was splitting the raw bearer on `.` without first stripping the prefix. For a `relay_pa_eyJ.eyJ.<sig>` token, `parts[0]` ended up as `relay_pa_eyJ<rest_of_header_b64>`. The underscore is valid in base64url, so `base64.RawURLEncoding.DecodeString` sometimes succeeded; the subsequent JSON unmarshal then failed because the decoded bytes weren't valid JSON. Net effect: every request bearing a relayauth-wrapped token returned **401 "invalid jwt header"** (or, depending on how dots fell in the prefix, "invalid jwt format").

## Production impact

The cloud repo's proactive runtime (`agentworkforce/cloud`) starts a `relayfile-mount` daemon inside per-fire Daytona sandboxes so handler-side writebacks (`ctx.github.comment` etc.) flush to relayfile cloud. Mint succeeded, daemon launched, and then:

```
2026/05/22 20:47:09 mount sync cycle failed: http 401 unauthorized: invalid jwt header
2026/05/22 20:47:09 mount sync cycle failed: http 401 unauthorized: invalid jwt header
2026/05/22 20:47:09 mount sync cycle failed: http 401 unauthorized: invalid jwt header
```

Verified end-to-end against `agentworkforce/proactive-agents#105/#106`:
- Handler ran successfully (`runner.handler.ok durationMs=3`)
- Draft comment files appeared at `/workspace/github/repos/AgentWorkforce/proactive-agents/issues/106/comments/create comment <uuid>.json`
- Daemon hit 401 on every poll cycle; nothing reached relayfile cloud
- `runScript` eventually 524'd from Daytona's proxy after the cleanup trap's `--once` flush also hammered 401s

Same flow underpins cloud-agent boxes (`packages/web/.../box/box-manager.ts`), which use the same mint helper.

## Fix

```diff
+var relayauthTokenPrefixes = []string{
+	"relay_pa_",
+	"relay_ws_",
+	"relay_id_",
+}
+
+func stripRelayauthTokenPrefix(raw string) string {
+	for _, prefix := range relayauthTokenPrefixes {
+		if strings.HasPrefix(raw, prefix) {
+			return strings.TrimPrefix(raw, prefix)
+		}
+	}
+	return raw
+}
+
 func parseBearer(authHeader string, verifier *bearerVerifier, now time.Time) (tokenClaims, *authError) {
 	...
 	raw := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer "))
+	raw = stripRelayauthTokenPrefix(raw)
 	parts := strings.Split(raw, ".")
```

Falls back to the raw input if no known prefix is present, so bare JWTs minted via `/v1/tokens` (no class wrapper) continue to parse unchanged.

## Test plan

- [x] `TestParseBearerStripsRelayauthTokenPrefixes` — exercises all three prefixes (`relay_pa_`, `relay_ws_`, `relay_id_`) against a real RS256 JWT, plus a bare-JWT sanity case + a `relay_pa_not-a-jwt` rejection case (header decode must still fail AFTER the strip)
- [x] All existing `TestParseBearer*` cases pass unchanged
- [x] `go test ./...` clean (8 packages, no regressions in mountsync/mountfuse/writeback/digest/schema)
- [ ] Post-merge + relayfile-cloud deploy: trigger an `issues.opened` event in `AgentWorkforce/proactive-agents`. Expected: mount daemon polls successfully (200 from `/v1/workspaces/.../fs/events`), `ctx.github.comment` draft file pushes to relayfile cloud, adapter writeback POSTs comment to GitHub, comment lands on the issue.

## Future-proofing

If relayauth adds new token classes (`relay_<class>_*`), append the prefix to `relayauthTokenPrefixes`. The list lives in `internal/httpapi/auth.go` next to its sole consumer.

## Possible follow-up

Independent investigation (cloud-side) surfaced a second potential issue: `scopeMatches` returns a 403 "missing required scope: fs:read" when checking a token with path-scoped grants (`relayfile:fs:read:/github/*`) against a coarse `fs:read` requirement. The Go-side code actually handles this correctly (path is the OPTIONAL 4th segment, plane/res/act match), so I believe the 403 came from a different curl test against a path-required endpoint via `scopeMatchesPath`. Confirming this after the prefix-strip is merged + deployed; will file a separate PR if a second issue surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)