### PR TITLE
test(mountsync): deterministic outbox writeback E2E + injectable clock

### DIFF
--- a/internal/mountsync/outbox.go
+++ b/internal/mountsync/outbox.go
@@ -226,7 +226,7 @@ func (s *Syncer) ensureOutboxRecord(pending pendingBulkWrite) (outboxRecord, err
 			return outboxRecord{}, err
 		}
 	}
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	now := s.now().UTC().Format(time.RFC3339Nano)
 	record := outboxRecord{
 		CommandID:     newOutboxCommandID(s.workspace, pending.remotePath, pending.snapshot.Hash, now),
 		WorkspaceID:   s.workspace,
@@ -259,7 +259,7 @@ func newOutboxCommandID(workspaceID, remotePath, hash, firstSeenAt string) strin
 
 func (s *Syncer) incrementOutboxAttempt(record outboxRecord, err error) error {
 	record.AttemptCount++
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	record.LastAttemptAt = now.Format(time.RFC3339Nano)
 	record.LastError = sanitizeOutboxError(err)
 	if record.AttemptCount >= s.maxOutboxAttemptsValue() {
@@ -315,7 +315,7 @@ func (s *Syncer) ackOutboxRecord(record outboxRecord, revision, correlationID st
 		return err
 	}
 	record.Status = outboxStatusAcked
-	record.AckedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	record.AckedAt = s.now().UTC().Format(time.RFC3339Nano)
 	record.DispatchStatus = "succeeded"
 	record.Revision = strings.TrimSpace(revision)
 	if strings.TrimSpace(correlationID) != "" {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -832,6 +832,11 @@ type SyncerOptions struct {
 	DigestProviders         []string
 	DigestTimezone          string
 	DigestNow               func() time.Time
+	// Now overrides the wall clock used by the outbox writeback path
+	// (first-seen stamping, retry-backoff scheduling, due-ness, ack time).
+	// Defaults to time.Now when nil. Tests inject a controllable clock to make
+	// retry-backoff and dead-letter timing deterministic without real sleeps.
+	Now func() time.Time
 }
 
 type Logger interface {
@@ -985,7 +990,18 @@ type Syncer struct {
 	rollingCoalescer     *RollingDigestCoalescer
 	circuit              *CloudErrorCircuit
 	maxOutboxAttempts    int
+	nowFn                func() time.Time
 	mu                   sync.Mutex
+}
+
+// now returns the current time using the injected clock when set (tests),
+// otherwise the wall clock. Used by the outbox writeback path so retry-backoff
+// and dead-letter timing are deterministic under test without real sleeps.
+func (s *Syncer) now() time.Time {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now()
 }
 
 type mountState struct {
@@ -1454,6 +1470,7 @@ func NewSyncer(client RemoteClient, opts SyncerOptions) (*Syncer, error) {
 		rollingCoalescer:     rollingCoalescer,
 		circuit:              NewCloudErrorCircuit(),
 		maxOutboxAttempts:    defaultOutboxMaxAttempts,
+		nowFn:                opts.Now,
 		state: mountState{
 			Files: map[string]trackedFile{},
 		},
@@ -1753,7 +1770,7 @@ func (s *Syncer) flushOutboxRecords(ctx context.Context, conflicted map[string]s
 	if err != nil {
 		return err
 	}
-	now := time.Now().UTC()
+	now := s.now().UTC()
 	due := make([]outboxRecord, 0, len(records))
 	for _, record := range records {
 		if record.AttemptCount >= s.maxOutboxAttemptsValue() && !record.NeedsAttention {

--- a/internal/mountsync/writeback_e2e_test.go
+++ b/internal/mountsync/writeback_e2e_test.go
@@ -1,0 +1,417 @@
+package mountsync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/relayfile"
+)
+
+// Deterministic end-to-end coverage of the outbound writeback path
+// (local write -> outbox -> cloud /fs/bulk -> dispatch-receipt poll -> ack),
+// plus retry-backoff, dead-letter, and schema-violation. The cloud is an
+// httptest server whose per-route behavior each subtest controls; time is an
+// injected clock (SyncerOptions.Now) so retry/backoff timing is exact with no
+// real sleeps.
+
+// fakeClock is a deterministic, advanceable clock for the outbox path.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock(start time.Time) *fakeClock { return &fakeClock{t: start} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// writebackTestCloud is a controllable httptest cloud. Only /fs/bulk and the
+// operation-poll route carry test-specific behavior; the pull routes return
+// empty so SyncOnce's mirror phase is a no-op and the test isolates writeback.
+type writebackTestCloud struct {
+	*httptest.Server
+
+	mu sync.Mutex
+	// bulk returns the HTTP status + response body for a POST /fs/bulk call.
+	// callNum is 1-based.
+	bulk func(callNum int, files []BulkWriteFile) (int, BulkWriteResponse)
+	// op returns the HTTP status + body for a GET /ops/{opID} poll.
+	op func(callNum int, opID string) (int, OperationStatus)
+
+	bulkCalls int
+	opCalls   int
+	lastFiles []BulkWriteFile
+}
+
+func newWritebackTestCloud(t *testing.T) *writebackTestCloud {
+	t.Helper()
+	c := &writebackTestCloud{}
+	c.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasSuffix(path, "/fs/tree") && r.Method == http.MethodGet:
+			writeJSONResponse(t, w, http.StatusOK, TreeResponse{Path: "/", Entries: []TreeEntry{}, NextCursor: nil})
+		case strings.HasSuffix(path, "/fs/events") && r.Method == http.MethodGet:
+			writeJSONResponse(t, w, http.StatusOK, EventFeed{Events: []FilesystemEvent{}, NextCursor: nil})
+		case strings.HasSuffix(path, "/fs/export") && r.Method == http.MethodGet:
+			writeJSONResponse(t, w, http.StatusOK, []RemoteFile{})
+		case strings.HasSuffix(path, "/fs/file") && r.Method == http.MethodGet:
+			writeJSONResponse(t, w, http.StatusNotFound, map[string]any{"code": "not_found", "message": "not found"})
+		case strings.Contains(path, "/ops/") && r.Method == http.MethodGet:
+			opID := path[strings.LastIndex(path, "/ops/")+len("/ops/"):]
+			c.mu.Lock()
+			c.opCalls++
+			n := c.opCalls
+			handler := c.op
+			c.mu.Unlock()
+			if handler == nil {
+				writeJSONResponse(t, w, http.StatusNotFound, map[string]any{"code": "not_found"})
+				return
+			}
+			status, body := handler(n, opID)
+			writeJSONResponse(t, w, status, body)
+		case strings.HasSuffix(path, "/fs/bulk") && r.Method == http.MethodPost:
+			var payload struct {
+				Files []BulkWriteFile `json:"files"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				writeJSONResponse(t, w, http.StatusBadRequest, map[string]any{"code": "bad_request"})
+				return
+			}
+			c.mu.Lock()
+			c.bulkCalls++
+			n := c.bulkCalls
+			c.lastFiles = payload.Files
+			handler := c.bulk
+			c.mu.Unlock()
+			if handler == nil {
+				writeJSONResponse(t, w, http.StatusServiceUnavailable, map[string]any{"code": "unavailable"})
+				return
+			}
+			status, body := handler(n, payload.Files)
+			writeJSONResponse(t, w, status, body)
+		default:
+			writeJSONResponse(t, w, http.StatusNotFound, map[string]any{"code": "not_found", "path": path})
+		}
+	}))
+	t.Cleanup(c.Server.Close)
+	return c
+}
+
+func (c *writebackTestCloud) bulkCallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bulkCalls
+}
+
+func (c *writebackTestCloud) opCallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.opCalls
+}
+
+// newWritebackSyncer wires a Syncer at NewHTTPClient(cloud) with the injected
+// clock and a seeded local draft file that becomes one pending outbox command.
+func newWritebackSyncer(t *testing.T, cloud *writebackTestCloud, clock *fakeClock) (*Syncer, string, string) {
+	t.Helper()
+	const workspaceID = "ws_writeback_e2e"
+	localDir := t.TempDir()
+	// A slack draft is the canonical writeback shape: a brand-new local file
+	// with no remote counterpart becomes exactly one outbox command.
+	draftID := "5ab77d67-1111-4111-8111-123456789abc"
+	remotePath := "/slack/channels/C123/messages/messages " + draftID + ".json"
+	messageDir := filepath.Join(localDir, "slack", "channels", "C123", "messages")
+	if err := os.MkdirAll(messageDir, 0o755); err != nil {
+		t.Fatalf("mkdir message dir: %v", err)
+	}
+	content := "{\"channel\":\"C123\",\"text\":\"hello writeback e2e\"}\n"
+	if err := os.WriteFile(filepath.Join(messageDir, "messages "+draftID+".json"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write draft: %v", err)
+	}
+
+	websocketEnabled := false
+	client := NewHTTPClient(cloud.Server.URL, "test-token", cloud.Server.Client())
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		WebSocket:   &websocketEnabled,
+		Now:         clock.now,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	return syncer, localDir, remotePath
+}
+
+func ackedOutbox(t *testing.T, localDir string) []outboxRecord {
+	return readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked"))
+}
+
+func failedOutbox(t *testing.T, localDir string) []outboxRecord {
+	return readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "failed"))
+}
+
+// okBulkWithOpID makes /fs/bulk accept every file and hand back an opId +
+// initial dispatch state, exercising the dispatch-receipt (poll) path.
+func okBulkWithOpID(opID string) func(int, []BulkWriteFile) (int, BulkWriteResponse) {
+	return func(_ int, files []BulkWriteFile) (int, BulkWriteResponse) {
+		results := make([]BulkWriteResult, 0, len(files))
+		for i, f := range files {
+			results = append(results, BulkWriteResult{
+				Path:      normalizeRemotePath(f.Path),
+				Revision:  fmt.Sprintf("rev_%d", i+1),
+				OpID:      opID,
+				Writeback: &relayfile.BulkWriteWritebackResult{Provider: "slack", State: "queued"},
+			})
+		}
+		return http.StatusAccepted, BulkWriteResponse{
+			Written: len(files), Results: results, CorrelationID: "corr_e2e",
+		}
+	}
+}
+
+func TestWritebackE2E_UploadPollAck(t *testing.T) {
+	cloud := newWritebackTestCloud(t)
+	clock := newFakeClock(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	cloud.bulk = okBulkWithOpID("op_ack_1")
+	cloud.op = func(_ int, opID string) (int, OperationStatus) {
+		return http.StatusOK, OperationStatus{OpID: opID, Status: "succeeded", Revision: "rev_1"}
+	}
+
+	syncer, localDir, _ := newWritebackSyncer(t, cloud, clock)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	if got := cloud.bulkCallCount(); got != 1 {
+		t.Fatalf("bulk calls = %d, want 1", got)
+	}
+	if got := cloud.opCallCount(); got != 1 {
+		t.Fatalf("op poll calls = %d, want 1", got)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("pending = %d, want 0 (acked)", len(pending))
+	}
+	acked := ackedOutbox(t, localDir)
+	if len(acked) != 1 {
+		t.Fatalf("acked = %d, want 1", len(acked))
+	}
+	if acked[0].DispatchStatus != "succeeded" {
+		t.Fatalf("dispatch status = %q, want succeeded", acked[0].DispatchStatus)
+	}
+	if acked[0].OpID != "op_ack_1" {
+		t.Fatalf("opId = %q, want op_ack_1", acked[0].OpID)
+	}
+	if strings.TrimSpace(acked[0].AckedAt) == "" {
+		t.Fatal("ackedAt not set")
+	}
+}
+
+func TestWritebackE2E_PollPendingThenAck(t *testing.T) {
+	cloud := newWritebackTestCloud(t)
+	clock := newFakeClock(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	cloud.bulk = okBulkWithOpID("op_poll_1")
+	// First poll: still running. Second poll: succeeded.
+	cloud.op = func(callNum int, opID string) (int, OperationStatus) {
+		if callNum == 1 {
+			return http.StatusOK, OperationStatus{OpID: opID, Status: "running"}
+		}
+		return http.StatusOK, OperationStatus{OpID: opID, Status: "succeeded", Revision: "rev_1"}
+	}
+
+	syncer, localDir, _ := newWritebackSyncer(t, cloud, clock)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	// After the first cycle the op is still running -> record stays pending
+	// with the opId recorded, not acked.
+	pending := readPendingOutboxRecordsForTest(t, localDir)
+	if len(pending) != 1 {
+		t.Fatalf("after running poll: pending = %d, want 1", len(pending))
+	}
+	if pending[0].OpID != "op_poll_1" {
+		t.Fatalf("pending opId = %q, want op_poll_1", pending[0].OpID)
+	}
+	if len(ackedOutbox(t, localDir)) != 0 {
+		t.Fatal("must not be acked while op is running")
+	}
+
+	// A record that already carries an opId is re-polled directly, regardless of
+	// backoff timing. Second flush -> op succeeded -> acked.
+	if err := syncer.FlushOutboxOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOutboxOnce: %v", err)
+	}
+	if len(readPendingOutboxRecordsForTest(t, localDir)) != 0 {
+		t.Fatal("expected acked after succeeded poll")
+	}
+	if acked := ackedOutbox(t, localDir); len(acked) != 1 || acked[0].DispatchStatus != "succeeded" {
+		t.Fatalf("acked = %+v, want one succeeded", acked)
+	}
+}
+
+func TestWritebackE2E_RetryBackoffIsExponential(t *testing.T) {
+	cloud := newWritebackTestCloud(t)
+	start := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	clock := newFakeClock(start)
+	// Every upload fails with a retryable server error.
+	cloud.bulk = func(_ int, _ []BulkWriteFile) (int, BulkWriteResponse) {
+		return http.StatusServiceUnavailable, BulkWriteResponse{}
+	}
+
+	syncer, localDir, _ := newWritebackSyncer(t, cloud, clock)
+
+	// Attempt 1 (via SyncOnce). The flush error is expected/surfaced.
+	_ = syncer.SyncOnce(context.Background())
+
+	// outboxBackoff: 500ms, 1s, 2s, 4s ... computed off the SAME injected `now`
+	// for LastAttemptAt and NextAttemptAt, so the delta is exact.
+	for attempt := 1; attempt <= 3; attempt++ {
+		pending := readPendingOutboxRecordsForTest(t, localDir)
+		if len(pending) != 1 {
+			t.Fatalf("attempt %d: pending = %d, want 1", attempt, len(pending))
+		}
+		rec := pending[0]
+		if rec.AttemptCount != attempt {
+			t.Fatalf("attempt %d: AttemptCount = %d", attempt, rec.AttemptCount)
+		}
+		last, err := time.Parse(time.RFC3339Nano, rec.LastAttemptAt)
+		if err != nil {
+			t.Fatalf("parse LastAttemptAt: %v", err)
+		}
+		next, err := time.Parse(time.RFC3339Nano, rec.NextAttemptAt)
+		if err != nil {
+			t.Fatalf("attempt %d: parse NextAttemptAt %q: %v", attempt, rec.NextAttemptAt, err)
+		}
+		if got, want := next.Sub(last), outboxBackoff(attempt); got != want {
+			t.Fatalf("attempt %d: backoff = %s, want %s", attempt, got, want)
+		}
+		// Not due just before NextAttemptAt; due exactly at it.
+		clock.advance(outboxBackoff(attempt) - time.Millisecond)
+		if syncer.outboxDue(rec, clock.now().UTC()) {
+			t.Fatalf("attempt %d: record due before NextAttemptAt", attempt)
+		}
+		clock.advance(time.Millisecond)
+		if !syncer.outboxDue(rec, clock.now().UTC()) {
+			t.Fatalf("attempt %d: record not due at NextAttemptAt", attempt)
+		}
+		// Next retry.
+		_ = syncer.FlushOutboxOnce(context.Background())
+	}
+}
+
+func TestWritebackE2E_DeadLetterAfterMaxAttempts(t *testing.T) {
+	cloud := newWritebackTestCloud(t)
+	clock := newFakeClock(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	cloud.bulk = func(_ int, _ []BulkWriteFile) (int, BulkWriteResponse) {
+		return http.StatusServiceUnavailable, BulkWriteResponse{}
+	}
+
+	syncer, localDir, _ := newWritebackSyncer(t, cloud, clock)
+	syncer.maxOutboxAttempts = 3 // shrink to keep the test tight
+
+	_ = syncer.SyncOnce(context.Background())
+	// Drive remaining attempts by advancing past each backoff window.
+	for i := 0; i < 5; i++ {
+		pending := readPendingOutboxRecordsForTest(t, localDir)
+		if len(pending) != 1 {
+			t.Fatalf("iteration %d: pending = %d, want 1", i, len(pending))
+		}
+		if pending[0].NeedsAttention {
+			break
+		}
+		clock.advance(outboxBackoffMax)
+		_ = syncer.FlushOutboxOnce(context.Background())
+	}
+
+	pending := readPendingOutboxRecordsForTest(t, localDir)
+	if len(pending) != 1 {
+		t.Fatalf("dead-letter: pending = %d, want 1 (held for attention)", len(pending))
+	}
+	rec := pending[0]
+	if !rec.NeedsAttention {
+		t.Fatalf("expected NeedsAttention after %d attempts, got attemptCount=%d", syncer.maxOutboxAttempts, rec.AttemptCount)
+	}
+	if rec.AttemptCount < syncer.maxOutboxAttempts {
+		t.Fatalf("AttemptCount = %d, want >= %d", rec.AttemptCount, syncer.maxOutboxAttempts)
+	}
+	if strings.TrimSpace(rec.NextAttemptAt) != "" {
+		t.Fatalf("dead-lettered record must not be rescheduled, NextAttemptAt = %q", rec.NextAttemptAt)
+	}
+	// A dead-lettered record is not due and is not retried.
+	if syncer.outboxDue(rec, clock.now().Add(24*time.Hour).UTC()) {
+		t.Fatal("dead-lettered record must never be due")
+	}
+	bulkBefore := cloud.bulkCallCount()
+	_ = syncer.FlushOutboxOnce(context.Background())
+	if cloud.bulkCallCount() != bulkBefore {
+		t.Fatal("dead-lettered record must not be re-uploaded")
+	}
+	if s := syncer.summarizeOutbox(); s.NeedsAttention != 1 {
+		t.Fatalf("summary NeedsAttention = %d, want 1", s.NeedsAttention)
+	}
+}
+
+func TestWritebackE2E_SchemaViolationFailsAndQuarantines(t *testing.T) {
+	cloud := newWritebackTestCloud(t)
+	clock := newFakeClock(time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC))
+	cloud.bulk = func(_ int, files []BulkWriteFile) (int, BulkWriteResponse) {
+		errs := make([]BulkWriteError, 0, len(files))
+		for _, f := range files {
+			errs = append(errs, BulkWriteError{
+				Path:    normalizeRemotePath(f.Path),
+				Code:    "schema_validation_failed",
+				Message: "body did not match the adapter schema: text is required",
+			})
+		}
+		return http.StatusAccepted, BulkWriteResponse{ErrorCount: len(errs), Errors: errs, CorrelationID: "corr_schema"}
+	}
+
+	syncer, localDir, _ := newWritebackSyncer(t, cloud, clock)
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+
+	// A schema violation is terminal for the command: it moves to failed/, not
+	// retried, and is NOT held as needs-attention (that's for transient retries).
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("schema violation: pending = %d, want 0", len(pending))
+	}
+	failed := failedOutbox(t, localDir)
+	if len(failed) != 1 {
+		t.Fatalf("failed = %d, want 1", len(failed))
+	}
+	if !strings.Contains(failed[0].LastError, "schema") {
+		t.Fatalf("failed record LastError = %q, want a schema message", failed[0].LastError)
+	}
+	// The offending local body is quarantined as a schema-invalid artifact.
+	conflictsDir := filepath.Join(localDir, ".relay", "conflicts")
+	var artifacts []string
+	_ = filepath.Walk(conflictsDir, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			artifacts = append(artifacts, path)
+		}
+		return nil
+	})
+	if len(artifacts) == 0 {
+		t.Fatalf("expected a schema-invalid artifact under %s", conflictsDir)
+	}
+}


### PR DESCRIPTION
## What

Adds deterministic end-to-end coverage of the outbound **writeback** path (local write → outbox → cloud `/fs/bulk` → dispatch-receipt poll → ack), the gap the overnight integration run was chartered to close (writebacks were previously only exercised via `../pear`, which mocks `RelayFileSync` entirely and runs long async retry loops).

## How

- **`SyncerOptions.Now` clock injection** — overrides the wall clock used by the outbox path (first-seen stamping, retry-backoff scheduling, due-ness, ack time). Defaults to `time.Now` when nil; tests inject a controllable clock so retry-backoff and dead-letter timing are exact with **no real sleeps**.
- **`writeback_e2e_test.go`** — drives the real syncer against an `httptest` cloud whose per-route behavior each subtest controls:
  - `UploadPollAck` — upload → poll → ack, asserts dispatch status/opId/ackedAt
  - `PollPendingThenAck` — op `running` first, acked on a later flush
  - `RetryBackoffIsExponential` — exact 500ms/1s/2s… backoff via injected clock; due-ness checked at the boundary
  - `DeadLetterAfterMaxAttempts` — held for attention, not rescheduled, never re-uploaded
  - `SchemaViolationFailsAndQuarantines` — terminal → `failed/` + quarantined artifact under `.relay/conflicts`

## Gates

- G1 `go build ./...` ✅
- G2 `go test ./...` ✅ (full suite green, incl. mountsync 109s)
- G4 `scripts/check-contract-surface.sh` ✅ (additive opts field only; no server/OpenAPI change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)