### PR TITLE
Preserve selected workspace during integration connect

### DIFF
--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-21T13:20:34.829Z",
+  "lastUpdated": "2026-05-28T07:49:59.646Z",
   "trajectories": {
     "traj_mfyus7zfgxt2": {
       "title": "062-sdk-setup-client-workflow",
@@ -277,6 +277,13 @@
       "startedAt": "2026-05-21T13:14:23.504Z",
       "completedAt": "2026-05-21T13:20:34.729Z",
       "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile-issues-188-189/.trajectories/completed/2026-05/traj_eud9obtnr1br.json"
+    },
+    "traj_0meitjjmvpf2": {
+      "title": "Address relayfile PR 215 feedback",
+      "status": "completed",
+      "startedAt": "2026-05-28T07:48:35.401Z",
+      "completedAt": "2026-05-28T07:49:59.552Z",
+      "path": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile-issue-214/.trajectories/completed/2026-05/traj_0meitjjmvpf2.json"
     }
   }
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1444,7 +1444,7 @@ func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinRes
 	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
 		if strings.TrimSpace(record.ID) == "" {
 			record.ID = joinedWorkspaceID
-		} else if joinedWorkspaceID != strings.TrimSpace(record.ID) {
+		} else {
 			record.RelayWorkspaceID = joinedWorkspaceID
 		}
 	}
@@ -4259,11 +4259,14 @@ func (c *workspaceCommandClient) refreshFromCloud() error {
 	if err != nil {
 		return err
 	}
+	requestedWorkspaceID := c.workspaceID
 	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
 		c.workspaceID = joinedWorkspaceID
 	}
 	record := c.record
-	record.ID = c.workspaceID
+	if strings.TrimSpace(record.ID) == "" {
+		record.ID = strings.TrimSpace(requestedWorkspaceID)
+	}
 	record.Scopes = append([]string(nil), c.scopes...)
 	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir, false)
 	if err != nil {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -72,16 +72,17 @@ type workspaceCatalog struct {
 }
 
 type workspaceRecord struct {
-	Name        string   `json:"name"`
-	ID          string   `json:"id,omitempty"`
-	CreatedAt   string   `json:"createdAt"`
-	LastUsedAt  string   `json:"lastUsedAt,omitempty"`
-	LocalDir    string   `json:"localDir,omitempty"`
-	Server      string   `json:"server,omitempty"`
-	CloudAPIURL string   `json:"cloudApiUrl,omitempty"`
-	AgentName   string   `json:"agentName,omitempty"`
-	Scopes      []string `json:"scopes,omitempty"`
-	Timezone    string   `json:"timezone,omitempty"`
+	Name             string   `json:"name"`
+	ID               string   `json:"id,omitempty"`
+	RelayWorkspaceID string   `json:"relayWorkspaceId,omitempty"`
+	CreatedAt        string   `json:"createdAt"`
+	LastUsedAt       string   `json:"lastUsedAt,omitempty"`
+	LocalDir         string   `json:"localDir,omitempty"`
+	Server           string   `json:"server,omitempty"`
+	CloudAPIURL      string   `json:"cloudApiUrl,omitempty"`
+	AgentName        string   `json:"agentName,omitempty"`
+	Scopes           []string `json:"scopes,omitempty"`
+	Timezone         string   `json:"timezone,omitempty"`
 }
 
 type apiClient struct {
@@ -1441,7 +1442,11 @@ func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinRes
 		return workspaceRecord{}, err
 	}
 	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
-		record.ID = joinedWorkspaceID
+		if strings.TrimSpace(record.ID) == "" {
+			record.ID = joinedWorkspaceID
+		} else if joinedWorkspaceID != strings.TrimSpace(record.ID) {
+			record.RelayWorkspaceID = joinedWorkspaceID
+		}
 	}
 	record.Server = serverURL
 	record.LocalDir = localDir
@@ -1465,6 +1470,16 @@ func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinRes
 		return workspaceRecord{}, err
 	}
 	return persisted, nil
+}
+
+func relayWorkspaceIDForRecord(record workspaceRecord, joined cloudWorkspaceJoinResponse) string {
+	if relayID := strings.TrimSpace(joined.WorkspaceID); relayID != "" {
+		return relayID
+	}
+	if relayID := strings.TrimSpace(record.RelayWorkspaceID); relayID != "" {
+		return relayID
+	}
+	return strings.TrimSpace(record.ID)
 }
 
 func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string, scopes []string) (cloudWorkspaceJoinResponse, error) {
@@ -2015,6 +2030,10 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err != nil {
 		return err
 	}
+	relayWorkspaceID := relayWorkspaceIDForRecord(record, joined)
+	if relayWorkspaceID != "" && relayWorkspaceID != record.ID {
+		fmt.Fprintf(stdout, "Workspace: %s (Relayfile runtime: %s)\n", record.ID, relayWorkspaceID)
+	}
 	// Atlassian-family providers: a single OAuth grant can cover multiple
 	// sites (cloudIds). Cloud's Jira/Confluence sync bails with a clear
 	// error if `metadata.cloudId` is unset and the grant has >1 site.
@@ -2027,7 +2046,7 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 			return err
 		}
 	}
