### PR TITLE
fix(mountsync): reset BootstrapComplete on write-only→mirror transition (#262)

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -989,6 +989,7 @@ type mountState struct {
 	BootstrapFilesSynced     int    `json:"bootstrapFilesSynced,omitempty"`
 	BootstrapFilesTotal      int    `json:"bootstrapFilesTotal,omitempty"`
 	BootstrapStartedAt       string `json:"bootstrapStartedAt,omitempty"`
+	SyncMode                 string `json:"syncMode,omitempty"`
 	GithubWorkingTreeHeadSHA string `json:"githubWorkingTreeHeadSha,omitempty"`
 	// IncrementalReadNotReadySince records first-seen timestamps for
 	// incremental create/update events whose remote content was not readable
@@ -4950,13 +4951,29 @@ func (s *Syncer) loadState() error {
 		state.Files = map[string]trackedFile{}
 	}
 	s.state = state
+	if s.state.BootstrapComplete && s.state.SyncMode == "write-only" && !s.writeOnly {
+		s.logf("syncMode transition write-only->mirror detected; resetting BootstrapComplete to force a full bootstrap pull (backfills records missed while write-only)")
+		s.state.BootstrapComplete = false
+		s.state.BootstrapCursor = ""
+		s.state.BootstrapStartedAt = ""
+		s.state.BootstrapFilesSynced = 0
+		s.state.BootstrapFilesTotal = 0
+	}
 	if s.githubWorkingTree != nil && strings.TrimSpace(s.state.GithubWorkingTreeHeadSHA) != "" {
 		s.githubWorkingTree.HeadSHA = strings.TrimSpace(s.state.GithubWorkingTreeHeadSHA)
 	}
 	return nil
 }
 
+func (s *Syncer) currentSyncMode() string {
+	if s.writeOnly {
+		return "write-only"
+	}
+	return "mirror"
+}
+
 func (s *Syncer) saveState() error {
+	s.state.SyncMode = s.currentSyncMode()
 	data, err := json.Marshal(s.state)
 	if err != nil {
 		return err

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -6926,6 +6926,88 @@ func TestMarkBootstrapCompleteClearsReadNotReadyMarkers(t *testing.T) {
 	}
 }
 
+func TestLoadStateResetsBootstrapCompleteOnlyOnWriteOnlyToMirrorSyncMode(t *testing.T) {
+	tests := []struct {
+		name                  string
+		syncMode              string
+		writeOnly             bool
+		wantBootstrapComplete bool
+		wantCleared           bool
+	}{
+		{
+			name:                  "write-only to mirror resets bootstrap",
+			syncMode:              "write-only",
+			writeOnly:             false,
+			wantBootstrapComplete: false,
+			wantCleared:           true,
+		},
+		{
+			name:                  "mirror to mirror keeps bootstrap",
+			syncMode:              "mirror",
+			writeOnly:             false,
+			wantBootstrapComplete: true,
+		},
+		{
+			name:                  "legacy unknown to mirror keeps bootstrap",
+			syncMode:              "",
+			writeOnly:             false,
+			wantBootstrapComplete: true,
+		},
+		{
+			name:                  "write-only stays write-only keeps bootstrap",
+			syncMode:              "write-only",
+			writeOnly:             true,
+			wantBootstrapComplete: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stateFile := filepath.Join(t.TempDir(), ".relayfile-mount-state.json")
+			if err := writeMountState(stateFile, mountState{
+				Files: map[string]trackedFile{
+					"/notion/Docs/a.md": {
+						Revision:    "rev_1",
+						ContentType: "text/markdown",
+						Hash:        hashString("# A"),
+					},
+				},
+				BootstrapComplete:    true,
+				BootstrapCursor:      "cursor_1",
+				BootstrapStartedAt:   time.Now().UTC().Format(time.RFC3339Nano),
+				BootstrapFilesSynced: 3,
+				BootstrapFilesTotal:  9,
+				SyncMode:             tc.syncMode,
+			}); err != nil {
+				t.Fatalf("seed state: %v", err)
+			}
+
+			syncer := &Syncer{stateFile: stateFile, writeOnly: tc.writeOnly}
+			if err := syncer.loadState(); err != nil {
+				t.Fatalf("load state: %v", err)
+			}
+
+			if got := syncer.state.BootstrapComplete; got != tc.wantBootstrapComplete {
+				t.Fatalf("BootstrapComplete = %v, want %v", got, tc.wantBootstrapComplete)
+			}
+			if tc.wantCleared {
+				if syncer.state.BootstrapCursor != "" {
+					t.Fatalf("BootstrapCursor = %q, want empty", syncer.state.BootstrapCursor)
+				}
+				if syncer.state.BootstrapStartedAt != "" {
+					t.Fatalf("BootstrapStartedAt = %q, want empty", syncer.state.BootstrapStartedAt)
+				}
+				if syncer.state.BootstrapFilesSynced != 0 {
+					t.Fatalf("BootstrapFilesSynced = %d, want 0", syncer.state.BootstrapFilesSynced)
+				}
+				if syncer.state.BootstrapFilesTotal != 0 {
+					t.Fatalf("BootstrapFilesTotal = %d, want 0", syncer.state.BootstrapFilesTotal)
+				}
+			}
+		})
+	}
+}
+
 func TestPullRemoteIncrementalDeleteEventStillDeletes(t *testing.T) {
 	client := &fakeClient{
 		files: map[string]RemoteFile{},


### PR DESCRIPTION
## Problem (relayfile#262)

The mount-sync daemon's **write-only** `Reconcile` branch calls `markBootstrapComplete()` *without* doing a pull:

```go
if s.writeOnly {
    if !s.state.BootstrapComplete {
        s.markBootstrapComplete()   // <- no full-tree pull happened
    }
}
```

This violates the daemon's own invariant — *"`BootstrapComplete` is set ONLY by a full-tree pull that mirrored the whole remote"* — and persists a **false** `BootstrapComplete=true` to the state file.

**Consequence (the trap):** a mount that was ever write-only and is later flipped to `syncMode=mirror` inherits that false `BootstrapComplete`. On restart, `pullRemote`'s *restart fast-path* (`BootstrapComplete && !forceFullReconcile && len(Files) > 0`) seeds the events cursor and **skips the bootstrap full pull**, so records that arrived while the mount was write-only **never backfill**. This is the trap that bit the Slack messages/DM mounts after pear#170 flipped them to mirror — the missed DM only backfilled after a manual `clearState`.

## Fix (reset-on-transition)

Persist the syncMode the state was last written under, and on a **strict** `write-only → mirror` transition, reset `BootstrapComplete` so the next reconcile performs a proper bootstrap full pull and backfills.

- Add `mountState.SyncMode` (`json:"syncMode,omitempty"`, additive/legacy-safe).
- Persist it in `saveState()` via a new `currentSyncMode()` helper.
- In `loadState()`, reset `BootstrapComplete` (+ clear bootstrap cursor/progress) **only** when `BootstrapComplete && SyncMode == "write-only" && !writeOnly`.

### Why strict (`== "write-only"`, not empty)
A legacy legitimately-*mirrored* state also loads with `SyncMode == ""`. Resetting on empty would force a needless full re-pull fleet-wide on upgrade and could reintroduce the bootstrap stall storm the fast-path was built to prevent (rw_517d60b6). So we reset **only** when we can positively identify the prior mode as write-only. The legitimate "BootstrapComplete after a real full-tree pull" path is untouched.

## Test

`TestLoadStateResetsBootstrapCompleteOnlyOnWriteOnlyToMirrorSyncMode` — table-driven, 4 cases:
1. write-only → mirror: **resets** `BootstrapComplete` and clears cursor/progress ✅
2. mirror → mirror: keeps `BootstrapComplete` ✅
3. legacy empty → mirror: keeps `BootstrapComplete` (no false reset) ✅
4. write-only → write-only: keeps `BootstrapComplete` (no transition) ✅

## Verification
- `go build ./...` — pass
- `go test ./internal/mountsync/` (full package) — pass, 0 failures
- existing `TestSyncOnceWriteOnlySkipsRemotePullButPushesLocalFiles` / `TestBootstrapCompleteGatesFastPath` still pass (legit path intact)
- `gofmt -l` — clean

---

⚠️ **DRAFT — do not merge.** Holding for operator review per directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)