### PR TITLE
Back off Relayfile mount websocket reconnects

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -44,6 +44,7 @@ const (
 	websocketReconcileEvery = 10
 	defaultMountMode        = "poll"
 	defaultMountInterval    = 30 * time.Second
+	minMountPollInterval    = 5 * time.Second
 	defaultMountTimeout     = 15 * time.Second
 )
 
@@ -3877,6 +3878,7 @@ func runMount(args []string) error {
 	if *interval <= 0 {
 		*interval = defaultMountInterval
 	}
+	*interval = enforcePollIntervalFloor(*interval)
 	if *timeout <= 0 {
 		*timeout = defaultMountTimeout
 	}
@@ -7416,13 +7418,20 @@ func clampJitterRatio(value float64) float64 {
 	return value
 }
 
+func enforcePollIntervalFloor(interval time.Duration) time.Duration {
+	if interval > 0 && interval < minMountPollInterval {
+		return minMountPollInterval
+	}
+	return interval
+}
+
 func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64) time.Duration {
 	if base <= 0 {
 		return 0
 	}
 	jitterRatio = clampJitterRatio(jitterRatio)
 	if jitterRatio == 0 {
-		return base
+		return enforcePollIntervalFloor(base)
 	}
 	if sample < 0 {
 		sample = 0
@@ -7437,7 +7446,7 @@ func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64)
 	if delay < time.Millisecond {
 		return time.Millisecond
 	}
-	return delay
+	return enforcePollIntervalFloor(delay)
 }
 
 var spawnBackgroundMountProcessFn = spawnBackgroundMountProcess
