### PR TITLE
fix(mount): retry transient cursor resolution instead of full export (#1499)

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3842,7 +3842,7 @@ func runMount(args []string) error {
 	intervalJitter := fs.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := fs.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", defaultMountTimeout), "per-sync timeout")
 	bootstrapTimeout := fs.Duration("bootstrap-timeout", durationEnv("RELAYFILE_BOOTSTRAP_TIMEOUT", 0), "hard cap for the one-time/full-tree bootstrap pull (0 = unbounded while making progress)")
-	cursorTimeout := fs.Duration("cursor-timeout", durationEnv("RELAYFILE_CURSOR_TIMEOUT", 20*time.Second), "independent timeout for events-cursor resolution")
+	cursorTimeout := fs.Duration("cursor-timeout", durationEnv("RELAYFILE_CURSOR_TIMEOUT", 60*time.Second), "independent timeout for events-cursor resolution")
 	fullReconcile := fs.Bool("full-reconcile", boolEnv("RELAYFILE_FORCE_FULL_RECONCILE", false), "force one full reconcile regardless of bootstrap-complete state (escape hatch)")
 	websocketEnabled := fs.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
 	lowMemory := fs.Bool("low-memory", boolEnv("RELAYFILE_MOUNT_LOW_MEMORY", false), "reduce mount memory use by omitting per-file public state and deferring content reads")
@@ -4154,7 +4154,7 @@ Common flags:
   --timeout 5m         per-sync timeout
   --bootstrap-timeout 0s
                        hard cap for initial/full-tree bootstrap (0 = progress-based)
-  --cursor-timeout 20s timeout for events-cursor resolution
+  --cursor-timeout 60s timeout for events-cursor resolution
   --full-reconcile     force one full reconcile regardless of bootstrap state
   --state-dir DIR      private mount state directory (default $HOME/.relayfile-mount-state)
   --state-file FILE    exact private state file override; wins over --state-dir

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -81,7 +81,7 @@ func main() {
 	intervalJitter := flag.Float64("interval-jitter", floatEnv("RELAYFILE_MOUNT_INTERVAL_JITTER", 0.2), "sync interval jitter ratio (0.0-1.0)")
 	timeout := flag.Duration("timeout", durationEnv("RELAYFILE_MOUNT_TIMEOUT", 15*time.Second), "per-sync timeout")
 	bootstrapTimeout := flag.Duration("bootstrap-timeout", durationEnv("RELAYFILE_BOOTSTRAP_TIMEOUT", 0), "hard cap for the one-time/full-tree bootstrap pull (0 = unbounded while making progress)")
-	cursorTimeout := flag.Duration("cursor-timeout", durationEnv("RELAYFILE_CURSOR_TIMEOUT", 20*time.Second), "independent timeout for events-cursor resolution")
+	cursorTimeout := flag.Duration("cursor-timeout", durationEnv("RELAYFILE_CURSOR_TIMEOUT", 60*time.Second), "independent timeout for events-cursor resolution")
 	fullReconcile := flag.Bool("full-reconcile", boolEnv("RELAYFILE_FORCE_FULL_RECONCILE", false), "force one full reconcile regardless of bootstrap-complete state (escape hatch)")
 	websocketEnabled := flag.Bool("websocket", boolEnv("RELAYFILE_MOUNT_WEBSOCKET", true), "enable websocket event streaming when available")
 	lazyRepos := flag.Bool("lazy-repos", lazyReposEnv(), "lazily materialize GitHub repo subtrees on first access")

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -80,7 +80,9 @@ const defaultFullPullEvery = 20
 const (
 	defaultBootstrapTimeout          = 0 * time.Second
 	defaultBootstrapIdleTimeout      = 90 * time.Second
-	defaultCursorTimeout             = 20 * time.Second
+	defaultCursorTimeout             = 60 * time.Second
+	defaultCursorResolutionAttempts  = 3
+	defaultCursorRetryBaseDelay      = 250 * time.Millisecond
 	defaultBootstrapReadWorkers      = 16
 	defaultIncrementalEventPageLimit = 50
 	defaultRetryAfterMaxDelay        = 60 * time.Second
@@ -645,9 +647,11 @@ type SyncerOptions struct {
 	// sentinel (<=0): the bootstrap runs to completion as long as it keeps
 	// applying files within the idle window.
 	BootstrapTimeout time.Duration
-	// CursorTimeout bounds resolveLatestEventCursor with its OWN short
-	// deadline derived from RootCtx. 0 falls back to env
-	// RELAYFILE_CURSOR_TIMEOUT, default 20s.
+	// CursorTimeout bounds each resolveLatestEventCursor attempt with its OWN
+	// deadline derived from RootCtx. Timeout-class failures are retried with
+	// backoff before the caller decides whether a full pull is safe.
+	//
+	// 0 falls back to env RELAYFILE_CURSOR_TIMEOUT, default 60s.
 	CursorTimeout time.Duration
 	// ForceFullReconcile, when non-nil and true, forces one full reconcile
 	// regardless of BootstrapComplete (escape hatch / clobber-remnant
@@ -2459,6 +2463,15 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
 			// No events feed on this backend — fall through to the
 			// full-pull bootstrap path. (Pre-fix behaviour.)
+		} else if isCursorResolutionRetryable(err) {
+			// A completed prior bootstrap with tracked files is reusable
+			// state. Under load, falling through from a transient cursor
+			// timeout to a full export recreates the production stall loop:
+			// full export exceeds the bootstrap watchdog, the cursor stays
+			// empty, and the next reuse repeats the same expensive path.
+			// Surface the cycle failure instead; the daemon will retry the
+			// cheap cursor path next reconcile without destroying progress.
+			return err
 		} else {
 			s.logf("restart fast-path: cursor resolution failed (%v); falling through to full pull", err)
 		}
@@ -4013,12 +4026,42 @@ func (s *Syncer) markIncrementalCheckpoint(pageStartCursor, pageCursor, phase, r
 }
 
 func (s *Syncer) resolveLatestEventCursor(ctx context.Context) (string, error) {
-	// Derive an OWN short deadline from rootCtx so a slow/hanging events
-	// feed can never wedge an otherwise healthy cycle (and is independent
-	// of whatever inbound per-cycle/bootstrap ctx the caller passed). The
-	// signature/return contract is unchanged; the inbound ctx is honored
-	// only for cancellation via rootCtx propagation.
-	cctx, cancel := context.WithTimeout(s.rootCtx, s.cursorTimeout)
+	var lastErr error
+	attempts := defaultCursorResolutionAttempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	for attempt := 0; attempt < attempts; attempt++ {
+		cursor, err := s.resolveLatestEventCursorOnce(ctx, s.cursorTimeout)
+		if err == nil {
+			return cursor, nil
+		}
+		lastErr = err
+		if !isCursorResolutionRetryable(err) || attempt == attempts-1 {
+			return "", err
+		}
+		delay := cursorResolutionRetryDelay(s.cursorTimeout, attempt)
+		s.logf("cursor resolution attempt %d/%d failed (%v); retrying in %s", attempt+1, attempts, err, delay)
+		if waitErr := waitWithContext(s.rootCtx, delay); waitErr != nil {
+			return "", waitErr
+		}
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", nil
+}
+
+func (s *Syncer) resolveLatestEventCursorOnce(ctx context.Context, timeout time.Duration) (string, error) {
+	// Derive an OWN deadline from rootCtx so a slow/hanging events feed can
+	// never wedge an otherwise healthy cycle (and is independent of whatever
+	// inbound per-cycle/bootstrap ctx the caller passed). The signature/return
+	// contract is unchanged; the inbound ctx is observed only for cancellation
+	// before starting an attempt.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	cctx, cancel := context.WithTimeout(s.rootCtx, timeout)
 	defer cancel()
 
 	// Preferred path (post cloud#927): /fs/events?direction=desc&limit=1
@@ -4055,6 +4098,38 @@ func (s *Syncer) resolveLatestEventCursor(ctx context.Context) (string, error) {
 		cursor = *feed.NextCursor
 	}
 	return latest, nil
+}
+
+func isCursorResolutionRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func cursorResolutionRetryDelay(timeout time.Duration, attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	delay := defaultCursorRetryBaseDelay
+	for i := 0; i < attempt; i++ {
+		delay *= 2
+	}
+	maxDelay := 2 * time.Second
+	if timeout > 0 && timeout/10 < maxDelay {
+		maxDelay = timeout / 10
+	}
+	if maxDelay < time.Millisecond {
+		maxDelay = time.Millisecond
+	}
+	if delay > maxDelay {
+		return maxDelay
+	}
+	return delay
 }
 
 func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted map[string]struct{}) error {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -4277,6 +4277,7 @@ type fakeClient struct {
 	listEventsCalls            int
 	latestEventIDCalls         int
 	latestEventIDErr           error
+	latestEventIDHook          func(call int) (string, error)
 	latestEventIDUnsupported   bool
 	readFileCalls              int
 	readFileCallsByPath        map[string]int
@@ -4411,6 +4412,9 @@ func (c *fakeClient) LatestEventID(ctx context.Context, workspaceID, provider st
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.latestEventIDCalls++
+	if c.latestEventIDHook != nil {
+		return c.latestEventIDHook(c.latestEventIDCalls)
+	}
 	if c.latestEventIDUnsupported {
 		return "", &HTTPError{StatusCode: http.StatusBadRequest, Code: "bad_request", Message: "direction=desc unsupported"}
 	}
@@ -6192,6 +6196,221 @@ func TestPullRestartFastPathSkipsFullPull(t *testing.T) {
 	if client.listTreeCalls != 0 || client.readFileCalls != 0 {
 		t.Fatalf("expected quiet post-restart cycle to remain a pure no-op; tree=%d read=%d",
 			client.listTreeCalls, client.readFileCalls)
+	}
+}
+
+func TestPullReusedMountWithPersistedCursorUsesIncrementalOnly(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_2",
+				ContentType: "text/markdown",
+				Content:     "# A v2",
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_1",
+				Type:     "file.created",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_1",
+			},
+			{
+				EventID:  "evt_2",
+				Type:     "file.updated",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_2",
+			},
+		},
+		revisionCounter: 2,
+		eventCounter:    2,
+	}
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte("# A v1"), 0o644); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+	if err := writeMountState(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState{
+		Files: map[string]trackedFile{
+			"/notion/Docs/A.md": {
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Hash:        hashBytes([]byte("# A v1")),
+			},
+		},
+		EventsCursor:      "evt_1",
+		BootstrapComplete: true,
+	}); err != nil {
+		t.Fatalf("write seed state: %v", err)
+	}
+
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_reuse_cursor",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reused cursor reconcile: %v", err)
+	}
+
+	if client.listTreeCalls != 0 {
+		t.Fatalf("expected persisted cursor reuse to skip full tree pull; got %d ListTree call(s)", client.listTreeCalls)
+	}
+	if client.latestEventIDCalls != 0 {
+		t.Fatalf("expected persisted cursor reuse not to resolve latest cursor; got %d call(s)", client.latestEventIDCalls)
+	}
+	assertLocalFileContent(t, localPath, "# A v2")
+	if got := strings.TrimSpace(syncer.state.EventsCursor); got != "evt_2" {
+		t.Fatalf("expected cursor to advance to evt_2, got %q", got)
+	}
+}
+
+func TestPullRestartFastPathRetriesCursorDeadlineBeforeFullPull(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_seed",
+				Type:     "file.created",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_1",
+			},
+		},
+		revisionCounter: 1,
+		eventCounter:    1,
+	}
+	client.latestEventIDHook = func(call int) (string, error) {
+		if call == 1 {
+			return "", context.DeadlineExceeded
+		}
+		return "evt_seed", nil
+	}
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte("# A"), 0o644); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+	if err := writeMountState(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState{
+		Files: map[string]trackedFile{
+			"/notion/Docs/A.md": {
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Hash:        hashBytes([]byte("# A")),
+			},
+		},
+		BootstrapComplete: true,
+	}); err != nil {
+		t.Fatalf("write seed state: %v", err)
+	}
+
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   "ws_restart_cursor_retry",
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		CursorTimeout: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("restart reconcile should retry cursor resolution: %v", err)
+	}
+
+	if client.latestEventIDCalls != 2 {
+		t.Fatalf("expected cursor resolution to retry once, got %d call(s)", client.latestEventIDCalls)
+	}
+	if client.listTreeCalls != 0 || client.readFileCalls != 0 {
+		t.Fatalf("expected retrying fast-path to avoid full pull; tree=%d read=%d", client.listTreeCalls, client.readFileCalls)
+	}
+	if got := strings.TrimSpace(syncer.state.EventsCursor); got != "evt_seed" {
+		t.Fatalf("expected retry to seed evt_seed, got %q", got)
+	}
+}
+
+func TestPullRestartFastPathTimeoutDoesNotFallBackToFullPull(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_seed",
+				Type:     "file.created",
+				Path:     "/notion/Docs/A.md",
+				Revision: "rev_1",
+			},
+		},
+		latestEventIDErr: context.DeadlineExceeded,
+		revisionCounter:  1,
+		eventCounter:     1,
+	}
+	localDir := t.TempDir()
+	localPath := filepath.Join(localDir, "Docs", "A.md")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("mkdir local: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte("# A"), 0o644); err != nil {
+		t.Fatalf("seed local: %v", err)
+	}
+	if err := writeMountState(filepath.Join(localDir, ".relayfile-mount-state.json"), mountState{
+		Files: map[string]trackedFile{
+			"/notion/Docs/A.md": {
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Hash:        hashBytes([]byte("# A")),
+			},
+		},
+		BootstrapComplete: true,
+	}); err != nil {
+		t.Fatalf("write seed state: %v", err)
+	}
+
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   "ws_restart_cursor_timeout",
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		CursorTimeout: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline after cursor retries, got %v", err)
+	}
+
+	if client.latestEventIDCalls != defaultCursorResolutionAttempts {
+		t.Fatalf("expected %d cursor attempts, got %d", defaultCursorResolutionAttempts, client.latestEventIDCalls)
+	}
+	if client.listTreeCalls != 0 || client.readFileCalls != 0 {
+		t.Fatalf("expected cursor timeout to avoid full pull fallback; tree=%d read=%d", client.listTreeCalls, client.readFileCalls)
+	}
+	if got := strings.TrimSpace(syncer.state.EventsCursor); got != "" {
+		t.Fatalf("expected cursor to remain empty after failed resolution, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem (#1499 relayfile warm-degrade stall loop)

On a reused/churned sticky box the restart fast-path resolved the events cursor under a **single 20s deadline** (`resolveLatestEventCursor`, `internal/mountsync/syncer.go`). Under cloud `/fs/export` API load that resolution hit `context deadline exceeded`, so the daemon **fell through to a full-tree bootstrap export**. The full export then:

- exceeded the 90s bootstrap watchdog, and
- exceeded the cloud per-fire `flushTimeoutSeconds:20` → **exit 124**,

leaving the state dir *non-empty without a completed bootstrap*. The next box reuse repeated the same expensive path — the sticky bad-state loop. It only escaped when a clear API window happened to let one full pull complete.

## Root cause (file:line)

- `internal/mountsync/syncer.go` `resolveLatestEventCursor` — one attempt, one fixed `cursorTimeout` (20s) deadline; any timeout returned an error.
- `internal/mountsync/syncer.go` restart fast-path in `pullRemote` (cursor-resolution-failed branch) — on **any** error it fell through to the full-pull/export bootstrap, including a *transient* timeout against already-reusable state (`BootstrapComplete` + tracked files).

## Fix

Make the cursor fast-path tolerant of transient slow-API windows so box reuse re-syncs **incrementally** instead of full-exporting:

1. **Retry with backoff.** `resolveLatestEventCursor` now retries timeout-class failures (`context.DeadlineExceeded` / `net.Error` timeout) with exponential backoff — `resolveLatestEventCursorOnce` + `isCursorResolutionRetryable` + `cursorResolutionRetryDelay`. Each attempt gets its own `rootCtx`-derived deadline.
2. **Raise the deadline 20s → 60s** (`defaultCursorTimeout` + both `--cursor-timeout` flags in `cmd/relayfile-mount` and `cmd/relayfile-cli`).
3. **Don't collapse reusable state into a full export.** When cursor resolution still fails with a retryable timeout, the restart fast-path returns the cycle error instead of running a full export. The next reconcile retries the cheap cursor path; on-disk mirror state is preserved. This breaks the full-export loop.

Non-timeout / `404` (no events feed) errors keep the prior fall-through-to-full-pull behavior — this change is scoped to the transient timeout class.

## Tests (`internal/mountsync/syncer_test.go`) — all GREEN

- `TestPullReusedMountWithPersistedCursorUsesIncrementalOnly` — a reused mount with a persisted `EventsCursor` takes the incremental path only: **no full tree pull, no cursor re-resolution**.
- `TestPullRestartFastPathRetriesCursorDeadlineBeforeFullPull` — a transient cursor deadline on restart **retries and seeds the cursor incrementally — no full pull**.
- `TestPullRestartFastPathTimeoutDoesNotFallBackToFullPull` — a persistent cursor deadline exhausts retries and **fails the cycle without a full pull**.

Full `go test ./internal/mountsync/` passes (~103s); `go vet` + `gofmt` clean.

## Rollout

This is a change to the Go **`relayfile-mount` daemon binary**, distributed via GitHub releases (`scripts/install.sh` → `releases/download/${RELAYFILE_VERSION:-latest}`). After merge it needs a **relayfile release/version bump** (e.g. `v0.8.4` → `v0.8.5`) so cloud-warmed sandboxes install the fixed daemon. Cloud must pin the new `RELAYFILE_VERSION` (or take latest) where it installs `relayfile-mount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)