### PR TITLE
fix(mount): bound unreadable incremental retries

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -96,16 +96,17 @@ const (
 	// and, having no resume cursor, restart from scratch every cycle (the
 	// #1499/#1516 non-convergence loop). Must stay strictly under
 	// defaultBootstrapIdleTimeout.
-	defaultExportTimeout             = 45 * time.Second
-	defaultCursorResolutionAttempts  = 3
-	defaultCursorRetryBaseDelay      = 250 * time.Millisecond
-	defaultBootstrapReadWorkers      = 16
-	defaultIncrementalEventPageLimit = 50
-	defaultRetryAfterMaxDelay        = 60 * time.Second
-	defaultWebSocketReconnectBase    = 1 * time.Second
-	defaultWebSocketReconnectMax     = 60 * time.Second
-	defaultWebSocketReconnectJitter  = 200 * time.Millisecond
-	DefaultWebSocketMaintenanceEvery = 1 * time.Second
+	defaultExportTimeout              = 45 * time.Second
+	defaultIncrementalReadNotReadyTTL = 5 * time.Minute
+	defaultCursorResolutionAttempts   = 3
+	defaultCursorRetryBaseDelay       = 250 * time.Millisecond
+	defaultBootstrapReadWorkers       = 16
+	defaultIncrementalEventPageLimit  = 50
+	defaultRetryAfterMaxDelay         = 60 * time.Second
+	defaultWebSocketReconnectBase     = 1 * time.Second
+	defaultWebSocketReconnectMax      = 60 * time.Second
+	defaultWebSocketReconnectJitter   = 200 * time.Millisecond
+	DefaultWebSocketMaintenanceEvery  = 1 * time.Second
 )
 
 // resolveDurationEnv returns the option value if non-zero, else parses the
