### PR TITLE
fix(cli): join and refresh cloud workspace tokens

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -49,6 +49,7 @@ const (
 )
 
 var defaultJoinScopes = []string{"fs:read", "fs:write"}
+var defaultInspectScopes = []string{"relayfile:fs:read:*"}
 
 type credentials struct {
 	Server    string `json:"server"`
@@ -579,6 +580,8 @@ func printWorkspaceUsage(w io.Writer, subcommand string) {
 	switch subcommand {
 	case "create":
 		fmt.Fprintln(w, "Usage: relayfile workspace create NAME")
+	case "join":
+		fmt.Fprintln(w, "Usage: relayfile workspace join WORKSPACE_ID [--name NAME] [--write]")
 	case "use":
 		fmt.Fprintln(w, "Usage: relayfile workspace use NAME")
 	case "list":
@@ -590,6 +593,7 @@ func printWorkspaceUsage(w io.Writer, subcommand string) {
 	default:
 		fmt.Fprintln(w, `Usage:
   relayfile workspace create NAME
+  relayfile workspace join WORKSPACE_ID [--name NAME] [--write]
   relayfile workspace use NAME
   relayfile workspace list [--names-only]
   relayfile workspace current [--verbose]
@@ -672,6 +676,7 @@ Usage:
   relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]
   relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]
   relayfile workspace create NAME
+  relayfile workspace join WORKSPACE_ID [--name NAME] [--write]
   relayfile workspace use NAME
   relayfile workspace list [--names-only]
   relayfile workspace current [--verbose]
@@ -706,7 +711,7 @@ Usage:
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
   login       Sign in via the Relayfile Cloud browser flow (or --api-key for self-hosted)
-  workspace   Create, select, list, show current, or delete locally tracked workspaces
+  workspace   Create, join, select, list, show current, or delete locally tracked workspaces
   integration Connect, discover, list, disconnect, or adopt workspace integrations
   ops         List or replay dead-lettered writeback ops
   writeback   Inspect or retry local writeback failures
@@ -837,7 +842,8 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := persistJoinedWorkspace(record, joined, tokenSet.APIURL, absLocalDir); err != nil {
+	record, err = persistJoinedWorkspace(record, joined, tokenSet.APIURL, absLocalDir, true)
+	if err != nil {
 		return err
 	}
 
@@ -1425,14 +1431,17 @@ func ensureWorkspaceForSetup(cloud cloudCredentials, name, localDir string) (wor
 	return record, true, nil
 }
 
-func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinResponse, cloudAPIURL, localDir string) error {
+func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinResponse, cloudAPIURL, localDir string, setDefault bool) (workspaceRecord, error) {
 	serverURL := strings.TrimRight(strings.TrimSpace(joined.RelayfileURL), "/")
 	if err := saveCredentials(credentials{
 		Server:    serverURL,
 		Token:     strings.TrimSpace(joined.Token),
 		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
-		return err
+		return workspaceRecord{}, err
+	}
+	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
+		record.ID = joinedWorkspaceID
 	}
 	record.Server = serverURL
 	record.LocalDir = localDir
@@ -1444,11 +1453,18 @@ func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinRes
 	if len(record.Scopes) == 0 {
 		record.Scopes = append([]string(nil), defaultJoinScopes...)
 	}
-	if _, err := upsertWorkspaceDetails(record); err != nil {
-		return err
+	persisted, err := upsertWorkspaceDetails(record)
+	if err != nil {
+		return workspaceRecord{}, err
 	}
-	_, err := setDefaultWorkspace(record.Name)
-	return err
+	if !setDefault {
+		return persisted, nil
+	}
+	persisted, err = setDefaultWorkspace(persisted.Name)
+	if err != nil {
+		return workspaceRecord{}, err
+	}
+	return persisted, nil
 }
 
 func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string, scopes []string) (cloudWorkspaceJoinResponse, error) {
@@ -1845,7 +1861,8 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		if rerr == nil {
 			joined, jerr := joinWorkspaceViaCloud(creds, record.ID, record.AgentName, record.Scopes)
 			if jerr == nil {
-				if perr := persistJoinedWorkspace(record, joined, creds.APIURL, record.LocalDir); perr == nil {
+				if persisted, perr := persistJoinedWorkspace(record, joined, creds.APIURL, record.LocalDir, true); perr == nil {
+					record = persisted
 					fmt.Fprintf(stdout, "Refreshed workspace token for %s (%s)\n", record.Name, record.ID)
 					return nil
 				} else if strings.TrimSpace(*workspaceFlag) != "" {
@@ -1909,11 +1926,13 @@ func loginWithAPIKey(serverValue, tokenValue string, stdout io.Writer) error {
 
 func runWorkspace(args []string, stdin io.Reader, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("workspace subcommand is required: create, use, list, current, or delete")
+		return errors.New("workspace subcommand is required: create, join, use, list, current, or delete")
 	}
 	switch args[0] {
 	case "create":
 		return runWorkspaceCreate(args[1:], stdout)
+	case "join":
+		return runWorkspaceJoin(args[1:], stdout)
 	case "use":
 		return runWorkspaceUse(args[1:], stdout)
 	case "list":
@@ -1988,7 +2007,8 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err != nil {
 		return err
 	}
-	if err := persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir); err != nil {
+	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir, true)
+	if err != nil {
 		return err
 	}
 	createdConnection, err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout)
@@ -3531,6 +3551,72 @@ func runWorkspaceCreate(args []string, stdout io.Writer) error {
 	return nil
 }
 
+func runWorkspaceJoin(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("workspace join", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cloudAPIURL := fs.String("cloud-api-url", envOrDefault("RELAYFILE_CLOUD_API_URL", defaultCloudAPIURL), "Relayfile Cloud API URL")
+	cloudToken := fs.String("cloud-token", strings.TrimSpace(os.Getenv("RELAYFILE_CLOUD_TOKEN")), "Relayfile Cloud access token; skips browser login when set")
+	name := fs.String("name", "", "local workspace name")
+	writeAccess := fs.Bool("write", false, "request read/write workspace token scopes")
+	noOpen := fs.Bool("no-open", false, "print browser URLs instead of opening them")
+	loginTimeout := fs.Duration("login-timeout", 5*time.Minute, "cloud login timeout")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"cloud-api-url": true,
+		"cloud-token":   true,
+		"name":          true,
+		"write":         false,
+		"no-open":       false,
+		"login-timeout": true,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: relayfile workspace join WORKSPACE_ID [--name NAME] [--write]")
+	}
+
+	workspaceID := strings.TrimSpace(fs.Arg(0))
+	if workspaceID == "" {
+		return errors.New("workspace id is required")
+	}
+	localName := strings.TrimSpace(*name)
+	if localName == "" {
+		if record, ok := workspaceRecordByID(workspaceID); ok && strings.TrimSpace(record.Name) != "" {
+			localName = record.Name
+		} else {
+			localName = workspaceID
+		}
+	}
+	scopes := append([]string(nil), defaultInspectScopes...)
+	if *writeAccess {
+		scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	record := workspaceRecord{
+		Name:      localName,
+		ID:        workspaceID,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		AgentName: "relayfile-cli",
+		Scopes:    scopes,
+	}
+	cloudCreds, err := ensureCloudCredentials(strings.TrimSpace(*cloudAPIURL), strings.TrimSpace(*cloudToken), *loginTimeout, !*noOpen, stdout)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
+	if err != nil {
+		return err
+	}
+	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, "", true)
+	if err != nil {
+		return err
+	}
+	mode := "read-only"
+	if *writeAccess {
+		mode = "read/write"
+	}
+	fmt.Fprintf(stdout, "Joined workspace %s (id: %s, %s)\n", localName, record.ID, mode)
+	return nil
+}
+
 func runWorkspaceUse(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("workspace use", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -4050,6 +4136,155 @@ See 'relayfile help' for the full command list and
 docs/guides/vfs-cloud-setup.md#known-limitations for details.`)
 }
 
+type workspaceCommandClient struct {
+	workspaceID string
+	record      workspaceRecord
+	client      *apiClient
+	scopes      []string
+	directToken bool
+}
+
+func prepareWorkspaceCommandClient(workspaceValue, serverFlag, tokenFlag string, requestedScopes []string) (*workspaceCommandClient, error) {
+	creds, _ := loadCredentials()
+	tokenValue := resolveToken(tokenFlag, creds)
+	directToken := strings.TrimSpace(tokenFlag) != "" || strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")) != ""
+	workspaceID, err := resolveWorkspaceIDWithToken(workspaceValue, tokenValue)
+	if err != nil {
+		return nil, err
+	}
+	record := workspaceRecordForCommand(workspaceValue, workspaceID)
+	scopes := effectiveCommandScopes(record, requestedScopes)
+	commandClient := &workspaceCommandClient{
+		workspaceID: workspaceID,
+		record:      record,
+		scopes:      scopes,
+		directToken: directToken,
+	}
+
+	tokenWorkspaceID := workspaceIDFromToken(tokenValue)
+	shouldJoin := !directToken && (strings.TrimSpace(tokenValue) == "" || relayfileTokenNeedsRefresh(tokenValue) || (tokenWorkspaceID != "" && tokenWorkspaceID != workspaceID))
+	if shouldJoin {
+		if err := commandClient.refreshFromCloud(); err == nil {
+			return commandClient, nil
+		} else if strings.TrimSpace(tokenValue) == "" {
+			return nil, err
+		}
+	}
+
+	client, err := newAPIClient(resolveServer(serverFlag, creds), tokenValue)
+	if err != nil {
+		return nil, err
+	}
+	commandClient.client = client
+	return commandClient, nil
+}
+
+func workspaceRecordForCommand(workspaceValue, workspaceID string) workspaceRecord {
+	if record, ok := workspaceRecordByName(strings.TrimSpace(workspaceValue)); ok {
+		return normalizeWorkspaceCommandRecord(record, workspaceID)
+	}
+	if record, ok := workspaceRecordByID(workspaceID); ok {
+		return normalizeWorkspaceCommandRecord(record, workspaceID)
+	}
+	return workspaceRecord{
+		Name:      workspaceID,
+		ID:        workspaceID,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		AgentName: "relayfile-cli",
+	}
+}
+
+func normalizeWorkspaceCommandRecord(record workspaceRecord, workspaceID string) workspaceRecord {
+	if strings.TrimSpace(record.ID) == "" {
+		record.ID = workspaceID
+	}
+	if strings.TrimSpace(record.Name) == "" {
+		record.Name = record.ID
+	}
+	if strings.TrimSpace(record.CreatedAt) == "" {
+		record.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	if strings.TrimSpace(record.AgentName) == "" {
+		record.AgentName = "relayfile-cli"
+	}
+	return record
+}
+
+func effectiveCommandScopes(record workspaceRecord, requestedScopes []string) []string {
+	if len(requestedScopes) > 0 {
+		return append([]string(nil), requestedScopes...)
+	}
+	if len(record.Scopes) > 0 {
+		return append([]string(nil), record.Scopes...)
+	}
+	return append([]string(nil), defaultJoinScopes...)
+}
+
+func (c *workspaceCommandClient) refreshFromCloud() error {
+	if c == nil {
+		return errors.New("workspace command client is nil")
+	}
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		return err
+	}
+	cloudCreds, err = refreshCloudCredentialsIfNeeded(cloudCreds)
+	if err != nil {
+		return err
+	}
+	joined, err := joinWorkspaceViaCloud(cloudCreds, c.workspaceID, c.record.AgentName, c.scopes)
+	if err != nil {
+		return err
+	}
+	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
+		c.workspaceID = joinedWorkspaceID
+	}
+	record := c.record
+	record.ID = c.workspaceID
+	record.Scopes = append([]string(nil), c.scopes...)
+	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir, false)
+	if err != nil {
+		return err
+	}
+	client, err := newAPIClient(strings.TrimRight(joined.RelayfileURL, "/"), joined.Token)
+	if err != nil {
+		return err
+	}
+	c.record = record
+	c.client = client
+	return nil
+}
+
+func (c *workspaceCommandClient) getWorkspaceBytes(ctx context.Context, pathForWorkspace func(string) string) ([]byte, string, error) {
+	body, contentType, err := c.client.getBytes(ctx, pathForWorkspace(c.workspaceID))
+	if err == nil || c.directToken || !isAPIAuthError(err) {
+		return body, contentType, err
+	}
+	if refreshErr := c.refreshFromCloud(); refreshErr != nil {
+		return body, contentType, err
+	}
+	return c.client.getBytes(ctx, pathForWorkspace(c.workspaceID))
+}
+
+func (c *workspaceCommandClient) getWorkspaceJSON(ctx context.Context, pathForWorkspace func(string) string, out any) error {
+	err := c.client.getJSON(ctx, pathForWorkspace(c.workspaceID), out)
+	if err == nil || c.directToken || !isAPIAuthError(err) {
+		return err
+	}
+	if refreshErr := c.refreshFromCloud(); refreshErr != nil {
+		return err
+	}
+	return c.client.getJSON(ctx, pathForWorkspace(c.workspaceID), out)
+}
+
+func isAPIAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var httpErr *apiError
+	return errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)
+}
+
 func runTree(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("tree", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -4071,33 +4306,22 @@ func runTree(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile tree [WORKSPACE] [PATH] [--depth N]")
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		return err
-	}
-	tokenValue := resolveToken(*token, creds)
-	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
-	if err != nil {
-		return err
-	}
-
 	remotePath := strings.TrimSpace(*pathFlag)
-	var workspaceID string
+	var workspaceValue string
 	switch fs.NArg() {
 	case 0:
-		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
 	case 1:
 		arg := strings.TrimSpace(fs.Arg(0))
 		if looksLikeRemotePathArg(arg) {
-			workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
 			remotePath = normalizeCLIPathArg(arg)
 		} else {
-			workspaceID, err = resolveWorkspaceIDWithToken(arg, tokenValue)
+			workspaceValue = arg
 		}
 	case 2:
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
 		remotePath = strings.TrimSpace(fs.Arg(1))
 	}
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
@@ -4111,11 +4335,13 @@ func runTree(args []string, stdout io.Writer) error {
 	query := url.Values{}
 	query.Set("path", remotePath)
 	query.Set("depth", strconv.Itoa(*depth))
-	body, _, err := client.getBytes(context.Background(), fmt.Sprintf("/v1/workspaces/%s/fs/tree?%s", url.PathEscape(workspaceID), query.Encode()))
+	body, _, err := commandClient.getWorkspaceBytes(context.Background(), func(workspaceID string) string {
+		return fmt.Sprintf("/v1/workspaces/%s/fs/tree?%s", url.PathEscape(workspaceID), query.Encode())
+	})
 	if err != nil {
 		return err
 	}
-	if _, err := upsertWorkspace(workspaceID); err != nil {
+	if _, err := upsertWorkspaceDetails(commandClient.record); err != nil {
 		return err
 	}
 	if *jsonOutput {
@@ -4228,25 +4454,15 @@ func runRead(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile read [WORKSPACE] PATH")
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		return err
-	}
-	tokenValue := resolveToken(*token, creds)
-	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
-	if err != nil {
-		return err
-	}
-
-	var workspaceID string
+	var workspaceValue string
 	var remotePath string
 	if fs.NArg() == 1 {
-		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
 		remotePath = strings.TrimSpace(fs.Arg(0))
 	} else {
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
 		remotePath = strings.TrimSpace(fs.Arg(1))
 	}
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
@@ -4256,11 +4472,13 @@ func runRead(args []string, stdout io.Writer) error {
 
 	query := url.Values{}
 	query.Set("path", remotePath)
-	body, _, err := client.getBytes(context.Background(), fmt.Sprintf("/v1/workspaces/%s/fs/file?%s", url.PathEscape(workspaceID), query.Encode()))
+	body, _, err := commandClient.getWorkspaceBytes(context.Background(), func(workspaceID string) string {
+		return fmt.Sprintf("/v1/workspaces/%s/fs/file?%s", url.PathEscape(workspaceID), query.Encode())
+	})
 	if err != nil {
 		return err
 	}
-	if _, err := upsertWorkspace(workspaceID); err != nil {
+	if _, err := upsertWorkspaceDetails(commandClient.record); err != nil {
 		return err
 	}
 	if *jsonOutput {
@@ -4380,29 +4598,22 @@ func runExport(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile export [WORKSPACE] --format FORMAT [--output FILE]")
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		return err
-	}
-	tokenValue := resolveToken(*token, creds)
-	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
-	if err != nil {
-		return err
-	}
-
-	workspaceID, err := resolveWorkspaceIDWithToken("", tokenValue)
+	workspaceValue := ""
 	if fs.NArg() == 1 {
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
 	}
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
-	path := fmt.Sprintf("/v1/workspaces/%s/fs/export?format=%s", url.PathEscape(workspaceID), url.QueryEscape(strings.ToLower(strings.TrimSpace(*format))))
-	body, _, err := client.getBytes(context.Background(), path)
+	exportFormat := url.QueryEscape(strings.ToLower(strings.TrimSpace(*format)))
+	body, _, err := commandClient.getWorkspaceBytes(context.Background(), func(workspaceID string) string {
+		return fmt.Sprintf("/v1/workspaces/%s/fs/export?format=%s", url.PathEscape(workspaceID), exportFormat)
+	})
 	if err != nil {
 		return err
 	}
-	if _, err := upsertWorkspace(workspaceID); err != nil {
+	if _, err := upsertWorkspaceDetails(commandClient.record); err != nil {
 		return err
 	}
 	if strings.TrimSpace(*output) == "" || strings.TrimSpace(*output) == "-" {
@@ -4432,24 +4643,18 @@ func runStatus(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile status [WORKSPACE] [--json]")
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		return err
-	}
-	tokenValue := resolveToken(*token, creds)
-	client, err := newAPIClient(resolveServer(*server, creds), tokenValue)
-	if err != nil {
-		return err
-	}
-
-	workspaceID, err := resolveWorkspaceIDWithToken("", tokenValue)
+	workspaceValue := ""
 	if fs.NArg() == 1 {
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
 	}
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
-	status, err := fetchWorkspaceSyncStatus(client, workspaceID)
+	var status syncStatusResponse
+	err = commandClient.getWorkspaceJSON(context.Background(), func(workspaceID string) string {
+		return fmt.Sprintf("/v1/workspaces/%s/sync/status", url.PathEscape(workspaceID))
+	}, &status)
 	if err != nil {
 		if isUnauthorizedAPIError(err) {
 			return ErrCloudRefreshExpired
@@ -4458,14 +4663,18 @@ func runStatus(args []string, stdout io.Writer) error {
 	}
 	var ingress *syncIngressStatusResponse
 	if statusNeedsIngressDiagnostics(status) {
-		if ingressStatus, err := fetchWorkspaceSyncIngressStatus(client, workspaceID); err == nil {
+		var ingressStatus syncIngressStatusResponse
+		if err := commandClient.getWorkspaceJSON(context.Background(), func(workspaceID string) string {
+			return fmt.Sprintf("/v1/workspaces/%s/sync/ingress", url.PathEscape(workspaceID))
+		}, &ingressStatus); err == nil {
 			ingress = &ingressStatus
 		}
 	}
-	if _, err := upsertWorkspace(workspaceID); err != nil {
+	record, err := upsertWorkspaceDetails(commandClient.record)
+	if err != nil {
 		return err
 	}
-	record, _ := workspaceRecordByID(workspaceID)
+	workspaceID := commandClient.workspaceID
 	persistedStallReason := readPersistedStallReason(record.LocalDir)
 	snapshot := buildSyncStateSnapshot(status, workspaceID, defaultMountMode, defaultMountInterval, record.LocalDir, readDaemonPID(record.LocalDir), persistedStallReason)
 	if *jsonOutput {
@@ -4797,37 +5006,26 @@ func runObserver(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile observer [WORKSPACE] [--no-open]")
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		if strings.TrimSpace(*token) == "" && strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")) == "" {
-			return err
-		}
-		creds = credentials{}
-	}
-	tokenValue := resolveToken(*token, creds)
-	if strings.TrimSpace(tokenValue) == "" {
-		return errors.New("token is required; run relayfile login or pass --token")
-	}
-	serverValue := resolveServer(*server, creds)
-	workspaceID, err := resolveWorkspaceIDWithToken("", tokenValue)
+	workspaceValue := ""
 	if fs.NArg() == 1 {
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
 	}
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
-	launchURL, err := buildObserverURL(*observerURL, serverValue, tokenValue, workspaceID)
+	launchURL, err := buildObserverURL(*observerURL, commandClient.client.baseURL, commandClient.client.token, commandClient.workspaceID)
 	if err != nil {
 		return err
 	}
-	if _, err := upsertWorkspace(workspaceID); err != nil {
+	if _, err := upsertWorkspaceDetails(commandClient.record); err != nil {
 		return err
 	}
 	if *noOpen {
 		fmt.Fprintln(stdout, launchURL)
 		return nil
 	}
-	fmt.Fprintf(stdout, "Opening observer for workspace %s\n", workspaceID)
+	fmt.Fprintf(stdout, "Opening observer for workspace %s\n", commandClient.workspaceID)
 	if err := openBrowser(launchURL); err != nil {
 		return fmt.Errorf("open observer: %w (rerun with --no-open to print the URL)", err)
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -167,6 +167,7 @@ func TestHelpFlagPrintsUsageForCommandsAndSubcommands(t *testing.T) {
 		{name: "login", args: []string{"login", "-h"}, want: "Usage: relayfile login"},
 		{name: "workspace group", args: []string{"workspace", "-h"}, want: "relayfile workspace create NAME"},
 		{name: "workspace create", args: []string{"workspace", "create", "-h"}, want: "Usage: relayfile workspace create NAME"},
+		{name: "workspace join", args: []string{"workspace", "join", "-h"}, want: "Usage: relayfile workspace join WORKSPACE_ID"},
 		{name: "workspace use", args: []string{"workspace", "use", "-h"}, want: "Usage: relayfile workspace use NAME"},
 		{name: "workspace list", args: []string{"workspace", "list", "-h"}, want: "Usage: relayfile workspace list"},
 		{name: "workspace current", args: []string{"workspace", "current", "-h"}, want: "Usage: relayfile workspace current"},
@@ -227,6 +228,20 @@ func TestHelpFlagPrintsUsageForCommandsAndSubcommands(t *testing.T) {
 	}
 }
 
+func TestWorkspaceRequiresSubcommandMentionsJoin(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var stdout bytes.Buffer
+	err := run([]string{"workspace"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected workspace without subcommand to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "create, join, use, list, current, or delete") {
+		t.Fatalf("workspace subcommand error = %q", got)
+	}
+}
+
 func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -245,6 +260,386 @@ func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "Default workspace set to ws_cloud") {
 		t.Fatalf("unexpected workspace use output: %q", got)
+	}
+}
+
+func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "http://placeholder.test",
+		AccessToken: "cld_access",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+
+	var seenJoin bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces/ws_cloud/join" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		seenJoin = true
+		if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+			t.Fatalf("unexpected join Authorization: %q", got)
+		}
+		var body cloudWorkspaceJoinRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode join body: %v", err)
+		}
+		if got, want := strings.Join(body.Scopes, ","), "relayfile:fs:read:*"; got != want {
+			t.Fatalf("join scopes = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"workspaceId":"ws_cloud","token":"rf_read","relayfileUrl":"https://relayfile.test"}`))
+	}))
+	defer server.Close()
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	cloudCreds.APIURL = server.URL
+	if err := saveCloudCredentials(cloudCreds); err != nil {
+		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "join", "ws_cloud", "--name", "cloud-prod", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace join failed: %v", err)
+	}
+	if !seenJoin {
+		t.Fatalf("expected cloud join call")
+	}
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	if creds.Token != "rf_read" || creds.Server != "https://relayfile.test" {
+		t.Fatalf("unexpected persisted credentials: %#v", creds)
+	}
+	record, ok := workspaceRecordByID("ws_cloud")
+	if !ok {
+		t.Fatalf("expected workspace catalog record")
+	}
+	if record.Name != "cloud-prod" || strings.Join(record.Scopes, ",") != "relayfile:fs:read:*" {
+		t.Fatalf("unexpected workspace record: %#v", record)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Joined workspace cloud-prod") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestTreeJoinsCloudWorkspaceWithoutServerCredentials(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "http://placeholder.test",
+		AccessToken: "cld_access",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:      "cloud-prod",
+		ID:        "ws_cloud",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		AgentName: "relayfile-cli",
+		Scopes:    append([]string(nil), defaultJoinScopes...),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	var joinCount int
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_cloud/join":
+			joinCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+				t.Fatalf("unexpected join Authorization: %q", got)
+			}
+			var body cloudWorkspaceJoinRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode join body: %v", err)
+			}
+			if got, want := strings.Join(body.Scopes, ","), "relayfile:fs:read:*"; got != want {
+				t.Fatalf("join scopes = %q, want %q", got, want)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case "/v1/workspaces/rw_cloud/fs/tree":
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected tree Authorization: %q", got)
+			}
+			if got := r.URL.Query().Get("path"); got != "/google-mail" {
+				t.Fatalf("unexpected tree path: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"path":"/google-mail","entries":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	cloudCreds.APIURL = server.URL
+	if err := saveCloudCredentials(cloudCreds); err != nil {
+		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"tree", "ws_cloud", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run tree failed: %v", err)
+	}
+	if joinCount != 1 {
+		t.Fatalf("expected 1 join, got %d", joinCount)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Tree /google-mail") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "http://placeholder.test",
+		AccessToken: "cld_access",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	oldToken := testJWTWithWorkspaceAndAgent("ws_cloud", "old")
+	if err := saveCredentials(credentials{
+		Server: "http://placeholder.test",
+		Token:  oldToken,
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:      "cloud-prod",
+		ID:        "ws_cloud",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		AgentName: "relayfile-cli",
+		Scopes:    append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("cloud-prod"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+
+	var joinCount int
+	var treeCount int
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_cloud/join":
+			joinCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_new","relayfileUrl":"` + server.URL + `"}`))
+		case "/v1/workspaces/ws_cloud/fs/tree":
+			treeCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer "+oldToken {
+				t.Fatalf("expected first tree to use old token, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Token has expired"}`))
+		case "/v1/workspaces/rw_cloud/fs/tree":
+			treeCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_new" {
+				t.Fatalf("unexpected refreshed tree Authorization: %q", got)
+			}
+			if got := r.URL.Query().Get("path"); got != "/google-mail" {
+				t.Fatalf("unexpected tree path: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"path":"/google-mail","entries":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	creds.Server = server.URL
+	if err := saveCredentials(creds); err != nil {
+		t.Fatalf("saveCredentials(server URL) failed: %v", err)
+	}
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	cloudCreds.APIURL = server.URL
+	if err := saveCloudCredentials(cloudCreds); err != nil {
+		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"tree", "cloud-prod", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run tree failed: %v", err)
+	}
+	if joinCount != 1 || treeCount != 2 {
+		t.Fatalf("joinCount/treeCount = %d/%d, want 1/2", joinCount, treeCount)
+	}
+	record, ok := workspaceRecordByName("cloud-prod")
+	if !ok {
+		t.Fatalf("expected refreshed workspace catalog record")
+	}
+	if record.ID != "rw_cloud" {
+		t.Fatalf("workspace record ID = %q, want rw_cloud", record.ID)
+	}
+	if record.Server != server.URL {
+		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)
+	}
+	if record.CloudAPIURL != server.URL {
+		t.Fatalf("workspace record CloudAPIURL = %q, want %q", record.CloudAPIURL, server.URL)
+	}
+	if record.LastUsedAt == "" {
+		t.Fatal("workspace record LastUsedAt was not refreshed")
+	}
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		t.Fatalf("loadWorkspaceCatalog failed: %v", err)
+	}
+	if catalog.Default != "cloud-prod" {
+		t.Fatalf("default workspace = %q, want cloud-prod", catalog.Default)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Tree /google-mail") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "http://placeholder.test",
+		AccessToken: "cld_access",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	oldToken := testJWTWithWorkspaceAndAgent("ws_cloud", "old")
+	if err := saveCredentials(credentials{
+		Server: "http://placeholder.test",
+		Token:  oldToken,
+	}); err != nil {
+		t.Fatalf("saveCredentials failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:      "cloud-prod",
+		ID:        "ws_cloud",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		AgentName: "relayfile-cli",
+		Scopes:    append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:      "other-prod",
+		ID:        "ws_other",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails(other) failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("other-prod"); err != nil {
+		t.Fatalf("setDefaultWorkspace(other) failed: %v", err)
+	}
+
+	var readCount int
+	var joinCount int
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_cloud/join":
+			joinCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+				t.Fatalf("unexpected join Authorization: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_new","relayfileUrl":"` + server.URL + `"}`))
+		case "/v1/workspaces/ws_cloud/fs/file":
+			readCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer "+oldToken {
+				t.Fatalf("expected first read to use old token, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Token has expired"}`))
+			return
+		case "/v1/workspaces/rw_cloud/fs/file":
+			readCount++
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_new" {
+				t.Fatalf("unexpected refreshed read Authorization: %q", got)
+			}
+			if got := r.URL.Query().Get("path"); got != "/google-mail/msg.json" {
+				t.Fatalf("unexpected read path: %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"path":"/google-mail/msg.json","revision":"1","contentType":"application/json","content":"ok"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	creds, err := loadCredentials()
+	if err != nil {
+		t.Fatalf("loadCredentials failed: %v", err)
+	}
+	creds.Server = server.URL
+	if err := saveCredentials(creds); err != nil {
+		t.Fatalf("saveCredentials(server URL) failed: %v", err)
+	}
+	cloudCreds, err := loadCloudCredentials()
+	if err != nil {
+		t.Fatalf("loadCloudCredentials failed: %v", err)
+	}
+	cloudCreds.APIURL = server.URL
+	if err := saveCloudCredentials(cloudCreds); err != nil {
+		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"read", "cloud-prod", "/google-mail/msg.json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run read failed: %v", err)
+	}
+	if joinCount != 1 || readCount != 2 {
+		t.Fatalf("joinCount/readCount = %d/%d, want 1/2", joinCount, readCount)
+	}
+	record, ok := workspaceRecordByName("cloud-prod")
+	if !ok {
+		t.Fatalf("expected refreshed workspace catalog record")
+	}
+	if record.ID != "rw_cloud" {
+		t.Fatalf("workspace record ID = %q, want rw_cloud", record.ID)
+	}
+	if record.Server != server.URL {
+		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)
+	}
+	if record.CloudAPIURL != server.URL {
+		t.Fatalf("workspace record CloudAPIURL = %q, want %q", record.CloudAPIURL, server.URL)
+	}
+	if record.LastUsedAt == "" {
+		t.Fatal("workspace record LastUsedAt was not refreshed")
+	}
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		t.Fatalf("loadWorkspaceCatalog failed: %v", err)
+	}
+	if catalog.Default != "other-prod" {
+		t.Fatalf("default workspace = %q, want other-prod", catalog.Default)
+	}
+	if got := stdout.String(); got != "ok" {
+		t.Fatalf("unexpected stdout: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `relayfile workspace join WORKSPACE_ID` with read-only inspect scopes by default and `--write` for read/write tokens
- let inspect commands (`tree`, `read`, `export`, `status`, `observer`) mint/refresh Cloud workspace tokens when only Cloud credentials are present
- retry inspect requests once on 401/403 by rejoining through Cloud, including app-workspace UUID -> canonical Relayfile workspace ID remapping
- avoid changing the default workspace during command-triggered token refresh; explicit setup/login/join flows still select the workspace

Fixes #211. Companion Cloud PR: AgentWorkforce/cloud#1248.

## Tests
- `go test ./...`
- `git diff --check`

## Review hardening
- Added a combined stale-token `tree <cloud-workspace-id> /google-mail` regression covering Cloud rejoin and canonical `rw_*` retry.
- Added coverage that command refresh updates the catalog token/workspace ID without switching an unrelated default workspace.