### PR TITLE
feat(mount): advertise outbox receipt capability

### DIFF
--- a/internal/mountsync/outbox.go
+++ b/internal/mountsync/outbox.go
@@ -18,6 +18,8 @@ const (
 	defaultOutboxMaxAttempts = 5
 	outboxBackoffBase        = 500 * time.Millisecond
 	outboxBackoffMax         = 30 * time.Second
+
+	outboxCapabilitiesSchemaVersion = 2
 )
 
 type outboxStatus string
@@ -58,9 +60,17 @@ type outboxSummary struct {
 	Acked          int `json:"acked"`
 }
 
+type outboxCapabilities struct {
+	SchemaVersion    int  `json:"schemaVersion"`
+	DispatchReceipts bool `json:"dispatchReceipts"`
+}
+
 func (s *Syncer) outboxPendingDir() string { return filepath.Join(s.outboxDir, "pending") }
 func (s *Syncer) outboxAckedDir() string   { return filepath.Join(s.outboxDir, "acked") }
 func (s *Syncer) outboxFailedDir() string  { return filepath.Join(s.outboxDir, "failed") }
+func (s *Syncer) outboxCapabilitiesPath() string {
+	return filepath.Join(s.outboxDir, "capabilities.json")
+}
 
 func (s *Syncer) ensureOutboxDirs() error {
 	for _, dir := range []string{s.outboxDir, s.outboxPendingDir(), s.outboxAckedDir(), s.outboxFailedDir()} {
@@ -68,7 +78,30 @@ func (s *Syncer) ensureOutboxDirs() error {
 			return err
 		}
 	}
+	if err := s.ensureOutboxCapabilities(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (s *Syncer) ensureOutboxCapabilities() error {
+	capabilities := outboxCapabilities{
+		SchemaVersion:    outboxCapabilitiesSchemaVersion,
+		DispatchReceipts: true,
+	}
+	data, err := json.Marshal(capabilities)
+	if err != nil {
+		return err
+	}
+	path := s.outboxCapabilitiesPath()
+	existing, err := os.ReadFile(path)
+	if err == nil && string(existing) == string(data) {
+		return nil
+	}
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return writeFileAtomic(path, data, 0o644)
 }
 
 func (s *Syncer) pendingOutboxPath(commandID string) string {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2425,6 +2425,34 @@ func TestFlushOutboxOnceFlushesPendingWithoutMirrorScan(t *testing.T) {
 	}
 }
 
+func TestFlushOutboxOnceWritesReceiptCapabilityMarkerWithEmptyOutbox(t *testing.T) {
+	localDir := t.TempDir()
+	client := &fakeClient{files: map[string]RemoteFile{}}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_flush_outbox_capabilities",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+		Interval:    30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.FlushOutboxOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOutboxOnce with empty outbox failed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(localDir, ".relay", "outbox", "capabilities.json"))
+	if err != nil {
+		t.Fatalf("expected outbox capabilities marker: %v", err)
+	}
+	var capabilities outboxCapabilities
+	if err := json.Unmarshal(data, &capabilities); err != nil {
+		t.Fatalf("decode outbox capabilities marker: %v", err)
+	}
+	if capabilities.SchemaVersion != outboxCapabilitiesSchemaVersion || !capabilities.DispatchReceipts {
+		t.Fatalf("unexpected capabilities marker: %+v", capabilities)
+	}
+}
+
 func TestFlushOutboxOnceReturnsErrorAndPreservesPendingState(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- write `.relay/outbox/capabilities.json` from the durable outbox setup path
- advertise dispatch receipt support with `{"schemaVersion":2,"dispatchReceipts":true}`
- cover the empty-outbox `--flush-outbox-once` case so cloud can feature-detect v0.8.21 receipt support without relying on op-bearing records being present

## Contract
Cloud should treat positive dispatch receipts as enabled when `.relay/outbox/capabilities.json` exists and parses with:

```json
{"schemaVersion":2,"dispatchReceipts":true}
```

Recommended guard: `dispatchReceipts === true && schemaVersion >= 2`.

The marker is written by `ensureOutboxDirs`, which is called by `listPendingOutboxRecords`; `FlushOutboxOnce` calls that even when the pending outbox is empty. v0.8.20 does not write this file, so absence remains the pre-PR2/null fallback path.

## Tests
- `go test ./internal/mountsync -run 'TestFlushOutboxOnceWritesReceiptCapabilityMarkerWithEmptyOutbox|TestFlushOutboxOnceFlushesPendingWithoutMirrorScan|TestOutboxAcksOnlyAfterWritebackOperationSucceeded' -count=1`\n- `git diff --check`\n\nNote: I also ran `go test ./internal/mountsync -count=1` with the same marker change before branching from merged #266; it passed.