### PR TITLE
fix: lazy github matcher for scoped roots

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -3114,13 +3114,21 @@ func isUnderLazyGithubRepoSubtree(remoteRoot, remotePath string) bool {
 	if !isUnderRemoteRoot(remoteRoot, remotePath) {
 		return false
 	}
-	rel := strings.TrimPrefix(remotePath, remoteRoot)
-	rel = strings.TrimPrefix(rel, "/")
-	if rel == "" {
+	absolute := strings.TrimPrefix(remotePath, "/")
+	return isLazyGithubRepoSubtreePath(absolute)
+}
+
+func isLazyGithubRepoSubtreePath(path string) bool {
+	if path == "" {
 		return false
 	}
-	segments := strings.Split(rel, "/")
-	return len(segments) >= 5 && segments[0] == "github" && segments[1] == "repos"
+	segments := strings.Split(path, "/")
+	for i := 0; i+1 < len(segments); i++ {
+		if segments[i] == "github" && segments[i+1] == "repos" {
+			return len(segments[i:]) >= 5
+		}
+	}
+	return false
 }
 
 func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]struct{}, prog bootstrapProgress) error {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -512,6 +512,18 @@ func TestIsUnderLazyGithubRepoSubtree(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "slack integration",
+			remoteRoot: "/",
+			remotePath: "/slack/channels/C123/messages/1711111000_000100.json",
+			want:       false,
+		},
+		{
+			name:       "memory integration",
+			remoteRoot: "/",
+			remotePath: "/memory/workspace/daily-ship.md",
+			want:       false,
+		},
+		{
 			name:       "root github dir",
 			remoteRoot: "/",
 			remotePath: "/github",
@@ -522,6 +534,30 @@ func TestIsUnderLazyGithubRepoSubtree(t *testing.T) {
 			remoteRoot: "/relay",
 			remotePath: "/relay/github/repos/octocat/hello-world/issues/issue-1.json",
 			want:       true,
+		},
+		{
+			name:       "scoped org remote root repo subtree file",
+			remoteRoot: "/github/repos/AgentWorkforce",
+			remotePath: "/github/repos/AgentWorkforce/cloud/pulls/123.json",
+			want:       true,
+		},
+		{
+			name:       "scoped org and repo remote root repo subtree file",
+			remoteRoot: "/github/repos/AgentWorkforce/cloud/pulls",
+			remotePath: "/github/repos/AgentWorkforce/cloud/pulls/123.json",
+			want:       true,
+		},
+		{
+			name:       "scoped org remote root repo root",
+			remoteRoot: "/github/repos/AgentWorkforce",
+			remotePath: "/github/repos/AgentWorkforce/cloud",
+			want:       false,
+		},
+		{
+			name:       "outside scoped org remote root",
+			remoteRoot: "/github/repos/AgentWorkforce",
+			remotePath: "/github/repos/OtherOrg/cloud/pulls/123.json",
+			want:       false,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- classify lazy GitHub repo content by finding the github/repos marker in the absolute remote path instead of the root-trimmed relative path
- keep the isUnderRemoteRoot guard so scoped mounts do not widen
- add scoped org-root, nested /relay, repo-dir, non-github, and outside-root matcher coverage

## Validation
- go test ./internal/mountsync -run 'TestIsUnderLazyGithubRepoSubtree|TestLazyReposSkipsEagerFetchOfIssuesOnStartup' -count=1\n- git diff --check origin/main..HEAD -- internal/mountsync/syncer.go internal/mountsync/syncer_test.go\n\n## Delivery note\nThis only updates the relayfile-mount binary source. Daily-ship is not delivered on merge alone; it still needs a relayfile release, Daytona snapshot pin bump, Worker-visible snapshot deploy, then the Cloud lazy flag deploy and bounded probe.