### PR TITLE
fix(mount): clamp exportTimeout under positive bootstrap hard cap + narrow 429 fallback to workspace_busy (#223 follow-up)

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1109,14 +1109,24 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if exportTimeout <= 0 {
 		exportTimeout = defaultExportTimeout
 	}
-	// The export's own deadline MUST elapse before the no-progress bootstrap
-	// watchdog so a slow export yields to the resumable tree pull while the
-	// bootstrap ctx is still alive. Clamp to a fraction of the idle window so a
-	// misconfiguration can't let the export outlive the watchdog (which would
-	// defeat the fall-through and re-create the #1499/#1516 stall loop).
-	if maxExportTimeout := bootstrapIdleTimeout * 3 / 4; maxExportTimeout > 0 && exportTimeout > maxExportTimeout {
+	// The export's own deadline MUST elapse before the bootstrap context can
+	// be canceled so a slow export yields to the resumable tree pull while the
+	// bootstrap ctx is still alive. Clamp to a fraction of the active bootstrap
+	// window so misconfiguration can't let the export outlive either the
+	// no-progress watchdog or a hard bootstrap cap (a positive
+	// RELAYFILE_BOOTSTRAP_TIMEOUT would otherwise cancel the parent ctx before
+	// the export sub-deadline, defeating the same-cycle tree fall-through and
+	// re-creating the #1499/#1516 stall loop).
+	maxExportTimeout := bootstrapIdleTimeout * 3 / 4
+	if bootstrapTimeout > 0 {
+		hardCapMax := bootstrapTimeout * 3 / 4
+		if maxExportTimeout <= 0 || hardCapMax < maxExportTimeout {
+			maxExportTimeout = hardCapMax
+		}
+	}
+	if maxExportTimeout > 0 && exportTimeout > maxExportTimeout {
 		if opts.Logger != nil {
-			opts.Logger.Printf("clamping exportTimeout from %s to %s (must stay strictly under bootstrapIdleTimeout %s so the export yields to the resumable tree pull before the watchdog fires)", exportTimeout, maxExportTimeout, bootstrapIdleTimeout)
+			opts.Logger.Printf("clamping exportTimeout from %s to %s (must stay strictly under the active bootstrap window — no-progress watchdog %s, hard cap %s — so the export yields to the resumable tree pull before the bootstrap ctx is canceled)", exportTimeout, maxExportTimeout, bootstrapIdleTimeout, bootstrapTimeout)
 		}
 		exportTimeout = maxExportTimeout
 	}
@@ -3014,8 +3024,10 @@ func exportSnapshotUnsupported(err error) bool {
 	// export keeps contending for the one overloaded invocation; fall through
 	// to pullRemoteFullTree, whose paginated ListTree + per-file reads are
 	// individually bounded, individually retried, and resume from the persisted
-	// cursor instead of restarting the whole export.
-	if httpErr.StatusCode == http.StatusTooManyRequests {
+	// cursor instead of restarting the whole export. Other 429 classes (for
+	// example global rate limits or queue pressure) are not export-specific and
+	// should remain visible to the caller after retries are exhausted.
+	if httpErr.StatusCode == http.StatusTooManyRequests && strings.EqualFold(httpErr.Code, "workspace_busy") {
 		return true
 	}
 	return httpErr.StatusCode == http.StatusBadRequest && strings.EqualFold(httpErr.Code, "bad_request")

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -833,6 +833,8 @@ func TestExportSnapshotOverloadedClassification(t *testing.T) {
 	supported := []error{
 		&HTTPError{StatusCode: 500, Code: "internal_error", Message: "boom"},
 		&HTTPError{StatusCode: 502, Message: "bad gateway"},
+		&HTTPError{StatusCode: 429, Code: "rate_limited", Message: "rate limit exceeded"},
+		&HTTPError{StatusCode: 429, Code: "queue_full", Message: "cloud write queue is full"},
 		errors.New("http2: server sent GOAWAY and closed the connection"),
 	}
 	for _, err := range supported {
@@ -932,6 +934,51 @@ func TestReconcileFallsBackToTreeWhenExportExceedsSubDeadline(t *testing.T) {
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
 	if !syncer.state.BootstrapComplete {
 		t.Fatalf("tree fallback should complete the bootstrap; loop would otherwise persist")
+	}
+}
+
+// TestReconcileFallsBackToTreeWhenExportExceedsHardBootstrapCap covers the
+// companion clamp: when a positive RELAYFILE_BOOTSTRAP_TIMEOUT (hard cap) is
+// shorter than the configured export sub-deadline, exportTimeout is clamped
+// below the hard cap so the export still yields to the resumable tree pull
+// while the parent bootstrap ctx is alive (rather than the hard cap cancelling
+// the parent first and propagating instead of falling through).
+func TestReconcileFallsBackToTreeWhenExportExceedsHardBootstrapCap(t *testing.T) {
+	base := &fakeClient{
+		files: map[string]RemoteFile{
+			"/notion/Docs/A.md": {
+				Path:        "/notion/Docs/A.md",
+				Revision:    "rev_1",
+				ContentType: "text/markdown",
+				Content:     "# A",
+			},
+		},
+	}
+	client := &fakeExportClient{fakeClient: base, exportBlockUntilCancel: true}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:      "ws_slow_export_hard_cap",
+		RemoteRoot:       "/notion",
+		LocalRoot:        localDir,
+		BootstrapTimeout: 200 * time.Millisecond,
+		ExportTimeout:    time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile should fall back to tree before hard bootstrap cap: %v", err)
+	}
+	if client.exportCalls != 1 {
+		t.Fatalf("expected one export snapshot attempt, got %d", client.exportCalls)
+	}
+	if base.listTreeCalls != 1 {
+		t.Fatalf("expected hard-cap-clamped export to fall back to list tree once, got %d calls", base.listTreeCalls)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "A.md"), "# A")
+	if !syncer.state.BootstrapComplete {
+		t.Fatalf("tree fallback should complete the bootstrap before the hard cap")
 	}
 }
 


### PR DESCRIPTION
## #223 follow-up — bring the pr-reviewer bot's hardening onto main

The pr-reviewer bot pushed two real hardening fixes (`5219a1b`) to the #223 branch **after** #223 was merged, so they never reached main. This brings them in cleanly — **hand-merged, not cherry-picked**, because the bot branched from #223's first commit (`9406189`) and a cherry-pick would silently revert the gemini clamp-warning log now on main. The bot commit's unrelated `.trajectories/*` debris is **excluded**.

Both fixes reviewed and concurred by me + CIGate + PortabilityDesign.

### 1. Clamp `exportTimeout` under a positive bootstrap hard cap
`exportTimeout` was previously clamped only below ¾·`bootstrapIdleTimeout` (the no-progress watchdog). If an operator sets a positive `RELAYFILE_BOOTSTRAP_TIMEOUT` (hard total cap) **shorter** than the export sub-deadline, the parent bootstrap ctx's hard cap fires *before* the export's own deadline → `pullRemoteFullExport` takes the `ctx.Err()!=nil` propagate branch instead of falling through to the resumable tree pull → same-cycle convergence defeated. Now clamps to the **min** of ¾·idle and ¾·hard-cap. No-op under the recommended unset (`0`/unbounded) config — purely defensive for the non-recommended config.

### 2. Narrow the 429 → tree fallback to `workspace_busy`
The 429 fall-through is now restricted to `Code == "workspace_busy"` (the DO-busy signal in ProbeV085's prod evidence). Other 429 classes (global `rate_limited`, `queue_full`) are not export-specific — flooding the per-file tree path wouldn't help and could worsen a global limit — so they remain visible to the caller after `doJSON` exhausts its Retry-After backoff.

### Tests (full `internal/mountsync` suite green, `go vet` + gofmt clean)
- `TestReconcileFallsBackToTreeWhenExportExceedsHardBootstrapCap` — `BootstrapTimeout=200ms` + `ExportTimeout=1s` → clamped to 150ms → falls to tree before the hard cap + bootstrap completes.
- `TestExportSnapshotOverloadedClassification` — +`429 rate_limited` and +`429 queue_full` in the *supported* (retry-export, not fall-to-tree) set.
- Existing `TestReconcileFallsBackToTreeWhenExportWorkspaceBusy` still green (workspace_busy still falls to tree).

### Contract
Zero cloud↔daemon contract change (still only the one optional `RELAYFILE_EXPORT_TIMEOUT` env from #223). Ships in the same operator relayfile release as #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)