-	return waitForInitialSync(joined.RelayfileURL, joined.Token, record.ID, provider, record.LocalDir, *timeout, stdout)
+	return waitForInitialSync(joined.RelayfileURL, joined.Token, relayWorkspaceID, provider, record.LocalDir, *timeout, stdout)
 }
 
 func isAtlassianProvider(provider string) bool {
@@ -2374,6 +2393,10 @@ func runIntegrationList(args []string, stdout io.Writer) error {
 	}
 	if *jsonOutput {
 		return writeJSON(stdout, entries)
+	}
+	relayWorkspaceID := relayWorkspaceIDForRecord(record, joined)
+	if relayWorkspaceID != "" && relayWorkspaceID != record.ID {
+		fmt.Fprintf(stdout, "Workspace: %s (Relayfile runtime: %s)\n", record.ID, relayWorkspaceID)
 	}
 	if len(entries) == 0 {
 		fmt.Fprintln(stdout, "No integrations connected")
@@ -5580,6 +5603,9 @@ func mergeWorkspaceRecords(current, update workspaceRecord) workspaceRecord {
 	if update.ID != "" {
 		merged.ID = update.ID
 	}
+	if update.RelayWorkspaceID != "" {
+		merged.RelayWorkspaceID = update.RelayWorkspaceID
+	}
 	if update.CreatedAt != "" {
 		merged.CreatedAt = update.CreatedAt
 	}
@@ -5628,7 +5654,7 @@ func workspaceRecordByID(id string) (workspaceRecord, bool) {
 	}
 	id = strings.TrimSpace(id)
 	for _, record := range catalog.Workspaces {
-		if record.ID == id {
+		if record.ID == id || record.RelayWorkspaceID == id {
 			return record, true
 		}
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -493,8 +493,11 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 	if !ok {
 		t.Fatalf("expected refreshed workspace catalog record")
 	}
-	if record.ID != "rw_cloud" {
-		t.Fatalf("workspace record ID = %q, want rw_cloud", record.ID)
+	if record.ID != "ws_cloud" {
+		t.Fatalf("workspace record ID = %q, want ws_cloud", record.ID)
+	}
+	if record.RelayWorkspaceID != "rw_cloud" {
+		t.Fatalf("relay workspace ID = %q, want rw_cloud", record.RelayWorkspaceID)
 	}
 	if record.Server != server.URL {
 		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)
@@ -619,8 +622,11 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected refreshed workspace catalog record")
 	}
-	if record.ID != "rw_cloud" {
-		t.Fatalf("workspace record ID = %q, want rw_cloud", record.ID)
+	if record.ID != "ws_cloud" {
+		t.Fatalf("workspace record ID = %q, want ws_cloud", record.ID)
+	}
+	if record.RelayWorkspaceID != "rw_cloud" {
+		t.Fatalf("relay workspace ID = %q, want rw_cloud", record.RelayWorkspaceID)
 	}
 	if record.Server != server.URL {
 		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -4412,3 +4412,64 @@ func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
 		t.Fatalf("integration connect github failed: %v", err)
 	}
 }
+
+func TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForSync(t *testing.T) {
+	record, _ := setupAdoptWorkspace(t)
+	record.ID = "50587328-441d-4acb-b8f3-dbe1b3c5de99"
+	if _, err := upsertWorkspaceDetails(record); err != nil {
+		t.Fatalf("upsert app workspace record failed: %v", err)
+	}
+
+	var server *httptest.Server
+	seen := map[string]int{}
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		seen[r.URL.Path]++
+		switch r.URL.Path {
+		case "/api/v1/auth/token/refresh":
+			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
+		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/join":
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_7ccfea89","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/connect-session":
+			_, _ = w.Write([]byte(`{"connectionId":"conn_slack","connectLink":"","backend":"nango"}`))
+		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/slack/status":
+			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"slack","backend":"nango"}`))
+		case "/v1/workspaces/rw_7ccfea89/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_7ccfea89","providers":[{"provider":"slack","status":"ready","lagSeconds":0}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+
+	var stdout bytes.Buffer
+	if err := run([]string{
+		"integration", "connect", "slack",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--no-open",
+		"--timeout", "5s",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration connect slack failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if seen["/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/connect-session"] != 1 {
+		t.Fatalf("connect-session did not use selected app workspace; seen=%v", seen)
+	}
+	if seen["/v1/workspaces/rw_7ccfea89/sync/status"] == 0 {
+		t.Fatalf("sync wait did not use joined relay workspace; seen=%v", seen)
+	}
+	persisted, ok := workspaceRecordByName("demo")
+	if !ok {
+		t.Fatal("expected persisted workspace record")
+	}
+	if persisted.ID != "50587328-441d-4acb-b8f3-dbe1b3c5de99" {
+		t.Fatalf("workspace ID = %q, want selected app workspace", persisted.ID)
+	}
+	if persisted.RelayWorkspaceID != "rw_7ccfea89" {
+		t.Fatalf("relay workspace ID = %q, want rw_7ccfea89", persisted.RelayWorkspaceID)
+	}
+	if !strings.Contains(stdout.String(), "Relayfile runtime: rw_7ccfea89") {
+		t.Fatalf("expected explicit runtime workspace output, got %q", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve the active/`--workspace` id as the Cloud integration route target instead of overwriting it with the joined Relayfile `rw_*` id.
- Store the joined runtime workspace separately as `relayWorkspaceId` and use it for Relayfile sync readiness waits.
- Surface the bound runtime workspace in human output when it differs from the selected workspace.

Fixes #214. Companion PRs: AgentWorkforce/cloud#1295 and AgentWorkforce/workforce#154.

## Verification
- `go test ./cmd/relayfile-cli -run 'TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForSync|TestIntegrationConnectNonAtlassianSkipsPicker'`
- `go test ./...`
