### PR TITLE
ci(publish): attach checksums.txt to releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -430,6 +430,18 @@ jobs:
           done
           chmod +x mount-binaries/relayfile-mount-*
 
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          # Publish a checksums.txt alongside the release binaries. Downstream
+          # consumers (e.g. agent-relay's relayfile-binary.ts verifyChecksum)
+          # require it and match entries by basename, so we cd into each dir to
+          # emit basenames (not paths). This is mandatory for the cloud Daytona
+          # mount daemon download to verify; do not drop it.
+          ( cd mount-binaries && sha256sum relayfile-mount-* ) > checksums.txt
+          ( cd packages/cli/bin && sha256sum relayfile-cli-* ) >> checksums.txt
+          cat checksums.txt
+
       - name: Commit version bump and create tag
         env:
           NEW_VERSION: ${{ needs.build.outputs.new_version }}
@@ -495,6 +507,7 @@ jobs:
           files: |
             packages/cli/bin/relayfile-cli-*
             mount-binaries/relayfile-mount-*
+            checksums.txt
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Generate + attach `checksums.txt` to every release in `publish.yml` (basename entries for relayfile-mount-* + relayfile-cli-*).

## Why
The release workflow uploads the binaries but stopped publishing `checksums.txt` (regressed from the old goreleaser layout — v0.1.6 had it, no v0.7.x does). agent-relay's `relayfile-binary.ts` `verifyChecksum()` is **mandatory** — it downloads `checksums.txt` from the release tag and throws on 404. So any consumer pinning a v0.7.x relayfile-mount tag can't install the daemon → the cloud Daytona persona path is stuck on **v0.1.6**, which predates the workspace-export 413→paginate fallback (v0.7.33/#195) + scoped mount paths (v0.7.39/#206). That's the root blocker for AgentWorkforce/cloud#1028.

## Robust, not a point-fix
Restores the supply-chain-verification contract (keeps verification mandatory) so **every future release** works — not just a one-off backfill of v0.7.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)