### PR TITLE
Add private mount state directory support

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3834,6 +3834,8 @@ func runMount(args []string) error {
 	remotePath := fs.String("remote-path", envOrDefault("RELAYFILE_REMOTE_PATH", "/"), "remote root path")
 	eventProvider := fs.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	stateFile := fs.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
+	stateDir := fs.String("state-dir", envOrDefault("RELAYFILE_MOUNT_STATE_DIR", mountsync.DefaultMountStateDir()), "directory for private mount state")
+	mountKind := fs.String("mount-kind", envOrDefault("RELAYFILE_MOUNT_KIND", mountsync.MountKindDaemon), "private state identity kind: daemon, flush, or initial-sync")
 	localDirFlag := fs.String("local-dir", "", "local mirror directory")
 	mode := fs.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", defaultMountMode), "mount mode: poll (recommended) or fuse")
 	interval := fs.Duration("interval", durationEnv("RELAYFILE_MOUNT_INTERVAL", defaultMountInterval), "sync interval")
@@ -3859,6 +3861,8 @@ func runMount(args []string) error {
 		"remote-path":         true,
 		"provider":            true,
 		"state-file":          true,
+		"state-dir":           true,
+		"mount-kind":          true,
 		"mode":                true,
 		"interval":            true,
 		"interval-jitter":     true,
@@ -4061,6 +4065,9 @@ func runMount(args []string) error {
 		EventProvider:      strings.TrimSpace(*eventProvider),
 		LocalRoot:          absLocalDir,
 		StateFile:          strings.TrimSpace(*stateFile),
+		StateDir:           strings.TrimSpace(*stateDir),
+		MountKind:          strings.TrimSpace(*mountKind),
+		ValidateState:      true,
 		WebSocket:          boolPtr(*websocketEnabled),
 		LowMemory:          boolPtr(*lowMemory),
 		RootCtx:            rootCtx,
@@ -4149,6 +4156,8 @@ Common flags:
                        hard cap for initial/full-tree bootstrap (0 = progress-based)
   --cursor-timeout 20s timeout for events-cursor resolution
   --full-reconcile     force one full reconcile regardless of bootstrap state
+  --state-dir DIR      private mount state directory (default $HOME/.relayfile-mount-state)
+  --state-file FILE    exact private state file override; wins over --state-dir
   --rehome             allow moving an already-registered mirror to a new LOCAL_DIR
   --no-websocket       disable websocket event streaming
   --low-memory         skip detailed per-file public state and defer content reads

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -300,6 +300,8 @@ func TestA13MountHelpListsSyncedMirrorLimitations(t *testing.T) {
 		"Directory listings can briefly omit",
 		"inotify/fsevents",
 		"--mode poll|fuse",
+		"--state-dir DIR",
+		"--state-file FILE",
 	} {
 		if !strings.Contains(got, fragment) {
 			t.Fatalf("expected mount --help to contain %q, got:\n%s", fragment, got)

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -40,6 +40,8 @@ type mountConfig struct {
 	eventProvider    string
 	localDir         string
 	stateFile        string
+	stateDir         string
+	mountKind        string
 	interval         time.Duration
 	intervalJitter   float64
 	timeout          time.Duration
@@ -73,6 +75,8 @@ func main() {
 	eventProvider := flag.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	localDir := flag.String("local-dir", strings.TrimSpace(os.Getenv("RELAYFILE_LOCAL_DIR")), "local mirror directory")
 	stateFile := flag.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
+	stateDir := flag.String("state-dir", envOrDefault("RELAYFILE_MOUNT_STATE_DIR", mountsync.DefaultMountStateDir()), "directory for private mount state")
+	mountKind := flag.String("mount-kind", envOrDefault("RELAYFILE_MOUNT_KIND", mountsync.MountKindDaemon), "private state identity kind: daemon, flush, or initial-sync")
 	interval := flag.Duration("interval", durationEnv("RELAYFILE_MOUNT_INTERVAL", 30*time.Second), "sync interval")
 	intervalJitter := flag.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := flag.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
@@ -128,6 +132,8 @@ func main() {
 		eventProvider:    strings.TrimSpace(*eventProvider),
 		localDir:         *localDir,
 		stateFile:        *stateFile,
+		stateDir:         *stateDir,
+		mountKind:        *mountKind,
 		interval:         *interval,
 		intervalJitter:   *intervalJitter,
 		timeout:          *timeout,
@@ -215,7 +221,7 @@ func runScopedPollingMountsWithRunner(
 		scoped.remotePath = remotePath
 		scoped.remotePaths = nil
 		scoped.localDir = scopedLocalDir(cfg.localDir, remotePath)
-		scoped.stateFile = scopedStateFile(cfg.stateFile, remotePath)
+		scoped.stateFile = cfg.stateFile
 		if err := os.MkdirAll(scoped.localDir, 0o755); err != nil {
 			return fmt.Errorf("create scoped local dir for %s: %w", remotePath, err)
 		}
@@ -294,6 +300,9 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 		EventProvider:      cfg.eventProvider,
 		LocalRoot:          cfg.localDir,
 		StateFile:          cfg.stateFile,
+		StateDir:           cfg.stateDir,
+		MountKind:          cfg.mountKind,
+		ValidateState:      true,
 		Scopes:             cfg.scopes,
 		WebSocket:          boolPtr(cfg.websocketEnabled),
 		RootCtx:            rootCtx,
@@ -455,23 +464,6 @@ func scopedLocalDir(localRoot, remotePath string) string {
 		return localRoot
 	}
 	return filepath.Join(localRoot, filepath.FromSlash(strings.TrimPrefix(remotePath, "/")))
-}
-
-func scopedStateFile(stateFile, remotePath string) string {
-	if strings.TrimSpace(stateFile) == "" {
-		return ""
-	}
-	remotePath = normalizeMountRemotePath(remotePath)
-	if remotePath == "/" {
-		return stateFile
-	}
-	ext := filepath.Ext(stateFile)
-	base := strings.TrimSuffix(stateFile, ext)
-	suffix := strings.NewReplacer("/", "-", "\\", "-", ":", "-").Replace(strings.Trim(remotePath, "/"))
-	if suffix == "" {
-		suffix = "root"
-	}
-	return base + "-" + suffix + ext
 }
 
 // readBootstrapProgress reads the in-progress bootstrap block from the

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -211,6 +211,9 @@ func runScopedPollingMountsWithRunner(
 	}
 	scopedMounts := make([]scopedMount, 0, len(remotePaths))
 	seen := map[string]struct{}{}
+	if len(remotePaths) > 1 && strings.TrimSpace(cfg.stateFile) != "" {
+		return fmt.Errorf("--state-file cannot be shared across multiple scoped mounts; use --state-dir instead")
+	}
 	for _, remotePath := range remotePaths {
 		remotePath := normalizeMountRemotePath(remotePath)
 		if _, ok := seen[remotePath]; ok {

--- a/cmd/relayfile-mount/main_test.go
+++ b/cmd/relayfile-mount/main_test.go
@@ -248,6 +248,61 @@ func TestScopedLocalDirKeepsProviderPrefixUnderMountRoot(t *testing.T) {
 	}
 }
 
+func TestRunScopedPollingMountsKeepsSharedStateDirForHashResolver(t *testing.T) {
+	stateDir := t.TempDir()
+	var got []mountConfig
+
+	err := runScopedPollingMountsWithRunner(
+		context.Background(),
+		mountConfig{localDir: t.TempDir(), stateDir: stateDir},
+		[]string{"/github", "/slack"},
+		func(_ context.Context, cfg mountConfig) error {
+			got = append(got, cfg)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runScopedPollingMountsWithRunner returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 scoped mounts, got %d", len(got))
+	}
+	for _, cfg := range got {
+		if cfg.stateDir != stateDir {
+			t.Fatalf("expected state dir %q, got %q", stateDir, cfg.stateDir)
+		}
+		if cfg.stateFile != "" {
+			t.Fatalf("expected state-file to stay empty so mountsync derives hashed path, got %q", cfg.stateFile)
+		}
+	}
+}
+
+func TestRunScopedPollingMountsKeepsExactStateFileOverride(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	var got []mountConfig
+
+	err := runScopedPollingMountsWithRunner(
+		context.Background(),
+		mountConfig{localDir: t.TempDir(), stateDir: t.TempDir(), stateFile: stateFile},
+		[]string{"/github", "/slack"},
+		func(_ context.Context, cfg mountConfig) error {
+			got = append(got, cfg)
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runScopedPollingMountsWithRunner returned error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 scoped mounts, got %d", len(got))
+	}
+	for _, cfg := range got {
+		if cfg.stateFile != stateFile {
+			t.Fatalf("expected exact state-file override %q, got %q", stateFile, cfg.stateFile)
+		}
+	}
+}
+
 func TestRunScopedPollingMountsCancelsSiblingsOnFirstError(t *testing.T) {
 	wantErr := errors.New("boom")
 	var canceled atomic.Bool

--- a/cmd/relayfile-mount/main_test.go
+++ b/cmd/relayfile-mount/main_test.go
@@ -277,29 +277,23 @@ func TestRunScopedPollingMountsKeepsSharedStateDirForHashResolver(t *testing.T) 
 	}
 }
 
-func TestRunScopedPollingMountsKeepsExactStateFileOverride(t *testing.T) {
+func TestRunScopedPollingMountsRejectsSharedExactStateFileOverride(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.json")
-	var got []mountConfig
 
 	err := runScopedPollingMountsWithRunner(
 		context.Background(),
 		mountConfig{localDir: t.TempDir(), stateDir: t.TempDir(), stateFile: stateFile},
 		[]string{"/github", "/slack"},
 		func(_ context.Context, cfg mountConfig) error {
-			got = append(got, cfg)
+			t.Fatalf("runner should not start with shared state-file override: %+v", cfg)
 			return nil
 		},
 	)
-	if err != nil {
-		t.Fatalf("runScopedPollingMountsWithRunner returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected shared state-file override to be rejected")
 	}
-	if len(got) != 2 {
-		t.Fatalf("expected 2 scoped mounts, got %d", len(got))
-	}
-	for _, cfg := range got {
-		if cfg.stateFile != stateFile {
-			t.Fatalf("expected exact state-file override %q, got %q", stateFile, cfg.stateFile)
-		}
+	if !strings.Contains(err.Error(), "use --state-dir") {
+		t.Fatalf("expected state-dir guidance, got %v", err)
 	}
 }
 
@@ -312,7 +306,7 @@ func TestRunScopedPollingMountsCancelsSiblingsOnFirstError(t *testing.T) {
 
 	err := runScopedPollingMountsWithRunner(
 		context.Background(),
-		mountConfig{localDir: t.TempDir(), stateFile: filepath.Join(t.TempDir(), "state.json")},
+		mountConfig{localDir: t.TempDir(), stateDir: t.TempDir()},
 		[]string{"/github", "/slack"},
 		func(ctx context.Context, cfg mountConfig) error {
 			started <- cfg.remotePath

--- a/cmd/relayfile-mount/main_test.go
+++ b/cmd/relayfile-mount/main_test.go
@@ -250,6 +250,7 @@ func TestScopedLocalDirKeepsProviderPrefixUnderMountRoot(t *testing.T) {
 
 func TestRunScopedPollingMountsKeepsSharedStateDirForHashResolver(t *testing.T) {
 	stateDir := t.TempDir()
+	var gotMu sync.Mutex
 	var got []mountConfig
 
 	err := runScopedPollingMountsWithRunner(
@@ -257,6 +258,8 @@ func TestRunScopedPollingMountsKeepsSharedStateDirForHashResolver(t *testing.T) 
 		mountConfig{localDir: t.TempDir(), stateDir: stateDir},
 		[]string{"/github", "/slack"},
 		func(_ context.Context, cfg mountConfig) error {
+			gotMu.Lock()
+			defer gotMu.Unlock()
 			got = append(got, cfg)
 			return nil
 		},

--- a/internal/mountsync/state_path.go
+++ b/internal/mountsync/state_path.go
@@ -1,0 +1,273 @@
+package mountsync
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	DefaultMountStateDirName  = ".relayfile-mount-state"
+	LegacyMountStateFileName  = ".relayfile-mount-state.json"
+	defaultPrivateStateFile   = "state.json"
+	MountKindDaemon           = "daemon"
+	MountKindFlush            = "flush"
+	MountKindInitialSync      = "initial-sync"
+	maxStatePathLength        = 1024
+	maxStatePathComponentSize = 255
+)
+
+type MountStatePathOptions struct {
+	WorkspaceID      string
+	RemoteRoot       string
+	LocalRoot        string
+	StateFile        string
+	StateDir         string
+	MountKind        string
+	ValidateOutside  bool
+	ScopedLocalRoots []string
+}
+
+type MountStatePath struct {
+	StateFile string
+	StateDir  string
+	MountID   string
+	Kind      string
+	Override  bool
+}
+
+func DefaultMountStateDir() string {
+	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		return filepath.Join(home, DefaultMountStateDirName)
+	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		return filepath.Join(home, DefaultMountStateDirName)
+	}
+	return filepath.Join(os.TempDir(), DefaultMountStateDirName)
+}
+
+func ResolveMountStatePath(opts MountStatePathOptions) (MountStatePath, error) {
+	localRoot := filepath.Clean(strings.TrimSpace(opts.LocalRoot))
+	if localRoot == "" || localRoot == "." {
+		return MountStatePath{}, fmt.Errorf("local root is required")
+	}
+	kind := NormalizeMountKind(opts.MountKind)
+	stateFile := strings.TrimSpace(opts.StateFile)
+	if stateFile != "" {
+		cleaned, err := cleanAbsolutePath(stateFile)
+		if err != nil {
+			return MountStatePath{}, fmt.Errorf("state file: %w", err)
+		}
+		if opts.ValidateOutside {
+			if err := validatePrivateStatePath(cleaned, localRoot, opts.ScopedLocalRoots); err != nil {
+				return MountStatePath{}, err
+			}
+		}
+		return MountStatePath{
+			StateFile: cleaned,
+			StateDir:  filepath.Dir(cleaned),
+			Kind:      kind,
+			Override:  true,
+		}, nil
+	}
+
+	stateDir := strings.TrimSpace(opts.StateDir)
+	if stateDir == "" {
+		stateDir = DefaultMountStateDir()
+	}
+	cleanDir, err := cleanAbsolutePath(stateDir)
+	if err != nil {
+		return MountStatePath{}, fmt.Errorf("state dir: %w", err)
+	}
+	mountID := MountStateID(opts.WorkspaceID, opts.RemoteRoot, localRoot, kind)
+	resolved := filepath.Join(cleanDir, mountID, defaultPrivateStateFile)
+	if opts.ValidateOutside {
+		if err := validatePrivateStatePath(resolved, localRoot, opts.ScopedLocalRoots); err != nil {
+			return MountStatePath{}, err
+		}
+	}
+	return MountStatePath{
+		StateFile: resolved,
+		StateDir:  cleanDir,
+		MountID:   mountID,
+		Kind:      kind,
+	}, nil
+}
+
+func NormalizeMountKind(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case MountKindFlush:
+		return MountKindFlush
+	case MountKindInitialSync:
+		return MountKindInitialSync
+	default:
+		return MountKindDaemon
+	}
+}
+
+func MountStateID(workspaceID, remoteRoot, localRoot, mountKind string) string {
+	input := strings.Join([]string{
+		strings.TrimSpace(workspaceID),
+		normalizeRemotePath(remoteRoot),
+		filepath.Clean(strings.TrimSpace(localRoot)),
+		NormalizeMountKind(mountKind),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])[:32]
+}
+
+func QuarantineLegacyMountState(localRoot, stateDir string) ([]string, error) {
+	localRoot = filepath.Clean(strings.TrimSpace(localRoot))
+	if localRoot == "" || localRoot == "." {
+		return nil, nil
+	}
+	stateDir = strings.TrimSpace(stateDir)
+	if stateDir == "" {
+		stateDir = DefaultMountStateDir()
+	}
+	stateDirAbs, err := cleanAbsolutePath(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	quarantineDir := filepath.Join(stateDirAbs, "quarantine")
+	candidates, err := legacyStateCandidates(localRoot)
+	if err != nil {
+		return nil, err
+	}
+	moved := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		info, err := os.Lstat(candidate)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return moved, err
+		}
+		if info.IsDir() {
+			continue
+		}
+		if err := os.MkdirAll(quarantineDir, 0o700); err != nil {
+			return moved, err
+		}
+		target := filepath.Join(quarantineDir, filepath.Base(localRoot)+"-"+filepath.Base(candidate))
+		target = uniqueQuarantinePath(target)
+		if err := os.Rename(candidate, target); err != nil {
+			return moved, err
+		}
+		moved = append(moved, target)
+	}
+	return moved, nil
+}
+
+func legacyStateCandidates(localRoot string) ([]string, error) {
+	entries, err := os.ReadDir(localRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var candidates []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == LegacyMountStateFileName ||
+			strings.HasPrefix(name, LegacyMountStateFileName+".tmp-") ||
+			strings.HasPrefix(name, "."+LegacyMountStateFileName+".tmp-") {
+			candidates = append(candidates, filepath.Join(localRoot, name))
+		}
+	}
+	return candidates, nil
+}
+
+func uniqueQuarantinePath(path string) string {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
+		return path
+	}
+	ext := filepath.Ext(path)
+	base := strings.TrimSuffix(path, ext)
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s-%d%s", base, i, ext)
+		if _, err := os.Lstat(candidate); os.IsNotExist(err) {
+			return candidate
+		}
+	}
+}
+
+func cleanAbsolutePath(path string) (string, error) {
+	if hasControlCharacter(path) {
+		return "", fmt.Errorf("contains control characters")
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func validatePrivateStatePath(statePath, localRoot string, extraRoots []string) error {
+	statePath = filepath.Clean(statePath)
+	if !filepath.IsAbs(statePath) {
+		return fmt.Errorf("state path must be absolute")
+	}
+	if len(statePath) > maxStatePathLength {
+		return fmt.Errorf("state path exceeds %d bytes", maxStatePathLength)
+	}
+	if err := validatePathComponents(statePath); err != nil {
+		return err
+	}
+	roots := append([]string{localRoot}, extraRoots...)
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		rootAbs, err := cleanAbsolutePath(root)
+		if err != nil {
+			return err
+		}
+		if pathInsideOrEqual(statePath, rootAbs) {
+			return fmt.Errorf("private state path %s must be outside local mount root %s", statePath, rootAbs)
+		}
+	}
+	return nil
+}
+
+func validatePathComponents(path string) error {
+	volume := filepath.VolumeName(path)
+	rest := strings.TrimPrefix(path[len(volume):], string(os.PathSeparator))
+	for _, part := range strings.Split(rest, string(os.PathSeparator)) {
+		if part == "" {
+			return fmt.Errorf("state path contains empty normalized segment")
+		}
+		if len(part) > maxStatePathComponentSize {
+			return fmt.Errorf("state path component %q exceeds %d bytes", part, maxStatePathComponentSize)
+		}
+		if hasControlCharacter(part) {
+			return fmt.Errorf("state path component %q contains control characters", part)
+		}
+	}
+	return nil
+}
+
+func hasControlCharacter(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+func pathInsideOrEqual(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}

--- a/internal/mountsync/state_path.go
+++ b/internal/mountsync/state_path.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -146,7 +147,7 @@ func QuarantineLegacyMountState(localRoot, stateDir string) ([]string, error) {
 			}
 			return moved, err
 		}
-		if info.IsDir() {
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			continue
 		}
 		if err := os.MkdirAll(quarantineDir, 0o700); err != nil {
@@ -154,12 +155,37 @@ func QuarantineLegacyMountState(localRoot, stateDir string) ([]string, error) {
 		}
 		target := filepath.Join(quarantineDir, filepath.Base(localRoot)+"-"+filepath.Base(candidate))
 		target = uniqueQuarantinePath(target)
-		if err := os.Rename(candidate, target); err != nil {
+		if err := moveRegularFile(candidate, target, info.Mode().Perm()); err != nil {
 			return moved, err
 		}
 		moved = append(moved, target)
 	}
 	return moved, nil
+}
+
+func moveRegularFile(src, dst string, perm os.FileMode) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	return os.Remove(src)
 }
 
 func legacyStateCandidates(localRoot string) ([]string, error) {

--- a/internal/mountsync/state_path.go
+++ b/internal/mountsync/state_path.go
@@ -41,9 +41,6 @@ type MountStatePath struct {
 }
 
 func DefaultMountStateDir() string {
-	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
-		return filepath.Join(home, DefaultMountStateDirName)
-	}
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		return filepath.Join(home, DefaultMountStateDirName)
 	}
@@ -51,9 +48,13 @@ func DefaultMountStateDir() string {
 }
 
 func ResolveMountStatePath(opts MountStatePathOptions) (MountStatePath, error) {
-	localRoot := filepath.Clean(strings.TrimSpace(opts.LocalRoot))
-	if localRoot == "" || localRoot == "." {
+	localRootInput := strings.TrimSpace(opts.LocalRoot)
+	if localRootInput == "" {
 		return MountStatePath{}, fmt.Errorf("local root is required")
+	}
+	localRoot, err := cleanAbsolutePath(localRootInput)
+	if err != nil {
+		return MountStatePath{}, fmt.Errorf("local root: %w", err)
 	}
 	kind := NormalizeMountKind(opts.MountKind)
 	stateFile := strings.TrimSpace(opts.StateFile)
@@ -110,10 +111,18 @@ func NormalizeMountKind(kind string) string {
 }
 
 func MountStateID(workspaceID, remoteRoot, localRoot, mountKind string) string {
+	localRoot = strings.TrimSpace(localRoot)
+	if localRoot == "" {
+		localRoot = filepath.Clean(localRoot)
+	} else if cleaned, err := cleanAbsolutePath(localRoot); err == nil {
+		localRoot = cleaned
+	} else {
+		localRoot = filepath.Clean(localRoot)
+	}
 	input := strings.Join([]string{
 		strings.TrimSpace(workspaceID),
 		normalizeRemotePath(remoteRoot),
-		filepath.Clean(strings.TrimSpace(localRoot)),
+		localRoot,
 		NormalizeMountKind(mountKind),
 	}, "\x00")
 	sum := sha256.Sum256([]byte(input))
@@ -121,9 +130,13 @@ func MountStateID(workspaceID, remoteRoot, localRoot, mountKind string) string {
 }
 
 func QuarantineLegacyMountState(localRoot, stateDir string) ([]string, error) {
-	localRoot = filepath.Clean(strings.TrimSpace(localRoot))
-	if localRoot == "" || localRoot == "." {
+	localRootInput := strings.TrimSpace(localRoot)
+	if localRootInput == "" {
 		return nil, nil
+	}
+	localRoot, err := cleanAbsolutePath(localRootInput)
+	if err != nil {
+		return nil, err
 	}
 	stateDir = strings.TrimSpace(stateDir)
 	if stateDir == "" {

--- a/internal/mountsync/state_path_test.go
+++ b/internal/mountsync/state_path_test.go
@@ -46,6 +46,56 @@ func TestResolveMountStatePathUsesStateDirAndStableMountID(t *testing.T) {
 	}
 }
 
+func TestResolveMountStatePathCanonicalizesRelativeLocalRoot(t *testing.T) {
+	parent := t.TempDir()
+	localName := "mount"
+	localDir := filepath.Join(parent, localName)
+	if err := os.MkdirAll(localDir, 0o755); err != nil {
+		t.Fatalf("mkdir local dir: %v", err)
+	}
+	stateDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(localDir); err != nil {
+		t.Fatalf("chdir local dir: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get local working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalWD); err != nil {
+			t.Fatalf("restore working directory: %v", err)
+		}
+	})
+
+	relative, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/github/repos/AgentWorkforce/relayfile",
+		LocalRoot:       ".",
+		StateDir:        stateDir,
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveMountStatePath(dot local root) failed: %v", err)
+	}
+	absolute, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/github/repos/AgentWorkforce/relayfile",
+		LocalRoot:       cwd,
+		StateDir:        stateDir,
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveMountStatePath(absolute) failed: %v", err)
+	}
+	if relative.MountID != absolute.MountID {
+		t.Fatalf("expected relative and absolute local roots to share mount id, got %q and %q", relative.MountID, absolute.MountID)
+	}
+}
+
 func TestResolveMountStatePathMountKindSeparatesState(t *testing.T) {
 	stateDir := t.TempDir()
 	localDir := t.TempDir()

--- a/internal/mountsync/state_path_test.go
+++ b/internal/mountsync/state_path_test.go
@@ -1,0 +1,204 @@
+package mountsync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveMountStatePathUsesStateDirAndStableMountID(t *testing.T) {
+	stateDir := t.TempDir()
+	localDir := t.TempDir()
+
+	first, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/github/repos/AgentWorkforce/cloud/issues/1290",
+		LocalRoot:       localDir,
+		StateDir:        stateDir,
+		MountKind:       MountKindDaemon,
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveMountStatePath failed: %v", err)
+	}
+	second, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/github/repos/AgentWorkforce/cloud/issues/1290",
+		LocalRoot:       localDir,
+		StateDir:        stateDir,
+		MountKind:       MountKindDaemon,
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveMountStatePath failed: %v", err)
+	}
+
+	if first.MountID == "" || first.MountID != second.MountID {
+		t.Fatalf("expected stable non-empty mount id, got %q and %q", first.MountID, second.MountID)
+	}
+	want := filepath.Join(stateDir, first.MountID, "state.json")
+	if first.StateFile != want {
+		t.Fatalf("expected state file %q, got %q", want, first.StateFile)
+	}
+	if strings.HasPrefix(first.StateFile, localDir+string(os.PathSeparator)) {
+		t.Fatalf("state file %q is inside local mount root %q", first.StateFile, localDir)
+	}
+}
+
+func TestResolveMountStatePathMountKindSeparatesState(t *testing.T) {
+	stateDir := t.TempDir()
+	localDir := t.TempDir()
+	input := MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/slack/channels/proj-cloud",
+		LocalRoot:       localDir,
+		StateDir:        stateDir,
+		ValidateOutside: true,
+	}
+	ids := map[string]bool{}
+	for _, kind := range []string{MountKindDaemon, MountKindFlush, MountKindInitialSync} {
+		input.MountKind = kind
+		resolved, err := ResolveMountStatePath(input)
+		if err != nil {
+			t.Fatalf("ResolveMountStatePath(%s) failed: %v", kind, err)
+		}
+		if ids[resolved.MountID] {
+			t.Fatalf("mount kind %s reused mount id %s", kind, resolved.MountID)
+		}
+		ids[resolved.MountID] = true
+	}
+}
+
+func TestResolveMountStatePathStateFileOverridesStateDir(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "exact.json")
+	resolved, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/memory/workspace",
+		LocalRoot:       t.TempDir(),
+		StateDir:        t.TempDir(),
+		StateFile:       stateFile,
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("ResolveMountStatePath failed: %v", err)
+	}
+	if !resolved.Override {
+		t.Fatal("expected explicit state-file override")
+	}
+	if resolved.StateFile != stateFile {
+		t.Fatalf("expected explicit state file %q, got %q", stateFile, resolved.StateFile)
+	}
+	if resolved.MountID != "" {
+		t.Fatalf("explicit state-file should not derive mount id, got %q", resolved.MountID)
+	}
+}
+
+func TestResolveMountStatePathRejectsPrivateStateInsideMountRoot(t *testing.T) {
+	localDir := t.TempDir()
+	_, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/google-mail/messages",
+		LocalRoot:       localDir,
+		StateFile:       filepath.Join(localDir, LegacyMountStateFileName),
+		ValidateOutside: true,
+	})
+	if err == nil {
+		t.Fatal("expected state file under local mount root to be rejected")
+	}
+	if !strings.Contains(err.Error(), "outside local mount root") {
+		t.Fatalf("expected local mount root error, got %v", err)
+	}
+}
+
+func TestResolveMountStatePathRejectsPrivateStateInsideScopedMountRoot(t *testing.T) {
+	localDir := t.TempDir()
+	scopedRoot := filepath.Join(localDir, "github", "repos", "AgentWorkforce", "cloud")
+	_, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:      "rw_123",
+		RemoteRoot:       "/github/repos/AgentWorkforce/cloud/issues/1290",
+		LocalRoot:        localDir,
+		StateFile:        filepath.Join(scopedRoot, LegacyMountStateFileName),
+		ValidateOutside:  true,
+		ScopedLocalRoots: []string{scopedRoot},
+	})
+	if err == nil {
+		t.Fatal("expected state file under scoped local root to be rejected")
+	}
+}
+
+func TestResolveMountStatePathAllowsRepeatedProviderSegmentsOutsideStatePath(t *testing.T) {
+	_, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/github/repos/AgentWorkforce/cloud/issues/1290/github/repos/AgentWorkforce/cloud/issues/1290",
+		LocalRoot:       t.TempDir(),
+		StateDir:        t.TempDir(),
+		ValidateOutside: true,
+	})
+	if err != nil {
+		t.Fatalf("repeated provider segments in remote payload path should not fail state validation: %v", err)
+	}
+}
+
+func TestResolveMountStatePathRejectsControlCharacters(t *testing.T) {
+	_, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     "rw_123",
+		RemoteRoot:      "/slack",
+		LocalRoot:       t.TempDir(),
+		StateDir:        filepath.Join(t.TempDir(), "bad\npath"),
+		ValidateOutside: true,
+	})
+	if err == nil {
+		t.Fatal("expected control character path to be rejected")
+	}
+}
+
+func TestQuarantineLegacyMountStateOnlyMovesExactPrivateStateFiles(t *testing.T) {
+	localDir := t.TempDir()
+	stateDir := t.TempDir()
+	files := map[string]string{
+		LegacyMountStateFileName:                         "state",
+		LegacyMountStateFileName + ".tmp-123":            "tmp",
+		"." + LegacyMountStateFileName + ".tmp-1":        "oldtmp",
+		LegacyMountStateFileName + ".backup":             "backup",
+		filepath.Join(".relay", "state.json"):            "public",
+		filepath.Join(".relay", "dead-letter", "x.json"): "dead",
+		"provider-state.json":                            "provider",
+	}
+	for name, body := range files {
+		path := filepath.Join(localDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	moved, err := QuarantineLegacyMountState(localDir, stateDir)
+	if err != nil {
+		t.Fatalf("QuarantineLegacyMountState failed: %v", err)
+	}
+	if len(moved) != 3 {
+		t.Fatalf("expected 3 quarantined files, got %d: %v", len(moved), moved)
+	}
+	for _, name := range []string{
+		LegacyMountStateFileName,
+		LegacyMountStateFileName + ".tmp-123",
+		"." + LegacyMountStateFileName + ".tmp-1",
+	} {
+		if _, err := os.Stat(filepath.Join(localDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be moved, stat err=%v", name, err)
+		}
+	}
+	for _, name := range []string{
+		LegacyMountStateFileName + ".backup",
+		filepath.Join(".relay", "state.json"),
+		filepath.Join(".relay", "dead-letter", "x.json"),
+		"provider-state.json",
+	} {
+		if _, err := os.Stat(filepath.Join(localDir, name)); err != nil {
+			t.Fatalf("expected %s to remain, stat err=%v", name, err)
+		}
+	}
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -621,6 +621,9 @@ type SyncerOptions struct {
 	RemoteRoot    string
 	LocalRoot     string
 	StateFile     string
+	StateDir      string
+	MountKind     string
+	ValidateState bool
 	EventProvider string
 	Scopes        []string
 	WebSocket     *bool
@@ -998,10 +1001,23 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if eventProvider == "" {
 		eventProvider = inferProviderFromRoot(remoteRoot)
 	}
-	stateFile := strings.TrimSpace(opts.StateFile)
-	if stateFile == "" {
-		stateFile = filepath.Join(localRoot, ".relayfile-mount-state.json")
+	stateFileOpt := opts.StateFile
+	if strings.TrimSpace(stateFileOpt) == "" && strings.TrimSpace(opts.StateDir) == "" && !opts.ValidateState {
+		stateFileOpt = filepath.Join(localRoot, LegacyMountStateFileName)
 	}
+	statePath, err := ResolveMountStatePath(MountStatePathOptions{
+		WorkspaceID:     workspace,
+		RemoteRoot:      remoteRoot,
+		LocalRoot:       localRoot,
+		StateFile:       stateFileOpt,
+		StateDir:        opts.StateDir,
+		MountKind:       opts.MountKind,
+		ValidateOutside: opts.ValidateState,
+	})
+	if err != nil {
+		return nil, err
+	}
+	stateFile := statePath.StateFile
 	publicStatePath := filepath.Join(localRoot, ".relay", "state.json")
 	conflictsDir := filepath.Join(localRoot, ".relay", "conflicts")
 	resolvedConflictsDir := filepath.Join(conflictsDir, "resolved")
@@ -1026,6 +1042,13 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	}
 	if err := os.MkdirAll(deadLetterDir, 0o755); err != nil {
 		return nil, err
+	}
+	if opts.ValidateState && !statePath.Override {
+		if moved, err := QuarantineLegacyMountState(localRoot, statePath.StateDir); err != nil {
+			return nil, err
+		} else if len(moved) > 0 && opts.Logger != nil {
+			opts.Logger.Printf("quarantined %d legacy private mount state file(s) outside mounted tree", len(moved))
+		}
 	}
 	websocketEnabled := true
 	if opts.WebSocket != nil {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1045,7 +1045,9 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	}
 	if opts.ValidateState && !statePath.Override {
 		if moved, err := QuarantineLegacyMountState(localRoot, statePath.StateDir); err != nil {
-			return nil, err
+			if opts.Logger != nil {
+				opts.Logger.Printf("warning: failed to quarantine legacy private mount state: %v", err)
+			}
 		} else if len(moved) > 0 && opts.Logger != nil {
 			opts.Logger.Printf("quarantined %d legacy private mount state file(s) outside mounted tree", len(moved))
 		}


### PR DESCRIPTION
## Summary
- add mountsync private state path resolution with `--state-dir`, exact `--state-file` override precedence, and mount-kind-separated state IDs
- keep CLI and `relayfile-mount` command surfaces on private state outside the mounted tree, while preserving legacy in-root defaults for direct internal `NewSyncer` embedders
- quarantine only the legacy private state file and its known temp variants from the mount root

## Scope
Relayfile-first implementation for the PR #1289 mount-state path recursion spec. Cloud mount-script wiring, snapshot pinning, and deploy/release follow-ups are intentionally left for the next sequence.

## Tests
- `go test ./internal/mountsync ./cmd/relayfile-mount ./cmd/relayfile-cli -count=1`
