### PR TITLE
fix(mount): converge bootstrap by yielding slow/empty/429 export to resumable tree pull (#1499 / cloud #1516 Gate B)

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -78,9 +78,19 @@ const defaultFullPullEvery = 20
 // defaultBootstrapIdleTimeout. The cursor resolution gets its own short
 // independent deadline so it can never hang an otherwise healthy cycle.
 const (
-	defaultBootstrapTimeout          = 0 * time.Second
-	defaultBootstrapIdleTimeout      = 90 * time.Second
-	defaultCursorTimeout             = 60 * time.Second
+	defaultBootstrapTimeout     = 0 * time.Second
+	defaultBootstrapIdleTimeout = 90 * time.Second
+	defaultCursorTimeout        = 60 * time.Second
+	// defaultExportTimeout bounds the single atomic full-tree export so a slow
+	// or 429-contended export yields to the resumable pullRemoteFullTree BEFORE
+	// the no-progress bootstrap watchdog (defaultBootstrapIdleTimeout) cancels
+	// the whole bootstrap. ExportFiles reports NO incremental progress until
+	// its whole body returns, so without this bound a doomed export can burn
+	// the entire watchdog window and be cancelled with zero files applied —
+	// and, having no resume cursor, restart from scratch every cycle (the
+	// #1499/#1516 non-convergence loop). Must stay strictly under
+	// defaultBootstrapIdleTimeout.
+	defaultExportTimeout             = 45 * time.Second
 	defaultCursorResolutionAttempts  = 3
 	defaultCursorRetryBaseDelay      = 250 * time.Millisecond
 	defaultBootstrapReadWorkers      = 16
@@ -653,6 +663,14 @@ type SyncerOptions struct {
 	//
 	// 0 falls back to env RELAYFILE_CURSOR_TIMEOUT, default 60s.
 	CursorTimeout time.Duration
+	// ExportTimeout bounds each atomic full-tree export (ExportFiles) with its
+	// OWN deadline derived from the bootstrap ctx, kept strictly under
+	// bootstrapIdleTimeout. When the export does not finish in time the syncer
+	// falls through to the resumable, per-page pullRemoteFullTree instead of
+	// retrying a doomed one-shot export. 0 falls back to env
+	// RELAYFILE_EXPORT_TIMEOUT, default 45s; values >= bootstrapIdleTimeout are
+	// clamped below it so the fall-through always fires before the watchdog.
+	ExportTimeout time.Duration
 	// ForceFullReconcile, when non-nil and true, forces one full reconcile
 	// regardless of BootstrapComplete (escape hatch / clobber-remnant
 	// recovery). nil falls back to env RELAYFILE_FORCE_FULL_RECONCILE.
@@ -796,6 +814,7 @@ type Syncer struct {
 	interval             time.Duration
 	fullPullEvery        int
 	cursorTimeout        time.Duration
+	exportTimeout        time.Duration
 	bootstrapTimeout     time.Duration
 	bootstrapIdleTimeout time.Duration
 	forceFullReconcile   bool
@@ -1086,6 +1105,18 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if bootstrapIdleTimeout <= 0 {
 		bootstrapIdleTimeout = defaultBootstrapIdleTimeout
 	}
+	exportTimeout := resolveDurationEnv(opts.ExportTimeout, "RELAYFILE_EXPORT_TIMEOUT", defaultExportTimeout, opts.Logger)
+	if exportTimeout <= 0 {
+		exportTimeout = defaultExportTimeout
+	}
+	// The export's own deadline MUST elapse before the no-progress bootstrap
+	// watchdog so a slow export yields to the resumable tree pull while the
+	// bootstrap ctx is still alive. Clamp to a fraction of the idle window so a
+	// misconfiguration can't let the export outlive the watchdog (which would
+	// defeat the fall-through and re-create the #1499/#1516 stall loop).
+	if maxExportTimeout := bootstrapIdleTimeout * 3 / 4; maxExportTimeout > 0 && exportTimeout > maxExportTimeout {
+		exportTimeout = maxExportTimeout
+	}
 	forceFullReconcile := false
 	if opts.ForceFullReconcile != nil {
 		forceFullReconcile = *opts.ForceFullReconcile
@@ -1168,6 +1199,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		interval:             opts.Interval,
 		fullPullEvery:        fullPullEvery,
 		cursorTimeout:        cursorTimeout,
+		exportTimeout:        exportTimeout,
 		bootstrapTimeout:     bootstrapTimeout,
 		bootstrapIdleTimeout: bootstrapIdleTimeout,
 		forceFullReconcile:   forceFullReconcile,
@@ -2617,9 +2649,36 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 }
 
 func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshotClient, conflicted map[string]struct{}, prog bootstrapProgress) (bool, error) {
-	files, err := client.ExportFiles(ctx, s.workspace, s.remoteRoot)
+	// Bound the atomic export with its OWN deadline, strictly under the
+	// no-progress bootstrap watchdog. ExportFiles is a single HTTP call that
+	// reports NO incremental progress until the whole body returns, so on a
+	// large/slow/429-throttled workspace it can consume the entire watchdog
+	// window and be cancelled with zero files applied — and, being a one-shot
+	// mirror with no resume cursor, every retry restarts from scratch and is
+	// cancelled again (the #1499/#1516 "non-empty without completed bootstrap
+	// -> forcing full reconcile" loop). The sub-deadline makes a doomed export
+	// fail EARLY, while the parent bootstrap ctx is still alive, so we can fall
+	// through to the resumable, per-page pullRemoteFullTree.
+	exportCtx := ctx
+	if s.exportTimeout > 0 {
+		var cancel context.CancelFunc
+		exportCtx, cancel = context.WithTimeout(ctx, s.exportTimeout)
+		defer cancel()
+	}
+	files, err := client.ExportFiles(exportCtx, s.workspace, s.remoteRoot)
 	if err != nil {
 		if exportSnapshotUnsupported(err) {
+			return false, nil
+		}
+		// The export's own sub-deadline elapsed (or it was otherwise
+		// cancelled) while the PARENT bootstrap ctx is still alive: the atomic
+		// export is too slow/contended for this workspace. Yield to the
+		// resumable tree pull rather than retrying a doomed full export. If the
+		// parent ctx itself is done (the outer watchdog fired), propagate — the
+		// next cycle's shorter export sub-deadline fires before the watchdog
+		// and converges via the tree path.
+		if ctx.Err() == nil && exportCtx.Err() != nil {
+			s.logf("export snapshot did not complete within %s; falling back to resumable tree pull", s.exportTimeout)
 			return false, nil
 		}
 		s.recordCloudFailure(err)
@@ -2662,11 +2721,18 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 	// healthy cycle will reconcile correctly. Mirrors the safeguard in
 	// pullRemoteFullTree.
 	if s.snapshotDeleteUnsafe(len(remotePaths)) {
-		s.logf("skipping snapshot delete pass (export): fresh remote export has %d files but %d are tracked locally (suspected partial/empty cloud export); preserving local state", len(remotePaths), len(s.state.Files))
-		// Export is atomic — a full snapshot was applied even if the
-		// delete pass is deferred for safety. Bootstrap is complete.
-		s.markBootstrapComplete()
-		return true, nil
+		// A 0/drastically-shrunk export for a workspace we KNOW has tracked
+		// files is NOT an authoritative mirror (the production empty-200
+		// export, #1499/#1516). Do NOT markBootstrapComplete here: that would
+		// lock in the stale/empty snapshot and let the restart fast-path skip
+		// recovery forever. Fall through to pullRemoteFullTree, whose paginated
+		// ListTree re-reads the real content via a DIFFERENT cloud code path
+		// and only marks bootstrap complete on a full traversal. If the tree
+		// listing is ALSO empty, its own circuit breaker preserves local state
+		// without marking complete, so the next cycle retries instead of
+		// converging on an empty mirror.
+		s.logf("export returned %d files but %d are tracked locally (suspected partial/empty cloud export); falling back to tree pull for an authoritative listing", len(remotePaths), len(s.state.Files))
+		return false, nil
 	}
 
 	if err := s.applyRemoteSnapshotDeletesRev(remotePaths, conflicted, maxObservedRevision); err != nil {
@@ -2938,6 +3004,15 @@ func exportSnapshotUnsupported(err error) bool {
 	// through to pullRemoteFullTree rather than retrying an export that can
 	// never fit.
 	if httpErr.StatusCode == http.StatusRequestEntityTooLarge {
+		return true
+	}
+	// HTTP 429 workspace_busy: the WorkspaceDO is persistently busy and doJSON
+	// has already exhausted its Retry-After backoff. Retrying the same atomic
+	// export keeps contending for the one overloaded invocation; fall through
+	// to pullRemoteFullTree, whose paginated ListTree + per-file reads are
+	// individually bounded, individually retried, and resume from the persisted
+	// cursor instead of restarting the whole export.
+	if httpErr.StatusCode == http.StatusTooManyRequests {
 		return true
 	}
 	return httpErr.StatusCode == http.StatusBadRequest && strings.EqualFold(httpErr.Code, "bad_request")

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1115,6 +1115,9 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	// misconfiguration can't let the export outlive the watchdog (which would
 	// defeat the fall-through and re-create the #1499/#1516 stall loop).
 	if maxExportTimeout := bootstrapIdleTimeout * 3 / 4; maxExportTimeout > 0 && exportTimeout > maxExportTimeout {
+		if opts.Logger != nil {
+			opts.Logger.Printf("clamping exportTimeout from %s to %s (must stay strictly under bootstrapIdleTimeout %s so the export yields to the resumable tree pull before the watchdog fires)", exportTimeout, maxExportTimeout, bootstrapIdleTimeout)
+		}
 		exportTimeout = maxExportTimeout
 	}
 	forceFullReconcile := false

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -822,6 +822,7 @@ func TestExportSnapshotOverloadedClassification(t *testing.T) {
 		&HTTPError{StatusCode: 503, Message: "Worker overloaded"},
 		errors.New("http 500 internal_error: Durable Object is overloaded. Requests queued for too long."),
 		&HTTPError{StatusCode: 413, Code: "payload_too_large", Message: "workspace export body is 3524788058 bytes, which exceeds the export body limit of 134217728; use paginated tree/read APIs instead"},
+		&HTTPError{StatusCode: 429, Code: "workspace_busy", Message: "workspace durable object is busy; retry after the advertised delay"},
 	}
 	for _, err := range unsupported {
 		if !exportSnapshotUnsupported(err) {
@@ -884,6 +885,200 @@ func TestReconcileFallsBackToTreeWhenExportPayloadTooLarge(t *testing.T) {
 		t.Fatalf("expected tree fallback to read one file, got %d calls", client.readFileCalls)
 	}
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+}
+
+// TestReconcileFallsBackToTreeWhenExportExceedsSubDeadline is the core #1499/
+// #1516 convergence regression: a slow atomic export that would otherwise run
+// until the no-progress bootstrap watchdog cancels it (with zero files applied
+// and no resume cursor -> permanent "non-empty without completed bootstrap"
+// loop) must instead hit its OWN short sub-deadline while the bootstrap ctx is
+// still alive, and fall through to the resumable, per-page pullRemoteFullTree.
+func TestReconcileFallsBackToTreeWhenExportExceedsSubDeadline(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{fakeClient: base, exportBlockUntilCancel: true}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   "ws_slow_export",
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		ExportTimeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree after export sub-deadline: %v", err)
+	}
+
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected slow export to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	if client.readFileCalls != 1 {
+		t.Fatalf("expected tree fallback to read one file, got %d calls", client.readFileCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+	if !syncer.state.BootstrapComplete {
+		t.Fatalf("tree fallback should complete the bootstrap; loop would otherwise persist")
+	}
+}
+
+// TestReconcileFallsBackToTreeWhenExportWorkspaceBusy covers the HTTP 429
+// workspace_busy signal (ProbeV085's prod evidence): after doJSON exhausts its
+// Retry-After backoff, the busy DO surfaces a 429 that must fall through to the
+// per-file-bounded tree path instead of retrying the contended atomic export.
+func TestReconcileFallsBackToTreeWhenExportWorkspaceBusy(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{
+		fakeClient: base,
+		exportErr: &HTTPError{
+			StatusCode: 429,
+			Code:       "workspace_busy",
+			Message:    "workspace durable object is busy; retry after the advertised delay",
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_busy_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree after 429 workspace_busy: %v", err)
+	}
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected 429 workspace_busy to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+}
+
+// TestExportEmptyButPopulatedTreeRecoversViaTreePull covers the empty-200
+// export (ProbeV085's "fresh remote export has 0 files but N tracked locally"):
+// a successful-but-empty export for a workspace we KNOW has tracked files must
+// NOT markBootstrapComplete (locking in the stale/empty mirror); it falls
+// through to the tree pull, which re-reads the real content via a different
+// cloud code path and recovers.
+func TestExportEmptyButPopulatedTreeRecoversViaTreePull(t *testing.T) {
+	disableWS := false
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{fakeClient: base, exportReturnsEmpty: true}
+	localDir := t.TempDir()
+	stateFile := filepath.Join(localDir, ".relayfile-mount-state.json")
+	if err := writeMountState(stateFile, mountState{
+		Files: map[string]trackedFile{
+			"/notion/Docs/A.md": {Revision: "rev_1", ContentType: "text/markdown", Hash: hashString("# A")},
+		},
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_empty200_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+		StateFile:   stateFile,
+		WebSocket:   &disableWS,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should recover via tree pull after empty-200 export: %v", err)
+	}
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected empty-200 export to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+	if !syncer.state.BootstrapComplete {
+		t.Fatalf("tree recovery should complete bootstrap; empty export must not have short-circuited it")
+	}
+}
+
+// TestFailedExportDoesNotAdvanceCursorOrCompleteBootstrap pins the pivotal
+// cursor-safety property: a propagated export failure (a transient 5xx that is
+// retried as an export, not a fall-through) must not advance EventsCursor nor
+// mark the bootstrap complete, so the next cycle re-attempts cleanly instead of
+// short-circuiting past unsynced content.
+func TestFailedExportDoesNotAdvanceCursorOrCompleteBootstrap(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{
+		fakeClient: base,
+		exportErr:  &HTTPError{StatusCode: 502, Message: "bad gateway"},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_failed_export",
+		RemoteRoot:  "/notion",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err == nil {
+		t.Fatalf("expected a propagated 502 export error, got nil")
+	}
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 0 {
+		t.Fatalf("transient 5xx should retry export, not fall to tree; got %d list tree calls", base.listTreeCalls)
+	}
+	if strings.TrimSpace(syncer.state.EventsCursor) != "" {
+		t.Fatalf("failed export must not advance the events cursor, got %q", syncer.state.EventsCursor)
+	}
+	if syncer.state.BootstrapComplete {
+		t.Fatalf("failed export must not mark bootstrap complete")
+	}
 }
 
 // TestResolveLatestEventCursorPrefersLatestEventID guards against regressing
@@ -4319,14 +4514,28 @@ type fakeExportClient struct {
 	tarErr        error
 	readFileCalls int
 	exportErr     error
+	// exportBlockUntilCancel makes ExportFiles block until its ctx is
+	// cancelled, simulating a slow atomic export that exceeds the export
+	// sub-deadline (or the bootstrap watchdog).
+	exportBlockUntilCancel bool
+	// exportReturnsEmpty makes ExportFiles return a successful but empty
+	// slice regardless of the populated tree, simulating the production
+	// empty-200 export for a workspace that DOES have records.
+	exportReturnsEmpty bool
 }
 
 func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {
-	_ = ctx
 	_ = workspaceID
 	c.exportCalls++
+	if c.exportBlockUntilCancel {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
 	if c.exportErr != nil {
 		return nil, c.exportErr
+	}
+	if c.exportReturnsEmpty {
+		return []RemoteFile{}, nil
 	}
 	base := normalizeRemotePath(path)
 	files := make([]RemoteFile, 0, len(c.files))


### PR DESCRIPTION
## Gate B — `/fs/export` non-convergence root cause + fix

Fixes the relayfile-mount daemon thread of #1499 / cloud #1516: a proactive persona's GitHub-issue workspace never finishes loading → the agent can't clone → 30-min timeout → **no PR artifact**.

### Root cause (confirmed in v0.8.5 source + prod `outputTail`)
The atomic full-tree export `pullRemoteFullExport` → `ExportFiles` is a **single HTTP call** that:
1. reports **NO incremental progress** until its whole body returns (`prog.touch()` only fires per-file *after* the body arrives), and
2. has **no resume cursor** ("Export is atomic … one-shot mirror with no resume cursor").

So on a slow / large / 429-contended workspace, the daemon's **no-progress bootstrap watchdog** (`bootstrapIdleTimeout = 90s`, `syncer.go:82`) cancels the export with **zero files applied**. On cancel, `exportSnapshotUnsupported` does **not** match `context.Canceled`/429, so `pullRemoteFullExport` returns `(true, err)` and `pullRemoteFull` **never falls through** to the resumable `pullRemoteFullTree`. `markBootstrapComplete()` is never reached → next cycle: `len(Files)>0 && !BootstrapComplete` → *"detected non-empty state without completed bootstrap; forcing full reconcile"* → atomic export → cancelled again. **Forever.**

Prod `outputTail` (ProbeV085) matched this verbatim: `bootstrap watchdog: no progress for 1m30s; cancelling full pull (will resume next cycle)` (34×), `detected non-empty state without completed bootstrap; forcing full reconcile` (33×), `http 429 workspace_busy` (12×), `fresh remote export has 0 files but N tracked locally`.

**Pivotal cursor check:** a cancelled export does **NOT** advance the events cursor — `EventsCursor` is only set after a *successful* `pullRemoteFull`. The bug is the export-vs-watchdog race + missing fall-through, not cursor advance.

### Fix (daemon-side, durable — handles slow + hung + empty + busy)
- **Export sub-deadline → resumable-tree fall-through.** Bound the export with its own deadline (`ExportTimeout` / env `RELAYFILE_EXPORT_TIMEOUT`, default **45s**), clamped strictly under `bootstrapIdleTimeout`. On sub-deadline expiry **while the parent bootstrap ctx is still alive**, fall through to the resumable per-page `pullRemoteFullTree`: per-page `prog.touch()` feeds the watchdog, per-page `saveState()` persists `BootstrapCursor` so it resumes across cancels and the bootstrap **COMPLETES** → the loop terminates. (Parent-ctx-dead = outer watchdog fired → propagate; next cycle's sub-deadline converges via the tree path.)
- **429 `workspace_busy` → fall to tree.** Classify HTTP 429 as export-unsupported (after `doJSON` exhausts its Retry-After backoff) so it yields to the per-file-bounded, individually-retried, resumable tree path instead of re-contending the one busy DO invocation.
- **Empty-200 export → no false completion.** A successful-but-empty export for a workspace with tracked files no longer calls `markBootstrapComplete()` (which locked in a stale/empty mirror); it falls through to the tree pull for an authoritative listing via a *different* cloud code path.

### Cross-boundary discipline (CLAUDE.md relayfile-source-of-truth)
This change adds **only one new OPTIONAL env** (`RELAYFILE_EXPORT_TIMEOUT`, safe 45s default) and touches **ZERO existing cloud↔daemon contract points** — no flag/env/`--state-file`/per-page-`saveState` changes. So cloud's `mount-script.ts` needs **no lockstep change**, only the snapshot version bump. Verified the companion contract from v0.8.5 source for CIGate's cloud PR #1553: env name `RELAYFILE_BOOTSTRAP_IDLE_TIMEOUT` (`syncer.go:1085`) + `resolveDurationEnv`→`time.ParseDuration` (so `300s` parses); `--once mount-kind=initial-sync` honors `--state-file`/`RELAYFILE_MOUNT_STATE_FILE` (`main.go:77/93`) and `saveState()` writes it **per page** during the tree pull (`syncer.go:3104` / `4724`) → the cloud outer-wrapper's watched progress file sees resumable-tree progress.

### Tests (full `internal/mountsync` suite green)
- `TestReconcileFallsBackToTreeWhenExportExceedsSubDeadline` — slow export → tree fallback + bootstrap **completes** (the convergence proof).
- `TestReconcileFallsBackToTreeWhenExportWorkspaceBusy` — 429 → tree fallback.
- `TestExportEmptyButPopulatedTreeRecoversViaTreePull` — empty-200 with tracked files → tree recovery, not short-circuited.
- `TestFailedExportDoesNotAdvanceCursorOrCompleteBootstrap` — pivotal cursor-safety: propagated 5xx export failure advances neither cursor nor BootstrapComplete.
- `TestExportSnapshotOverloadedClassification` — +429 workspace_busy case.

### Operator release steps (this PR ships code+tests only; release is `workflow_dispatch`, operator-gated)
1. Merge this PR.
2. Cut a relayfile release `vX.Y.Z` (publish.yml — operator).
3. Bump cloud snapshot `RELAYFILE_MOUNT_VERSION` to `vX.Y.Z` (`rebuild-snapshot.yml`) — the prod mount-version lever is the **Daytona snapshot pin**, not `@agent-relay/sdk RELAYFILE_VERSION`.
4. rebuild-snapshot → ProbeV085 runs the post-fix re-probe (fresh `small` issue → export converges → `runner.started` → real `codex/small-issue-<n>` PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)