### PR TITLE
fix(mountsync): independent rootCtx-derived deadline for outbox/writeback flush

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -97,7 +97,16 @@ const (
 	// and, having no resume cursor, restart from scratch every cycle (the
 	// #1499/#1516 non-convergence loop). Must stay strictly under
 	// defaultBootstrapIdleTimeout.
-	defaultExportTimeout              = 45 * time.Second
+	defaultExportTimeout = 45 * time.Second
+	// defaultOutboxFlushTimeout bounds a durable writeback/outbox flush with
+	// its OWN deadline derived from rootCtx (see outboxContext), independent of
+	// the tiny per-cycle RELAYFILE_MOUNT_TIMEOUT. A small outbound write (e.g. a
+	// Slack reply draft) must not share — and be starved by — the same 15s
+	// budget as a full-tree mirror pull on a large workspace; when it does, the
+	// write sits in the outbox retrying across cycles for minutes (the
+	// churn-digest "context deadline exceeded" / late-reply failure mode). This
+	// mirrors bootstrapContext's "derive from rootCtx, not the per-cycle ctx".
+	defaultOutboxFlushTimeout         = 60 * time.Second
 	defaultIncrementalReadNotReadyTTL = 5 * time.Minute
 	defaultCursorResolutionAttempts   = 3
 	defaultCursorRetryBaseDelay       = 250 * time.Millisecond
@@ -795,6 +804,11 @@ type SyncerOptions struct {
 	// RELAYFILE_EXPORT_TIMEOUT, default 45s; values >= bootstrapIdleTimeout are
 	// clamped below it so the fall-through always fires before the watchdog.
 	ExportTimeout time.Duration
+	// OutboxFlushTimeout bounds a durable writeback/outbox flush with its OWN
+	// deadline derived from RootCtx (see outboxContext), so the tiny per-cycle
+	// RELAYFILE_MOUNT_TIMEOUT that bounds a mirror cycle cannot starve an
+	// outbound write. 0 falls back to env RELAYFILE_OUTBOX_TIMEOUT, default 60s.
+	OutboxFlushTimeout time.Duration
 	// IncrementalReadNotReadyTTL bounds how long an incremental create/update
 	// event may keep returning ReadFile 404 before the syncer treats it as a
 	// delete and advances past the event. 0 falls back to env
@@ -954,6 +968,7 @@ type Syncer struct {
 	fullPullEvery        int
 	cursorTimeout        time.Duration
 	exportTimeout        time.Duration
+	outboxFlushTimeout   time.Duration
 	bootstrapTimeout     time.Duration
 	bootstrapIdleTimeout time.Duration
 	readNotReadyTTL      time.Duration
@@ -1310,6 +1325,10 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 	if exportTimeout <= 0 {
 		exportTimeout = defaultExportTimeout
 	}
+	outboxFlushTimeout := resolveDurationEnv(opts.OutboxFlushTimeout, "RELAYFILE_OUTBOX_TIMEOUT", defaultOutboxFlushTimeout, opts.Logger)
+	if outboxFlushTimeout <= 0 {
+		outboxFlushTimeout = defaultOutboxFlushTimeout
+	}
 	// The export's own deadline MUST elapse before the bootstrap context can
 	// be canceled so a slow export yields to the resumable tree pull while the
 	// bootstrap ctx is still alive. Clamp to a fraction of the active bootstrap
@@ -1420,6 +1439,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		fullPullEvery:        fullPullEvery,
 		cursorTimeout:        cursorTimeout,
 		exportTimeout:        exportTimeout,
+		outboxFlushTimeout:   outboxFlushTimeout,
 		bootstrapTimeout:     bootstrapTimeout,
 		bootstrapIdleTimeout: bootstrapIdleTimeout,
 		readNotReadyTTL:      readNotReadyTTL,
@@ -1753,8 +1773,13 @@ func (s *Syncer) flushOutboxRecords(ctx context.Context, conflicted map[string]s
 	if len(due) == 0 {
 		return nil
 	}
+	// The actual cloud upload runs under its OWN rootCtx-derived deadline, not
+	// the inbound per-cycle ctx, so a 15s mirror budget cannot cancel a
+	// writeback mid-flight and leave it retrying for minutes (see outboxContext).
+	flushCtx, cancel := s.outboxContext(ctx)
+	defer cancel()
 	for _, chunk := range chunkOutboxRecords(due, maxWritebackBatchBytes()) {
-		if err := s.flushOutboxRecordChunk(ctx, chunk, conflicted); err != nil {
+		if err := s.flushOutboxRecordChunk(flushCtx, chunk, conflicted); err != nil {
 			return err
 		}
 	}
@@ -2816,6 +2841,29 @@ func (s *Syncer) bootstrapContext(parent context.Context) (context.Context, cont
 		cancel()
 	}
 	return ctx, wrapped, prog
+}
+
+// outboxContext returns a deadline for a durable writeback/outbox flush. Like
+// bootstrapContext, it is derived from s.rootCtx (NOT the inbound per-cycle
+// ctx) so the tiny per-cycle RELAYFILE_MOUNT_TIMEOUT that bounds a mirror cycle
+// cannot starve an outbound write — a small Slack/Notion writeback must not
+// share, and lose, the same 15s budget as a full-tree pull on a large
+// workspace. rootCtx cancellation (process shutdown) still propagates.
+//
+// Callers MUST defer the returned CancelFunc.
+func (s *Syncer) outboxContext(parent context.Context) (context.Context, context.CancelFunc) {
+	root := s.rootCtx
+	if root == nil {
+		// Defensive: NewSyncer always sets rootCtx, but never derive from a nil
+		// parent — fall back to the inbound ctx so behaviour degrades to the
+		// pre-fix per-cycle deadline rather than panicking.
+		root = parent
+	}
+	timeout := s.outboxFlushTimeout
+	if timeout <= 0 {
+		timeout = defaultOutboxFlushTimeout
+	}
+	return context.WithTimeout(root, timeout)
 }
 
 func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{}) error {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2031,6 +2031,90 @@ func TestOutboxPersistsBeforeBulkWriteFailure(t *testing.T) {
 	}
 }
 
+// TestOutboxFlushUsesIndependentDeadlineNotPerCycleCtx proves the fix for the
+// churn-digest "context deadline exceeded" / minutes-late-reply failure: the
+// durable writeback upload must run under its OWN rootCtx-derived deadline
+// (outboxContext), so a tiny per-cycle RELAYFILE_MOUNT_TIMEOUT — or even an
+// already-expired inbound ctx — cannot starve or cancel it. Without the fix the
+// inbound (expired) ctx flows straight into WriteFilesBulk and the flush fails.
+func TestOutboxFlushUsesIndependentDeadlineNotPerCycleCtx(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("seed local command failed: %v", err)
+	}
+
+	// First pass: persist a pending outbox record via a canceled upload.
+	firstClient := &fakeClient{
+		files: map[string]RemoteFile{},
+		bulkWriteResponseFunc: func(ctx context.Context, _ string, _ []BulkWriteFile) (BulkWriteResponse, error) {
+			_ = ctx
+			return BulkWriteResponse{}, context.Canceled
+		},
+	}
+	first, err := NewSyncer(firstClient, SyncerOptions{
+		WorkspaceID: "ws_outbox_deadline",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer first: %v", err)
+	}
+	if err := first.SyncOnce(context.Background()); err == nil {
+		t.Fatal("expected first upload to fail")
+	}
+	forcePendingOutboxDueForTest(t, localDir)
+
+	// Second pass: hand the flush an ALREADY-EXPIRED per-cycle ctx. The upload
+	// must still run, under the rootCtx-derived outbox deadline (30s here).
+	var sawRemaining time.Duration
+	secondClient := &fakeClient{
+		files: map[string]RemoteFile{},
+		bulkWriteResponseFunc: func(ctx context.Context, _ string, _ []BulkWriteFile) (BulkWriteResponse, error) {
+			if dl, ok := ctx.Deadline(); !ok {
+				t.Error("expected outbox upload ctx to carry a deadline")
+			} else {
+				sawRemaining = time.Until(dl)
+			}
+			// A per-cycle-sized expiry must not cancel the upload mid-flight.
+			time.Sleep(40 * time.Millisecond)
+			if ctx.Err() != nil {
+				t.Errorf("outbox upload ctx cancelled mid-flight: %v", ctx.Err())
+			}
+			return BulkWriteResponse{}, nil
+		},
+	}
+	second, err := NewSyncer(secondClient, SyncerOptions{
+		WorkspaceID:        "ws_outbox_deadline",
+		RemoteRoot:         "/slack/channels/C123/messages",
+		LocalRoot:          localDir,
+		RootCtx:            context.Background(),
+		OutboxFlushTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer second: %v", err)
+	}
+
+	tinyCtx, cancel := context.WithTimeout(context.Background(), 15*time.Millisecond)
+	defer cancel()
+	time.Sleep(20 * time.Millisecond) // the inbound per-cycle ctx is now expired
+	if tinyCtx.Err() == nil {
+		t.Fatal("precondition: expected inbound per-cycle ctx to be already expired")
+	}
+
+	if err := second.flushDueOutboxRecords(tinyCtx, nil); err != nil {
+		t.Fatalf("outbox flush should survive an expired per-cycle ctx, got: %v", err)
+	}
+	if secondClient.bulkWriteCalls != 1 {
+		t.Fatalf("expected exactly one upload, got %d", secondClient.bulkWriteCalls)
+	}
+	if sawRemaining < 5*time.Second {
+		t.Fatalf("expected upload to run under the ~30s outbox deadline, saw %s remaining (looks like the expired per-cycle ctx leaked through)", sawRemaining)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("expected pending outbox empty after ack, got %+v", pending)
+	}
+}
+
 func TestOutboxRestartReloadsPendingAndFlushesWithPersistedCommandID(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.8.21",
+  "version": "0.8.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.21.tgz",
-      "integrity": "sha512-f7ey4SQviL416Sz5oWU0AQLyjehGxpwqo10UVt5Uf5wIsGupQ1MmYEUrpVtYxWpk7Oe2i513rxcvhKRBkt508w==",
+      "version": "0.8.22",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.22.tgz",
+      "integrity": "sha512-2ryx3vHdWT6Nknz5SqDaI7MNIBAm+PPeNPwwokdiWxVBpSz1K+6yAh8GCA6SoaQJBW9tDc1KcNtcUbarYFFOWw==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.21.tgz",
-      "integrity": "sha512-ZCrywpvqmEwFvJCxtrC1R4rj8wVPkvIvyK984YsNSVrNVeY4yhfF9oFCy7UR6qeCLBau8ZHrkEYmVyUwuQXbOA==",
+      "version": "0.8.22",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.22.tgz",
+      "integrity": "sha512-VXKhdAqnf8Ubh/czOeeMiXuLLXEAUSqsknLtpmAVKWN7aEC+bzIbkxFfxwSZGGR+M8gwIE/ZbbxHO+9Xqgu82w==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.21.tgz",
-      "integrity": "sha512-CQNBCkDVtnUp6ev6uwerjs91+xHSgRzqJwq9BzqpzGJOc1gpYCHQutyA2mE8kbkzI64vtSPM7F9vmj/Q7XkRrw==",
+      "version": "0.8.22",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.22.tgz",
+      "integrity": "sha512-lEvM2yAElbzbRfI51vpHQdy+mVgTWb4qiT/OHda4DtHraMrYoUzLQ4HM4X0FDDlH6WnqE/AIs5iM/f9sMA3/BA==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.8.21",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.21.tgz",
-      "integrity": "sha512-VsjHHt67uniidurVinq0HlzrSqIa+eEHOuq8NSKFS6eyZIasawpo7YBnC8LFS72ZNCWwkZ2A9jX3xAkOTzuWoA==",
+      "version": "0.8.22",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.22.tgz",
+      "integrity": "sha512-1n7FYTPvSGrnPjVTcGDJZQYxURgLjyP2yhneZh+3mBuTvnfk828was0FKwEx1vVvtP2AbDAXwWANouk1BgaY5g==",
       "cpu": [
         "x64"
       ],
@@ -5276,7 +5276,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5288,7 +5288,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5301,7 +5301,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6109,7 +6109,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6138,10 +6138,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.8.21",
+      "version": "0.8.22",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.8.21",
+        "@relayfile/core": "0.8.22",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6153,10 +6153,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.8.21",
-        "@relayfile/mount-darwin-x64": "0.8.21",
-        "@relayfile/mount-linux-arm64": "0.8.21",
-        "@relayfile/mount-linux-x64": "0.8.21"
+        "@relayfile/mount-darwin-arm64": "0.8.22",
+        "@relayfile/mount-darwin-x64": "0.8.22",
+        "@relayfile/mount-linux-arm64": "0.8.22",
+        "@relayfile/mount-linux-x64": "0.8.22"
       }
     }
   }


### PR DESCRIPTION
## Problem

The mount wraps **both** the mirror pull and the durable writeback/outbox push in one per-cycle context bounded by `RELAYFILE_MOUNT_TIMEOUT` (default **15s**). On a large mounted tree (a real churn-digest box carries ~2,829 files / 1,252 Slack across 40 channels), a single cloud round-trip routinely exceeds 15s, so the writeback push is cancelled mid-flight and the outbox record retries across cycles for minutes. Symptoms in prod mount logs:

```
mount local change failed: context deadline exceeded
mount sync cycle failed: context deadline exceeded
```

…and provider writebacks (e.g. a Slack reply draft) landing ~10 min late — or not at all before the ephemeral sandbox tears down (cleanup `flushExitCode:1`).

## Fix

A small outbound write must not share — and be starved by — the same budget as a full-tree mirror. `bootstrapContext` already solves exactly this for the heavy initial/periodic pull (*"derive from rootCtx, not the per-cycle ctx, so a tiny `RELAYFILE_MOUNT_TIMEOUT` cannot starve it"*). This applies the symmetric treatment to the outbox flush:

- **`outboxContext()`** — derives the flush deadline from `s.rootCtx` with its own budget (default **60s**, env **`RELAYFILE_OUTBOX_TIMEOUT`**). Process-shutdown cancellation via `rootCtx` still propagates.
- **`flushOutboxRecords()`** runs the cloud upload under that deadline instead of the inbound per-cycle ctx.

## Test

`TestOutboxFlushUsesIndependentDeadlineNotPerCycleCtx` hands the flush an **already-expired** per-cycle ctx and asserts the upload still completes under the rootCtx-derived deadline.

- **Proven red→green:** without the fix the expired ctx leaks through (`saw -5.78ms remaining`) and the upload is cancelled; with it, the upload runs under the ~60s outbox deadline.
- Full `internal/mountsync` suite green (no regressions); `gofmt` clean.

## Rollout note

This reaches prod only via a **Daytona snapshot rebuild** (the `RELAYFILE_MOUNT_VERSION` pin) — merge alone does not deploy it.

## Companion (cloud repo, separate PR)

- Raise the cloud teardown flush wrap (`sandbox-orchestrator.ts` `flushTimeoutSeconds`, currently 20s) above the new 60s outbox budget so writebacks drain before SIGKILL.
- Narrow over-broad persona mount scope (churn-digest mounts all 40 Slack channels) — pending verification that scope drives the mounted tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)