### PR TITLE
fix(mountsync): quarantine remote path/dir collisions instead of wedging the mount

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -325,6 +325,7 @@ type syncStateGuards struct {
 	TombstonesPending        uint64              `json:"tombstonesPending,omitempty"`
 	TombstonesConfirmed      uint64              `json:"tombstonesConfirmed,omitempty"`
 	TombstonesAgedOut        uint64              `json:"tombstonesAgedOut,omitempty"`
+	PathCollisionQuarantined uint64              `json:"pathCollisionQuarantined,omitempty"`
 	LastAppliedRevision      string              `json:"lastAppliedRevision,omitempty"`
 	Circuit                  *syncStateGuardCirc `json:"circuit,omitempty"`
 }
@@ -6056,6 +6057,7 @@ func readGuardCounters(localDir string) *syncStateGuards {
 			TombstonesPending        uint64 `json:"tombstonesPending"`
 			TombstonesConfirmed      uint64 `json:"tombstonesConfirmed"`
 			TombstonesAgedOut        uint64 `json:"tombstonesAgedOut"`
+			PathCollisionQuarantined uint64 `json:"pathCollisionQuarantined"`
 		} `json:"counters"`
 		LastAppliedRevision string `json:"lastAppliedRevision"`
 		Circuit             *struct {
@@ -6081,6 +6083,7 @@ func readGuardCounters(localDir string) *syncStateGuards {
 		view.Counters.TombstonesPending == 0 &&
 		view.Counters.TombstonesConfirmed == 0 &&
 		view.Counters.TombstonesAgedOut == 0 &&
+		view.Counters.PathCollisionQuarantined == 0 &&
 		view.LastAppliedRevision == "" &&
 		view.Circuit == nil
 	if zero {
@@ -6094,6 +6097,7 @@ func readGuardCounters(localDir string) *syncStateGuards {
 		TombstonesPending:        view.Counters.TombstonesPending,
 		TombstonesConfirmed:      view.Counters.TombstonesConfirmed,
 		TombstonesAgedOut:        view.Counters.TombstonesAgedOut,
+		PathCollisionQuarantined: view.Counters.PathCollisionQuarantined,
 		LastAppliedRevision:      view.LastAppliedRevision,
 	}
 	if view.Circuit != nil {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2408,6 +2408,7 @@ func TestReadGuardCountersAcceptsMirrorStateGuardsShape(t *testing.T) {
 		Guards: &syncStateGuards{
 			SkippedOversizeWriteback: 3,
 			SnapshotDeleteBlocked:    2,
+			PathCollisionQuarantined: 5,
 			LastAppliedRevision:      "rev_9",
 			Circuit: &syncStateGuardCirc{
 				Open:       true,
@@ -2423,11 +2424,31 @@ func TestReadGuardCountersAcceptsMirrorStateGuardsShape(t *testing.T) {
 	if got == nil {
 		t.Fatalf("expected guard counters")
 	}
-	if got.SkippedOversizeWriteback != 3 || got.SnapshotDeleteBlocked != 2 || got.LastAppliedRevision != "rev_9" {
+	if got.SkippedOversizeWriteback != 3 || got.SnapshotDeleteBlocked != 2 || got.PathCollisionQuarantined != 5 || got.LastAppliedRevision != "rev_9" {
 		t.Fatalf("unexpected guard counters: %#v", got)
 	}
 	if got.Circuit == nil || !got.Circuit.Open || got.Circuit.OpenEvents != 1 || got.Circuit.Failures != 4 {
 		t.Fatalf("unexpected circuit counters: %#v", got.Circuit)
+	}
+}
+
+func TestReadGuardCountersAcceptsMountsyncCountersShape(t *testing.T) {
+	localDir := t.TempDir()
+	stateDir := filepath.Join(localDir, ".relay")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir .relay failed: %v", err)
+	}
+	payload := []byte(`{"counters":{"pathCollisionQuarantined":7}}` + "\n")
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), payload, 0o644); err != nil {
+		t.Fatalf("write state failed: %v", err)
+	}
+
+	got := readGuardCounters(localDir)
+	if got == nil {
+		t.Fatalf("expected guard counters")
+	}
+	if got.PathCollisionQuarantined != 7 {
+		t.Fatalf("expected path collision counter, got %#v", got)
 	}
 }
 

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -952,6 +952,7 @@ type Syncer struct {
 	forceFullReconcile   bool
 	incrementalCycles    int
 	oversizedLogged      map[string]struct{}
+	quarantinedPaths     map[string]struct{}
 	lazyRepos            bool
 	lowMemory            bool
 	writeOnly            bool
@@ -1024,6 +1025,23 @@ type telemetryCounters struct {
 	// and a directory); the daemon quarantines the path so a single collision
 	// can't wedge the whole mount. See isRemotePathCollision.
 	PathCollisionQuarantined uint64 `json:"pathCollisionQuarantined,omitempty"`
+}
+
+// quarantineRemotePath records a remote path that can't be materialized
+// locally because of a file/directory name collision. It counts every
+// occurrence (consistent with the other defensive counters), but logs each
+// distinct path only once per process so a persistently-colliding path does not
+// spam the log on every sync cycle. Mirrors the oversizedLogged dedup pattern.
+func (s *Syncer) quarantineRemotePath(remotePath, detail string, cause error) {
+	s.state.Counters.PathCollisionQuarantined++
+	if s.quarantinedPaths == nil {
+		s.quarantinedPaths = map[string]struct{}{}
+	}
+	if _, seen := s.quarantinedPaths[remotePath]; seen {
+		return
+	}
+	s.quarantinedPaths[remotePath] = struct{}{}
+	s.logf("quarantining remote path %s: %s (%v); skipping so the sync cycle can complete — fix is adapter-side (a name emitted as both a file and a directory)", remotePath, detail, cause)
 }
 
 // isRemotePathCollision reports whether err is a POSIX path-shape collision:
@@ -1386,6 +1404,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		readNotReadyTTL:      readNotReadyTTL,
 		forceFullReconcile:   forceFullReconcile,
 		oversizedLogged:      map[string]struct{}{},
+		quarantinedPaths:     map[string]struct{}{},
 		lazyRepos:            lazyRepos,
 		lowMemory:            lowMemory,
 		layoutRegistrar:      opts.ProviderLayoutRegistrar,
@@ -4514,8 +4533,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	// pass through to disk unchanged.
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
 		if isRemotePathCollision(err) {
-			s.state.Counters.PathCollisionQuarantined++
-			s.logf("quarantining remote path %s: cannot create parent directory (%v); skipping so the sync cycle can complete — fix is adapter-side (a name emitted as both a file and a directory)", remotePath, err)
+			s.quarantineRemotePath(remotePath, "cannot create parent directory", err)
 			return nil
 		}
 		return err
@@ -4531,8 +4549,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	if shouldWrite {
 		if err := writeFileAtomic(localPath, remoteBytes, 0o644); err != nil {
 			if isRemotePathCollision(err) {
-				s.state.Counters.PathCollisionQuarantined++
-				s.logf("quarantining remote path %s: cannot write file (%v); skipping so the sync cycle can complete", remotePath, err)
+				s.quarantineRemotePath(remotePath, "cannot write file (target is a directory)", err)
 				return nil
 			}
 			return err

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 	"unicode/utf8"
 
@@ -1016,6 +1017,29 @@ type telemetryCounters struct {
 	TombstonesPending        uint64 `json:"tombstonesPending,omitempty"`
 	TombstonesConfirmed      uint64 `json:"tombstonesConfirmed,omitempty"`
 	TombstonesAgedOut        uint64 `json:"tombstonesAgedOut,omitempty"`
+	// PathCollisionQuarantined counts apply attempts skipped because a remote
+	// path could not be represented on the local filesystem — an ancestor
+	// component exists as a regular file (or the target is a directory). The
+	// fix belongs in the emitting adapter (do not emit one name as both a file
+	// and a directory); the daemon quarantines the path so a single collision
+	// can't wedge the whole mount. See isRemotePathCollision.
+	PathCollisionQuarantined uint64 `json:"pathCollisionQuarantined,omitempty"`
+}
+
+// isRemotePathCollision reports whether err is a POSIX path-shape collision:
+// an ancestor path component is a regular file (ENOTDIR), or the target name is
+// already a directory / already exists with the wrong type (EISDIR/EEXIST).
+// This happens when an adapter emits the same name as both a file and a
+// directory — e.g. the Slack adapter writing a thread reply leaf
+// `replies/<ts>.json` while also nesting that reply's children under a
+// directory at the same stem. Such a path can never be materialized here, so
+// failing the sync cycle on it would wedge the mount forever (bootstrap never
+// completes, the teardown writeback flush hangs and is killed at its timeout,
+// and the run is marked FAILED). The daemon logs + counts it and moves on.
+func isRemotePathCollision(err error) bool {
+	return errors.Is(err, syscall.ENOTDIR) ||
+		errors.Is(err, syscall.EISDIR) ||
+		errors.Is(err, syscall.EEXIST)
 }
 
 type trackedFile struct {
@@ -4489,6 +4513,11 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	// materializeProviderLayouts; remote-supplied .layout.md payloads still
 	// pass through to disk unchanged.
 	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		if isRemotePathCollision(err) {
+			s.state.Counters.PathCollisionQuarantined++
+			s.logf("quarantining remote path %s: cannot create parent directory (%v); skipping so the sync cycle can complete — fix is adapter-side (a name emitted as both a file and a directory)", remotePath, err)
+			return nil
+		}
 		return err
 	}
 	remoteHash := hashBytes(remoteBytes)
@@ -4501,6 +4530,11 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	}
 	if shouldWrite {
 		if err := writeFileAtomic(localPath, remoteBytes, 0o644); err != nil {
+			if isRemotePathCollision(err) {
+				s.state.Counters.PathCollisionQuarantined++
+				s.logf("quarantining remote path %s: cannot write file (%v); skipping so the sync cycle can complete", remotePath, err)
+				return nil
+			}
 			return err
 		}
 	}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1028,7 +1028,7 @@ type telemetryCounters struct {
 
 // isRemotePathCollision reports whether err is a POSIX path-shape collision:
 // an ancestor path component is a regular file (ENOTDIR), or the target name is
-// already a directory / already exists with the wrong type (EISDIR/EEXIST).
+// already a directory / already exists with the wrong type (EISDIR/os.ErrExist).
 // This happens when an adapter emits the same name as both a file and a
 // directory — e.g. the Slack adapter writing a thread reply leaf
 // `replies/<ts>.json` while also nesting that reply's children under a
@@ -1039,7 +1039,7 @@ type telemetryCounters struct {
 func isRemotePathCollision(err error) bool {
 	return errors.Is(err, syscall.ENOTDIR) ||
 		errors.Is(err, syscall.EISDIR) ||
-		errors.Is(err, syscall.EEXIST)
+		errors.Is(err, os.ErrExist)
 }
 
 type trackedFile struct {
@@ -5954,7 +5954,7 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 	// otherwise be the mechanism by which the mount root was clobbered
 	// by an 11MB file. If the target exists and is a directory, refuse.
 	if info, err := os.Lstat(path); err == nil && info.IsDir() {
-		return fmt.Errorf("refusing to replace directory %s with a file", path)
+		return fmt.Errorf("refusing to replace directory %s with a file: %w", path, os.ErrExist)
 	}
 	if err := os.Rename(tmpName, path); err != nil {
 		return err

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -4111,6 +4111,26 @@ func TestApplyRemoteFile_QuarantinesPathCollision(t *testing.T) {
 	} else if !info.IsDir() {
 		t.Fatalf("expected replies path to remain a directory")
 	}
+
+	// Re-applying the SAME colliding path counts each occurrence (cumulative,
+	// like the other guard counters) but is logged only once — so a persistent
+	// collision doesn't spam the log every cycle.
+	countBefore := syncer.state.Counters.PathCollisionQuarantined
+	distinctBefore := len(syncer.quarantinedPaths)
+	if err := syncer.applyRemoteFile(child, RemoteFile{
+		Path:        child,
+		Revision:    "rev_child_again",
+		ContentType: "application/json",
+		Content:     "{\"emoji\":\"tada\"}\n",
+	}, nil); err != nil {
+		t.Fatalf("re-applying the colliding child should still quarantine, got error: %v", err)
+	}
+	if got := syncer.state.Counters.PathCollisionQuarantined; got != countBefore+1 {
+		t.Fatalf("counter should increment per occurrence: got %d, want %d", got, countBefore+1)
+	}
+	if got := len(syncer.quarantinedPaths); got != distinctBefore {
+		t.Fatalf("distinct quarantined paths should not grow on a repeat: got %d, want %d", got, distinctBefore)
+	}
 }
 
 func TestApplyRemoteFile_NestedIndexAndLayout(t *testing.T) {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -4091,6 +4091,26 @@ func TestApplyRemoteFile_QuarantinesPathCollision(t *testing.T) {
 	if _, ok := syncer.state.Files[child]; ok {
 		t.Fatalf("quarantined child must not be recorded as a tracked file")
 	}
+
+	// The inverse collision is also non-fatal: a remote file targets a local
+	// path that already exists as a directory.
+	dirRemotePath := "/slack/channels/C1/threads/T1/replies"
+	if err := syncer.applyRemoteFile(dirRemotePath, RemoteFile{
+		Path:        dirRemotePath,
+		Revision:    "rev_dir_collision",
+		ContentType: "application/json",
+		Content:     "{\"kind\":\"file\"}\n",
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteFile(directory target) should quarantine the collision, got error: %v", err)
+	}
+	if got := syncer.state.Counters.PathCollisionQuarantined; got < 2 {
+		t.Fatalf("expected both path collisions to be counted, got %d", got)
+	}
+	if info, err := os.Stat(filepath.Join(localDir, "slack", "channels", "C1", "threads", "T1", "replies")); err != nil {
+		t.Fatalf("stat replies directory failed: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected replies path to remain a directory")
+	}
 }
 
 func TestApplyRemoteFile_NestedIndexAndLayout(t *testing.T) {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -4034,6 +4034,65 @@ func TestApplyRemoteFile_IndexAndLayoutFiles(t *testing.T) {
 	}
 }
 
+// TestApplyRemoteFile_QuarantinesPathCollision pins the resilience fix for the
+// Slack-adapter file/dir collision: a thread reply emitted as a leaf file
+// `replies/<ts>.json` whose children are also nested under a directory at the
+// same stem. The child cannot be materialized (its parent is a regular file →
+// ENOTDIR), but that single path must NOT fail the apply — it is quarantined so
+// the sync cycle completes and bootstrap can finish. Before the fix this
+// returned ENOTDIR, which aborted every cycle and wedged the mount forever.
+func TestApplyRemoteFile_QuarantinesPathCollision(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_path_collision",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+
+	// The reply leaf applies fine as a regular file.
+	leaf := "/slack/channels/C1/threads/T1/replies/1780911014_625209.json"
+	if err := syncer.applyRemoteFile(leaf, RemoteFile{
+		Path:        leaf,
+		Revision:    "rev_leaf",
+		ContentType: "application/json",
+		Content:     "{\"text\":\"reply\"}\n",
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteFile(leaf) failed: %v", err)
+	}
+
+	// A child UNDER the leaf forces mkdir of a path whose parent is a regular
+	// file. With the fix this is quarantined (nil error), not propagated.
+	child := leaf + "/reactions/tada--U1.json"
+	if err := syncer.applyRemoteFile(child, RemoteFile{
+		Path:        child,
+		Revision:    "rev_child",
+		ContentType: "application/json",
+		Content:     "{\"emoji\":\"tada\"}\n",
+	}, nil); err != nil {
+		t.Fatalf("applyRemoteFile(child) should quarantine the collision, got error: %v", err)
+	}
+
+	// The collision counter advanced, the leaf is intact, and the colliding
+	// child was not (and cannot be) materialized.
+	if got := syncer.state.Counters.PathCollisionQuarantined; got == 0 {
+		t.Fatalf("expected PathCollisionQuarantined > 0, got %d", got)
+	}
+	leafLocal := filepath.Join(localDir, "slack", "channels", "C1", "threads", "T1", "replies", "1780911014_625209.json")
+	if info, err := os.Stat(leafLocal); err != nil {
+		t.Fatalf("stat leaf failed: %v", err)
+	} else if info.IsDir() {
+		t.Fatalf("expected reply leaf to be a regular file, got directory")
+	}
+	if _, ok := syncer.state.Files[child]; ok {
+		t.Fatalf("quarantined child must not be recorded as a tracked file")
+	}
+}
+
 func TestApplyRemoteFile_NestedIndexAndLayout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

A single remote path that can't be represented on a POSIX filesystem wedges an entire mount **forever**.

In `applyRemoteFile`, `os.MkdirAll` / `writeFileAtomic` returns an error (e.g. `ENOTDIR`: an ancestor path component is a regular file) that propagates up and **aborts the whole sync cycle** before `markBootstrapComplete()` is ever reached. Result:

- `state.BootstrapComplete` stays `false` → every cycle re-enters "forcing full reconcile", re-hits the same path, aborts again. Permanent loop.
- The teardown writeback flush can never observe a drained/reconciled mount → it hangs and is killed at its timeout (`flushExitCode: 124`).
- The cloud run is recorded **FAILED** even though the persona handler fully succeeded.

### How it ships today
The Slack adapter emits a thread reply as **both** a leaf file `replies/<ts>.json` **and** a directory of the same stem holding that reply's children (reactions / nested replies) — one name that is simultaneously a file and a directory. Observed in production:

```
mount sync cycle failed: mkdir .../slack/channels/<id>/threads/<ts>/replies/<replyTs>.json: not a directory
detected non-empty state without completed bootstrap; forcing full reconcile (538 tracked files)   <- repeats forever
```

(Root cause is adapter-side and is being fixed separately in `relayfile-adapters`; this PR is daemon hardening so one bad path can't take down a whole mount.)

## Fix

Make a path/type collision **non-fatal**: classify `ENOTDIR`/`EISDIR`/`EEXIST` from `MkdirAll`/`writeFileAtomic` as a collision, log it, bump a new `PathCollisionQuarantined` telemetry counter, and **skip just that path** (`return nil`) so the rest of the cycle completes and bootstrap can finish.

- The caller's normal success bookkeeping then records the path as present-on-remote, so the snapshot delete pass won't tombstone anything for it.
- Mirrors the existing **"skipping denied file" (403) quarantine-and-continue** precedent in the same bootstrap loop.
- `isRemotePathCollision` is a small, documented `errors.Is` helper.

## Test

`TestApplyRemoteFile_QuarantinesPathCollision` reproduces the exact shape: apply the reply leaf as a file, then apply a child under it (forcing `mkdir` of a path whose parent is a regular file). Asserts the apply returns `nil` (quarantined, not propagated), the counter advances, the leaf stays intact, and the colliding child is not tracked. Full `internal/mountsync` package suite passes (`go test ./internal/mountsync/`, ~104s).

## Impact
Fixes the daily-ship nightly FAILED runs end-to-end: with the collision quarantined, the slack mount finishes bootstrap, the flush drains, the run goes green — and the previously-degraded mount (partial user/channel sync → unresolved @-mentions, `ts:''` posts) becomes fully populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)