### PR TITLE
Harden tier2 scoped writeback harness

### DIFF
--- a/cmd/relayfile-mount/fuse_mount.go
+++ b/cmd/relayfile-mount/fuse_mount.go
@@ -18,6 +18,9 @@ func init() {
 
 func runFuseMount(ctx context.Context, cfg mountConfig) error {
 	httpClient := mountsync.NewHTTPClient(cfg.baseURL, cfg.token, &http.Client{Timeout: cfg.timeout})
+	if cfg.logHTTPStatus {
+		httpClient.SetHTTPStatusLogger(log.Default())
+	}
 
 	fuseCfg := mountfuse.Config{
 		Client:      httpClient,

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -53,6 +53,7 @@ type mountConfig struct {
 	lowMemory        bool
 	pprofAddr        string
 	memlogInterval   time.Duration
+	logHTTPStatus    bool
 	scopes           []string
 	once             bool
 	mode             string
@@ -88,6 +89,7 @@ func main() {
 	lowMemory := flag.Bool("low-memory", boolEnv("RELAYFILE_MOUNT_LOW_MEMORY", false), "reduce mount memory use by omitting per-file public state and deferring content reads")
 	pprofAddr := flag.String("pprof-addr", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PPROF_ADDR")), "optional pprof listen address, e.g. 127.0.0.1:6060")
 	memlogInterval := flag.Duration("memlog-interval", durationEnv("RELAYFILE_MOUNT_MEMLOG_INTERVAL", 0), "optional interval for logging runtime memory stats")
+	logHTTPStatus := flag.Bool("log-http-status", boolEnv("RELAYFILE_MOUNT_LOG_HTTP_STATUS", false), "log Relayfile HTTP response statuses for mount observability")
 	mode := flag.String("mode", envOrDefault("RELAYFILE_MOUNT_MODE", mountModePoll), "mount mode: poll (synced mirror, recommended) or fuse")
 	fuse := flag.Bool("fuse", boolEnv("RELAYFILE_MOUNT_FUSE", false), "shortcut for --mode=fuse")
 	once := flag.Bool("once", false, "run one sync cycle and exit")
@@ -145,6 +147,7 @@ func main() {
 		lowMemory:        *lowMemory,
 		pprofAddr:        strings.TrimSpace(*pprofAddr),
 		memlogInterval:   *memlogInterval,
+		logHTTPStatus:    *logHTTPStatus,
 		scopes:           parseTokenScopes(strings.TrimSpace(*token)),
 		once:             *once,
 		mode:             resolvedMode,
@@ -297,6 +300,9 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 	// per-cycle / bootstrap / cursor contexts; NewSyncHTTPClient wires a
 	// transport that bounds connect/handshake/time-to-first-byte only.
 	client := mountsync.NewHTTPClient(cfg.baseURL, cfg.token, mountsync.NewSyncHTTPClient())
+	if cfg.logHTTPStatus {
+		client.SetHTTPStatusLogger(log.Default())
+	}
 	syncer, err := mountsync.NewSyncer(client, mountsync.SyncerOptions{
 		WorkspaceID:        cfg.workspaceID,
 		RemoteRoot:         cfg.remotePath,

--- a/internal/mountsync/http_client_test.go
+++ b/internal/mountsync/http_client_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -42,6 +43,46 @@ func TestHTTPClientRetriesTransientFailure(t *testing.T) {
 	}
 	if atomic.LoadInt32(&calls) != 2 {
 		t.Fatalf("expected exactly 2 calls (1 retry), got %d", atomic.LoadInt32(&calls))
+	}
+}
+
+func TestHTTPClientLogsRetriedHTTPStatus(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"code":"workspace_busy","reason":"write_admission_limit"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/notion","entries":[],"nextCursor":null}`))
+	}))
+	defer server.Close()
+
+	logger := &captureLogger{}
+	client := NewHTTPClient(server.URL, "token", server.Client())
+	client.SetHTTPStatusLogger(logger)
+
+	if _, err := client.ListTree(context.Background(), "ws_retry", "/notion", 2, ""); err != nil {
+		t.Fatalf("expected retry to recover from transient 429, got error: %v", err)
+	}
+	logs := strings.Join(logger.lines, "\n")
+	if !strings.Contains(logs, "relayfile http 429") {
+		t.Fatalf("expected retried 429 status to be logged, got %q", logs)
+	}
+	if !strings.Contains(logs, `retry-after="0"`) {
+		t.Fatalf("expected Retry-After header to be logged, got %q", logs)
+	}
+	if !strings.Contains(logs, "relayfile http 200") {
+		t.Fatalf("expected final 200 status to be logged, got %q", logs)
+	}
+	for _, line := range logger.lines {
+		if strings.Contains(line, "relayfile http 200") && strings.Contains(line, "retry-after=") {
+			t.Fatalf("did not expect Retry-After field on final 200 log line %q", line)
+		}
 	}
 }
 

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -241,13 +241,14 @@ type LazyMaterializeClient interface {
 }
 
 type HTTPClient struct {
-	baseURL    string
-	token      string
-	tokenMu    sync.RWMutex
-	httpClient *http.Client
-	maxRetries int
-	baseDelay  time.Duration
-	maxDelay   time.Duration
+	baseURL          string
+	token            string
+	tokenMu          sync.RWMutex
+	httpClient       *http.Client
+	maxRetries       int
+	baseDelay        time.Duration
+	maxDelay         time.Duration
+	httpStatusLogger Logger
 }
 
 // NewSyncTransport builds the *http.Transport used by every mount-daemon
@@ -322,6 +323,35 @@ func NewHTTPClient(baseURL, token string, httpClient *http.Client) *HTTPClient {
 		baseDelay:  100 * time.Millisecond,
 		maxDelay:   defaultRetryAfterMaxDelay,
 	}
+}
+
+func (c *HTTPClient) SetHTTPStatusLogger(logger Logger) {
+	c.httpStatusLogger = logger
+}
+
+func (c *HTTPClient) logHTTPStatus(method, requestPath string, statusCode int, retryAfter string, attempt int) {
+	if c.httpStatusLogger == nil {
+		return
+	}
+	retryAfter = strings.TrimSpace(retryAfter)
+	if retryAfter == "" {
+		c.httpStatusLogger.Printf(
+			"relayfile http %d method=%s path=%s attempt=%d",
+			statusCode,
+			method,
+			requestPath,
+			attempt+1,
+		)
+		return
+	}
+	c.httpStatusLogger.Printf(
+		"relayfile http %d method=%s path=%s retry-after=%q attempt=%d",
+		statusCode,
+		method,
+		requestPath,
+		retryAfter,
+		attempt+1,
+	)
 }
 
 func (c *HTTPClient) ListTree(ctx context.Context, workspaceID, path string, depth int, cursor string) (TreeResponse, error) {
@@ -490,6 +520,7 @@ func (c *HTTPClient) ExportGithubWorkingTreeTar(ctx context.Context, workspaceID
 			return GithubWorkingTreeTar{}, err
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+			c.logHTTPStatus(http.MethodGet, requestPath, resp.StatusCode, resp.Header.Get("Retry-After"), attempt)
 			return GithubWorkingTreeTar{
 				Body:        resp.Body,
 				ContentType: resp.Header.Get("Content-Type"),
@@ -500,6 +531,7 @@ func (c *HTTPClient) ExportGithubWorkingTreeTar(ctx context.Context, workspaceID
 		if readErr != nil {
 			return GithubWorkingTreeTar{}, readErr
 		}
+		c.logHTTPStatus(http.MethodGet, requestPath, resp.StatusCode, resp.Header.Get("Retry-After"), attempt)
 		if (resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode >= 500 && resp.StatusCode <= 599)) && attempt < c.maxRetries {
 			if waitErr := waitWithContext(ctx, c.retryDelay(attempt+1, resp.Header.Get("Retry-After"))); waitErr != nil {
 				return GithubWorkingTreeTar{}, waitErr
@@ -585,6 +617,7 @@ func (c *HTTPClient) doJSON(
 		if readErr != nil {
 			return readErr
 		}
+		c.logHTTPStatus(method, requestPath, resp.StatusCode, resp.Header.Get("Retry-After"), attempt)
 
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 			if out == nil || len(payloadBytes) == 0 {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -248,6 +248,7 @@ type HTTPClient struct {
 	maxRetries       int
 	baseDelay        time.Duration
 	maxDelay         time.Duration
+	httpStatusLogMu  sync.RWMutex
 	httpStatusLogger Logger
 }
 
@@ -326,16 +327,21 @@ func NewHTTPClient(baseURL, token string, httpClient *http.Client) *HTTPClient {
 }
 
 func (c *HTTPClient) SetHTTPStatusLogger(logger Logger) {
+	c.httpStatusLogMu.Lock()
+	defer c.httpStatusLogMu.Unlock()
 	c.httpStatusLogger = logger
 }
 
 func (c *HTTPClient) logHTTPStatus(method, requestPath string, statusCode int, retryAfter string, attempt int) {
-	if c.httpStatusLogger == nil {
+	c.httpStatusLogMu.RLock()
+	logger := c.httpStatusLogger
+	c.httpStatusLogMu.RUnlock()
+	if logger == nil {
 		return
 	}
 	retryAfter = strings.TrimSpace(retryAfter)
 	if retryAfter == "" {
-		c.httpStatusLogger.Printf(
+		logger.Printf(
 			"relayfile http %d method=%s path=%s attempt=%d",
 			statusCode,
 			method,
@@ -344,7 +350,7 @@ func (c *HTTPClient) logHTTPStatus(method, requestPath string, statusCode int, r
 		)
 		return
 	}
-	c.httpStatusLogger.Printf(
+	logger.Printf(
 		"relayfile http %d method=%s path=%s retry-after=%q attempt=%d",
 		statusCode,
 		method,

--- a/test/load/README.md
+++ b/test/load/README.md
@@ -28,9 +28,11 @@ RELAYFILE_TIER2_WORKSPACE_TOKEN=<workspace-token> \
 npm run test:load:tier2-scoped-writeback
 ```
 
-`RELAYFILE_TIER2_WORKSPACE_TOKEN` is always required because the harness seeds
-and verifies the Relayfile workspace directly. `RELAYFILE_TIER2_RELAYAUTH_API_KEY`
-is optional; when omitted, the workspace token is also used to mint path tokens.
+Alternatively, provide `RELAYFILE_TIER2_RELAYAUTH_API_KEY=<relayauth-api-key>`
+instead of `RELAYFILE_TIER2_WORKSPACE_TOKEN`; the harness mints a temporary
+workspace token before minting scoped path tokens. When a workspace token is
+provided directly, it must be able to mint RelayAuth path tokens. The harness
+uses a run-scoped data-plane path token to seed and verify Relayfile contents.
 Direct Relayfile and RelayAuth API calls are bounded by
 `RELAYFILE_TIER2_API_TIMEOUT_MS`, defaulting to 45000 ms.
 

--- a/test/load/tier2-cfdo-scoped-writeback.mjs
+++ b/test/load/tier2-cfdo-scoped-writeback.mjs
@@ -16,7 +16,6 @@ const REQUIRED_ENV = [
   "RELAYFILE_TIER2_RELAYFILE_URL",
   "RELAYFILE_TIER2_RELAYAUTH_URL",
   "RELAYFILE_TIER2_WORKSPACE_ID",
-  "RELAYFILE_TIER2_WORKSPACE_TOKEN",
 ];
 
 function nowIso() {
@@ -36,7 +35,8 @@ Required for a real run:
   RELAYFILE_TIER2_RELAYAUTH_URL=https://dev-<stage>-api.relayauth.dev
   RELAYFILE_TIER2_WORKSPACE_ID=<disposable-workspace-id>
   RELAYFILE_TIER2_WORKSPACE_TOKEN=<workspace-token>
-  RELAYFILE_TIER2_RELAYAUTH_API_KEY=<relayauth-api-key>  # optional for minting
+    # OR
+  RELAYFILE_TIER2_RELAYAUTH_API_KEY=<relayauth-api-key>  # mints a workspace token first
 
 Optional:
   RELAYFILE_TIER2_MEMBER_COUNT=6
@@ -101,6 +101,10 @@ function normalizeRemotePath(raw) {
 
 function pathScope(root) {
   return `relayfile:fs:write:${normalizeRemotePath(root)}/*`;
+}
+
+function tokenPath(root) {
+  return `${normalizeRemotePath(root)}/*`;
 }
 
 function scopedLocalDir(localRoot, remotePath) {
@@ -203,6 +207,9 @@ function missingCredentialReasons(env = process.env) {
   if (trimEnv("RELAYFILE_TIER2_RUN", env) !== "1") {
     missing.push("RELAYFILE_TIER2_RUN=1");
   }
+  if (!trimEnv("RELAYFILE_TIER2_WORKSPACE_TOKEN", env) && !trimEnv("RELAYFILE_TIER2_RELAYAUTH_API_KEY", env)) {
+    missing.push("RELAYFILE_TIER2_WORKSPACE_TOKEN or RELAYFILE_TIER2_RELAYAUTH_API_KEY");
+  }
   return missing;
 }
 
@@ -210,9 +217,10 @@ function buildConfig() {
   const runId =
     trimEnv("RELAYFILE_TIER2_RUN_ID") ||
     `tier2-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+  const normalizedRunId = runId.toLowerCase();
   return {
     startedAt: nowIso(),
-    runId,
+    runId: normalizedRunId,
     relayfileUrl: normalizeBaseUrl(trimEnv("RELAYFILE_TIER2_RELAYFILE_URL"), "RELAYFILE_TIER2_RELAYFILE_URL"),
     relayauthUrl: normalizeBaseUrl(trimEnv("RELAYFILE_TIER2_RELAYAUTH_URL"), "RELAYFILE_TIER2_RELAYAUTH_URL"),
     workspaceId: trimEnv("RELAYFILE_TIER2_WORKSPACE_ID"),
@@ -267,6 +275,7 @@ async function requestJSON(config, { method, api = "relayfile", path: requestPat
       headers: {
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...(body ? { "Content-Type": "application/json" } : {}),
+        ...(api === "relayfile" ? { "X-Correlation-Id": `tier2-${config.runId}` } : {}),
         ...headers,
       },
       body: body ? JSON.stringify(body) : undefined,
@@ -305,20 +314,50 @@ async function requestJSON(config, { method, api = "relayfile", path: requestPat
   };
 }
 
-async function mintPathToken(config, member) {
-  const headers = {};
-  if (config.relayAuthApiKey) {
-    headers["x-api-key"] = config.relayAuthApiKey;
+async function mintWorkspaceToken(config) {
+  const response = await requestJSON(config, {
+    api: "relayauth",
+    method: "POST",
+    path: "/v1/tokens/workspace",
+    headers: {
+      "x-api-key": config.relayAuthApiKey,
+    },
+    body: {
+      workspaceId: config.workspaceId,
+      name: `tier2-cfdo-${config.runId}`,
+      scopes: ["relayauth:token:create:*", "relayfile:fs:read:*", "relayfile:fs:write:*"],
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`workspace token mint failed: ${response.status} ${JSON.stringify(response.body ?? response.text)}`);
   }
+  const workspaceToken = response.body?.key;
+  if (typeof workspaceToken !== "string" || !workspaceToken.startsWith("relay_ws_")) {
+    throw new Error("workspace token mint did not return a relay_ws_ key");
+  }
+  config.workspaceToken = workspaceToken;
+  return {
+    status: response.status,
+    durationMs: response.durationMs,
+    tokenPrefix: workspaceToken.slice(0, 9),
+    workspaceToken: {
+      id: response.body?.workspaceToken?.id,
+      kind: response.body?.workspaceToken?.kind,
+      workspaceId: response.body?.workspaceToken?.workspaceId,
+      scopes: response.body?.workspaceToken?.scopes,
+    },
+  };
+}
+
+async function mintPathToken(config, member) {
   const response = await requestJSON(config, {
     api: "relayauth",
     method: "POST",
     path: "/v1/tokens/path",
-    token: config.relayAuthApiKey ? "" : config.workspaceToken,
-    headers,
+    token: config.workspaceToken,
     body: {
       workspaceId: config.workspaceId,
-      paths: [member.remoteRoot],
+      paths: [tokenPath(member.remoteRoot)],
       ttlSeconds: config.tokenTtlSeconds,
       agentName: `tier2-member-${member.index}`,
     },
@@ -335,6 +374,36 @@ async function mintPathToken(config, member) {
   return { token: accessToken, scopes, mintResponse: response };
 }
 
+async function mintRunDataPlaneToken(config) {
+  const runRoot = `/team-tier2/${config.runId}`;
+  const response = await requestJSON(config, {
+    api: "relayauth",
+    method: "POST",
+    path: "/v1/tokens/path",
+    token: config.workspaceToken,
+    body: {
+      workspaceId: config.workspaceId,
+      paths: [tokenPath(runRoot)],
+      ttlSeconds: config.tokenTtlSeconds,
+      agentName: "tier2-data-plane",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`data-plane token mint failed: ${response.status} ${JSON.stringify(response.body ?? response.text)}`);
+  }
+  const accessToken = response.body?.accessToken;
+  if (typeof accessToken !== "string" || accessToken.trim() === "") {
+    throw new Error("data-plane token mint did not return accessToken");
+  }
+  return {
+    token: accessToken,
+    scopes: scopesFromToken(accessToken),
+    paths: response.body?.paths,
+    status: response.status,
+    durationMs: response.durationMs,
+  };
+}
+
 async function seedRemote(config, members) {
   const files = members.map((member) => ({
     path: `${member.remoteRoot}/README.md`,
@@ -344,7 +413,7 @@ async function seedRemote(config, members) {
   const response = await requestJSON(config, {
     method: "POST",
     path: `/v1/workspaces/${encodeURIComponent(config.workspaceId)}/fs/bulk`,
-    token: config.workspaceToken,
+    token: config.dataPlaneToken,
     body: { files },
   });
   if (!response.ok) {
@@ -358,7 +427,7 @@ async function readRemoteFile(config, remotePath) {
   return requestJSON(config, {
     method: "GET",
     path: `/v1/workspaces/${encodeURIComponent(config.workspaceId)}/fs/file?${query.toString()}`,
-    token: config.workspaceToken,
+    token: config.dataPlaneToken,
   });
 }
 
@@ -448,6 +517,7 @@ async function runMountOnce(config, binaryPath, member, phase, extraArgs = []) {
     config.mountTimeout,
     "--bootstrap-timeout",
     "0",
+    "--log-http-status",
     ...extraArgs,
   ];
   const started = Date.now();
@@ -580,7 +650,7 @@ async function directAdmissionProbe(config, members) {
       requestJSON(config, {
         method: "POST",
         path: `/v1/workspaces/${encodeURIComponent(config.workspaceId)}/fs/bulk`,
-        token: config.workspaceToken,
+        token: config.dataPlaneToken,
         headers: { "X-Relayfile-Write-Class": "foreground_content" },
         body: { files: [file] },
       }),
@@ -651,7 +721,7 @@ async function runHarness() {
       writesPerMember: config.writesPerMember,
       apiTimeoutMs: config.apiTimeoutMs,
       mountTimeout: config.mountTimeout,
-      tokenSource: config.relayAuthApiKey ? "relayauth-api-key" : "workspace-token",
+      tokenSource: config.relayAuthApiKey ? "relayauth-api-key-via-workspace-token" : "workspace-token",
       evidencePath: config.evidencePath,
     },
     workRoot,
@@ -662,11 +732,21 @@ async function runHarness() {
     })),
   });
   try {
+    if (config.relayAuthApiKey) {
+      evidence.workspaceTokenMint = await mintWorkspaceToken(config);
+    }
     const binaryPath = await buildMountBinary(workRoot);
     evidence.binary = { path: binaryPath };
 
     await prepareMemberRoots(config, workRoot, members);
-    evidence.seed = { remote: await seedRemote(config, members) };
+    const dataPlaneToken = await mintRunDataPlaneToken(config);
+    config.dataPlaneToken = dataPlaneToken.token;
+    evidence.dataPlaneToken = {
+      paths: dataPlaneToken.paths,
+      scopes: dataPlaneToken.scopes,
+      status: dataPlaneToken.status,
+      durationMs: dataPlaneToken.durationMs,
+    };
 
     for (const member of members) {
       const tokenResult = await mintPathToken(config, member);
@@ -678,6 +758,7 @@ async function runHarness() {
       remoteRoot: member.remoteRoot,
       scopes: member.scopes,
     }));
+    evidence.seed = { remote: await seedRemote(config, members) };
 
     const initialMounts = await Promise.all(
       members.map((member) => runMountOnce(config, binaryPath, member, "bootstrap")),
@@ -691,7 +772,7 @@ async function runHarness() {
 
     await writeMemberChanges(config, members);
     const writebackMounts = await Promise.all(
-      members.map((member) => runMountOnce(config, binaryPath, member, "writeback", ["--full-reconcile"])),
+      members.map((member) => runMountOnce(config, binaryPath, member, "writeback")),
     );
     evidence.mounts = [...initialMounts, ...writebackMounts].map(redactMountResult);
     assertNoPathology(writebackMounts);
@@ -764,6 +845,7 @@ async function selfTest() {
   );
   const good = [pathScope("/team-tier2/run/member-1"), "relayfile:fs:read:/team-tier2/run/member-1/*"];
   validateMemberWriteScopes(good, "/team-tier2/run/member-1");
+  assert.equal(tokenPath("/team-tier2/run/member-1"), "/team-tier2/run/member-1/*");
   assert.throws(() => validateMemberWriteScopes([], "/team-tier2/run/member-1"), /no scopes/);
   assert.throws(() => validateMemberWriteScopes(["fs:write"], "/team-tier2/run/member-1"), /broad/);
   assert.throws(() => validateMemberWriteScopes([pathScope("/team-tier2/run/member-1"), "relayfile:fs:write"], "/team-tier2/run/member-1"), /broad/);
@@ -842,7 +924,9 @@ async function selfTest() {
   }
   const missing = missingCredentialReasons({});
   assert(missing.includes("RELAYFILE_TIER2_RUN=1"));
-  assert(missing.includes("RELAYFILE_TIER2_WORKSPACE_TOKEN"));
+  assert(missing.includes("RELAYFILE_TIER2_WORKSPACE_TOKEN or RELAYFILE_TIER2_RELAYAUTH_API_KEY"));
+  assert(!missingCredentialReasons({ RELAYFILE_TIER2_WORKSPACE_TOKEN: "relay_ws_test" }).includes("RELAYFILE_TIER2_WORKSPACE_TOKEN or RELAYFILE_TIER2_RELAYAUTH_API_KEY"));
+  assert(!missingCredentialReasons({ RELAYFILE_TIER2_RELAYAUTH_API_KEY: "rak_test" }).includes("RELAYFILE_TIER2_WORKSPACE_TOKEN or RELAYFILE_TIER2_RELAYAUTH_API_KEY"));
   console.log("tier2 harness self-test passed");
 }
 


### PR DESCRIPTION
## Summary
- fix the Tier-2 harness API-key credential path: WEB/RelayAuth API key now mints one relay_ws_ workspace token via /v1/tokens/workspace, then uses Bearer relay_ws_ for /v1/tokens/path
- keep data-plane operations on relay_pa_ path tokens: run-scoped relay_pa_ for seed/read/admission probes, per-member relay_pa_ tokens for member writebacks
- request paths as <root>/* so minted scopes match the strict relayfile:fs:write:<root>/* allowlist
- add opt-in relayfile-mount HTTP status logging and enable it in the harness so retried mount/writeback 429 + Retry-After responses are observable
- lowercase harness run IDs as a temporary harness-only workaround; #232 fixed the real path-case bug on main

## Production evidence already captured
- /tmp/relayfile-tier2-prod-full-20260601t071420z.json: N=6x2, no #1602 pathology, scoped correctness verified
- /tmp/relayfile-tier2-prod-saturate-20260601t071950z.json: N=16x2, 8x write_admission_limit 429 with Retry-After=5, no 500/object-reset/context-deadline

## Verification
- npm run test:load:tier2-scoped-writeback:self-test
- go test ./cmd/relayfile-mount ./internal/mountsync -count=1

## Notes
- x-api-key is no longer sent to /v1/tokens/path; that endpoint receives only Bearer relay_ws_.
- The mount HTTP status logger omits retry-after= when the header is absent, avoiding false positive Retry-After observations on successful 200 responses.
- This branch is rebased on main after #232 (squash 7497f16).