@@ -786,6 +787,11 @@ type SyncerOptions struct {
 	// RELAYFILE_EXPORT_TIMEOUT, default 45s; values >= bootstrapIdleTimeout are
 	// clamped below it so the fall-through always fires before the watchdog.
 	ExportTimeout time.Duration
+	// IncrementalReadNotReadyTTL bounds how long an incremental create/update
+	// event may keep returning ReadFile 404 before the syncer treats it as a
+	// delete and advances past the event. 0 falls back to env
+	// RELAYFILE_INCREMENTAL_READ_NOT_READY_TTL, default 5m.
+	IncrementalReadNotReadyTTL time.Duration
 	// ForceFullReconcile, when non-nil and true, forces one full reconcile
 	// regardless of BootstrapComplete (escape hatch / clobber-remnant
 	// recovery). nil falls back to env RELAYFILE_FORCE_FULL_RECONCILE.
@@ -941,6 +947,7 @@ type Syncer struct {
 	exportTimeout        time.Duration
 	bootstrapTimeout     time.Duration
 	bootstrapIdleTimeout time.Duration
+	readNotReadyTTL      time.Duration
 	forceFullReconcile   bool
 	incrementalCycles    int
 	oversizedLogged      map[string]struct{}
@@ -983,6 +990,12 @@ type mountState struct {
 	BootstrapFilesTotal      int    `json:"bootstrapFilesTotal,omitempty"`
 	BootstrapStartedAt       string `json:"bootstrapStartedAt,omitempty"`
 	GithubWorkingTreeHeadSHA string `json:"githubWorkingTreeHeadSha,omitempty"`
+	// IncrementalReadNotReadySince records first-seen timestamps for
+	// incremental create/update events whose remote content was not readable
+	// yet. The daemon retries these without advancing EventsCursor until the
+	// TTL expires, then treats a still-unreadable path as deleted so
+	// create-then-delete events cannot wedge the mount forever.
+	IncrementalReadNotReadySince map[string]string `json:"incrementalReadNotReadySince,omitempty"`
 }
 
 type incrementalCheckpoint struct {
@@ -1256,6 +1269,10 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		}
 		exportTimeout = maxExportTimeout
 	}
+	readNotReadyTTL := resolveDurationEnv(opts.IncrementalReadNotReadyTTL, "RELAYFILE_INCREMENTAL_READ_NOT_READY_TTL", defaultIncrementalReadNotReadyTTL, opts.Logger)
+	if readNotReadyTTL <= 0 {
+		readNotReadyTTL = defaultIncrementalReadNotReadyTTL
+	}
 	forceFullReconcile := false
 	if opts.ForceFullReconcile != nil {
 		forceFullReconcile = *opts.ForceFullReconcile
@@ -1342,6 +1359,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		exportTimeout:        exportTimeout,
 		bootstrapTimeout:     bootstrapTimeout,
 		bootstrapIdleTimeout: bootstrapIdleTimeout,
+		readNotReadyTTL:      readNotReadyTTL,
 		forceFullReconcile:   forceFullReconcile,
 		oversizedLogged:      map[string]struct{}{},
 		lazyRepos:            lazyRepos,
@@ -4165,6 +4183,7 @@ func (s *Syncer) applyIncrementalChanges(
 			return err
 		}
 		if skipped {
+			s.clearIncrementalReadNotReady(remotePath)
 			s.markIncrementalCheckpoint(pageStartCursor, pageCursor, "changed", remotePath)
 			continue
 		}
@@ -4172,6 +4191,15 @@ func (s *Syncer) applyIncrementalChanges(
 		if err != nil {
 			var httpErr *HTTPError
 			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				if s.incrementalReadNotReadyExpired(remotePath, time.Now().UTC()) {
+					s.logf("changed event for %s remained unreadable for at least %s; treating as deleted and advancing events cursor", remotePath, s.readNotReadyTTL)
+					s.clearIncrementalReadNotReady(remotePath)
+					if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
+						return err
+					}
+					s.markIncrementalCheckpoint(pageStartCursor, pageCursor, "changed", remotePath)
+					continue
+				}
 				s.logf("changed event for %s is not readable yet; preserving events cursor for retry", remotePath)
 				return &IncrementalReadNotReadyError{
 					Path:       remotePath,
@@ -4185,6 +4213,7 @@ func (s *Syncer) applyIncrementalChanges(
 				if markErr := s.markReadDenied(remotePath); markErr != nil {
 					return markErr
 				}
+				s.clearIncrementalReadNotReady(remotePath)
 				s.markIncrementalCheckpoint(pageStartCursor, pageCursor, "changed", remotePath)
 				continue
 			}
@@ -4193,6 +4222,7 @@ func (s *Syncer) applyIncrementalChanges(
 		if err := s.applyRemoteFile(remotePath, file, conflicted); err != nil {
 			return err
 		}
+		s.clearIncrementalReadNotReady(remotePath)
 		s.markIncrementalCheckpoint(pageStartCursor, pageCursor, "changed", remotePath)
 	}
 
@@ -4208,6 +4238,7 @@ func (s *Syncer) applyIncrementalChanges(
 		if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
 			return err
 		}
+		s.clearIncrementalReadNotReady(remotePath)
 		s.markIncrementalCheckpoint(pageStartCursor, pageCursor, "deleted", remotePath)
 	}
 	return nil
@@ -4266,6 +4297,34 @@ func (s *Syncer) markIncrementalCheckpoint(pageStartCursor, pageCursor, phase, r
 		PageCursor: strings.TrimSpace(pageCursor),
 		Phase:      strings.TrimSpace(phase),
 		Path:       normalizeRemotePath(remotePath),
+	}
+}
+
+func (s *Syncer) incrementalReadNotReadyExpired(remotePath string, now time.Time) bool {
+	remotePath = normalizeRemotePath(remotePath)
+	if s.state.IncrementalReadNotReadySince == nil {
+		s.state.IncrementalReadNotReadySince = map[string]string{}
+	}
+	raw := strings.TrimSpace(s.state.IncrementalReadNotReadySince[remotePath])
+	if raw == "" {
+		s.state.IncrementalReadNotReadySince[remotePath] = now.Format(time.RFC3339Nano)
+		return false
+	}
+	firstSeen, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		s.state.IncrementalReadNotReadySince[remotePath] = now.Format(time.RFC3339Nano)
+		return false
+	}
+	return !now.Before(firstSeen.Add(s.readNotReadyTTL))
+}
+
+func (s *Syncer) clearIncrementalReadNotReady(remotePath string) {
+	if s.state.IncrementalReadNotReadySince == nil {
+		return
+	}
+	delete(s.state.IncrementalReadNotReadySince, normalizeRemotePath(remotePath))
+	if len(s.state.IncrementalReadNotReadySince) == 0 {
+		s.state.IncrementalReadNotReadySince = nil
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -6477,6 +6477,9 @@ func TestPullRemoteIncrementalChangedPath404RetriesWithoutAdvancingCursor(t *tes
 	if _, ok := syncer.state.Files["/notion/Docs/002.md"]; !ok {
 		t.Fatalf("expected 404 changed path to remain tracked for retry")
 	}
+	if _, ok := syncer.state.IncrementalReadNotReadySince["/notion/Docs/002.md"]; !ok {
+		t.Fatalf("expected read-not-ready timestamp to be recorded for retry")
+	}
 	if checkpoint := syncer.state.IncrementalCheckpoint; checkpoint == nil ||
 		checkpoint.Phase != "changed" ||
 		checkpoint.Path != "/notion/Docs/001.md" {
@@ -6492,6 +6495,9 @@ func TestPullRemoteIncrementalChangedPath404RetriesWithoutAdvancingCursor(t *tes
 	}
 	if persisted.EventsCursor != "evt_000" {
 		t.Fatalf("persisted EventsCursor = %q, want unchanged evt_000", persisted.EventsCursor)
+	}
+	if _, ok := persisted.IncrementalReadNotReadySince["/notion/Docs/002.md"]; !ok {
+		t.Fatalf("expected persisted read-not-ready timestamp for retry")
 	}
 	if checkpoint := persisted.IncrementalCheckpoint; checkpoint == nil ||
 		checkpoint.Phase != "changed" ||
@@ -6529,6 +6535,9 @@ func TestPullRemoteIncrementalChangedPath404RetriesWithoutAdvancingCursor(t *tes
 	}
 	if checkpoint := resumedSyncer.state.IncrementalCheckpoint; checkpoint != nil {
 		t.Fatalf("expected checkpoint to clear after completed page, got %#v", checkpoint)
+	}
+	if resumedSyncer.state.IncrementalReadNotReadySince != nil {
+		t.Fatalf("expected read-not-ready state to clear after materialization, got %#v", resumedSyncer.state.IncrementalReadNotReadySince)
 	}
 	assertLocalFileContent(t, missingPath, "# 002")
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "003.md"), "# 003")
@@ -6602,6 +6611,144 @@ func TestPullRemoteIncrementalCreatedThreadReply404RetriesWithoutAdvancingCursor
 		t.Fatalf("EventsCursor = %q, want evt_168287", got)
 	}
 	assertLocalFileContent(t, localReplyPath, `{"text":"materialized reply"}`)
+}
+
+func TestPullRemoteIncrementalReadNotReadyBeforeTTLStillRetriesAndMaterializes(t *testing.T) {
+	const remotePath = "/notion/Docs/slow.md"
+	ttl := time.Hour
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		events: []FilesystemEvent{
+			{EventID: "evt_001", Type: "file.created", Path: remotePath, Revision: "rev_001"},
+		},
+		revisionCounter: 1,
+		eventCounter:    1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:                "ws_not_ready_before_ttl",
+		RemoteRoot:                 "/notion",
+		LocalRoot:                  localDir,
+		FullPullEvery:              -1,
+		WebSocket:                  boolPtr(false),
+		CursorTimeout:              time.Second,
+		BootstrapTimeout:           time.Second,
+		IncrementalReadNotReadyTTL: ttl,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	syncer.loaded = true
+	syncer.state = mountState{
+		Files:             map[string]trackedFile{},
+		EventsCursor:      "evt_000",
+		BootstrapComplete: true,
+		IncrementalReadNotReadySince: map[string]string{
+			remotePath: time.Now().UTC().Add(-ttl + time.Minute).Format(time.RFC3339Nano),
+		},
+	}
+
+	err = syncer.Reconcile(context.Background())
+	var notReadyErr *IncrementalReadNotReadyError
+	if !errors.As(err, &notReadyErr) || notReadyErr.Path != remotePath {
+		t.Fatalf("expected under-TTL 404 to remain retryable, got %v", err)
+	}
+	if got := syncer.state.EventsCursor; got != "evt_000" {
+		t.Fatalf("EventsCursor = %q, want unchanged evt_000", got)
+	}
+	if _, err := os.Stat(filepath.Join(localDir, "Docs", "slow.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("under-TTL unreadable file should remain absent locally; stat err=%v", err)
+	}
+
+	client.files[remotePath] = RemoteFile{
+		Path:        remotePath,
+		Revision:    "rev_001",
+		ContentType: "text/markdown",
+		Content:     "# slow",
+	}
+	resumedSyncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:                "ws_not_ready_before_ttl",
+		RemoteRoot:                 "/notion",
+		LocalRoot:                  localDir,
+		FullPullEvery:              -1,
+		WebSocket:                  boolPtr(false),
+		CursorTimeout:              time.Second,
+		BootstrapTimeout:           time.Second,
+		IncrementalReadNotReadyTTL: ttl,
+	})
+	if err != nil {
+		t.Fatalf("new resumed syncer failed: %v", err)
+	}
+	if err := resumedSyncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile after under-TTL file appeared failed: %v", err)
+	}
+	if got := resumedSyncer.state.EventsCursor; got != "evt_001" {
+		t.Fatalf("EventsCursor = %q, want evt_001", got)
+	}
+	if resumedSyncer.state.IncrementalReadNotReadySince != nil {
+		t.Fatalf("expected read-not-ready state to clear after materialization, got %#v", resumedSyncer.state.IncrementalReadNotReadySince)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "slow.md"), "# slow")
+}
+
+func TestPullRemoteIncrementalPersistentReadNotReadyAfterTTLAdvancesAsDelete(t *testing.T) {
+	const remotePath = "/notion/Docs/gone.md"
+	ttl := time.Minute
+	client := &fakeClient{
+		files: map[string]RemoteFile{},
+		events: []FilesystemEvent{
+			{EventID: "evt_001", Type: "file.created", Path: remotePath, Revision: "rev_001"},
+			{EventID: "evt_002", Type: "file.created", Path: "/notion/Docs/after.md", Revision: "rev_002"},
+		},
+		revisionCounter: 2,
+		eventCounter:    2,
+	}
+	client.files["/notion/Docs/after.md"] = RemoteFile{
+		Path:        "/notion/Docs/after.md",
+		Revision:    "rev_002",
+		ContentType: "text/markdown",
+		Content:     "# after",
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:                "ws_not_ready_after_ttl",
+		RemoteRoot:                 "/notion",
+		LocalRoot:                  localDir,
+		FullPullEvery:              -1,
+		WebSocket:                  boolPtr(false),
+		CursorTimeout:              time.Second,
+		BootstrapTimeout:           time.Second,
+		IncrementalReadNotReadyTTL: ttl,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	syncer.loaded = true
+	syncer.state = mountState{
+		Files:             map[string]trackedFile{},
+		EventsCursor:      "evt_000",
+		BootstrapComplete: true,
+		IncrementalReadNotReadySince: map[string]string{
+			remotePath: time.Now().UTC().Add(-ttl - time.Second).Format(time.RFC3339Nano),
+		},
+	}
+
+	if err := syncer.Reconcile(context.Background()); err != nil {
+		t.Fatalf("expired read-not-ready should advance as delete, got %v", err)
+	}
+	if got := syncer.state.EventsCursor; got != "evt_002" {
+		t.Fatalf("EventsCursor = %q, want evt_002", got)
+	}
+	if syncer.state.IncrementalReadNotReadySince != nil {
+		t.Fatalf("expected expired read-not-ready state to clear, got %#v", syncer.state.IncrementalReadNotReadySince)
+	}
+	if _, ok := syncer.state.Files[remotePath]; ok {
+		t.Fatalf("expired persistent 404 should not remain tracked")
+	}
+	if _, err := os.Stat(filepath.Join(localDir, "Docs", "gone.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expired persistent 404 should not materialize locally; stat err=%v", err)
+	}
+	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "after.md"), "# after")
 }
 
 func TestPullRemoteIncrementalDeleteEventStillDeletes(t *testing.T) {


### PR DESCRIPTION
## Summary
- bound incremental create/update ReadFile 404 retries with a wall-clock TTL so create-then-delete events cannot stall the events cursor forever
- persist first read-not-ready timestamps in private mount state and clear them when the path materializes, is denied, skipped by hash, or is deleted
- keep transient read-after-write 404s retryable until the TTL expires

## Validation
- go test ./internal/mountsync -run 'TestPullRemoteIncremental(ChangedPath404RetriesWithoutAdvancingCursor|CreatedThreadReply404RetriesWithoutAdvancingCursor|ReadNotReadyBeforeTTLStillRetriesAndMaterializes|PersistentReadNotReadyAfterTTLAdvancesAsDelete|DeleteEventStillDeletes)' -count=1 -v\n- go test ./internal/mountsync\n- go test ./cmd/relayfile-mount\n- npm run typecheck --workspace=packages/sdk/typescript\n- npm run build --workspace=packages/sdk/typescript\n\n## Release note\nTargeting fast-follow v0.8.19 so cloud Daytona snapshots can skip v0.8.18 and pick up the bounded liveness fix.