### PR TITLE
feat(mount): ack outbox after dispatch receipt

### DIFF
--- a/internal/mountfuse/fuse_test.go
+++ b/internal/mountfuse/fuse_test.go
@@ -78,6 +78,10 @@ func (f *fakeRemoteClient) WriteFilesBulk(_ context.Context, _ string, _ []mount
 	return mountsync.BulkWriteResponse{}, nil
 }
 
+func (f *fakeRemoteClient) GetOperation(_ context.Context, _, _ string) (mountsync.OperationStatus, error) {
+	return mountsync.OperationStatus{}, &mountsync.HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+}
+
 func (f *fakeRemoteClient) DeleteFile(_ context.Context, _, path, baseRevision string) error {
 	if f.deleteErr != nil {
 		return f.deleteErr

--- a/internal/mountfuse/layout_test.go
+++ b/internal/mountfuse/layout_test.go
@@ -47,6 +47,10 @@ func (c *layoutRemoteClient) WriteFilesBulk(_ context.Context, _ string, _ []mou
 	return mountsync.BulkWriteResponse{}, nil
 }
 
+func (c *layoutRemoteClient) GetOperation(_ context.Context, _, _ string) (mountsync.OperationStatus, error) {
+	return mountsync.OperationStatus{}, &mountsync.HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+}
+
 func (c *layoutRemoteClient) DeleteFile(_ context.Context, _, _, _ string) error {
 	return nil
 }

--- a/internal/mountsync/bootstrap_test.go
+++ b/internal/mountsync/bootstrap_test.go
@@ -179,6 +179,10 @@ func (c *bootstrapClient) WriteFilesBulk(ctx context.Context, workspaceID string
 	return BulkWriteResponse{}, nil
 }
 
+func (c *bootstrapClient) GetOperation(ctx context.Context, workspaceID, opID string) (OperationStatus, error) {
+	return OperationStatus{}, &HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+}
+
 func (c *bootstrapClient) DeleteFile(ctx context.Context, workspaceID, path, baseRevision string) error {
 	return nil
 }

--- a/internal/mountsync/outbox.go
+++ b/internal/mountsync/outbox.go
@@ -44,6 +44,8 @@ type outboxRecord struct {
 	AttemptCount   int          `json:"attemptCount"`
 	LastError      string       `json:"lastError,omitempty"`
 	NeedsAttention bool         `json:"needsAttention,omitempty"`
+	OpID           string       `json:"opId,omitempty"`
+	DispatchStatus string       `json:"dispatchStatus,omitempty"`
 	AckedAt        string       `json:"ackedAt,omitempty"`
 	Revision       string       `json:"revision,omitempty"`
 	CorrelationID  string       `json:"correlationId,omitempty"`
@@ -111,6 +113,8 @@ func (s *Syncer) readOutboxRecord(path string) (outboxRecord, error) {
 	record.ContentType = strings.TrimSpace(record.ContentType)
 	record.Encoding = normalizeEncoding(record.Encoding)
 	record.Hash = strings.TrimSpace(record.Hash)
+	record.OpID = strings.TrimSpace(record.OpID)
+	record.DispatchStatus = strings.TrimSpace(record.DispatchStatus)
 	record.CorrelationID = strings.TrimSpace(record.CorrelationID)
 	if record.CorrelationID == "" {
 		record.CorrelationID = record.CommandID
@@ -274,6 +278,7 @@ func (s *Syncer) ackOutboxRecord(record outboxRecord, revision, correlationID st
 	}
 	record.Status = outboxStatusAcked
 	record.AckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	record.DispatchStatus = "succeeded"
 	record.Revision = strings.TrimSpace(revision)
 	if strings.TrimSpace(correlationID) != "" {
 		record.CorrelationID = strings.TrimSpace(correlationID)

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -235,6 +235,7 @@ type RemoteClient interface {
 	ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error)
 	WriteFile(ctx context.Context, workspaceID, path, baseRevision, contentType, content string) (WriteResult, error)
 	WriteFilesBulk(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error)
+	GetOperation(ctx context.Context, workspaceID, opID string) (OperationStatus, error)
 	DeleteFile(ctx context.Context, workspaceID, path, baseRevision string) error
 }
 
@@ -489,6 +490,12 @@ func (c *HTTPClient) WriteFilesBulk(ctx context.Context, workspaceID string, fil
 	}
 	var out BulkWriteResponse
 	err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("/v1/workspaces/%s/fs/bulk", url.PathEscape(workspaceID)), nil, body, &out)
+	return out, err
+}
+
+func (c *HTTPClient) GetOperation(ctx context.Context, workspaceID, opID string) (OperationStatus, error) {
+	var out OperationStatus
+	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/v1/workspaces/%s/ops/%s", url.PathEscape(workspaceID), url.PathEscape(opID)), nil, nil, &out)
 	return out, err
 }
 
@@ -1755,11 +1762,26 @@ func (s *Syncer) flushOutboxRecords(ctx context.Context, conflicted map[string]s
 }
 
 func (s *Syncer) flushOutboxRecordChunk(ctx context.Context, records []outboxRecord, conflicted map[string]struct{}) error {
-	files := outboxRecordsAsBulkFiles(records)
+	var firstErr error
+	uploadRecords := make([]outboxRecord, 0, len(records))
+	for _, record := range records {
+		if strings.TrimSpace(record.OpID) != "" {
+			if err := s.settleOutboxRecord(ctx, record); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		uploadRecords = append(uploadRecords, record)
+	}
+	if len(uploadRecords) == 0 {
+		return firstErr
+	}
+
+	files := outboxRecordsAsBulkFiles(uploadRecords)
 	response, err := s.client.WriteFilesBulk(ctx, s.workspace, files)
 	if err != nil {
 		s.recordCloudFailure(err)
-		for _, record := range records {
+		for _, record := range uploadRecords {
 			if incErr := s.incrementOutboxAttempt(record, err); incErr != nil {
 				return incErr
 			}
@@ -1774,8 +1796,7 @@ func (s *Syncer) flushOutboxRecordChunk(ctx context.Context, records []outboxRec
 	}
 	resultsByPath := response.resultsByPath()
 
-	var firstErr error
-	for _, record := range records {
+	for _, record := range uploadRecords {
 		tracked, exists := s.state.Files[record.RemotePath]
 		pendingWrite, pendingErr := outboxRecordAsPending(record, s.localRoot, s.remoteRoot, tracked, exists)
 		if pendingErr != nil {
@@ -1829,11 +1850,80 @@ func (s *Syncer) flushOutboxRecordChunk(ctx context.Context, records []outboxRec
 		if strings.TrimSpace(revision) == "" {
 			revision = s.state.Files[pendingWrite.remotePath].Revision
 		}
-		if err := s.ackOutboxRecord(record, revision, response.CorrelationID); err != nil && firstErr == nil {
+		record.Revision = revision
+		if strings.TrimSpace(response.CorrelationID) != "" {
+			record.CorrelationID = strings.TrimSpace(response.CorrelationID)
+		}
+		record.OpID = strings.TrimSpace(result.OpID)
+		if result.Writeback != nil {
+			record.DispatchStatus = strings.TrimSpace(result.Writeback.State)
+		}
+		if record.OpID == "" {
+			// Legacy servers only prove upload acceptance. Keep compatibility
+			// with v0.8.20-era clouds; v0.8.21+ receipts use opId below.
+			if err := s.ackOutboxRecord(record, revision, response.CorrelationID); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := s.saveOutboxRecord(record); err != nil && firstErr == nil {
+			firstErr = err
+			continue
+		}
+		if err := s.settleOutboxRecord(ctx, record); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
+}
+
+func (s *Syncer) settleOutboxRecord(ctx context.Context, record outboxRecord) error {
+	op, err := s.client.GetOperation(ctx, s.workspace, record.OpID)
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			record.NeedsAttention = true
+			record.LastError = fmt.Sprintf("writeback op %s not found", record.OpID)
+			record.NextAttemptAt = ""
+			record.DispatchStatus = "not_found"
+			return s.saveOutboxRecord(record)
+		}
+		s.recordCloudFailure(err)
+		return s.incrementOutboxAttempt(record, err)
+	}
+	s.recordCloudSuccess()
+
+	status := strings.TrimSpace(op.Status)
+	if status == "" {
+		status = "pending"
+	}
+	record.DispatchStatus = status
+	if strings.TrimSpace(op.OpID) != "" {
+		record.OpID = strings.TrimSpace(op.OpID)
+	}
+	switch status {
+	case "succeeded":
+		revision := strings.TrimSpace(record.Revision)
+		if revision == "" {
+			revision = strings.TrimSpace(op.Revision)
+		}
+		return s.ackOutboxRecord(record, revision, record.CorrelationID)
+	case "failed", "dead_lettered", "canceled":
+		record.NeedsAttention = true
+		record.NextAttemptAt = ""
+		if op.LastError != nil && strings.TrimSpace(*op.LastError) != "" {
+			record.LastError = strings.TrimSpace(*op.LastError)
+		} else {
+			record.LastError = fmt.Sprintf("writeback op %s status %s", record.OpID, status)
+		}
+		return s.saveOutboxRecord(record)
+	case "pending", "running", "queued":
+		record.LastError = ""
+		return s.saveOutboxRecord(record)
+	default:
+		record.LastError = fmt.Sprintf("writeback op %s status %s", record.OpID, status)
+		return s.saveOutboxRecord(record)
+	}
 }
 
 func chunkOutboxRecords(records []outboxRecord, maxBytes int64) [][]outboxRecord {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2157,6 +2157,163 @@ func TestOutboxRetryAfterServerCommitUsesSameCommandIDAndDedupes(t *testing.T) {
 	}
 }
 
+func TestOutboxAcksOnlyAfterWritebackOperationSucceeded(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("seed local command failed: %v", err)
+	}
+	client := &fakeClient{
+		files:      map[string]RemoteFile{},
+		operations: map[string]OperationStatus{},
+	}
+	client.bulkWriteResponseFunc = func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error) {
+		_ = ctx
+		_ = workspaceID
+		if len(files) != 1 {
+			t.Fatalf("expected one outbox file, got %+v", files)
+		}
+		path := normalizeRemotePath(files[0].Path)
+		client.revisionCounter++
+		revision := fmt.Sprintf("rev_%d", client.revisionCounter)
+		client.files[path] = RemoteFile{Path: path, Revision: revision, ContentType: files[0].ContentType, Content: files[0].Content}
+		opID := "op_dispatch_receipt_1"
+		client.operations[opID] = OperationStatus{
+			OpID:     opID,
+			Path:     path,
+			Revision: revision,
+			Provider: "slack",
+			Status:   "running",
+		}
+		return BulkWriteResponse{
+			Written: 1,
+			Results: []BulkWriteResult{{
+				Path:        path,
+				Revision:    revision,
+				ContentType: files[0].ContentType,
+				OpID:        opID,
+				Writeback:   &relayfile.BulkWriteWritebackResult{Provider: "slack", State: "pending"},
+			}},
+			CorrelationID: "corr_receipt_pending",
+		}, nil
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_outbox_dispatch_receipt",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync with running op should keep pending without failing: %v", err)
+	}
+	pending := readPendingOutboxRecordsForTest(t, localDir)
+	if len(pending) != 1 || pending[0].OpID != "op_dispatch_receipt_1" || pending[0].DispatchStatus != "running" {
+		t.Fatalf("expected pending outbox with running op id, got %+v", pending)
+	}
+	if acked := readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked")); len(acked) != 0 {
+		t.Fatalf("expected no acked record before op succeeded, got %+v", acked)
+	}
+
+	client.operations["op_dispatch_receipt_1"] = OperationStatus{
+		OpID:     "op_dispatch_receipt_1",
+		Path:     "/slack/channels/C123/messages/command.json",
+		Revision: pending[0].Revision,
+		Provider: "slack",
+		Status:   "succeeded",
+	}
+	forcePendingOutboxDueForTest(t, localDir)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("sync after op success failed: %v", err)
+	}
+	if client.bulkWriteCalls != 1 {
+		t.Fatalf("expected success polling to avoid re-upload, got %d bulk calls", client.bulkWriteCalls)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("expected pending empty after op success, got %+v", pending)
+	}
+	acked := readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked"))
+	if len(acked) != 1 || acked[0].OpID != "op_dispatch_receipt_1" || acked[0].DispatchStatus != "succeeded" {
+		t.Fatalf("expected acked succeeded receipt, got %+v", acked)
+	}
+}
+
+func TestOutboxLostBulkResponseRetryRecoversOpIDWithoutDuplicateDispatch(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("seed local command failed: %v", err)
+	}
+	client := &fakeClient{
+		files:                          map[string]RemoteFile{},
+		operations:                     map[string]OperationStatus{},
+		bulkWriteResponseFuncOwnsWrite: true,
+	}
+	var seenIdentity string
+	var providerDispatches int
+	client.bulkWriteResponseFunc = func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error) {
+		_ = ctx
+		_ = workspaceID
+		if len(files) != 1 || files[0].ContentIdentity == nil {
+			t.Fatalf("expected one content-identified write, got %+v", files)
+		}
+		path := normalizeRemotePath(files[0].Path)
+		opID := "op_lost_response_1"
+		if seenIdentity == "" {
+			seenIdentity = files[0].ContentIdentity.Key
+			client.revisionCounter++
+			revision := fmt.Sprintf("rev_%d", client.revisionCounter)
+			client.files[path] = RemoteFile{Path: path, Revision: revision, ContentType: files[0].ContentType, Content: files[0].Content}
+			client.operations[opID] = OperationStatus{OpID: opID, Path: path, Revision: revision, Provider: "slack", Status: "succeeded"}
+			providerDispatches++
+			return BulkWriteResponse{}, context.Canceled
+		}
+		if files[0].ContentIdentity.Key != seenIdentity {
+			t.Fatalf("retry minted new content identity: got %s want %s", files[0].ContentIdentity.Key, seenIdentity)
+		}
+		remote := client.files[path]
+		return BulkWriteResponse{
+			Written: 0,
+			Results: []BulkWriteResult{{
+				Path:            remote.Path,
+				Revision:        remote.Revision,
+				ContentType:     remote.ContentType,
+				OpID:            opID,
+				ContentIdentity: files[0].ContentIdentity,
+				Writeback:       &relayfile.BulkWriteWritebackResult{Provider: "slack", State: "succeeded"},
+			}},
+			CorrelationID: "corr_lost_response_recovered",
+		}, nil
+	}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_outbox_lost_response_receipt",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err == nil {
+		t.Fatal("expected first lost response to fail")
+	}
+	forcePendingOutboxDueForTest(t, localDir)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("retry after lost response failed: %v", err)
+	}
+	if client.bulkWriteCalls != 2 {
+		t.Fatalf("expected exactly two upload attempts, got %d", client.bulkWriteCalls)
+	}
+	if providerDispatches != 1 {
+		t.Fatalf("expected one provider dispatch after deduped retry, got %d", providerDispatches)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("expected pending outbox empty after recovered receipt, got %+v", pending)
+	}
+	acked := readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked"))
+	if len(acked) != 1 || acked[0].OpID != "op_lost_response_1" || acked[0].DispatchStatus != "succeeded" {
+		t.Fatalf("expected acked receipt for recovered op, got %+v", acked)
+	}
+}
+
 func TestOutboxRetryCapSurfacesNeedsAttention(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
@@ -5249,6 +5406,8 @@ type fakeClient struct {
 	lastBulkWriteResponse          BulkWriteResponse
 	bulkWriteResponseFunc          func(ctx context.Context, workspaceID string, files []BulkWriteFile) (BulkWriteResponse, error)
 	bulkWriteResponseFuncOwnsWrite bool
+	operations                     map[string]OperationStatus
+	getOperationCalls              int
 	deleteCalls                    []deleteCall
 	eventsUnsupported              bool
 	listEventsErrAfter             int
@@ -5591,6 +5750,19 @@ func (c *fakeClient) WriteFilesBulk(ctx context.Context, workspaceID string, fil
 	}
 	c.lastBulkWriteResponse = response
 	return response, nil
+}
+
+func (c *fakeClient) GetOperation(ctx context.Context, workspaceID, opID string) (OperationStatus, error) {
+	_ = ctx
+	_ = workspaceID
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.getOperationCalls++
+	op, ok := c.operations[opID]
+	if !ok {
+		return OperationStatus{}, &HTTPError{StatusCode: 404, Code: "not_found", Message: "not found"}
+	}
+	return op, nil
 }
 
 func (c *fakeClient) DeleteFile(ctx context.Context, workspaceID, path, baseRevision string) error {

--- a/internal/mountsync/types.go
+++ b/internal/mountsync/types.go
@@ -15,6 +15,8 @@ type BulkWriteError = relayfile.BulkWriteError
 
 type BulkWriteResult = relayfile.BulkWriteResult
 
+type OperationStatus = relayfile.OperationStatus
+
 type BulkWriteResponse struct {
 	Written       int               `json:"written"`
 	ErrorCount    int               `json:"errorCount"`

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -203,9 +203,17 @@ type BulkWriteError struct {
 }
 
 type BulkWriteResult struct {
-	Path        string `json:"path"`
-	Revision    string `json:"revision"`
-	ContentType string `json:"contentType,omitempty"`
+	Path            string                    `json:"path"`
+	Revision        string                    `json:"revision"`
+	ContentType     string                    `json:"contentType,omitempty"`
+	OpID            string                    `json:"opId,omitempty"`
+	ContentIdentity *ContentIdentity          `json:"contentIdentity,omitempty"`
+	Writeback       *BulkWriteWritebackResult `json:"writeback,omitempty"`
+}
+
+type BulkWriteWritebackResult struct {
+	Provider string `json:"provider,omitempty"`
+	State    string `json:"state,omitempty"`
 }
 
 type DeleteRequest struct {
@@ -1445,6 +1453,10 @@ func (s *Store) BulkWrite(workspaceID string, files []BulkWriteFile) (int, []Bul
 		if contentType == "" {
 			contentType = "text/markdown"
 		}
+		if existingOp, ok := findOperationByContentIdentityLocked(ws, input.ContentIdentity, now); ok {
+			results = append(results, bulkWriteResultFromOperationLocked(ws, existingOp, path, contentType))
+			continue
+		}
 		_, existed := ws.Files[path]
 		revision := s.nextRevisionLocked()
 		file := ws.Files[path]
@@ -1466,11 +1478,16 @@ func (s *Store) BulkWrite(workspaceID string, files []BulkWriteFile) (int, []Bul
 			eventType = "file.updated"
 		}
 		result, task := s.recordWriteWithContentIdentityLocked(ws, path, revision, eventType, file.Provider, "", input.ContentIdentity)
-		_ = result
 		results = append(results, BulkWriteResult{
-			Path:        path,
-			Revision:    revision,
-			ContentType: contentType,
+			Path:            path,
+			Revision:        revision,
+			ContentType:     contentType,
+			OpID:            result.OpID,
+			ContentIdentity: cloneContentIdentity(input.ContentIdentity),
+			Writeback: &BulkWriteWritebackResult{
+				Provider: result.Writeback.Provider,
+				State:    result.Writeback.State,
+			},
 		})
 		tasks = append(tasks, queuedTask{task: task})
 		written++
@@ -1483,6 +1500,72 @@ func (s *Store) BulkWrite(workspaceID string, files []BulkWriteFile) (int, []Bul
 		s.enqueueWriteback(queued.task)
 	}
 	return written, results, errorsOut
+}
+
+func findOperationByContentIdentityLocked(ws *workspaceState, identity *ContentIdentity, now time.Time) (OperationStatus, bool) {
+	if ws == nil || identity == nil {
+		return OperationStatus{}, false
+	}
+	kind := strings.TrimSpace(identity.Kind)
+	key := strings.TrimSpace(identity.Key)
+	if kind == "" || key == "" {
+		return OperationStatus{}, false
+	}
+	var matched OperationStatus
+	found := false
+	for _, op := range ws.Ops {
+		if op.ContentIdentity == nil || strings.TrimSpace(op.ContentIdentity.Kind) != kind || strings.TrimSpace(op.ContentIdentity.Key) != key {
+			continue
+		}
+		if contentIdentityExpired(op.ContentIdentity, op.CreatedAt, now) {
+			continue
+		}
+		if !found || op.CreatedAt < matched.CreatedAt || (op.CreatedAt == matched.CreatedAt && op.OpID < matched.OpID) {
+			matched = op
+			found = true
+		}
+	}
+	return matched, found
+}
+
+func contentIdentityExpired(identity *ContentIdentity, createdAt string, now time.Time) bool {
+	if identity == nil || identity.TTLSeconds <= 0 {
+		return false
+	}
+	created, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(createdAt))
+	if err != nil {
+		return false
+	}
+	return !now.Before(created.Add(time.Duration(identity.TTLSeconds) * time.Second))
+}
+
+func bulkWriteResultFromOperationLocked(ws *workspaceState, op OperationStatus, fallbackPath, fallbackContentType string) BulkWriteResult {
+	path := normalizePath(op.Path)
+	if path == "/" || path == "" {
+		path = normalizePath(fallbackPath)
+	}
+	revision := strings.TrimSpace(op.Revision)
+	contentType := strings.TrimSpace(fallbackContentType)
+	if file, ok := ws.Files[path]; ok {
+		if revision == "" {
+			revision = file.Revision
+		}
+		if strings.TrimSpace(file.ContentType) != "" {
+			contentType = file.ContentType
+		}
+	}
+	result := BulkWriteResult{
+		Path:            path,
+		Revision:        revision,
+		ContentType:     contentType,
+		OpID:            op.OpID,
+		ContentIdentity: cloneContentIdentity(op.ContentIdentity),
+		Writeback: &BulkWriteWritebackResult{
+			Provider: op.Provider,
+			State:    op.Status,
+		},
+	}
+	return result
 }
 
 func (s *Store) ExportWorkspace(workspaceID string) ([]File, error) {

--- a/internal/relayfile/store_test.go
+++ b/internal/relayfile/store_test.go
@@ -4447,6 +4447,58 @@ func TestBulkWriteContentIdentityReachesProviderWriteAction(t *testing.T) {
 	}
 }
 
+func TestBulkWriteContentIdentityRetryReturnsExistingOperationWithoutDuplicateDispatch(t *testing.T) {
+	queue := &countingWritebackQueue{inner: NewInMemoryWritebackQueue(10)}
+	store := NewStoreWithOptions(StoreOptions{
+		DisableWorkers: true,
+		WritebackQueue: queue,
+	})
+	t.Cleanup(store.Close)
+
+	identity := &ContentIdentity{
+		Kind:       "mount-command",
+		Key:        "mountcmd_retry_same_identity",
+		TTLSeconds: 604800,
+	}
+	file := BulkWriteFile{
+		Path:            "/slack/channels/C123/messages/draft@1.json",
+		ContentType:     "application/json",
+		Content:         `{"text":"hello"}`,
+		ContentIdentity: identity,
+	}
+	written, firstResults, errs := store.BulkWrite("ws_bulk_identity_dedupe", []BulkWriteFile{file})
+	if len(errs) != 0 {
+		t.Fatalf("first bulk write returned errors: %+v", errs)
+	}
+	if written != 1 || len(firstResults) != 1 || firstResults[0].OpID == "" {
+		t.Fatalf("expected first write with op id, written=%d results=%+v", written, firstResults)
+	}
+	firstOpID := firstResults[0].OpID
+
+	written, retryResults, errs := store.BulkWrite("ws_bulk_identity_dedupe", []BulkWriteFile{file})
+	if len(errs) != 0 {
+		t.Fatalf("retry bulk write returned errors: %+v", errs)
+	}
+	if written != 0 {
+		t.Fatalf("expected deduped retry to avoid a second write, got written=%d", written)
+	}
+	if len(retryResults) != 1 || retryResults[0].OpID != firstOpID {
+		t.Fatalf("expected retry to return existing op %s, got %+v", firstOpID, retryResults)
+	}
+	if retryResults[0].ContentIdentity == nil || *retryResults[0].ContentIdentity != *identity {
+		t.Fatalf("expected retry result identity %+v, got %+v", identity, retryResults[0].ContentIdentity)
+	}
+	if retryResults[0].Writeback == nil || retryResults[0].Writeback.State != "pending" {
+		t.Fatalf("expected retry result writeback pending, got %+v", retryResults[0].Writeback)
+	}
+	if depth := queue.Depth(); depth != 1 {
+		t.Fatalf("expected one provider dispatch queued after deduped retry, got depth=%d", depth)
+	}
+	if atomic.LoadInt32(&queue.tryCalls) != 1 {
+		t.Fatalf("expected exactly one queue attempt, got %d", atomic.LoadInt32(&queue.tryCalls))
+	}
+}
+
 func TestProviderWriteActionReceivesFileDeletePayload(t *testing.T) {
 	actions := make(chan WritebackAction, 10)
 	store := NewStoreWithOptions(StoreOptions{

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -2989,6 +2989,35 @@ components:
         message:
           type: string
 
+    BulkWriteWritebackResult:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+        state:
+          type: string
+          description: Current writeback operation state for this bulk-written file.
+
+    BulkWriteResult:
+      type: object
+      additionalProperties: false
+      required: [path, revision]
+      properties:
+        path:
+          type: string
+        revision:
+          type: string
+        contentType:
+          type: string
+        opId:
+          type: string
+          description: Writeback operation id created or recovered for this file.
+        contentIdentity:
+          $ref: '#/components/schemas/ContentIdentity'
+        writeback:
+          $ref: '#/components/schemas/BulkWriteWritebackResult'
+
     BulkWriteResponse:
       type: object
       additionalProperties: false
@@ -3004,6 +3033,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BulkWriteError'
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BulkWriteResult'
         correlationId:
           type: string
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,16 +6108,56 @@
       }
     },
     "packages/sdk/typescript/node_modules/@relayfile/mount-darwin-arm64": {
-      "optional": true
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.20.tgz",
+      "integrity": "sha512-vzuhqraeCulj84I57atgsUjFM9SJwBqeW0EIPzG38TmXWSGEBbOuiKjL0Fs0Ups+HaTJQ+fCp06f/HqlZbxVTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "packages/sdk/typescript/node_modules/@relayfile/mount-darwin-x64": {
-      "optional": true
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.20.tgz",
+      "integrity": "sha512-sEQ3kTF56im7ZnKbWXREocCtchy05tswrwKxWckzHpvrqhyK30MeGIwAm5q0Wnqgs+Je0JgRc840H28ydyDpKA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "packages/sdk/typescript/node_modules/@relayfile/mount-linux-arm64": {
-      "optional": true
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.20.tgz",
+      "integrity": "sha512-N/Hfz0FX/Ahzxj88hE/G9zt82B+h4DqYLqopUNpGH2y0oNvIfvlt8/dvvPlmkzz/voeu/LjLuPdQSV2hNEJg0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "packages/sdk/typescript/node_modules/@relayfile/mount-linux-x64": {
-      "optional": true
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.20.tgz",
+      "integrity": "sha512-I91QHXOO0G4g4hQrJhH9eKJEwqz3tcqPKSAmEGm2M2aw/iI+vxrZploJOfOu7mP7vMo/ccq9cJMQCX4/BF0utA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     }
   }
 }

--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -143,11 +143,28 @@ class BulkWriteError:
 
 
 @dataclass
+class BulkWriteWritebackResult:
+    provider: str | None = None
+    state: str | None = None
+
+
+@dataclass
+class BulkWriteResult:
+    path: str
+    revision: str
+    content_type: str | None = None
+    op_id: str | None = None
+    content_identity: ContentIdentity | None = None
+    writeback: BulkWriteWritebackResult | None = None
+
+
+@dataclass
 class BulkWriteResponse:
     written: int
     error_count: int
     errors: list[BulkWriteError]
     correlation_id: str
+    results: list[BulkWriteResult] | None = None
 
 
 @dataclass

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -106,6 +106,17 @@ export interface BulkWriteResponse {
     code: string;
     message: string;
   }>;
+  results?: Array<{
+    path: string;
+    revision: string;
+    contentType?: string;
+    opId?: string;
+    contentIdentity?: ContentIdentity;
+    writeback?: {
+      provider?: string;
+      state?: string;
+    };
+  }>;
   correlationId: string;
 }
 


### PR DESCRIPTION
## Summary
- extend `/fs/bulk` per-file results with `opId`, `contentIdentity`, and writeback state so the mount can recover the server operation created for a command draft
- dedupe bulk write retries by stable `contentIdentity` so a lost `/fs/bulk` response returns the original opId instead of enqueueing a second provider dispatch
- keep durable outbox records pending until `GET /ops/{opId}` reports `succeeded`; failed/dead-lettered/canceled ops stay pending with `needsAttention`, and legacy no-opId servers retain the v0.8.20 upload-ack fallback
- persist the positive receipt as `.relay/outbox/acked/<commandId>.json` with `opId` and `dispatchStatus:"succeeded"` for cloud2029

## Receipt Semantics
Delivery is now keyed to the writeback operation reaching `succeeded`, which is set by the provider ACK path after real adapter success. Sync revisions and `/fs/bulk` 202 responses are not treated as delivery proof when an opId receipt is available. Pending/running operations remain pending so the server can finish after sandbox teardown without the mount re-uploading.

## Tests
- `go test ./internal/relayfile -run 'TestBulkWriteContentIdentity(RetryReturnsExistingOperationWithoutDuplicateDispatch|ReachesProviderWriteAction|AppearsInPendingWritebacks)' -count=1`\n- `go test ./internal/mountsync -run 'TestOutbox(AcksOnlyAfterWritebackOperationSucceeded|LostBulkResponseRetryRecoversOpIDWithoutDuplicateDispatch|RestartReloadsPendingAndFlushesWithPersistedCommandID|RetryAfterServerCommitUsesSameCommandIDAndDedupes)|TestFlushOutboxOnce' -count=1`\n- `go test ./internal/mountsync ./internal/mountfuse ./internal/relayfile ./internal/httpapi -count=1`\n- `go test ./...`\n- `scripts/check-contract-surface.sh`\n- `git diff --check`\n\nTypeScript SDK typecheck was attempted, but this checkout is missing pre-existing workspace/type dependencies (`@relayfile/core`, Node type declarations, `tar`), so `npm run typecheck --workspace=packages/sdk/typescript` fails before reaching this change.\n\n## Follow-up Coordination\nCloud2029 has the on-disk receipt/gate contract: compare this-run draft remote paths to `.relay/outbox/acked/*.json` records with matching `remotePath`, non-empty `opId`, and `dispatchStatus:"succeeded"`; fire only for no record, missing opId, or `needsAttention:true` pending records.