@@ -7488,6 +7497,7 @@ func spawnBackgroundMountProcess(originalArgs []string, localDir, pidFile, logFi
 }
 
 func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, workspaceID, serverURL string, timeout, interval time.Duration, intervalJitter float64, websocketEnabled, once, daemonized bool, pidFile, logFile string) error {
+	interval = enforcePollIntervalFloor(interval)
 	httpClient, _ := syncerClient(syncer)
 	record, _ := workspaceRecordByID(workspaceID)
 	if record.ID == "" {
@@ -7732,6 +7742,8 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 
 	timer := time.NewTimer(jitteredIntervalWithSample(interval, intervalJitter, mathrand.Float64()))
 	defer timer.Stop()
+	wsTicker := time.NewTicker(mountsync.DefaultWebSocketMaintenanceEvery)
+	defer wsTicker.Stop()
 	cycle := 0
 	for {
 		select {
@@ -7739,9 +7751,17 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			log.Printf("mount sync stopping: %v", rootCtx.Err())
 			writeSnapshot()
 			return nil
+		case <-wsTicker.C:
+			if websocketEnabled {
+				ctx, cancel := context.WithTimeout(rootCtx, timeout)
+				if err := syncer.MaintainWebSocket(ctx); err != nil {
+					log.Printf("websocket unavailable; using polling sync: %v", err)
+				}
+				cancel()
+			}
 		case <-timer.C:
 			cycle++
-			reconcile := !websocketEnabled || cycle%websocketReconcileEvery == 0
+			reconcile := shouldReconcileMountCycle(websocketEnabled, cycle)
 			if reconcile {
 				_ = runCycle(true)
 			}
@@ -7761,6 +7781,10 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			timer.Reset(jitteredIntervalWithSample(interval, intervalJitter, mathrand.Float64()))
 		}
 	}
+}
+
+func shouldReconcileMountCycle(websocketEnabled bool, cycle int) bool {
+	return !websocketEnabled || cycle%websocketReconcileEvery == 0
 }
 
 func correlationID() string {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -55,6 +55,37 @@ func TestResolveServerDefaultsToHostedRelayfile(t *testing.T) {
 	}
 }
 
+func TestEnforcePollIntervalFloor(t *testing.T) {
+	if got := enforcePollIntervalFloor(time.Second); got != minMountPollInterval {
+		t.Fatalf("expected interval floor %s, got %s", minMountPollInterval, got)
+	}
+	if got := enforcePollIntervalFloor(defaultMountInterval); got != defaultMountInterval {
+		t.Fatalf("expected default interval passthrough, got %s", got)
+	}
+	if got := jitteredIntervalWithSample(minMountPollInterval, 0.2, 0); got != minMountPollInterval {
+		t.Fatalf("expected jittered interval floor %s, got %s", minMountPollInterval, got)
+	}
+	if got := jitteredIntervalWithSample(time.Second, 0, 0.5); got != minMountPollInterval {
+		t.Fatalf("expected non-jittered interval floor %s, got %s", minMountPollInterval, got)
+	}
+}
+
+func TestWebSocketMaintenanceDoesNotLowerReconcileCadence(t *testing.T) {
+	for cycle := 1; cycle < websocketReconcileEvery; cycle++ {
+		if shouldReconcileMountCycle(true, cycle) {
+			t.Fatalf("websocket-enabled cycle %d reconciled before cadence floor", cycle)
+		}
+	}
+	if !shouldReconcileMountCycle(true, websocketReconcileEvery) {
+		t.Fatalf("expected websocket-enabled cycle %d to reconcile", websocketReconcileEvery)
+	}
+	for cycle := 1; cycle <= websocketReconcileEvery; cycle++ {
+		if !shouldReconcileMountCycle(false, cycle) {
+			t.Fatalf("expected websocket-disabled cycle %d to reconcile", cycle)
+		}
+	}
+}
+
 func TestObserverPrintsFragmentLaunchURL(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
+++ b/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
@@ -201,12 +201,12 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 	}
 
 	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:               cloud.URL(),
-		AccessToken:          cloud.expiredAccessToken,
-		RefreshToken:         cloud.refreshToken,
-		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		APIURL:                cloud.URL(),
+		AccessToken:           cloud.expiredAccessToken,
+		RefreshToken:          cloud.refreshToken,
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
 		RefreshTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-		UpdatedAt:            time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
 		t.Fatalf("saveCloudCredentials failed: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 		t.Fatalf("currentRelayToken failed: %v", err)
 	}
 	relay.RejectToken(currentToken)
-	waitForCondition(t, 5*time.Second, "cloud token refresh + workspace rejoin", func() bool {
+	waitForCondition(t, 12*time.Second, "cloud token refresh + workspace rejoin", func() bool {
 		creds, loadErr := loadCredentials()
 		if loadErr != nil {
 			return false
@@ -283,12 +283,12 @@ type productizedProviderStatus struct {
 func newProductizedRelayfileMock(t *testing.T) *productizedRelayfileMock {
 	t.Helper()
 	mock := &productizedRelayfileMock{
-		t:             t,
-		files:         map[string]productizedRemoteFile{},
-		providers:     map[string]*productizedProviderStatus{},
-		validTokens:   map[string]struct{}{},
+		t:              t,
+		files:          map[string]productizedRemoteFile{},
+		providers:      map[string]*productizedProviderStatus{},
+		validTokens:    map[string]struct{}{},
 		rejectedTokens: map[string]struct{}{},
-		conflictOnce:  map[string]struct{}{},
+		conflictOnce:   map[string]struct{}{},
 	}
 	mock.server = httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
 	return mock
@@ -686,8 +686,8 @@ func (m *productizedCloudMock) serveJoinWorkspace(w http.ResponseWriter, r *http
 
 	m.relay.ActivateToken(token)
 	writeMockJSON(w, http.StatusOK, cloudWorkspaceJoinResponse{
-		WorkspaceID: m.workspaceID,
-		Token:       token,
+		WorkspaceID:  m.workspaceID,
+		Token:        token,
 		RelayfileURL: m.relay.URL(),
 	})
 }
@@ -801,7 +801,7 @@ func waitForFile(t *testing.T, path, description string) {
 
 func assertFileContentEventually(t *testing.T, path, want string) {
 	t.Helper()
-	waitForCondition(t, 5*time.Second, path, func() bool {
+	waitForCondition(t, 12*time.Second, path, func() bool {
 		data, err := os.ReadFile(path)
 		return err == nil && string(data) == want
 	})

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -26,6 +26,7 @@ const (
 	mountModePoll           = "poll"
 	mountModeFuse           = "fuse"
 	websocketReconcileEvery = 10
+	minMountPollInterval    = 5 * time.Second
 )
 
 var errFuseModeUnavailable = errors.New("fuse mode is not available in this build")
@@ -100,6 +101,7 @@ func main() {
 	if *interval <= 0 {
 		*interval = 30 * time.Second
 	}
+	*interval = enforcePollIntervalFloor(*interval)
 	if *timeout <= 0 {
 		*timeout = 15 * time.Second
 	}
@@ -357,15 +359,25 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	timer := time.NewTimer(jitteredIntervalWithSample(cfg.interval, cfg.intervalJitter, rng.Float64()))
 	defer timer.Stop()
+	wsTicker := time.NewTicker(mountsync.DefaultWebSocketMaintenanceEvery)
+	defer wsTicker.Stop()
 	cycle := 0
 	for {
 		select {
 		case <-rootCtx.Done():
 			log.Printf("mount sync stopping: %v", rootCtx.Err())
 			return nil
+		case <-wsTicker.C:
+			if cfg.websocketEnabled {
+				ctx, cancel := context.WithTimeout(rootCtx, cfg.timeout)
+				if err := syncer.MaintainWebSocket(ctx); err != nil {
+					log.Printf("websocket unavailable; using polling sync: %v", err)
+				}
+				cancel()
+			}
 		case <-timer.C:
 			cycle++
-			reconcile := !cfg.websocketEnabled || cycle%websocketReconcileEvery == 0
+			reconcile := shouldReconcileMountCycle(cfg.websocketEnabled, cycle)
 			if reconcile {
 				run(true)
 			}
@@ -624,6 +636,10 @@ func normalizeTokenScopes(raw any) []string {
 	return values
 }
 
+func shouldReconcileMountCycle(websocketEnabled bool, cycle int) bool {
+	return !websocketEnabled || cycle%websocketReconcileEvery == 0
+}
+
 func clampJitterRatio(value float64) float64 {
 	if value < 0 {
 		return 0
@@ -634,13 +650,20 @@ func clampJitterRatio(value float64) float64 {
 	return value
 }
 
+func enforcePollIntervalFloor(interval time.Duration) time.Duration {
+	if interval > 0 && interval < minMountPollInterval {
+		return minMountPollInterval
+	}
+	return interval
+}
+
 func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64) time.Duration {
 	if base <= 0 {
 		return 0
 	}
 	jitterRatio = clampJitterRatio(jitterRatio)
 	if jitterRatio == 0 {
-		return base
+		return enforcePollIntervalFloor(base)
 	}
 	if sample < 0 {
 		sample = 0
@@ -655,5 +678,5 @@ func jitteredIntervalWithSample(base time.Duration, jitterRatio, sample float64)
 	if delay < time.Millisecond {
 		return time.Millisecond
 	}
-	return delay
+	return enforcePollIntervalFloor(delay)
 }

--- a/cmd/relayfile-mount/main_test.go
+++ b/cmd/relayfile-mount/main_test.go
@@ -83,6 +83,37 @@ func TestJitteredIntervalWithSample(t *testing.T) {
 	}
 }
 
+func TestEnforcePollIntervalFloor(t *testing.T) {
+	if got := enforcePollIntervalFloor(time.Second); got != minMountPollInterval {
+		t.Fatalf("expected interval floor %s, got %s", minMountPollInterval, got)
+	}
+	if got := enforcePollIntervalFloor(30 * time.Second); got != 30*time.Second {
+		t.Fatalf("expected long interval passthrough, got %s", got)
+	}
+	if got := jitteredIntervalWithSample(minMountPollInterval, 0.2, 0); got != minMountPollInterval {
+		t.Fatalf("expected jittered interval floor %s, got %s", minMountPollInterval, got)
+	}
+	if got := jitteredIntervalWithSample(time.Second, 0, 0.5); got != minMountPollInterval {
+		t.Fatalf("expected non-jittered interval floor %s, got %s", minMountPollInterval, got)
+	}
+}
+
+func TestWebSocketMaintenanceDoesNotLowerReconcileCadence(t *testing.T) {
+	for cycle := 1; cycle < websocketReconcileEvery; cycle++ {
+		if shouldReconcileMountCycle(true, cycle) {
+			t.Fatalf("websocket-enabled cycle %d reconciled before cadence floor", cycle)
+		}
+	}
+	if !shouldReconcileMountCycle(true, websocketReconcileEvery) {
+		t.Fatalf("expected websocket-enabled cycle %d to reconcile", websocketReconcileEvery)
+	}
+	for cycle := 1; cycle <= websocketReconcileEvery; cycle++ {
+		if !shouldReconcileMountCycle(false, cycle) {
+			t.Fatalf("expected websocket-disabled cycle %d to reconcile", cycle)
+		}
+	}
+}
+
 func TestResolveMountMode(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -80,6 +80,11 @@ const (
 	defaultCursorTimeout             = 20 * time.Second
 	defaultBootstrapReadWorkers      = 16
 	defaultIncrementalEventPageLimit = 50
+	defaultRetryAfterMaxDelay        = 60 * time.Second
+	defaultWebSocketReconnectBase    = 1 * time.Second
+	defaultWebSocketReconnectMax     = 60 * time.Second
+	defaultWebSocketReconnectJitter  = 200 * time.Millisecond
+	DefaultWebSocketMaintenanceEvery = 1 * time.Second
 )
 
 // resolveDurationEnv returns the option value if non-zero, else parses the
@@ -281,7 +286,7 @@ func NewHTTPClient(baseURL, token string, httpClient *http.Client) *HTTPClient {
 		httpClient: httpClient,
 		maxRetries: 3,
 		baseDelay:  100 * time.Millisecond,
-		maxDelay:   2 * time.Second,
+		maxDelay:   defaultRetryAfterMaxDelay,
 	}
 }
 
@@ -695,6 +700,10 @@ type Syncer struct {
 	rootCtx              context.Context
 	wsConn               *websocket.Conn
 	wsCancel             context.CancelFunc
+	wsNextAttempt        time.Time
+	wsReconnectFailures  int
+	wsConnecting         bool
+	wsGeneration         int64
 	bulkFlushThreshold   int
 	mode                 string
 	interval             time.Duration
@@ -1763,15 +1772,10 @@ func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
 		return err
 	}
 
-	// Check if websocket connection is needed while holding the lock,
-	// then release before connecting to avoid deadlock with readWebSocketLoop.
-	needsWS := s.websocket && s.wsConn == nil
 	s.mu.Unlock()
 
-	if needsWS {
-		if err := s.connectWebSocket(ctx); err != nil {
-			s.logf("websocket unavailable; using polling sync: %v", err)
-		}
+	if err := s.MaintainWebSocket(ctx); err != nil {
+		s.logf("websocket unavailable; using polling sync: %v", err)
 	}
 
 	// Re-acquire lock for the remainder of the sync operation.
@@ -1854,35 +1858,53 @@ func (s *Syncer) runRollingDigestJobsLocked(ctx context.Context) error {
 
 func (s *Syncer) connectWebSocket(ctx context.Context) error {
 	s.mu.Lock()
-	if !s.websocket || s.wsConn != nil {
+	if !s.websocketConnectDueLocked(time.Now()) {
 		s.mu.Unlock()
 		return nil
 	}
+	s.wsConnecting = true
+	generation := s.wsGeneration
 	s.mu.Unlock()
 
 	httpClient, ok := s.client.(*HTTPClient)
 	if !ok {
+		s.finishWebSocketConnectFailure(generation, 0)
 		return nil
 	}
 
 	wsURL, err := httpClient.websocketURL(s.workspace)
 	if err != nil {
+		s.finishWebSocketConnectFailure(generation, 0)
 		return err
 	}
-	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+	conn, response, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
 		HTTPHeader: http.Header{
 			"Authorization": []string{"Bearer " + httpClient.Token()},
 		},
 	})
 	if err != nil {
-		return err
+		retryAfter := retryAfterFromResponse(response)
+		s.finishWebSocketConnectFailure(generation, retryAfter)
+		return webSocketDialError{err: err, retryAfter: retryAfter}
 	}
 
 	readCtx, cancel := context.WithCancel(s.rootCtx)
 
 	s.mu.Lock()
+	if s.wsGeneration != generation || s.wsConn != nil {
+		if s.wsGeneration == generation {
+			s.wsConnecting = false
+		}
+		s.mu.Unlock()
+		cancel()
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+		return nil
+	}
+	s.wsConnecting = false
 	s.wsConn = conn
 	s.wsCancel = cancel
+	s.wsNextAttempt = time.Time{}
+	s.wsReconnectFailures = 0
 	s.mu.Unlock()
 
 	go s.readWebSocketLoop(readCtx, conn)
@@ -1994,6 +2016,7 @@ func (s *Syncer) handleWebSocketDisconnect(conn *websocket.Conn) {
 		s.wsCancel = nil
 	}
 	s.wsConn = nil
+	s.scheduleWebSocketReconnectLocked(0)
 }
 
 func (s *Syncer) ResetWebSocket() {
@@ -2002,6 +2025,10 @@ func (s *Syncer) ResetWebSocket() {
 	cancel := s.wsCancel
 	s.wsConn = nil
 	s.wsCancel = nil
+	s.wsNextAttempt = time.Time{}
+	s.wsReconnectFailures = 0
+	s.wsConnecting = false
+	s.wsGeneration++
 	s.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -2009,6 +2036,77 @@ func (s *Syncer) ResetWebSocket() {
 	if conn != nil {
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}
+}
+
+func (s *Syncer) MaintainWebSocket(ctx context.Context) error {
+	s.mu.Lock()
+	needsWS := s.websocketConnectDueLocked(time.Now())
+	s.mu.Unlock()
+	if !needsWS {
+		return nil
+	}
+	if err := s.connectWebSocket(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Syncer) websocketConnectDueLocked(now time.Time) bool {
+	if !s.websocket || s.wsConn != nil || s.wsConnecting {
+		return false
+	}
+	return s.wsNextAttempt.IsZero() || !now.Before(s.wsNextAttempt)
+}
+
+func (s *Syncer) scheduleWebSocketReconnectLocked(retryAfter time.Duration) {
+	if s.wsConn != nil {
+		return
+	}
+	s.wsReconnectFailures++
+	delay := retryAfter
+	if delay <= 0 {
+		delay = websocketReconnectDelay(s.wsReconnectFailures)
+	}
+	if delay > defaultWebSocketReconnectMax {
+		delay = defaultWebSocketReconnectMax
+	}
+	s.wsNextAttempt = time.Now().Add(delay)
+}
+
+func (s *Syncer) finishWebSocketConnectFailure(
+	generation int64,
+	retryAfter time.Duration,
+) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.wsGeneration != generation {
+		return
+	}
+	s.wsConnecting = false
+	s.scheduleWebSocketReconnectLocked(retryAfter)
+}
+
+func websocketReconnectDelay(failures int) time.Duration {
+	if failures <= 0 {
+		failures = 1
+	}
+	delay := defaultWebSocketReconnectBase
+	for i := 1; i < failures; i++ {
+		delay *= 2
+		if delay >= defaultWebSocketReconnectMax {
+			delay = defaultWebSocketReconnectMax
+			break
+		}
+	}
+	jitter := time.Duration(time.Now().UnixNano()%int64(defaultWebSocketReconnectJitter*2)) - defaultWebSocketReconnectJitter
+	delay += jitter
+	if delay < defaultWebSocketReconnectBase {
+		return defaultWebSocketReconnectBase
+	}
+	if delay > defaultWebSocketReconnectMax {
+		return defaultWebSocketReconnectMax
+	}
+	return delay
 }
 
 func (s *Syncer) HTTPClient() (*HTTPClient, bool) {
@@ -4637,10 +4735,33 @@ func (c *HTTPClient) websocketURL(workspaceID string) (string, error) {
 	return base.String(), nil
 }
 
+type webSocketDialError struct {
+	err        error
+	retryAfter time.Duration
+}
+
+func (e webSocketDialError) Error() string {
+	if e.err == nil {
+		return "websocket dial failed"
+	}
+	return e.err.Error()
+}
+
+func (e webSocketDialError) Unwrap() error {
+	return e.err
+}
+
+func retryAfterFromResponse(response *http.Response) time.Duration {
+	if response == nil {
+		return 0
+	}
+	return parseRetryAfter(response.Header.Get("Retry-After"))
+}
+
 func (c *HTTPClient) retryDelay(attempt int, retryAfterHeader string) time.Duration {
 	maxDelay := c.maxDelay
 	if maxDelay <= 0 {
-		maxDelay = 2 * time.Second
+		maxDelay = defaultRetryAfterMaxDelay
 	}
 	if retryAfter := parseRetryAfter(retryAfterHeader); retryAfter > 0 {
 		if retryAfter > maxDelay {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -50,6 +50,115 @@ func markLocalDirtyForTest(t *testing.T, syncer *Syncer, remotePath, localPath s
 	syncer.state.Files[normalizeRemotePath(remotePath)] = tracked
 }
 
+func TestHTTPClientRetryDelayHonorsRetryAfter(t *testing.T) {
+	client := NewHTTPClient("https://example.test", "token", nil)
+	if got := client.retryDelay(1, "30"); got != 30*time.Second {
+		t.Fatalf("expected Retry-After 30s, got %s", got)
+	}
+	if got := client.retryDelay(1, "999"); got != defaultRetryAfterMaxDelay {
+		t.Fatalf("expected Retry-After cap %s, got %s", defaultRetryAfterMaxDelay, got)
+	}
+}
+
+func TestWebSocketReconnectDelayBounds(t *testing.T) {
+	if got := websocketReconnectDelay(1); got < defaultWebSocketReconnectBase || got > defaultWebSocketReconnectBase+defaultWebSocketReconnectJitter {
+		t.Fatalf("first reconnect delay out of bounds: %s", got)
+	}
+	if got := websocketReconnectDelay(20); got < defaultWebSocketReconnectMax-defaultWebSocketReconnectJitter || got > defaultWebSocketReconnectMax {
+		t.Fatalf("capped reconnect delay out of bounds: %s", got)
+	}
+}
+
+func TestWebSocketConnectDueRespectsScheduledBackoff(t *testing.T) {
+	syncer := &Syncer{websocket: true}
+	now := time.Now()
+	if !syncer.websocketConnectDueLocked(now) {
+		t.Fatal("expected websocket connect to be due before a backoff is scheduled")
+	}
+	syncer.wsNextAttempt = now.Add(time.Minute)
+	if syncer.websocketConnectDueLocked(now) {
+		t.Fatal("expected websocket connect to wait for scheduled backoff")
+	}
+	syncer.wsNextAttempt = time.Time{}
+	syncer.wsConnecting = true
+	if syncer.websocketConnectDueLocked(now) {
+		t.Fatal("expected websocket connect to wait while another dial is in progress")
+	}
+}
+
+func TestMaintainWebSocketHonorsRetryAfter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "17")
+		http.Error(w, "busy", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "token", server.Client())
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_retry_after",
+		RemoteRoot:  "/",
+		LocalRoot:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer failed: %v", err)
+	}
+
+	before := time.Now()
+	if err := syncer.MaintainWebSocket(context.Background()); err == nil {
+		t.Fatal("expected websocket dial to fail")
+	}
+
+	syncer.mu.Lock()
+	nextAttempt := syncer.wsNextAttempt
+	connecting := syncer.wsConnecting
+	syncer.mu.Unlock()
+
+	if connecting {
+		t.Fatal("expected websocket connecting flag to be cleared after failed dial")
+	}
+	if nextAttempt.Before(before.Add(16*time.Second)) || nextAttempt.After(before.Add(18*time.Second)) {
+		t.Fatalf("expected Retry-After based reconnect around 17s, got %s from now", time.Until(nextAttempt))
+	}
+}
+
+func TestWebSocketConnectFailureDoesNotClearNewGeneration(t *testing.T) {
+	syncer := &Syncer{
+		websocket:    true,
+		wsConnecting: true,
+		wsGeneration: 2,
+	}
+
+	syncer.finishWebSocketConnectFailure(1, 17*time.Second)
+
+	syncer.mu.Lock()
+	defer syncer.mu.Unlock()
+	if !syncer.wsConnecting {
+		t.Fatal("stale dial failure cleared the current generation's connecting flag")
+	}
+	if !syncer.wsNextAttempt.IsZero() {
+		t.Fatalf("stale dial failure scheduled backoff for current generation: %s", syncer.wsNextAttempt)
+	}
+}
+
+func TestResetWebSocketInvalidatesInFlightDialGeneration(t *testing.T) {
+	syncer := &Syncer{
+		websocket:    true,
+		wsConnecting: true,
+	}
+
+	syncer.ResetWebSocket()
+	syncer.finishWebSocketConnectFailure(0, 17*time.Second)
+
+	syncer.mu.Lock()
+	defer syncer.mu.Unlock()
+	if syncer.wsGeneration != 1 {
+		t.Fatalf("expected reset to advance websocket generation, got %d", syncer.wsGeneration)
+	}
+	if !syncer.wsNextAttempt.IsZero() {
+		t.Fatalf("stale dial scheduled backoff after reset: %s", syncer.wsNextAttempt)
+	}
+}
+
 type fakeProviderLayoutRegistrar struct {
 	calls    []string
 	manifest map[string]ProviderLayoutManifest


### PR DESCRIPTION
## Summary
- add jittered exponential websocket reconnect backoff, including Retry-After handling from failed websocket upgrades
- prevent stale in-flight dials from publishing after ResetWebSocket/auth refresh by using a websocket generation guard
- keep websocket maintenance on a 1s ticker without lowering HTTP reconcile cadence or the 5s polling floor

## Companion
- Companion to AgentWorkforce/cloud#1224 for cloud#1215 Phase 1: WorkspaceDO read/backpressure resilience.

## Verification
- go test ./internal/mountsync ./cmd/relayfile-mount ./cmd/relayfile-cli