### PR TITLE
fix(mountsync): preserve scoped write path case

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -4322,12 +4322,12 @@ func (s *Syncer) canWritePath(filePath string) bool {
 }
 
 func scopeGrantsWrite(scope, filePath string) bool {
-	scope = strings.ToLower(strings.TrimSpace(scope))
+	scope = strings.TrimSpace(scope)
 	if scope == "" {
 		return false
 	}
 	// Short-form scope without plane prefix.
-	if scope == "fs:write" || scope == "fs:manage" {
+	if strings.EqualFold(scope, "fs:write") || strings.EqualFold(scope, "fs:manage") {
 		return true
 	}
 
@@ -4336,9 +4336,9 @@ func scopeGrantsWrite(scope, filePath string) bool {
 		return false
 	}
 
-	plane := segments[0]
-	res := segments[1]
-	act := segments[2]
+	plane := strings.ToLower(strings.TrimSpace(segments[0]))
+	res := strings.ToLower(strings.TrimSpace(segments[1]))
+	act := strings.ToLower(strings.TrimSpace(segments[2]))
 
 	// Plane must be "relayfile" or wildcard.
 	if plane != "relayfile" && plane != "*" {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3198,6 +3198,21 @@ func TestCanWritePathWithRelayauthScopes(t *testing.T) {
 	}
 }
 
+func TestScopeGrantsWritePreservesPathCase(t *testing.T) {
+	if !scopeGrantsWrite("relayfile:fs:write:/README.md/*", "/README.md") {
+		t.Fatalf("write scope over /README.md must grant /README.md (case preserved)")
+	}
+	if !scopeGrantsWrite("relayfile:fs:write:/packages/web/lib/MyComponent/*", "/packages/web/lib/MyComponent/index.ts") {
+		t.Fatalf("write scope over /packages/web/lib/MyComponent must grant files under it")
+	}
+	if !scopeGrantsWrite("RELAYFILE:FS:WRITE:/Foo/*", "/Foo/bar.ts") {
+		t.Fatalf("plane/resource/action must stay case-insensitive")
+	}
+	if scopeGrantsWrite("relayfile:fs:write:/Foo/*", "/foo/bar.ts") {
+		t.Fatalf("case-mismatched path must NOT be granted (paths are case-sensitive)")
+	}
+}
+
 func TestCanReadPathWithPerFileScopes(t *testing.T) {
 	scopes := map[string]struct{}{
 		"relayfile:fs:read:/src/app.ts": {},


### PR DESCRIPTION
## Summary

- preserve the case of the path segment in `scopeGrantsWrite`
- keep `plane:resource:action` matching case-insensitive
- add a regression for uppercase file and CamelCase directory write scopes

Fixes #231.

## Context

The Tier-2 production scoped-writeback harness exposed that mountsync lowercased the full write scope before comparing its path segment to the case-preserved remote path. Narrow write scopes over real repo paths such as `README.md`, `LAYOUT.md`, or CamelCase directories could therefore deny the member's own in-scope writeback.

ClaudeGateB also audited the Cloud TS read-side matcher: it already preserves scope path case and only lowercases non-path scope metadata. This change restores Go write-side parity with the already-correct read-side semantics.

## Verification

- RED anchor: `go test ./internal/mountsync -run TestScopeGrantsWritePreservesPathCase -count=1` failed on origin/main before this fix
- `go test ./internal/mountsync -run 'TestScopeGrantsWritePreservesPathCase|TestCanWritePathWithRelayauthScopes|TestCanWritePathWithShortScopes' -count=1`
- `go test ./internal/mountsync -run 'TestScopeGrantsWritePreservesPathCase' -count=1`
- `go test ./internal/mountsync -count=1`
