### PR TITLE
Unify relayfile cloud auth with agent-relay

### DIFF
--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -5,13 +5,9 @@ package main
 import (
 	"bytes"
 	"errors"
-	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -418,7 +414,7 @@ func TestMountBackgroundRefusesExistingDaemonFromProcessScan(t *testing.T) {
 	t.Cleanup(func() { listProcessCommands = oldList })
 
 	var stdout bytes.Buffer
-	err := run([]string{"mount", "demo", "--background"}, strings.NewReader(""), &stdout, &stdout)
+	err := run([]string{"mount", "demo", "--token", testJWTWithWorkspace("ws_demo"), "--background"}, strings.NewReader(""), &stdout, &stdout)
 	if err == nil {
 		t.Fatalf("expected mount --background to refuse an existing daemon")
 	}
@@ -480,7 +476,7 @@ func TestMountBackgroundClearsDeadStructuredPIDBeforeStart(t *testing.T) {
 	t.Cleanup(func() { spawnBackgroundMountProcessFn = oldSpawn })
 
 	var stdout bytes.Buffer
-	if err := run([]string{"mount", "demo", "--background"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+	if err := run([]string{"mount", "demo", "--token", testJWTWithWorkspace("ws_demo"), "--background"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run mount failed: %v\noutput:\n%s", err, stdout.String())
 	}
 	if !spawned {
@@ -586,7 +582,7 @@ func TestRestartClearsStaleDaemonPID(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected restart to reach mount and fail without credentials")
 	}
-	if !strings.Contains(err.Error(), "token is required") {
+	if !strings.Contains(err.Error(), "agent-relay cloud session") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Contains(stdout.String(), "Stopped background mount") {
@@ -597,88 +593,6 @@ func TestRestartClearsStaleDaemonPID(t *testing.T) {
 	}
 	if _, err := os.Stat(mountPIDFile(localDir)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected stale pid file to be removed, got err=%v", err)
-	}
-}
-
-// TestA2RunCloudLoginReturnsStateMismatchSentinel exercises productized
-// cloud-mount contract A2: when the OAuth callback's `state` parameter does
-// not match the value the CLI generated, runCloudLogin must return the
-// ErrCloudLoginStateMismatch sentinel so main() can exit 10.
-func TestA2RunCloudLoginReturnsStateMismatchSentinel(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	// Read stdout via a pipe so the test can wait for the listener URL line
-	// before forging the callback request.
-	pipeR, pipeW := io.Pipe()
-	scannerOut := make(chan string, 1)
-	go func() {
-		// Pull at most a few KB until we see the login URL the function
-		// prints, then forward the rest into a discard sink.
-		buf := make([]byte, 0, 4096)
-		tmp := make([]byte, 256)
-		re := regexp.MustCompile(`Sign in to Relayfile Cloud:\s+(\S+)`)
-		for {
-			n, err := pipeR.Read(tmp)
-			if n > 0 {
-				buf = append(buf, tmp[:n]...)
-				if matches := re.FindSubmatch(buf); matches != nil {
-					scannerOut <- string(matches[1])
-					_, _ = io.Copy(io.Discard, pipeR)
-					return
-				}
-			}
-			if err != nil {
-				close(scannerOut)
-				return
-			}
-		}
-	}()
-
-	loginErr := make(chan error, 1)
-	go func() {
-		_, err := runCloudLogin("https://cloud.example.test", 10*time.Second, false, pipeW)
-		_ = pipeW.Close()
-		loginErr <- err
-	}()
-
-	var loginURL string
-	select {
-	case loginURL = <-scannerOut:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("runCloudLogin did not print login URL in time")
-	}
-
-	parsed, err := url.Parse(loginURL)
-	if err != nil {
-		t.Fatalf("parse login URL failed: %v", err)
-	}
-	redirectURI := parsed.Query().Get("redirect_uri")
-	if redirectURI == "" {
-		t.Fatalf("login URL missing redirect_uri: %s", loginURL)
-	}
-	callback, err := url.Parse(redirectURI)
-	if err != nil {
-		t.Fatalf("parse redirect_uri failed: %v", err)
-	}
-	q := callback.Query()
-	q.Set("state", "tampered-or-replayed")
-	q.Set("access_token", "bogus")
-	callback.RawQuery = q.Encode()
-
-	resp, err := http.Get(callback.String())
-	if err != nil {
-		t.Fatalf("forge callback request failed: %v", err)
-	}
-	_ = resp.Body.Close()
-
-	select {
-	case err := <-loginErr:
-		if !errors.Is(err, ErrCloudLoginStateMismatch) {
-			t.Fatalf("expected ErrCloudLoginStateMismatch, got: %v", err)
-		}
-	case <-time.After(3 * time.Second):
-		t.Fatalf("runCloudLogin did not return after state mismatch")
 	}
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -15,7 +15,6 @@ import (
 	"log"
 	mathrand "math/rand/v2"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -40,6 +39,7 @@ const (
 	defaultServerURL        = "https://api.relayfile.dev"
 	defaultCloudAPIURL      = "https://agentrelay.com/cloud"
 	defaultObserverURL      = "https://agentrelay.com/observer/file"
+	minAgentRelayCLIVersion = "8.7.0"
 	configDirName           = ".relayfile"
 	websocketReconcileEvery = 10
 	defaultMountMode        = "poll"
@@ -58,12 +58,34 @@ type credentials struct {
 }
 
 type cloudCredentials struct {
-	APIURL                string `json:"apiUrl"`
-	AccessToken           string `json:"accessToken"`
-	RefreshToken          string `json:"refreshToken,omitempty"`
-	AccessTokenExpiresAt  string `json:"accessTokenExpiresAt,omitempty"`
-	RefreshTokenExpiresAt string `json:"refreshTokenExpiresAt,omitempty"`
-	UpdatedAt             string `json:"updatedAt,omitempty"`
+	APIURL               string `json:"apiUrl"`
+	AccessToken          string `json:"accessToken"`
+	AccessTokenExpiresAt string `json:"accessTokenExpiresAt,omitempty"`
+	UpdatedAt            string `json:"updatedAt,omitempty"`
+}
+
+type agentRelayCloudSession struct {
+	APIURL      string `json:"apiUrl"`
+	AccessToken string `json:"accessToken"`
+	Auth        struct {
+		APIURL      string `json:"apiUrl"`
+		AccessToken string `json:"accessToken"`
+	} `json:"auth"`
+}
+
+type agentRelayActiveWorkspace struct {
+	ID                       string            `json:"id"`
+	Name                     string            `json:"name"`
+	Key                      string            `json:"key"`
+	Slug                     string            `json:"slug"`
+	CloudWorkspaceID         string            `json:"cloudWorkspaceId"`
+	RelayfileWorkspaceID     string            `json:"relayfileWorkspaceId"`
+	RelaycastWorkspaceID     string            `json:"relaycastWorkspaceId"`
+	RelayauthWorkspaceID     string            `json:"relayauthWorkspaceId"`
+	OrganizationID           string            `json:"organizationId"`
+	URLs                     map[string]string `json:"urls"`
+	RelayfileURL             string            `json:"relayfileUrl"`
+	RelayfileURLAlternateKey string            `json:"relayfileURL"`
 }
 
 type workspaceCatalog struct {
@@ -247,10 +269,6 @@ type cloudIntegrationReadyResponse struct {
 	State        string `json:"state,omitempty"`
 }
 
-type cloudTokenRefreshRequest struct {
-	RefreshToken string `json:"refreshToken"`
-}
-
 type cloudIntegrationCatalogResponse struct {
 	Providers []integrationCatalogEntry `json:"providers"`
 	Version   string                    `json:"version,omitempty"`
@@ -431,24 +449,10 @@ func parseRetryAfter(value string) time.Duration {
 	return 0
 }
 
-// cloudLoginStateMismatchExitCode is the exit code mandated by productized
-// cloud-mount contract A2 when the browser callback's state parameter does
-// not match the value the CLI generated. The dedicated code lets shells and
-// CI distinguish a tampered/replayed login flow from a generic CLI error.
-const cloudLoginStateMismatchExitCode = 10
-
-// ErrCloudLoginStateMismatch is returned by runCloudLogin when the OAuth
-// callback's `state` query parameter does not match the value the CLI
-// generated. main() maps this sentinel to exit code 10 per A2.
-var ErrCloudLoginStateMismatch = errors.New("Relayfile Cloud login state mismatch")
-
 func main() {
 	log.SetFlags(0)
 	if err := run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
-		if errors.Is(err, ErrCloudLoginStateMismatch) {
-			os.Exit(cloudLoginStateMismatchExitCode)
-		}
 		os.Exit(1)
 	}
 }
@@ -715,8 +719,8 @@ Usage:
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
-  login       Sign in via the Relayfile Cloud browser flow (or --api-key for self-hosted)
-  workspace   Create, join, select, list, show current, or delete locally tracked workspaces
+  login       Sign in via agent-relay login (or --api-key for self-hosted)
+  workspace   Create, join, select via agent-relay, list, show current, or delete locally tracked workspaces
   integration Connect, discover, list, disconnect, or adopt workspace integrations
   ops         List or replay dead-lettered writeback ops
   writeback   Inspect or retry local writeback failures
@@ -915,34 +919,236 @@ func ensureCloudCredentials(cloudAPIURL, explicitToken string, timeout time.Dura
 			AccessToken: explicitToken,
 			UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
 		}
-		if err := saveCloudCredentials(creds); err != nil {
-			return cloudCredentials{}, err
-		}
 		return creds, nil
 	}
 
-	creds, err := loadCloudCredentials()
-	if err == nil {
-		if strings.TrimSpace(creds.APIURL) == "" {
-			creds.APIURL = cloudAPIURL
-		}
-		if strings.TrimRight(strings.TrimSpace(creds.APIURL), "/") != cloudAPIURL {
-			creds.APIURL = cloudAPIURL
-		}
-		refreshed, refreshErr := refreshCloudCredentialsIfNeeded(creds)
-		if refreshErr == nil {
-			return refreshed, nil
-		}
-	}
-
-	creds, err = runCloudLogin(cloudAPIURL, timeout, shouldOpenBrowser, stdout)
+	creds, err := cloudCredentialsFromAgentRelay()
 	if err != nil {
 		return cloudCredentials{}, err
 	}
-	if err := saveCloudCredentials(creds); err != nil {
+	return creds, nil
+}
+
+func agentRelayBinary() string {
+	if value := strings.TrimSpace(os.Getenv("AGENT_RELAY_BIN")); value != "" {
+		return value
+	}
+	return "agent-relay"
+}
+
+func ensureAgentRelayCLICompatible() error {
+	bin := agentRelayBinary()
+	versionOutput, err := exec.Command(bin, "--version").CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(versionOutput))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("agent-relay CLI >= %s required; run `npm install -g agent-relay@%s` or set AGENT_RELAY_BIN to a compatible binary (%s)", minAgentRelayCLIVersion, minAgentRelayCLIVersion, detail)
+	}
+	version := firstSemver(string(versionOutput))
+	if version == "" || compareSemver(version, minAgentRelayCLIVersion) < 0 {
+		if version == "" {
+			version = strings.TrimSpace(string(versionOutput))
+		}
+		return fmt.Errorf("agent-relay CLI >= %s required; found %q. Run `npm install -g agent-relay@%s` or update the sandbox image", minAgentRelayCLIVersion, version, minAgentRelayCLIVersion)
+	}
+	for _, args := range [][]string{
+		{"cloud", "session", "--help"},
+		{"workspace", "active", "--help"},
+		{"workspace", "switch", "--help"},
+	} {
+		output, err := exec.Command(bin, args...).CombinedOutput()
+		if err != nil {
+			detail := strings.TrimSpace(string(output))
+			if detail == "" {
+				detail = err.Error()
+			}
+			return fmt.Errorf("agent-relay CLI >= %s required with `%s`; run `npm install -g agent-relay@%s` or update the sandbox image (%s)", minAgentRelayCLIVersion, strings.Join(append([]string{"agent-relay"}, args...), " "), minAgentRelayCLIVersion, detail)
+		}
+	}
+	return nil
+}
+
+func firstSemver(value string) string {
+	fields := strings.Fields(strings.TrimSpace(value))
+	for _, field := range fields {
+		field = strings.TrimPrefix(field, "v")
+		if isSemver(field) {
+			return field
+		}
+	}
+	return ""
+}
+
+func isSemver(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func compareSemver(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	maxParts := len(aParts)
+	if len(bParts) > maxParts {
+		maxParts = len(bParts)
+	}
+	for i := 0; i < maxParts; i++ {
+		var aValue, bValue int
+		if i < len(aParts) {
+			aValue, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bValue, _ = strconv.Atoi(bParts[i])
+		}
+		if aValue < bValue {
+			return -1
+		}
+		if aValue > bValue {
+			return 1
+		}
+	}
+	return 0
+}
+
+func runAgentRelayJSON(args []string, out any) error {
+	if err := ensureAgentRelayCLICompatible(); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, agentRelayBinary(), args...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("agent-relay %s timed out; run 'agent-relay login' and try again", strings.Join(args, " "))
+	}
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return fmt.Errorf("agent-relay %s failed: %s", strings.Join(args, " "), detail)
+	}
+	if err := json.Unmarshal(output, out); err != nil {
+		return fmt.Errorf("parse agent-relay %s output: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func runAgentRelayLogin(stdin io.Reader, stdout io.Writer, noOpen bool) error {
+	if err := ensureAgentRelayCLICompatible(); err != nil {
+		return err
+	}
+	args := []string{"login"}
+	if noOpen {
+		args = append(args, "--no-open")
+	}
+	cmd := exec.Command(agentRelayBinary(), args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stdout
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("agent-relay login failed: %w", err)
+	}
+	return nil
+}
+
+func cloudCredentialsFromAgentRelay() (cloudCredentials, error) {
+	var session agentRelayCloudSession
+	if err := runAgentRelayJSON([]string{"cloud", "session", "--json"}, &session); err != nil {
 		return cloudCredentials{}, err
 	}
-	return creds, nil
+	apiURL := strings.TrimRight(strings.TrimSpace(session.APIURL), "/")
+	accessToken := strings.TrimSpace(session.AccessToken)
+	if apiURL == "" {
+		apiURL = strings.TrimRight(strings.TrimSpace(session.Auth.APIURL), "/")
+	}
+	if accessToken == "" {
+		accessToken = strings.TrimSpace(session.Auth.AccessToken)
+	}
+	if apiURL == "" {
+		apiURL = defaultCloudAPIURL
+	}
+	if accessToken == "" {
+		return cloudCredentials{}, errors.New("agent-relay cloud session --json did not include an accessToken")
+	}
+	return cloudCredentials{
+		APIURL:      apiURL,
+		AccessToken: accessToken,
+		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func activeWorkspaceFromAgentRelay() (agentRelayActiveWorkspace, error) {
+	var workspace agentRelayActiveWorkspace
+	if err := runAgentRelayJSON([]string{"workspace", "active", "--json"}, &workspace); err != nil {
+		return agentRelayActiveWorkspace{}, err
+	}
+	if strings.TrimSpace(workspace.RelayfileWorkspaceID) == "" {
+		return agentRelayActiveWorkspace{}, errors.New("agent-relay workspace active --json did not include relayfileWorkspaceId")
+	}
+	if strings.TrimSpace(workspace.CloudWorkspaceID) == "" {
+		workspace.CloudWorkspaceID = workspace.ID
+	}
+	if strings.TrimSpace(workspace.Name) == "" {
+		workspace.Name = firstNonEmpty(workspace.Slug, workspace.RelayfileWorkspaceID, workspace.CloudWorkspaceID, workspace.ID)
+	}
+	return workspace, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func agentRelayWorkspaceMatches(value string, workspace agentRelayActiveWorkspace) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return true
+	}
+	for _, candidate := range []string{
+		workspace.ID,
+		workspace.Name,
+		workspace.Key,
+		workspace.Slug,
+		workspace.CloudWorkspaceID,
+		workspace.RelayfileWorkspaceID,
+		workspace.RelaycastWorkspaceID,
+		workspace.RelayauthWorkspaceID,
+	} {
+		if value == strings.TrimSpace(candidate) {
+			return true
+		}
+	}
+	if id, ok := catalogWorkspaceID(value); ok {
+		for _, candidate := range []string{
+			workspace.ID,
+			workspace.CloudWorkspaceID,
+			workspace.RelayfileWorkspaceID,
+		} {
+			if strings.TrimSpace(id) == strings.TrimSpace(candidate) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func loadCloudCredentials() (cloudCredentials, error) {
@@ -950,7 +1156,7 @@ func loadCloudCredentials() (cloudCredentials, error) {
 	payload, err := os.ReadFile(cloudCredentialsPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return creds, fmt.Errorf("cloud credentials not found at %s; run relayfile setup or relayfile login", cloudCredentialsPath())
+			return creds, fmt.Errorf("legacy cloud credentials not found at %s; run agent-relay login", cloudCredentialsPath())
 		}
 		return creds, err
 	}
@@ -963,110 +1169,11 @@ func loadCloudCredentials() (cloudCredentials, error) {
 	return creds, nil
 }
 
-func refreshCloudCredentialsIfNeeded(creds cloudCredentials) (cloudCredentials, error) {
-	if !cloudAccessTokenExpiredSoon(creds) {
-		if strings.TrimSpace(creds.APIURL) == "" {
-			creds.APIURL = defaultCloudAPIURL
-		}
-		return creds, nil
-	}
-	return refreshCloudCredentials(creds)
-}
-
-func cloudAccessTokenExpiredSoon(creds cloudCredentials) bool {
-	if strings.TrimSpace(creds.AccessToken) == "" {
-		return true
-	}
-	expiry, ok := parseRFC3339(strings.TrimSpace(creds.AccessTokenExpiresAt))
-	if !ok {
-		return false
-	}
-	return !time.Now().UTC().Before(expiry.Add(-60 * time.Second))
-}
-
 // ErrCloudRefreshExpired indicates the cloud refresh token cannot mint new
 // access tokens. The mount loop uses this to enter the read-only degraded
 // state described in the productized cloud-mount contract acceptance test
 // A9 ("Cloud refresh token expired").
-var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'relayfile login' to sign in again.")
-
-func refreshCloudCredentials(creds cloudCredentials) (cloudCredentials, error) {
-	if strings.TrimSpace(creds.RefreshToken) == "" {
-		return creds, ErrCloudRefreshExpired
-	}
-	refreshed, err := refreshCloudCredentialsOnce(creds)
-	if err == nil {
-		return refreshed, nil
-	}
-	if !isCloudRefreshAuthRejection(err) {
-		return creds, fmt.Errorf("refresh cloud session: %w", err)
-	}
-
-	diskCreds, diskErr := loadCloudCredentials()
-	if diskErr == nil {
-		if strings.TrimSpace(diskCreds.APIURL) == "" {
-			diskCreds.APIURL = creds.APIURL
-		}
-		diskChanged := !sameCloudRefreshMaterial(creds, diskCreds)
-		if diskChanged && !cloudAccessTokenExpiredSoon(diskCreds) {
-			return diskCreds, nil
-		}
-		if diskChanged {
-			refreshed, retryErr := refreshCloudCredentialsOnce(diskCreds)
-			if retryErr == nil {
-				return refreshed, nil
-			}
-			if !isCloudRefreshAuthRejection(retryErr) {
-				return diskCreds, fmt.Errorf("refresh cloud session: %w", retryErr)
-			}
-		}
-	}
-	return creds, ErrCloudRefreshExpired
-}
-
-func refreshCloudCredentialsOnce(creds cloudCredentials) (cloudCredentials, error) {
-	client, err := newAPIClient(creds.APIURL, creds.AccessToken)
-	if err != nil {
-		return creds, err
-	}
-	var refreshed cloudCredentials
-	err = client.postJSON(context.Background(), "/api/v1/auth/token/refresh", cloudTokenRefreshRequest{
-		RefreshToken: creds.RefreshToken,
-	}, &refreshed)
-	if err != nil {
-		return creds, err
-	}
-	if strings.TrimSpace(refreshed.APIURL) == "" {
-		refreshed.APIURL = creds.APIURL
-	}
-	if strings.TrimSpace(refreshed.RefreshToken) == "" {
-		refreshed.RefreshToken = creds.RefreshToken
-	}
-	if strings.TrimSpace(refreshed.RefreshTokenExpiresAt) == "" {
-		refreshed.RefreshTokenExpiresAt = creds.RefreshTokenExpiresAt
-	}
-	refreshed.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	if err := saveCloudCredentials(refreshed); err != nil {
-		return creds, err
-	}
-	return refreshed, nil
-}
-
-func isCloudRefreshAuthRejection(err error) bool {
-	var httpErr *apiError
-	if !errors.As(err, &httpErr) {
-		return false
-	}
-	return httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden
-}
-
-func sameCloudRefreshMaterial(a, b cloudCredentials) bool {
-	return strings.TrimSpace(a.APIURL) == strings.TrimSpace(b.APIURL) &&
-		strings.TrimSpace(a.AccessToken) == strings.TrimSpace(b.AccessToken) &&
-		strings.TrimSpace(a.AccessTokenExpiresAt) == strings.TrimSpace(b.AccessTokenExpiresAt) &&
-		strings.TrimSpace(a.RefreshToken) == strings.TrimSpace(b.RefreshToken) &&
-		strings.TrimSpace(a.RefreshTokenExpiresAt) == strings.TrimSpace(b.RefreshTokenExpiresAt)
-}
+var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay login' to sign in again.")
 
 func providerPromptText(entries []integrationCatalogEntry) string {
 	ids := make([]string, 0, len(entries)+1)
@@ -1438,13 +1545,6 @@ func ensureWorkspaceForSetup(cloud cloudCredentials, name, localDir string) (wor
 
 func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinResponse, cloudAPIURL, localDir string, setDefault bool) (workspaceRecord, error) {
 	serverURL := strings.TrimRight(strings.TrimSpace(joined.RelayfileURL), "/")
-	if err := saveCredentials(credentials{
-		Server:    serverURL,
-		Token:     strings.TrimSpace(joined.Token),
-		UpdatedAt: time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		return workspaceRecord{}, err
-	}
 	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
 		if strings.TrimSpace(record.ID) == "" {
 			record.ID = joinedWorkspaceID
@@ -1463,13 +1563,6 @@ func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinRes
 		record.Scopes = append([]string(nil), defaultJoinScopes...)
 	}
 	persisted, err := upsertWorkspaceDetails(record)
-	if err != nil {
-		return workspaceRecord{}, err
-	}
-	if !setDefault {
-		return persisted, nil
-	}
-	persisted, err = setDefaultWorkspace(persisted.Name)
 	if err != nil {
 		return workspaceRecord{}, err
 	}
@@ -1514,84 +1607,6 @@ func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string
 		return cloudWorkspaceJoinResponse{}, errors.New("cloud join response missing relayfileUrl")
 	}
 	return joined, nil
-}
-
-func runCloudLogin(cloudAPIURL string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (cloudCredentials, error) {
-	if timeout <= 0 {
-		timeout = 5 * time.Minute
-	}
-	state, err := randomURLSafe(24)
-	if err != nil {
-		return cloudCredentials{}, err
-	}
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return cloudCredentials{}, err
-	}
-	defer listener.Close()
-
-	tokenCh := make(chan cloudCredentials, 1)
-	errCh := make(chan error, 1)
-	server := &http.Server{}
-	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/callback" {
-			http.NotFound(w, r)
-			return
-		}
-		if got := r.URL.Query().Get("state"); got != state {
-			http.Error(w, "Relayfile Cloud login state mismatch", http.StatusBadRequest)
-			errCh <- ErrCloudLoginStateMismatch
-			return
-		}
-		if loginError := strings.TrimSpace(r.URL.Query().Get("error")); loginError != "" {
-			http.Error(w, "Relayfile Cloud login failed", http.StatusBadRequest)
-			errCh <- fmt.Errorf("Relayfile Cloud login failed: %s", loginError)
-			return
-		}
-		tokens, err := readCloudCredentialsFromQuery(r.URL.Query(), cloudAPIURL)
-		if err != nil {
-			http.Error(w, "Relayfile Cloud login callback was missing token fields", http.StatusBadRequest)
-			errCh <- err
-			return
-		}
-		fmt.Fprintln(w, "Relayfile Cloud login complete. You can close this tab.")
-		tokenCh <- tokens
-	})
-
-	go func() {
-		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
-		}
-	}()
-	defer server.Close()
-
-	redirectURI := "http://" + listener.Addr().String() + "/callback"
-	loginURL, err := buildCloudURL(cloudAPIURL, "api/v1/cli/login")
-	if err != nil {
-		return cloudCredentials{}, err
-	}
-	query := loginURL.Query()
-	query.Set("redirect_uri", redirectURI)
-	query.Set("state", state)
-	loginURL.RawQuery = query.Encode()
-
-	fmt.Fprintf(stdout, "Sign in to Relayfile Cloud: %s\n", loginURL.String())
-	if shouldOpenBrowser {
-		if err := openBrowser(loginURL.String()); err != nil {
-			return cloudCredentials{}, fmt.Errorf("open cloud login: %w", err)
-		}
-	}
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case tokens := <-tokenCh:
-		return tokens, nil
-	case err := <-errCh:
-		return cloudCredentials{}, err
-	case <-timer.C:
-		return cloudCredentials{}, fmt.Errorf("Relayfile Cloud login timed out after %s", timeout)
-	}
 }
 
 func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (bool, error) {
@@ -1864,47 +1879,17 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		return loginWithAPIKey(strings.TrimSpace(*server), prompted, stdout)
 	}
 
-	// Default: cloud browser flow.
-	cloudAPI := strings.TrimRight(strings.TrimSpace(*cloudAPIURL), "/")
-	if cloudAPI == "" {
-		cloudAPI = defaultCloudAPIURL
+	if (strings.TrimSpace(*cloudAPIURL) != "" && strings.TrimRight(strings.TrimSpace(*cloudAPIURL), "/") != defaultCloudAPIURL) ||
+		strings.TrimSpace(*cloudToken) != "" || *loginTimeout != 5*time.Minute || *skipWorkspace || strings.TrimSpace(*workspaceFlag) != "" {
+		fmt.Fprintln(stdout, "warning: relayfile login delegates to agent-relay login; relayfile cloud/workspace refresh flags are deprecated and ignored")
 	}
-	creds, err := ensureCloudCredentials(cloudAPI, strings.TrimSpace(*cloudToken), *loginTimeout, !*noOpen, stdout)
-	if err != nil {
+	if err := runAgentRelayLogin(stdin, stdout, *noOpen); err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "Signed in to Relayfile Cloud at %s\n", creds.APIURL)
-
-	if !*skipWorkspace {
-		record, rerr := resolveWorkspaceRecord(strings.TrimSpace(*workspaceFlag))
-		if rerr == nil {
-			joined, jerr := joinWorkspaceViaCloud(creds, record.ID, record.AgentName, record.Scopes)
-			if jerr == nil {
-				if persisted, perr := persistJoinedWorkspace(record, joined, creds.APIURL, record.LocalDir, true); perr == nil {
-					record = persisted
-					fmt.Fprintf(stdout, "Refreshed workspace token for %s (%s)\n", record.Name, record.ID)
-					return nil
-				} else if strings.TrimSpace(*workspaceFlag) != "" {
-					return fmt.Errorf("refresh workspace token: persist refreshed credentials: %w", perr)
-				} else {
-					fmt.Fprintf(stdout, "warning: workspace token refresh succeeded but persisting it failed: %v\n", perr)
-				}
-			} else if strings.TrimSpace(*workspaceFlag) != "" {
-				return fmt.Errorf("refresh workspace token: %w", jerr)
-			} else {
-				fmt.Fprintf(stdout, "warning: could not refresh workspace token for %s: %v\n", record.Name, jerr)
-			}
-		} else if strings.TrimSpace(*workspaceFlag) != "" {
-			return rerr
-		}
+	if err := removeCredentialFile(cloudCredentialsPath()); err != nil {
+		fmt.Fprintf(stdout, "warning: could not clear stale relayfile cloud credentials: %v\n", err)
 	}
-
-	if !*skipWorkspace {
-		if err := removeCredentialFile(credentialsPath()); err != nil {
-			fmt.Fprintf(stdout, "warning: could not clear stale server credentials: %v\n", err)
-		}
-		fmt.Fprintln(stdout, "Run 'relayfile setup' to create or join a workspace, or 'relayfile mount WORKSPACE' if you already have one.")
-	}
+	fmt.Fprintln(stdout, "Relayfile now uses the active agent-relay cloud session and workspace.")
 	return nil
 }
 
@@ -3142,7 +3127,7 @@ func retryDeadLetterWriteback(workspaceID string, record workspaceRecord, dl dea
 	}
 	tokenValue := resolveToken("", creds)
 	if tokenValue == "" {
-		return errors.New("token is required; run relayfile login or set RELAYFILE_TOKEN")
+		return errors.New("token is required; set RELAYFILE_TOKEN or pass explicit relayfile credentials")
 	}
 	server := strings.TrimSpace(record.Server)
 	if server == "" {
@@ -3656,15 +3641,16 @@ func runWorkspaceUse(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile workspace use NAME")
 	}
 
-	record, err := setDefaultWorkspace(fs.Arg(0))
-	if err != nil {
+	if err := ensureAgentRelayCLICompatible(); err != nil {
 		return err
 	}
-	workspaceID := record.ID
-	if workspaceID == "" {
-		workspaceID = record.Name
+	cmd := exec.Command(agentRelayBinary(), "workspace", "switch", fs.Arg(0))
+	cmd.Stdout = stdout
+	cmd.Stderr = stdout
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("agent-relay workspace switch failed: %w", err)
 	}
-	fmt.Fprintf(stdout, "Default workspace set to %s (id: %s)\n", record.Name, workspaceID)
+	fmt.Fprintln(stdout, "Relayfile uses the active agent-relay workspace.")
 	return nil
 }
 
@@ -3746,6 +3732,9 @@ func activeWorkspaceName(token string) (string, string) {
 		}
 		return tokenWS, "token"
 	}
+	if workspace, err := activeWorkspaceFromAgentRelay(); err == nil {
+		return workspace.Name, "agent-relay"
+	}
 	catalog, err := loadWorkspaceCatalog()
 	if err != nil {
 		return "", ""
@@ -3772,7 +3761,7 @@ func runWorkspaceCurrent(args []string, stdout io.Writer) error {
 	tokenValue := resolveToken(*token, creds)
 	name, source := activeWorkspaceName(tokenValue)
 	if name == "" {
-		return errors.New("no active workspace; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run 'relayfile workspace use NAME'")
+		return errors.New("no active workspace; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run 'agent-relay workspace switch NAME'")
 	}
 	if !*verbose {
 		fmt.Fprintln(stdout, name)
@@ -3834,9 +3823,8 @@ func runMount(args []string) error {
 	fs := flag.NewFlagSet("mount", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
-	creds, _ := loadCredentials()
-	server := fs.String("server", resolveServer("", creds), "relayfile server URL")
-	token := fs.String("token", resolveToken("", creds), "bearer token")
+	server := fs.String("server", resolveServer("", credentials{}), "relayfile server URL")
+	token := fs.String("token", strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")), "bearer token")
 	remotePath := fs.String("remote-path", envOrDefault("RELAYFILE_REMOTE_PATH", "/"), "remote root path")
 	eventProvider := fs.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	stateFile := fs.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
@@ -3907,24 +3895,75 @@ func runMount(args []string) error {
 	localDir := ""
 	localDirExplicit := false
 	tokenValue := strings.TrimSpace(*token)
+	canonicalWorkspaceID := ""
+	requestedWorkspace := ""
+	activeWorkspace := agentRelayActiveWorkspace{}
+	usesAgentRelayWorkspace := false
+	if fs.NArg() > 0 {
+		requestedWorkspace = strings.TrimSpace(fs.Arg(0))
+	}
 	if tokenValue == "" {
-		return errors.New("token is required; run relayfile login or pass --token")
+		cloudCreds, cerr := ensureCloudCredentials("", "", 0, false, io.Discard)
+		if cerr != nil {
+			return fmt.Errorf("resolve agent-relay cloud session: %w", cerr)
+		}
+		resolvedActiveWorkspace, werr := activeWorkspaceFromAgentRelay()
+		if werr != nil {
+			return fmt.Errorf("resolve active agent-relay workspace: %w", werr)
+		}
+		activeWorkspace = resolvedActiveWorkspace
+		usesAgentRelayWorkspace = true
+		if requestedWorkspace != "" && !agentRelayWorkspaceMatches(requestedWorkspace, activeWorkspace) {
+			return fmt.Errorf(
+				"relayfile mount without --token uses active agent-relay workspace %s (%s); pass --token for explicit workspace %q or run 'agent-relay workspace switch %s'",
+				defaultIfBlank(activeWorkspace.Name, activeWorkspace.RelayfileWorkspaceID),
+				activeWorkspace.RelayfileWorkspaceID,
+				requestedWorkspace,
+				requestedWorkspace,
+			)
+		}
+		cloudWorkspaceID := firstNonEmpty(activeWorkspace.CloudWorkspaceID, activeWorkspace.ID, activeWorkspace.Key, activeWorkspace.RelayfileWorkspaceID)
+		if cloudWorkspaceID == "" {
+			return errors.New("agent-relay workspace active --json did not include cloudWorkspaceId")
+		}
+		joined, jerr := joinWorkspaceViaCloud(cloudCreds, cloudWorkspaceID, "relayfile-cli", defaultJoinScopes)
+		if jerr != nil {
+			return fmt.Errorf("mint relayfile runtime credentials: %w", jerr)
+		}
+		tokenValue = joined.Token
+		*server = strings.TrimRight(joined.RelayfileURL, "/")
+		canonicalWorkspaceID = strings.TrimSpace(activeWorkspace.RelayfileWorkspaceID)
+		if canonicalWorkspaceID == "" {
+			canonicalWorkspaceID = strings.TrimSpace(joined.WorkspaceID)
+		}
 	}
 	var err error
 	switch fs.NArg() {
 	case 0:
-		workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+		if canonicalWorkspaceID != "" {
+			workspaceID = canonicalWorkspaceID
+		} else {
+			workspaceID, err = resolveWorkspaceIDWithToken("", tokenValue)
+		}
 		localDir = strings.TrimSpace(*localDirFlag)
 		localDirExplicit = localDir != ""
 	case 1:
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		if canonicalWorkspaceID != "" {
+			workspaceID = canonicalWorkspaceID
+		} else {
+			workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		}
 		localDir = strings.TrimSpace(*localDirFlag)
 		localDirExplicit = localDir != ""
 	case 2:
 		if strings.TrimSpace(*localDirFlag) != "" {
 			return errors.New("local directory specified twice")
 		}
-		workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		if canonicalWorkspaceID != "" {
+			workspaceID = canonicalWorkspaceID
+		} else {
+			workspaceID, err = resolveWorkspaceIDWithToken(fs.Arg(0), tokenValue)
+		}
 		localDir = fs.Arg(1)
 		localDirExplicit = true
 	}
@@ -3936,6 +3975,11 @@ func runMount(args []string) error {
 		recordedLocalDir = strings.TrimSpace(record.LocalDir)
 	} else if record, ok := workspaceRecordByName(workspaceID); ok && strings.TrimSpace(record.ID) == "" {
 		recordedLocalDir = strings.TrimSpace(record.LocalDir)
+	}
+	if recordedLocalDir == "" && usesAgentRelayWorkspace && requestedWorkspace != "" && agentRelayWorkspaceMatches(requestedWorkspace, activeWorkspace) {
+		if record, ok := workspaceRecordByName(requestedWorkspace); ok {
+			recordedLocalDir = strings.TrimSpace(record.LocalDir)
+		}
 	}
 	if localDir == "" {
 		localDir = recordedLocalDir
@@ -4262,11 +4306,7 @@ func (c *workspaceCommandClient) refreshFromCloud() error {
 	if c == nil {
 		return errors.New("workspace command client is nil")
 	}
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		return err
-	}
-	cloudCreds, err = refreshCloudCredentialsIfNeeded(cloudCreds)
+	cloudCreds, err := ensureCloudCredentials("", "", 0, false, io.Discard)
 	if err != nil {
 		return err
 	}
@@ -4807,7 +4847,7 @@ func daemonCredentialFreshnessAuthLine(localDir string) string {
 	if !ok {
 		return ""
 	}
-	latest, ok := latestCredentialModTime(credentialsPath(), cloudCredentialsPath())
+	latest, ok := latestCredentialModTime(credentialsPath(), agentRelayCloudAuthPath())
 	if ok && latest.After(startedAt) {
 		return "auth: daemon predates last login - restart the daemon"
 	}
@@ -4831,29 +4871,10 @@ func latestCredentialModTime(paths ...string) (time.Time, bool) {
 }
 
 func cloudCredentialAuthLine(now time.Time) string {
-	if _, err := os.Stat(cloudCredentialsPath()); errors.Is(err, os.ErrNotExist) {
-		return "auth: server credentials only"
+	if _, err := cloudCredentialsFromAgentRelay(); err != nil {
+		return "auth: agent-relay session unavailable - run 'agent-relay login'"
 	}
-	creds, err := loadCloudCredentials()
-	if err != nil {
-		return "auth: cloud credentials unreadable - run 'relayfile login'"
-	}
-	if strings.TrimSpace(creds.AccessToken) == "" {
-		return "auth: cloud access token missing - run 'relayfile login'"
-	}
-	if expiry, ok := parseRFC3339(creds.RefreshTokenExpiresAt); ok && !now.Before(expiry) {
-		return "auth: cloud session expired - run 'relayfile login'"
-	}
-	if expiry, ok := parseRFC3339(creds.AccessTokenExpiresAt); ok {
-		remaining := expiry.Sub(now)
-		if remaining <= 0 {
-			return "auth: access token expired - run 'relayfile login'"
-		}
-		if remaining <= 15*time.Minute {
-			return fmt.Sprintf("auth: access token expires in %s", formatAuthDuration(remaining))
-		}
-	}
-	return "auth: ok"
+	return "auth: agent-relay session ok"
 }
 
 func formatAuthDuration(d time.Duration) string {
@@ -5112,7 +5133,7 @@ func newAPIClient(server, token string) (*apiClient, error) {
 		server = defaultServerURL
 	}
 	if token == "" {
-		return nil, errors.New("token is required; run relayfile login or pass --token")
+		return nil, errors.New("token is required; set RELAYFILE_TOKEN or pass --token")
 	}
 	return &apiClient{
 		baseURL:    strings.TrimRight(server, "/"),
@@ -5318,6 +5339,14 @@ func cloudCredentialsPath() string {
 	return filepath.Join(configDir(), "cloud-credentials.json")
 }
 
+func agentRelayCloudAuthPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".agentworkforce", "relay", "cloud-auth.json")
+	}
+	return filepath.Join(home, ".agentworkforce", "relay", "cloud-auth.json")
+}
+
 func workspacesPath() string {
 	return filepath.Join(configDir(), "workspaces.json")
 }
@@ -5368,7 +5397,7 @@ func loadCredentials() (credentials, error) {
 	payload, err := os.ReadFile(credentialsPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return creds, fmt.Errorf("credentials not found at %s; run relayfile login", credentialsPath())
+			return creds, fmt.Errorf("credentials not found at %s; run relayfile login --api-key for self-hosted credentials or pass --token", credentialsPath())
 		}
 		return creds, err
 	}
@@ -5723,6 +5752,10 @@ func resolveWorkspaceIDWithToken(value, token string) (string, error) {
 		return workspaceID, nil
 	}
 
+	if workspace, err := activeWorkspaceFromAgentRelay(); err == nil {
+		return strings.TrimSpace(workspace.RelayfileWorkspaceID), nil
+	}
+
 	catalog, err := loadWorkspaceCatalog()
 	if err != nil {
 		return "", err
@@ -5734,7 +5767,7 @@ func resolveWorkspaceIDWithToken(value, token string) (string, error) {
 		}
 		return defaultName, nil
 	}
-	return "", errors.New("workspace is required; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run relayfile workspace use NAME")
+	return "", errors.New("workspace is required; pass WORKSPACE, set RELAYFILE_WORKSPACE, or run 'agent-relay workspace switch NAME'")
 }
 
 func catalogWorkspaceID(name string) (string, bool) {
@@ -5816,33 +5849,6 @@ func workspaceIDFromToken(token string) string {
 		}
 	}
 	return ""
-}
-
-func readCloudCredentialsFromQuery(values url.Values, fallbackAPIURL string) (cloudCredentials, error) {
-	accessToken := strings.TrimSpace(values.Get("access_token"))
-	refreshToken := strings.TrimSpace(values.Get("refresh_token"))
-	accessTokenExpiresAt := strings.TrimSpace(values.Get("access_token_expires_at"))
-	if accessToken == "" {
-		return cloudCredentials{}, errors.New("cloud login callback missing access_token")
-	}
-	if refreshToken == "" {
-		return cloudCredentials{}, errors.New("cloud login callback missing refresh_token")
-	}
-	if accessTokenExpiresAt == "" {
-		return cloudCredentials{}, errors.New("cloud login callback missing access_token_expires_at")
-	}
-	apiURL := strings.TrimRight(strings.TrimSpace(values.Get("api_url")), "/")
-	if apiURL == "" {
-		apiURL = strings.TrimRight(strings.TrimSpace(fallbackAPIURL), "/")
-	}
-	return cloudCredentials{
-		APIURL:                apiURL,
-		AccessToken:           accessToken,
-		RefreshToken:          refreshToken,
-		AccessTokenExpiresAt:  accessTokenExpiresAt,
-		RefreshTokenExpiresAt: strings.TrimSpace(values.Get("refresh_token_expires_at")),
-		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
-	}, nil
 }
 
 func fetchWorkspaceSyncStatus(client *apiClient, workspaceID string) (syncStatusResponse, error) {
@@ -7756,7 +7762,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	degraded := false
 	var lastDegradedNotice time.Time
 	const degradedRecoveryInterval = time.Minute
-	const degradedStallReason = "cloud session expired — run 'relayfile login' to refresh"
+	const degradedStallReason = "cloud session expired — run 'agent-relay login' to refresh"
 
 	enterDegraded := func() {
 		if !degraded {
@@ -7792,18 +7798,12 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		if !force && !relayfileTokenNeedsRefresh(httpClient.Token()) {
 			return nil
 		}
-		cloudCreds, err := loadCloudCredentials()
+		cloudCreds, err := ensureCloudCredentials("", "", 0, false, io.Discard)
 		if err != nil {
-			return nil
-		}
-		cloudCreds, err = refreshCloudCredentialsIfNeeded(cloudCreds)
-		if err != nil {
-			// Surface the typed error so the loop can enter degraded
-			// state per A9. Other refresh errors stay non-fatal.
 			if errors.Is(err, ErrCloudRefreshExpired) {
 				return err
 			}
-			log.Printf("cloud session refresh failed: %v", err)
+			log.Printf("agent-relay cloud session refresh failed: %v", err)
 			return nil
 		}
 		joined, err := joinWorkspaceViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
@@ -7812,13 +7812,6 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		}
 		httpClient.SetToken(joined.Token)
 		syncer.ResetWebSocket()
-		if err := saveCredentials(credentials{
-			Server:    strings.TrimRight(joined.RelayfileURL, "/"),
-			Token:     joined.Token,
-			UpdatedAt: time.Now().UTC().Format(time.RFC3339),
-		}); err != nil {
-			return err
-		}
 		record.Server = strings.TrimRight(joined.RelayfileURL, "/")
 		record.CloudAPIURL = cloudCreds.APIURL
 		if _, err := upsertWorkspaceDetails(record); err != nil {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -245,20 +247,31 @@ func TestWorkspaceRequiresSubcommandMentionsJoin(t *testing.T) {
 func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	logPath := filepath.Join(t.TempDir(), "agent-relay.log")
+	t.Setenv("AGENT_RELAY_LOG", logPath)
+	installFakeAgentRelay(t, `
+printf '%s\n' "$*" >> "$AGENT_RELAY_LOG"
+if [ "$*" = "workspace switch ws_cloud" ]; then
+  echo "agent-relay workspace switch ok"
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
 
 	var stdout bytes.Buffer
 	if err := run([]string{"workspace", "use", "ws_cloud"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run workspace use failed: %v", err)
 	}
 
-	catalog, err := loadWorkspaceCatalog()
+	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
-		t.Fatalf("loadWorkspaceCatalog failed: %v", err)
+		t.Fatalf("read fake agent-relay log failed: %v", err)
 	}
-	if catalog.Default != "ws_cloud" {
-		t.Fatalf("expected default workspace ws_cloud, got %q", catalog.Default)
+	if strings.TrimSpace(string(logBytes)) != "workspace switch ws_cloud" {
+		t.Fatalf("expected agent-relay workspace switch call, got %q", string(logBytes))
 	}
-	if got := stdout.String(); !strings.Contains(got, "Default workspace set to ws_cloud") {
+	if got := stdout.String(); !strings.Contains(got, "Relayfile uses the active agent-relay workspace") {
 		t.Fatalf("unexpected workspace use output: %q", got)
 	}
 }
@@ -266,13 +279,6 @@ func TestWorkspaceUseSetsDefaultWorkspace(t *testing.T) {
 func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:      "http://placeholder.test",
-		AccessToken: "cld_access",
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
 
 	var seenJoin bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -294,14 +300,7 @@ func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
 		_, _ = w.Write([]byte(`{"workspaceId":"ws_cloud","token":"rf_read","relayfileUrl":"https://relayfile.test"}`))
 	}))
 	defer server.Close()
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	cloudCreds.APIURL = server.URL
-	if err := saveCloudCredentials(cloudCreds); err != nil {
-		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "ws_cloud")
 
 	var stdout bytes.Buffer
 	if err := run([]string{"workspace", "join", "ws_cloud", "--name", "cloud-prod", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
@@ -310,12 +309,8 @@ func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
 	if !seenJoin {
 		t.Fatalf("expected cloud join call")
 	}
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	if creds.Token != "rf_read" || creds.Server != "https://relayfile.test" {
-		t.Fatalf("unexpected persisted credentials: %#v", creds)
+	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("expected workspace join not to persist relayfile token credentials, got err=%v", err)
 	}
 	record, ok := workspaceRecordByID("ws_cloud")
 	if !ok {
@@ -333,12 +328,6 @@ func TestTreeJoinsCloudWorkspaceWithoutServerCredentials(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:      "http://placeholder.test",
-		AccessToken: "cld_access",
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
 		Name:      "cloud-prod",
 		ID:        "ws_cloud",
@@ -381,14 +370,7 @@ func TestTreeJoinsCloudWorkspaceWithoutServerCredentials(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	cloudCreds.APIURL = server.URL
-	if err := saveCloudCredentials(cloudCreds); err != nil {
-		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
 
 	var stdout bytes.Buffer
 	if err := run([]string{"tree", "ws_cloud", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
@@ -473,14 +455,7 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 	if err := saveCredentials(creds); err != nil {
 		t.Fatalf("saveCredentials(server URL) failed: %v", err)
 	}
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	cloudCreds.APIURL = server.URL
-	if err := saveCloudCredentials(cloudCreds); err != nil {
-		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
 
 	var stdout bytes.Buffer
 	if err := run([]string{"tree", "cloud-prod", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
@@ -524,12 +499,6 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:      "http://placeholder.test",
-		AccessToken: "cld_access",
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
 	oldToken := testJWTWithWorkspaceAndAgent("ws_cloud", "old")
 	if err := saveCredentials(credentials{
 		Server: "http://placeholder.test",
@@ -602,14 +571,7 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	if err := saveCredentials(creds); err != nil {
 		t.Fatalf("saveCredentials(server URL) failed: %v", err)
 	}
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	cloudCreds.APIURL = server.URL
-	if err := saveCloudCredentials(cloudCreds); err != nil {
-		t.Fatalf("saveCloudCredentials(server URL) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
 
 	var stdout bytes.Buffer
 	if err := run([]string{"read", "cloud-prod", "/google-mail/msg.json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
@@ -1150,12 +1112,8 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 		}
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	if creds.Server != "https://relayfile.test" || creds.Token != "rf_join" {
-		t.Fatalf("unexpected saved credentials: %#v", creds)
+	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("expected setup not to persist relayfile token credentials, got err=%v", err)
 	}
 	catalog, err := loadWorkspaceCatalog()
 	if err != nil {
@@ -1256,33 +1214,11 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	}); err != nil {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:               "https://stale.example.test",
-		AccessToken:          "cld_old",
-		RefreshToken:         "refresh_123",
-		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
-
 	seen := map[string]bool{}
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/auth/token/refresh":
-			seen["refresh"] = true
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_old" {
-				t.Fatalf("unexpected refresh Authorization: %q", got)
-			}
-			var body cloudTokenRefreshRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode refresh body failed: %v", err)
-			}
-			if body.RefreshToken != "refresh_123" {
-				t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
-			}
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case "/api/v1/workspaces/ws_123/join":
 			seen["join"] = true
 			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
@@ -1319,18 +1255,10 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 		}
 	}))
 	defer server.Close()
-
-	creds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	creds.APIURL = server.URL
-	if err := saveCloudCredentials(creds); err != nil {
-		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_new", "demo", "ws_123", "ws_123")
 
 	var stdout bytes.Buffer
-	err = run([]string{
+	err := run([]string{
 		"integration", "connect", "notion",
 		"--workspace", "demo",
 		"--cloud-api-url", server.URL,
@@ -1341,7 +1269,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	if err != nil {
 		t.Fatalf("run integration connect failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"refresh", "join", "connect", "status", "sync"} {
+	for _, key := range []string{"join", "connect", "status", "sync"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
@@ -1483,7 +1411,7 @@ func TestStatusIncludesLocalMirrorAndDaemonCounts(t *testing.T) {
 	}
 }
 
-func TestStatusRendersExpiredCloudSessionAuthLine(t *testing.T) {
+func TestStatusRendersUnavailableAgentRelaySessionAuthLine(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -1509,22 +1437,17 @@ func TestStatusRendersExpiredCloudSessionAuthLine(t *testing.T) {
 	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:                "https://cloud.relayfile.test",
-		AccessToken:           "cloud_token",
-		AccessTokenExpiresAt:  time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
-		RefreshToken:          "refresh_token",
-		RefreshTokenExpiresAt: time.Now().UTC().Add(-time.Minute).Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
+	installFakeAgentRelay(t, `
+echo "session expired" >&2
+exit 1
+`)
 
 	var stdout bytes.Buffer
 	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run status failed: %v", err)
 	}
-	if got := stdout.String(); !strings.Contains(got, "auth: cloud session expired - run 'relayfile login'") {
-		t.Fatalf("expected expired auth line, got %q", got)
+	if got := stdout.String(); !strings.Contains(got, "auth: agent-relay session unavailable - run 'agent-relay login'") {
+		t.Fatalf("expected agent-relay unavailable auth line, got %q", got)
 	}
 }
 
@@ -1563,9 +1486,20 @@ func TestStatusWarnsWhenDaemonPredatesLastLogin(t *testing.T) {
 	if err := saveCredentials(credentials{Server: server.URL, Token: "token"}); err != nil {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
-	loginTime := startedAt.Add(30 * time.Minute)
-	if err := os.Chtimes(credentialsPath(), loginTime, loginTime); err != nil {
+	oldLoginTime := startedAt.Add(-30 * time.Minute)
+	if err := os.Chtimes(credentialsPath(), oldLoginTime, oldLoginTime); err != nil {
 		t.Fatalf("chtimes credentials failed: %v", err)
+	}
+	agentRelayAuthPath := agentRelayCloudAuthPath()
+	if err := os.MkdirAll(filepath.Dir(agentRelayAuthPath), 0o700); err != nil {
+		t.Fatalf("mkdir agent-relay auth dir failed: %v", err)
+	}
+	if err := os.WriteFile(agentRelayAuthPath, []byte(`{"accessToken":"new"}`), 0o600); err != nil {
+		t.Fatalf("write agent-relay auth failed: %v", err)
+	}
+	loginTime := startedAt.Add(30 * time.Minute)
+	if err := os.Chtimes(agentRelayAuthPath, loginTime, loginTime); err != nil {
+		t.Fatalf("chtimes agent-relay auth failed: %v", err)
 	}
 
 	var stdout bytes.Buffer
@@ -1719,7 +1653,7 @@ func TestMountRequiresLocalDirWhenWorkspaceHasNoRecordedMirror(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	err := run([]string{"mount", "demo", "--token", testJWTWithWorkspace("ws_demo"), "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected mount without LOCAL_DIR to fail when no localDir is recorded")
 	}
@@ -1768,7 +1702,7 @@ func TestMountUsesRecordedLocalDirWhenOmitted(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	if err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := run([]string{"mount", "demo", "--server", server.URL, "--token", testJWTWithWorkspace("ws_demo"), "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("run mount failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(localDir, "notion", "Docs", "A.md"))
@@ -1777,6 +1711,58 @@ func TestMountUsesRecordedLocalDirWhenOmitted(t *testing.T) {
 	}
 	if string(data) != "# A" {
 		t.Fatalf("unexpected mirrored content: %q", data)
+	}
+}
+
+func TestMountWithoutTokenRejectsWorkspaceOutsideAgentRelayActive(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "stale",
+		Workspaces: []workspaceRecord{
+			{
+				Name:       "active",
+				ID:         "rw_active",
+				LocalDir:   localDir,
+				CreatedAt:  now,
+				LastUsedAt: now,
+			},
+			{
+				Name:       "stale",
+				ID:         "rw_stale",
+				LocalDir:   localDir,
+				CreatedAt:  now,
+				LastUsedAt: now,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	joinCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/workspaces/rw_active/join" {
+			joinCalls++
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_active","token":"` + testJWTWithWorkspace("rw_active") + `","relayfileUrl":"` + r.Host + `"}`))
+			return
+		}
+		t.Fatalf("unexpected path: %s", r.URL.Path)
+	}))
+	defer server.Close()
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "active", "rw_active", "rw_active")
+
+	err := run([]string{"mount", "stale", localDir, "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected mount to reject stale workspace")
+	}
+	if !strings.Contains(err.Error(), "uses active agent-relay workspace active (rw_active)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if joinCalls != 0 {
+		t.Fatalf("expected no runtime token mint for mismatched workspace, got %d calls", joinCalls)
 	}
 }
 
@@ -1819,7 +1805,7 @@ func TestMountUsesLegacyRecordedLocalDirWhenOmitted(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	if err := run([]string{"mount", "demo", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := run([]string{"mount", "demo", "--server", server.URL, "--token", testJWTWithWorkspace("demo"), "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("run mount failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(localDir, "notion", "Docs", "Legacy.md"))
@@ -1878,7 +1864,7 @@ func TestMountRefusesExplicitLocalDirThatRehomesRecordedMirror(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	err := run([]string{"mount", "demo", otherDir, "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	err := run([]string{"mount", "demo", otherDir, "--token", testJWTWithWorkspace("ws_demo"), "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected mount to refuse re-homing a recorded mirror")
 	}
@@ -1922,7 +1908,7 @@ func TestMountRehomeRefusesRunningRecordedDaemon(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	err := run([]string{"mount", "demo", otherDir, "--token", testJWTWithWorkspace("ws_demo"), "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected rehome to refuse while old mirror has a running daemon")
 	}
@@ -1970,7 +1956,7 @@ func TestMountRehomeRefusesUnverifiedRecordedDaemon(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	err := run([]string{"mount", "demo", otherDir, "--token", testJWTWithWorkspace("ws_demo"), "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected rehome to refuse unverified mount state")
 	}
@@ -2026,7 +2012,7 @@ func TestMountRehomeAllowsExplicitMoveAndPersistsLocalDir(t *testing.T) {
 		t.Fatalf("saveCredentials failed: %v", err)
 	}
 
-	if err := run([]string{"mount", "demo", otherDir, "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+	if err := run([]string{"mount", "demo", otherDir, "--server", server.URL, "--token", testJWTWithWorkspace("ws_demo"), "--rehome", "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("run mount --rehome failed: %v", err)
 	}
 	data, err := os.ReadFile(filepath.Join(otherDir, "notion", "Docs", "Rehomed.md"))
@@ -2083,12 +2069,6 @@ func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	localDir := t.TempDir()
 	oldToken := testJWTWithWorkspaceAndAgent("ws_refresh", "old")
 	newToken := testJWTWithWorkspaceAndAgent("ws_refresh", "new")
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:      defaultCloudAPIURL,
-		AccessToken: "cld_access",
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
 		Name:       "demo",
 		ID:         "ws_refresh",
@@ -2143,15 +2123,7 @@ func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-
-	cloudCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	cloudCreds.APIURL = server.URL
-	if err := saveCloudCredentials(cloudCreds); err != nil {
-		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "demo", "ws_refresh", "ws_refresh")
 
 	if err := run([]string{
 		"mount", "ws_refresh", localDir,
@@ -2165,12 +2137,8 @@ func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	if joinCalls != 1 || exportCalls != 2 {
 		t.Fatalf("expected 1 join and 2 export calls, got join=%d events=%d export=%d", joinCalls, eventCalls, exportCalls)
 	}
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	if creds.Token != newToken {
-		t.Fatalf("expected refreshed token to be persisted, got %q", creds.Token)
+	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("expected refreshed relayfile token not to be persisted, got err=%v", err)
 	}
 }
 
@@ -2182,6 +2150,55 @@ func clearRelayfileEnv(t *testing.T) {
 	t.Setenv("RELAYFILE_WORKSPACE", "")
 	t.Setenv("RELAYFILE_CLOUD_API_URL", "")
 	t.Setenv("RELAYFILE_CLOUD_TOKEN", "")
+	t.Setenv("AGENT_RELAY_BIN", "")
+}
+
+func installFakeAgentRelay(t *testing.T, scriptBody string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "agent-relay")
+	script := `#!/bin/sh
+set -eu
+if [ "$*" = "--version" ]; then
+  echo "8.7.0"
+  exit 0
+fi
+if [ "$*" = "cloud session --help" ]; then
+  echo "Usage: agent-relay cloud session [options]"
+  echo "  --json"
+  exit 0
+fi
+if [ "$*" = "workspace active --help" ]; then
+  echo "Usage: agent-relay workspace active [options]"
+  echo "  --json"
+  exit 0
+fi
+if [ "$*" = "workspace switch --help" ]; then
+  echo "Usage: agent-relay workspace switch [options] <name>"
+  exit 0
+fi
+` + scriptBody + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake agent-relay failed: %v", err)
+	}
+	t.Setenv("AGENT_RELAY_BIN", path)
+	return path
+}
+
+func installFakeAgentRelaySession(t *testing.T, apiURL, accessToken, name, cloudWorkspaceID, relayfileWorkspaceID string) {
+	t.Helper()
+	body := fmt.Sprintf(`
+if [ "$*" = "cloud session --json" ]; then
+  echo '{"apiUrl":%q,"accessToken":%q}'
+  exit 0
+fi
+if [ "$*" = "workspace active --json" ]; then
+  echo '{"name":%q,"cloudWorkspaceId":%q,"relayfileWorkspaceId":%q}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`, apiURL, accessToken, name, cloudWorkspaceID, relayfileWorkspaceID)
+	installFakeAgentRelay(t, body)
 }
 
 func testJWTWithWorkspace(workspaceID string) string {
@@ -2192,126 +2209,6 @@ func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"` + agentName + `","aud":"relayfile"}`))
 	return header + "." + payload + ".sig"
-}
-
-func TestRefreshCloudCredentialsReturnsSentinelOnInvalidGrant(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/auth/token/refresh" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"code":"invalid_grant","message":"refresh token expired"}`))
-	}))
-	defer server.Close()
-
-	_, err := refreshCloudCredentials(cloudCredentials{
-		APIURL:       server.URL,
-		AccessToken:  "cld_old",
-		RefreshToken: "rt_expired",
-	})
-	if !errors.Is(err, ErrCloudRefreshExpired) {
-		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
-	}
-}
-
-func TestRefreshCloudCredentialsRetriesWithReloadedDiskTokenOnAuthRejection(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	var refreshTokens []string
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/auth/token/refresh" {
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		var body cloudTokenRefreshRequest
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode refresh body failed: %v", err)
-		}
-		refreshTokens = append(refreshTokens, body.RefreshToken)
-		switch body.RefreshToken {
-		case "rt_stale":
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"code":"invalid_grant","message":"Invalid or expired refresh token"}`))
-		case "rt_disk":
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"rt_new","accessTokenExpiresAt":"2030-05-01T00:00:00Z","refreshTokenExpiresAt":"2030-06-01T00:00:00Z"}`))
-		default:
-			t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
-		}
-	}))
-	defer server.Close()
-
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:               server.URL,
-		AccessToken:          "cld_disk_old",
-		RefreshToken:         "rt_disk",
-		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
-
-	refreshed, err := refreshCloudCredentials(cloudCredentials{
-		APIURL:               server.URL,
-		AccessToken:          "cld_stale",
-		RefreshToken:         "rt_stale",
-		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
-	})
-	if err != nil {
-		t.Fatalf("refreshCloudCredentials failed: %v", err)
-	}
-	if refreshed.AccessToken != "cld_new" || refreshed.RefreshToken != "rt_new" {
-		t.Fatalf("unexpected refreshed credentials: %#v", refreshed)
-	}
-	if got := strings.Join(refreshTokens, ","); got != "rt_stale,rt_disk" {
-		t.Fatalf("unexpected refresh token attempts: %s", got)
-	}
-
-	diskCreds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	if diskCreds.AccessToken != "cld_new" || diskCreds.RefreshToken != "rt_new" {
-		t.Fatalf("expected refreshed credentials on disk, got: %#v", diskCreds)
-	}
-}
-
-func TestRefreshCloudCredentialsReturnsSentinelOnUnauthorized(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte(`{"code":"unauthorized","message":"unauthenticated"}`))
-	}))
-	defer server.Close()
-
-	_, err := refreshCloudCredentials(cloudCredentials{
-		APIURL:       server.URL,
-		AccessToken:  "cld_old",
-		RefreshToken: "rt_expired",
-	})
-	if !errors.Is(err, ErrCloudRefreshExpired) {
-		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
-	}
-}
-
-func TestRefreshCloudCredentialsReturnsSentinelWithoutRefreshToken(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	_, err := refreshCloudCredentials(cloudCredentials{
-		APIURL:      "https://cloud.example.test",
-		AccessToken: "cld_old",
-	})
-	if !errors.Is(err, ErrCloudRefreshExpired) {
-		t.Fatalf("expected ErrCloudRefreshExpired, got: %v", err)
-	}
 }
 
 func TestStatusSurfacesDegradedStallReason(t *testing.T) {
@@ -2334,7 +2231,7 @@ func TestStatusSurfacesDegradedStallReason(t *testing.T) {
 	persisted := syncStateFile{
 		WorkspaceID: "ws_demo",
 		Mode:        defaultMountMode,
-		StallReason: "cloud session expired — run 'relayfile login' to refresh",
+		StallReason: "cloud session expired — run 'agent-relay login' to refresh",
 	}
 	if err := writeMirrorStateFile(localDir, persisted); err != nil {
 		t.Fatalf("writeMirrorStateFile failed: %v", err)
@@ -2358,7 +2255,7 @@ func TestStatusSurfacesDegradedStallReason(t *testing.T) {
 	if !strings.Contains(got, "stall: cloud session expired") {
 		t.Fatalf("expected degraded stall reason in status output, got: %q", got)
 	}
-	if !strings.Contains(got, "relayfile login") {
+	if !strings.Contains(got, "agent-relay login") {
 		t.Fatalf("expected recovery hint in status output, got: %q", got)
 	}
 }
@@ -3139,13 +3036,7 @@ func TestOpsReplayPostsToCloudAndRemovesLocalRecord(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:               server.URL,
-		AccessToken:          "cld_token",
-		AccessTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, server.URL, "cld_token", "demo", "ws_demo", "ws_demo")
 
 	var stdout bytes.Buffer
 	if err := run([]string{
@@ -3213,311 +3104,130 @@ func TestLoginWithExplicitTokenPersistsServerCreds(t *testing.T) {
 	}
 }
 
-// TestLoginDefaultsToCloudBrowserFlow covers the new default behavior: when
-// no --token is provided, runLogin runs the cloud browser flow. We use
-// --cloud-token to skip the actual browser handshake — ensureCloudCredentials
-// short-circuits to writing cloud credentials when an explicit token is set.
-func TestLoginDefaultsToCloudBrowserFlow(t *testing.T) {
+// TestLoginDelegatesToAgentRelay covers the unified auth behavior: relayfile
+// login no longer writes its own cloud credential store; it delegates to the
+// canonical agent-relay login command.
+func TestLoginDelegatesToAgentRelay(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-	if err := saveCredentials(credentials{
-		Server: "https://relayfile-old.test",
-		Token:  "stale_server_token",
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "https://cloud.relayfile.test",
+		AccessToken: "stale_cloud_token",
 	}); err != nil {
-		t.Fatalf("saveCredentials failed: %v", err)
+		t.Fatalf("saveCloudCredentials failed: %v", err)
 	}
+	logPath := filepath.Join(t.TempDir(), "agent-relay.log")
+	t.Setenv("AGENT_RELAY_LOG", logPath)
+	installFakeAgentRelay(t, `
+printf '%s\n' "$*" >> "$AGENT_RELAY_LOG"
+if [ "$*" = "login --no-open" ]; then
+  echo "agent-relay login ok"
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
 
 	var stdout bytes.Buffer
 	if err := run([]string{
 		"login",
-		"--cloud-api-url", "https://cloud.relayfile.test",
-		"--cloud-token", "cld_browser_token",
+		"--no-open",
 	}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
 	}
 
 	got := stdout.String()
-	if !strings.Contains(got, "Signed in to Relayfile Cloud") {
-		t.Fatalf("expected cloud sign-in confirmation, got %q", got)
+	if !strings.Contains(got, "agent-relay login ok") {
+		t.Fatalf("expected delegated agent-relay output, got %q", got)
 	}
-	creds, err := loadCloudCredentials()
+	if !strings.Contains(got, "Relayfile now uses the active agent-relay cloud session and workspace.") {
+		t.Fatalf("expected relayfile canonical-session note, got %q", got)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake agent-relay log failed: %v", err)
+	}
+	if strings.TrimSpace(string(logBytes)) != "login --no-open" {
+		t.Fatalf("expected agent-relay login --no-open, got %q", string(logBytes))
+	}
+	if _, err := os.Stat(cloudCredentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("expected stale relayfile cloud credentials removed, got err=%v", err)
+	}
+}
+
+func TestEnsureCloudCredentialsUsesAgentRelaySession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if err := saveCloudCredentials(cloudCredentials{
+		APIURL:      "https://stale-cloud.test",
+		AccessToken: "stale_cloud_token",
+	}); err != nil {
+		t.Fatalf("saveCloudCredentials failed: %v", err)
+	}
+	installFakeAgentRelay(t, `
+if [ "$*" = "cloud session --json" ]; then
+  echo '{"apiUrl":"https://relay-cloud.test","accessToken":"agent_cloud_token"}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	creds, err := ensureCloudCredentials("", "", 0, false, io.Discard)
+	if err != nil {
+		t.Fatalf("ensureCloudCredentials failed: %v", err)
+	}
+	if creds.APIURL != "https://relay-cloud.test" {
+		t.Fatalf("expected agent-relay APIURL, got %q", creds.APIURL)
+	}
+	if creds.AccessToken != "agent_cloud_token" {
+		t.Fatalf("expected agent-relay access token, got %q", creds.AccessToken)
+	}
+	stale, err := loadCloudCredentials()
 	if err != nil {
 		t.Fatalf("loadCloudCredentials failed: %v", err)
 	}
-	if creds.AccessToken != "cld_browser_token" {
-		t.Fatalf("expected stored cloud access token, got %q", creds.AccessToken)
-	}
-	if creds.APIURL != "https://cloud.relayfile.test" {
-		t.Fatalf("expected APIURL stored, got %q", creds.APIURL)
-	}
-	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
-		t.Fatalf("expected stale server credentials removed, got err=%v", err)
+	if stale.AccessToken != "stale_cloud_token" {
+		t.Fatalf("expected relayfile cloud credential file to be ignored and left untouched, got %q", stale.AccessToken)
 	}
 }
 
-// TestLoginRefreshesWorkspaceTokenForDefaultWorkspace covers the fix for
-// the bug where `relayfile login` only refreshed cloud-credentials.json
-// even when a workspace was already registered locally. After login, the
-// data-plane JWT in credentials.json should also be refreshed via the
-// cloud's workspace join endpoint.
-func TestLoginRefreshesWorkspaceTokenForDefaultWorkspace(t *testing.T) {
+func TestEnsureCloudCredentialsRejectsStaleAgentRelayBeforeSessionCommand(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
+	marker := filepath.Join(t.TempDir(), "session-called")
+	path := filepath.Join(t.TempDir(), "agent-relay")
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+if [ "$*" = "--version" ]; then
+  echo "8.3.7"
+  exit 0
+fi
+if [ "$*" = "cloud session --json" ]; then
+  touch %q
+  echo '{"apiUrl":"https://relay-cloud.test","accessToken":"agent_cloud_token"}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`, marker)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake stale agent-relay failed: %v", err)
+	}
+	t.Setenv("AGENT_RELAY_BIN", path)
 
-	seen := map[string]bool{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_demo/join":
-			seen["join"] = true
-			if r.Method != http.MethodPost {
-				t.Fatalf("expected join POST, got %s", r.Method)
-			}
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_browser_token" {
-				t.Fatalf("unexpected join Authorization: %q", got)
-			}
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
-		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	if _, err := upsertWorkspaceDetails(workspaceRecord{
-		Name: "demo",
-		ID:   "ws_demo",
-	}); err != nil {
-		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
-	}
-	if _, err := setDefaultWorkspace("demo"); err != nil {
-		t.Fatalf("setDefaultWorkspace failed: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	if err := run([]string{
-		"login",
-		"--cloud-api-url", server.URL,
-		"--cloud-token", "cld_browser_token",
-	}, strings.NewReader(""), &stdout, &stdout); err != nil {
-		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
-	}
-
-	if !seen["join"] {
-		t.Fatalf("expected /workspaces/ws_demo/join request, none seen. output:\n%s", stdout.String())
-	}
-	got := stdout.String()
-	if !strings.Contains(got, "Refreshed workspace token for demo") {
-		t.Fatalf("expected refresh confirmation, got %q", got)
-	}
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	if creds.Token != "rf_refreshed" {
-		t.Fatalf("expected refreshed workspace token, got %q", creds.Token)
-	}
-	if creds.Server != "https://relayfile.test" {
-		t.Fatalf("expected refreshed server URL, got %q", creds.Server)
-	}
-	if strings.TrimSpace(creds.UpdatedAt) == "" {
-		t.Fatalf("expected credentials updatedAt to be set")
-	}
-	cloud, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	if cloud.AccessToken != "cld_browser_token" {
-		t.Fatalf("expected refreshed cloud token to remain stored, got %q", cloud.AccessToken)
-	}
-	if strings.TrimSpace(cloud.UpdatedAt) == "" {
-		t.Fatalf("expected cloud credentials updatedAt to be set")
-	}
-}
-
-// TestLoginSkipsWorkspaceRefreshWhenFlagSet covers --skip-workspace-refresh:
-// even with a workspace registered, no /join call should fire and
-// existing credentials.json must be preserved.
-func TestLoginSkipsWorkspaceRefreshWhenFlagSet(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-	if err := saveCredentials(credentials{
-		Server: "https://relayfile-old.test",
-		Token:  "stale_server_token",
-	}); err != nil {
-		t.Fatalf("saveCredentials failed: %v", err)
-	}
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-	}))
-	defer server.Close()
-
-	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
-		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
-	}
-	if _, err := setDefaultWorkspace("demo"); err != nil {
-		t.Fatalf("setDefaultWorkspace failed: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	if err := run([]string{
-		"login",
-		"--cloud-api-url", server.URL,
-		"--cloud-token", "cld_browser_token",
-		"--skip-workspace-refresh",
-	}, strings.NewReader(""), &stdout, &stdout); err != nil {
-		t.Fatalf("run login failed: %v\noutput:\n%s", err, stdout.String())
-	}
-
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	if creds.Server != "https://relayfile-old.test" {
-		t.Fatalf("expected existing server credentials preserved, got server %q", creds.Server)
-	}
-	if creds.Token != "stale_server_token" {
-		t.Fatalf("expected existing server token preserved, got %q", creds.Token)
-	}
-	if strings.Contains(stdout.String(), "Run 'relayfile setup'") {
-		t.Fatalf("expected no workspace setup hint with --skip-workspace-refresh, got %q", stdout.String())
-	}
-}
-
-// TestLoginRejectsWorkspaceWithSkipFlag asserts that passing both
-// --workspace and --skip-workspace-refresh fails fast with a clear
-// error. The two are contradictory — --skip-workspace-refresh silently
-// winning would make an explicit --workspace a no-op while the command
-// still reports success.
-func TestLoginRejectsWorkspaceWithSkipFlag(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	clearRelayfileEnv(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-	}))
-	defer server.Close()
-
-	var stdout bytes.Buffer
-	err := run([]string{
-		"login",
-		"--cloud-api-url", server.URL,
-		"--cloud-token", "cld_browser_token",
-		"--workspace", "demo",
-		"--skip-workspace-refresh",
-	}, strings.NewReader(""), &stdout, &stdout)
+	_, err := ensureCloudCredentials("", "", 0, false, io.Discard)
 	if err == nil {
-		t.Fatalf("expected error for contradictory flag combo, got nil\noutput:\n%s", stdout.String())
+		t.Fatal("expected stale agent-relay CLI to be rejected")
 	}
-	if !strings.Contains(err.Error(), "--workspace cannot be used with --skip-workspace-refresh") {
-		t.Fatalf("expected mutually-exclusive flag error, got %v", err)
-	}
-}
-
-// TestLoginExplicitWorkspaceReturnsErrorWhenPersistFails asserts that with
-// an explicit --workspace target, a failure to write the refreshed
-// workspace token to credentials.json surfaces as a non-zero exit / error
-// — symmetric with the join and resolve failure branches. Before this
-// guard, a persist failure was downgraded to a warning even under
-// --workspace, so the command reported success while leaving the on-disk
-// JWT stale.
-func TestLoginExplicitWorkspaceReturnsErrorWhenPersistFails(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	clearRelayfileEnv(t)
-
-	seen := map[string]bool{}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_demo/join":
-			seen["join"] = true
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
-		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
+	got := err.Error()
+	for _, want := range []string{"agent-relay CLI >= 8.7.0 required", "8.3.7", "npm install -g agent-relay@8.7.0", "sandbox image"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, got)
 		}
-	}))
-	defer server.Close()
-
-	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
-		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
-	if _, err := setDefaultWorkspace("demo"); err != nil {
-		t.Fatalf("setDefaultWorkspace failed: %v", err)
-	}
-
-	// Force only the credentials.json rename to fail by pre-creating
-	// that exact path as a directory. writeFileAtomically still
-	// succeeds at CreateTemp/Write/Chmod/Close; only the final
-	// os.Rename(tmp, credentialsPath()) errors because the destination
-	// is a non-empty directory. cloud-credentials.json (different
-	// path) writes normally.
-	if err := os.MkdirAll(credentialsPath(), 0o755); err != nil {
-		t.Fatalf("pre-create credentials path as dir failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(credentialsPath(), "blocker"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("write blocker file failed: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	err := run([]string{
-		"login",
-		"--cloud-api-url", server.URL,
-		"--cloud-token", "cld_browser_token",
-		"--workspace", "demo",
-	}, strings.NewReader(""), &stdout, &stdout)
-	if err == nil {
-		t.Fatalf("expected error for explicit --workspace with persist failure, got nil\noutput:\n%s", stdout.String())
-	}
-	if !strings.Contains(err.Error(), "persist refreshed credentials") {
-		t.Fatalf("expected persist failure in error, got %v", err)
-	}
-	if !seen["join"] {
-		t.Fatalf("expected /workspaces/ws_demo/join to have been called before persist; seen=%v", seen)
-	}
-}
-
-// TestLoginDefaultWorkspaceWarnsWhenPersistFails confirms the unchanged
-// behavior for the implicit default-workspace path: persist failures
-// remain a warning so the cloud login itself still counts as successful.
-func TestLoginDefaultWorkspaceWarnsWhenPersistFails(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	clearRelayfileEnv(t)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_demo/join":
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_refreshed","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
-		default:
-			t.Fatalf("unexpected path: %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	if _, err := upsertWorkspaceDetails(workspaceRecord{Name: "demo", ID: "ws_demo"}); err != nil {
-		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
-	}
-	if _, err := setDefaultWorkspace("demo"); err != nil {
-		t.Fatalf("setDefaultWorkspace failed: %v", err)
-	}
-
-	if err := os.MkdirAll(credentialsPath(), 0o755); err != nil {
-		t.Fatalf("pre-create credentials path as dir failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(credentialsPath(), "blocker"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("write blocker file failed: %v", err)
-	}
-
-	var stdout bytes.Buffer
-	if err := run([]string{
-		"login",
-		"--cloud-api-url", server.URL,
-		"--cloud-token", "cld_browser_token",
-	}, strings.NewReader(""), &stdout, &stdout); err != nil {
-		t.Fatalf("default-workspace login should not error on persist failure: %v\noutput:\n%s", err, stdout.String())
-	}
-	got := stdout.String()
-	if !strings.Contains(got, "warning: workspace token refresh succeeded but persisting it failed") {
-		t.Fatalf("expected persist-failure warning in output, got %q", got)
+	if _, statErr := os.Stat(marker); !os.IsNotExist(statErr) {
+		t.Fatalf("expected cloud session command to be skipped, stat err=%v", statErr)
 	}
 }
 
@@ -3578,6 +3288,64 @@ func TestWorkspaceCurrentPrintsActiveWorkspace(t *testing.T) {
 	}
 	if got := strings.TrimSpace(stdout.String()); !strings.Contains(got, "source: default") {
 		t.Fatalf("expected verbose output to include source, got %q", got)
+	}
+}
+
+func TestWorkspaceCurrentPrefersAgentRelayActiveWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspace("stale-local-default"); err != nil {
+		t.Fatalf("upsertWorkspace failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("stale-local-default"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+	installFakeAgentRelay(t, `
+if [ "$*" = "workspace active --json" ]; then
+  echo '{"name":"canonical","cloudWorkspaceId":"rw_cloud","relayfileWorkspaceId":"rw_relayfile","relaycastWorkspaceId":"rw_relaycast","relayauthWorkspaceId":"rw_relayauth"}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"workspace", "current", "--verbose"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run workspace current failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	got := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(got, "canonical") {
+		t.Fatalf("expected canonical active workspace, got %q", got)
+	}
+	if !strings.Contains(got, "source: agent-relay") {
+		t.Fatalf("expected agent-relay source, got %q", got)
+	}
+}
+
+func TestResolveWorkspaceUsesAgentRelayRelayfileWorkspaceID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspace("stale-local-default"); err != nil {
+		t.Fatalf("upsertWorkspace failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("stale-local-default"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+	installFakeAgentRelay(t, `
+if [ "$*" = "workspace active --json" ]; then
+  echo '{"name":"canonical","cloudWorkspaceId":"rw_cloud","relayfileWorkspaceId":"rw_relayfile"}'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	got, err := resolveWorkspaceIDWithToken("", "")
+	if err != nil {
+		t.Fatalf("resolveWorkspaceIDWithToken failed: %v", err)
+	}
+	if got != "rw_relayfile" {
+		t.Fatalf("expected relayfile workspace id from agent-relay descriptor, got %q", got)
 	}
 }
 
@@ -3701,8 +3469,8 @@ func TestWorkspaceListNamesOnlyRestoresBareOutput(t *testing.T) {
 }
 
 // adoptTestServer wires the cloud endpoints the adopt verb exercises:
-// token refresh (so credential bootstrap succeeds), workspace join (mints
-// the relayfile JWT for the workspace), and the new POST .../adopt route.
+// workspace join (mints the relayfile JWT for the workspace), and the new
+// POST .../adopt route.
 // Each test injects its own adopt handler so it can simulate the four
 // distinct outcomes — success (fresh insert), success (replacement),
 // 409 refusal, 404 missing-connection — without rebuilding the rest of
@@ -3714,30 +3482,6 @@ func newAdoptTestServer(t *testing.T, adoptHandler func(http.ResponseWriter, *ht
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/auth/token/refresh":
-			if r.Method != http.MethodPost {
-				t.Errorf("expected refresh POST, got %s", r.Method)
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				return
-			}
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_old" {
-				t.Errorf("unexpected refresh Authorization: %q", got)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
-				return
-			}
-			var body cloudTokenRefreshRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Errorf("decode refresh body failed: %v", err)
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			if body.RefreshToken != "refresh_123" {
-				t.Errorf("unexpected refresh token: %q", body.RefreshToken)
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			seen["refresh"]++
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
 			if r.Method != http.MethodPost {
 				t.Errorf("expected join POST, got %s", r.Method)
@@ -3794,27 +3538,12 @@ func setupAdoptWorkspace(t *testing.T) (workspaceRecord, string) {
 	if err != nil {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:               "https://stale.example.test",
-		AccessToken:          "cld_old",
-		RefreshToken:         "refresh_123",
-		AccessTokenExpiresAt: time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
 	return record, localDir
 }
 
 func pointAdoptCloudCredentials(t *testing.T, apiURL string) {
 	t.Helper()
-	creds, err := loadCloudCredentials()
-	if err != nil {
-		t.Fatalf("loadCloudCredentials failed: %v", err)
-	}
-	creds.APIURL = apiURL
-	if err := saveCloudCredentials(creds); err != nil {
-		t.Fatalf("saveCloudCredentials(update) failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, apiURL, "cld_new", "demo", "ws_123", "ws_123")
 }
 
 func TestIntegrationAdoptForwardsConnectionIdAndPersistsLocalState(t *testing.T) {
@@ -4037,9 +3766,6 @@ func newSetMetadataTestServer(t *testing.T, metadataHandler func(http.ResponseWr
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/auth/token/refresh":
-			seen["refresh"]++
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
 			seen["join"]++
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
@@ -4160,9 +3886,6 @@ func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, cho
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/auth/token/refresh":
-			seen["refresh"]++
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
 			seen["join"]++
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
@@ -4361,8 +4084,6 @@ func TestIntegrationConnectJiraAlreadyConnectedSkipsPicker(t *testing.T) {
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/auth/token/refresh":
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/status":
@@ -4407,8 +4128,6 @@ func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/auth/token/refresh":
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/connect-session":
@@ -4453,8 +4172,6 @@ func TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForS
 		w.Header().Set("Content-Type", "application/json")
 		seen[r.URL.Path]++
 		switch r.URL.Path {
-		case "/api/v1/auth/token/refresh":
-			_, _ = w.Write([]byte(`{"apiUrl":"` + server.URL + `","accessToken":"cld_new","refreshToken":"refresh_123","accessTokenExpiresAt":"2030-05-01T00:00:00Z"}`))
 		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/join":
 			_, _ = w.Write([]byte(`{"workspaceId":"rw_7ccfea89","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/connect-session":

--- a/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
+++ b/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
@@ -33,6 +33,7 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 
 	cloud := newProductizedCloudMock(t, relay)
 	defer cloud.Close()
+	installFakeAgentRelaySession(t, cloud.URL(), cloud.initialAccessToken, "demo", cloud.workspaceID, cloud.workspaceID)
 
 	var setupOut bytes.Buffer
 	if err := run([]string{
@@ -88,13 +89,13 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 		t.Fatalf("expected github and notion integrations, got %v", providers)
 	}
 
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
 	record, err := resolveWorkspaceRecord("demo")
 	if err != nil {
 		t.Fatalf("resolveWorkspaceRecord failed: %v", err)
+	}
+	runtimeToken := cloud.LastRelayfileToken()
+	if runtimeToken == "" {
+		t.Fatalf("expected setup/connect/list to mint a relayfile runtime token")
 	}
 
 	prevLogWriter := log.Writer()
@@ -106,7 +107,7 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 
 	disableWebSocket := false
 	syncer, err := mountsync.NewSyncer(
-		mountsync.NewHTTPClient(creds.Server, creds.Token, relay.HTTPClient()),
+		mountsync.NewHTTPClient(relay.URL(), runtimeToken, relay.HTTPClient()),
 		mountsync.SyncerOptions{
 			WorkspaceID: record.ID,
 			RemoteRoot:  "/",
@@ -139,7 +140,7 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 			syncer,
 			localDir,
 			record.ID,
-			creds.Server,
+			relay.URL(),
 			500*time.Millisecond,
 			100*time.Millisecond,
 			0,
@@ -200,28 +201,12 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 		t.Fatalf("expected github and notion providers in status, got %v", providers)
 	}
 
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:                cloud.URL(),
-		AccessToken:           cloud.expiredAccessToken,
-		RefreshToken:          cloud.refreshToken,
-		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
-		RefreshTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-		UpdatedAt:             time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
-
-	currentToken, err := currentRelayToken()
-	if err != nil {
-		t.Fatalf("currentRelayToken failed: %v", err)
-	}
+	installFakeAgentRelaySession(t, cloud.URL(), cloud.refreshedToken, "demo", cloud.workspaceID, cloud.workspaceID)
+	currentToken := runtimeToken
+	joinCountBeforeRefresh := cloud.JoinCount()
 	relay.RejectToken(currentToken)
 	waitForCondition(t, 12*time.Second, "cloud token refresh + workspace rejoin", func() bool {
-		creds, loadErr := loadCredentials()
-		if loadErr != nil {
-			return false
-		}
-		return cloud.RefreshCount() >= 1 && cloud.JoinCount() >= 3 && creds.Token != currentToken
+		return cloud.JoinCount() > joinCountBeforeRefresh && cloud.LastRelayfileToken() != currentToken
 	})
 
 	relay.UpsertFile("/github/repos/acme/api/pulls/42/after-refresh.md", "text/markdown", "# After refresh\n")
@@ -573,11 +558,9 @@ type productizedCloudMock struct {
 	relay              *productizedRelayfileMock
 	workspaceID        string
 	initialAccessToken string
-	expiredAccessToken string
 	refreshedToken     string
-	refreshToken       string
 	joinCount          int
-	refreshCount       int
+	lastRelayfileToken string
 	providers          map[string]string
 }
 
@@ -588,9 +571,7 @@ func newProductizedCloudMock(t *testing.T, relay *productizedRelayfileMock) *pro
 		relay:              relay,
 		workspaceID:        "ws_productized",
 		initialAccessToken: "cld_setup",
-		expiredAccessToken: "cld_expired",
 		refreshedToken:     "cld_refreshed",
-		refreshToken:       "cld_refresh",
 		providers:          map[string]string{},
 	}
 	mock.server = httptest.NewServer(http.HandlerFunc(mock.serveHTTP))
@@ -611,18 +592,16 @@ func (m *productizedCloudMock) JoinCount() int {
 	return m.joinCount
 }
 
-func (m *productizedCloudMock) RefreshCount() int {
+func (m *productizedCloudMock) LastRelayfileToken() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.refreshCount
+	return m.lastRelayfileToken
 }
 
 func (m *productizedCloudMock) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/api/v1/workspaces" && r.Method == http.MethodPost:
 		m.serveCreateWorkspace(w, r)
-	case r.URL.Path == "/api/v1/auth/token/refresh" && r.Method == http.MethodPost:
-		m.serveRefreshCloudToken(w, r)
 	case strings.HasSuffix(r.URL.Path, "/join") && r.Method == http.MethodPost:
 		m.serveJoinWorkspace(w, r)
 	case strings.HasSuffix(r.URL.Path, "/integrations/connect-session") && r.Method == http.MethodPost:
@@ -651,29 +630,6 @@ func (m *productizedCloudMock) serveCreateWorkspace(w http.ResponseWriter, r *ht
 	})
 }
 
-func (m *productizedCloudMock) serveRefreshCloudToken(w http.ResponseWriter, r *http.Request) {
-	if got := bearerToken(r); got != m.expiredAccessToken {
-		m.t.Fatalf("unexpected refresh token auth header: %q", got)
-	}
-	var body cloudTokenRefreshRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		m.t.Fatalf("decode refresh request failed: %v", err)
-	}
-	if body.RefreshToken != m.refreshToken {
-		m.t.Fatalf("unexpected refresh token: %q", body.RefreshToken)
-	}
-	m.mu.Lock()
-	m.refreshCount++
-	m.mu.Unlock()
-	writeMockJSON(w, http.StatusOK, cloudCredentials{
-		APIURL:                m.URL(),
-		AccessToken:           m.refreshedToken,
-		RefreshToken:          m.refreshToken,
-		AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
-		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
-	})
-}
-
 func (m *productizedCloudMock) serveJoinWorkspace(w http.ResponseWriter, r *http.Request) {
 	got := bearerToken(r)
 	if got != m.initialAccessToken && got != m.refreshedToken {
@@ -682,6 +638,7 @@ func (m *productizedCloudMock) serveJoinWorkspace(w http.ResponseWriter, r *http
 	m.mu.Lock()
 	m.joinCount++
 	token := fmt.Sprintf("rf_token_%d", m.joinCount)
+	m.lastRelayfileToken = token
 	m.mu.Unlock()
 
 	m.relay.ActivateToken(token)
@@ -769,14 +726,6 @@ func syncStateProviders(entries []syncStateProvider) []string {
 	}
 	sort.Strings(out)
 	return out
-}
-
-func currentRelayToken() (string, error) {
-	creds, err := loadCredentials()
-	if err != nil {
-		return "", err
-	}
-	return creds.Token, nil
 }
 
 func waitForCondition(t *testing.T, timeout time.Duration, description string, predicate func() bool) {

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -12,7 +12,7 @@ The `relayfile` CLI is the primary interface for humans and CI systems to intera
 ### Design principles
 
 - **Minimal flags, sensible defaults.** The happy path should require as few arguments as possible.
-- **Config file over flags over env vars.** Credentials and server URL are stored once via `relayfile login`; individual commands inherit them automatically. Environment variables (`RELAYFILE_TOKEN`, etc.) override config for CI/CD use.
+- **Canonical auth over local fallbacks.** Cloud login and active workspace selection are owned by `agent-relay login` and the `@agent-relay/cloud` session. Explicit Relayfile tokens (`--token`, `RELAYFILE_TOKEN`, or self-hosted `relayfile login --api-key`) remain available for CI and self-hosted deployments.
 - **Composable with pipes and scripts.** All commands emit structured JSON when `--json` is passed; human-readable tables otherwise.
 - **No implicit destructive actions.** Deletes require confirmation unless `--yes` is passed.
 
@@ -26,21 +26,40 @@ The `relayfile` CLI is the primary interface for humans and CI systems to intera
 |----------|--------|----------|
 | 1 | `--token` flag | One-off override |
 | 2 | `RELAYFILE_TOKEN` env var | CI/CD pipelines |
-| 3 | `~/.relayfile/credentials.json` | Interactive use after `relayfile login` |
+| 3 | `agent-relay cloud session --json` + `agent-relay workspace active --json` | Cloud-hosted interactive use |
+| 4 | `~/.relayfile/credentials.json` | Self-hosted/API-key compatibility |
 
-### Auth flow: API key (v1)
+### Auth flow: Cloud-hosted
 
 ```
-relayfile login --server https://api.relayfile.dev
+agent-relay login
+agent-relay workspace switch my-project
+relayfile mount
+```
+
+1. `agent-relay login` writes the canonical cloud session in the relay SDK store.
+2. `agent-relay workspace switch <name>` selects the active relay workspace.
+3. `relayfile` commands call `agent-relay cloud session --json` for a short-lived access token and `agent-relay workspace active --json` for the canonical `relayfileWorkspaceId`.
+4. Relayfile runtime tokens are minted with Cloud `/join` and kept in memory; they are not persisted as a second cloud session.
+
+Relayfile requires the `agent-relay` CLI binary on `PATH` to be version
+`8.7.0` or newer, because that is the first published CLI version with the
+`cloud session --json` and `workspace active --json` surfaces. Operators can
+override the binary with `AGENT_RELAY_BIN`. Sandboxes and Daytona/base images
+that run relayfile must install or update `agent-relay` before exercising the
+Cloud-hosted path. The cloud/workforce sandbox image owner is responsible for
+that runtime rollout; Relayfile enforces the version at startup but does not
+update deployed images itself.
+
+### Auth flow: API key / self-hosted
+
+```
+relayfile login --api-key --server https://api.relayfile.dev
 ```
 
 1. Prompts the user for an API key (paste from dashboard or generate via API).
 2. Validates the key by calling `GET /health` on the target server.
 3. Writes `~/.relayfile/credentials.json`.
-
-### Auth flow: OAuth via browser (future, v2)
-
-Same as `gh auth login` — opens a browser, completes device-code flow, stores refresh token. Not in scope for v1; the credential file schema reserves fields for it.
 
 ### Credential file: `~/.relayfile/credentials.json`
 
@@ -55,7 +74,7 @@ Same as `gh auth login` — opens a browser, completes device-code flow, stores 
 
 - `server` — base URL for all API calls. Default: `https://api.relayfile.dev`.
 - `token` — Bearer JWT or API key.
-- `refreshToken` / `expiresAt` — reserved for OAuth flow (v2). Null for API-key auth.
+- `refreshToken` / `expiresAt` — legacy fields. Cloud-hosted refresh is owned by `agent-relay`.
 - File permissions: `0600` (user-only read/write).
 
 ---
@@ -84,11 +103,12 @@ relayfile setup [--provider github] [--workspace my-project] [--local-dir ./rela
 
 **Behavior:**
 
-1. Start a localhost callback and open the Cloud login URL at `/api/v1/cli/login`.
-2. Store Cloud login tokens in `~/.relayfile/cloud-credentials.json`.
-3. Create and join a Cloud workspace, then store the Relayfile VFS URL/token in `~/.relayfile/credentials.json`.
-4. Request a hosted Nango connect session for the selected integration and wait until the Cloud status endpoint reports it ready.
-5. Start the existing `relayfile mount` sync loop so the user and agent see ordinary files.
+1. Ensure the user has run `agent-relay login`; `relayfile setup` reads the canonical relay session instead of starting its own login flow.
+2. Use `agent-relay cloud session --json` for the Cloud access token.
+3. Use `agent-relay workspace active --json` for the canonical workspace descriptor and `relayfileWorkspaceId`.
+4. Create/join the Cloud workspace when needed, minting Relayfile runtime credentials without persisting them as a second login.
+5. Request a hosted Nango connect session for the selected integration and wait until the Cloud status endpoint reports it ready.
+6. Start the existing `relayfile mount` sync loop so the user and agent see ordinary files.
 
 Re-running `relayfile setup` with the same workspace name reuses the locally
 tracked workspace ID, refreshes the Cloud session if needed, re-joins to mint a
@@ -102,23 +122,23 @@ This path is intentionally a wrapper over the lower-level commands and Cloud API
 
 ### `relayfile login`
 
-Authenticate and store credentials.
+Authenticate through the canonical relay session.
 
 ```
-relayfile login [--server URL]
+relayfile login [--no-open]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--server` | `https://api.relayfile.dev` | Server base URL |
+| `--no-open` | `false` | Forwarded to `agent-relay login --no-open` |
+| `--api-key` | `false` | Preserve the self-hosted/API-key credential path |
+| `--server` | `https://api.relayfile.dev` | Server base URL for `--api-key` |
 
 **Behavior:**
 
-1. Prompt for API key (stdin, or `--token` flag for non-interactive).
-2. Call `GET <server>/health` to validate connectivity.
-3. Call a token-validated endpoint (e.g., `GET /v1/workspaces` with limit=1) to verify the token is accepted.
-4. Write `~/.relayfile/credentials.json` with `0600` permissions.
-5. Print confirmation: `Logged in to <server> as <agent-name>`.
+1. Default path delegates to `agent-relay login`.
+2. Relayfile does not write `~/.relayfile/cloud-credentials.json`.
+3. `--api-key` keeps the self-hosted compatibility path and writes `~/.relayfile/credentials.json` with `0600` permissions.
 
 **Errors:**
 - Server unreachable: `Error: cannot reach <server> — check the URL and your network.`
@@ -513,9 +533,8 @@ These flags apply to all commands:
 
 ```
 ~/.relayfile/
-  cloud-credentials.json    # Cloud login tokens (access + refresh) (0600)
-  credentials.json          # Relayfile VFS workspace token (0600)
-  workspaces.json           # workspace name → ID mapping + default + lastUsedAt
+  credentials.json          # self-hosted/API-key credentials only (0600)
+  workspaces.json           # local workspace metadata: names, ids, localDir, history
 
 <local-dir>/
   <provider>/               # one top-level dir per connected provider
@@ -540,12 +559,12 @@ The CLI resolves tokens in this order, first match wins:
 
 1. `--token` flag
 2. `RELAYFILE_TOKEN` environment variable
-3. `~/.relayfile/credentials.json` → `token` field
+3. self-hosted only: `~/.relayfile/credentials.json` → `token` field
 
 If no token is found, the CLI prints:
 
 ```
-Error: not authenticated. Run 'relayfile login' or set RELAYFILE_TOKEN.
+Error: not authenticated. Run 'agent-relay login' for Cloud or set RELAYFILE_TOKEN.
 ```
 
 ---

--- a/docs/guides/vfs-cloud-setup.md
+++ b/docs/guides/vfs-cloud-setup.md
@@ -312,15 +312,15 @@ If the mount has not reconciled for ≥10 minutes it logs `mount stalled: <reaso
 ### Token expired
 
 ```
-error: cloud session expired. Run 'relayfile login' to sign in again.
+error: cloud session expired. Run 'agent-relay login' to sign in again.
 ```
 
-Run `relayfile login`. The running mount continues serving local reads from disk until the process is restarted.
+Run `agent-relay login`. The running mount continues serving local reads from disk until the process is restarted.
 
 If the refresh token itself expires (default 7 days), the mount enters degraded mode: local reads work, local writes are refused and logged to `.relay/permissions-denied.log` with reason `cloud_session_expired`. Fix:
 
 ```bash
-relayfile login
+agent-relay login
 relayfile stop my-project
 relayfile mount --background my-project ./relayfile-mount
 ```
@@ -368,9 +368,8 @@ relayfile mount --mode=poll my-project ./relayfile-mount
 
 ```
 ~/.relayfile/
-  cloud-credentials.json    # Cloud login tokens (0600)
-  credentials.json          # Relayfile VFS workspace token (0600)
-  workspaces.json           # workspace name → ID mapping
+  credentials.json          # self-hosted/API-key credentials only (0600)
+  workspaces.json           # local workspace metadata
 
 <local-dir>/
   github/                   # GitHub files

--- a/docs/productized-cloud-mount-contract.md
+++ b/docs/productized-cloud-mount-contract.md
@@ -63,14 +63,13 @@ step **MUST** be idempotent on re-run:
 1. **Print intent.** A single line stating: "Relayfile setup. This signs
    you in, connects an integration, and prepares a local VFS mount."
 2. **Cloud login.**
-   - If `--cloud-token`/`$RELAYFILE_CLOUD_TOKEN` is set, skip the browser
-     and persist the supplied token.
-   - Otherwise: bind a localhost callback (`http://127.0.0.1:<port>/callback`),
-     open `${cloud-api-url}/api/v1/cli/login?redirect_uri=…&state=…`,
-     verify state, and capture `access_token`, `refresh_token`,
-     `access_token_expires_at`, `refresh_token_expires_at`, `api_url`.
-   - Persist to `~/.relayfile/cloud-credentials.json` with `0600` perms
-     and the `cloudCredentials` schema in §5.1.
+   - Cloud authentication is owned by `agent-relay login` and the
+     `@agent-relay/cloud` session store.
+   - Relayfile obtains Cloud auth by invoking
+     `agent-relay cloud session --json`, which returns only `apiUrl`,
+     `accessToken`, and `accessTokenExpiresAt`.
+   - Relayfile does not persist `~/.relayfile/cloud-credentials.json` as a
+     Cloud session source of truth.
 3. **Workspace name.** Use `--workspace`, else prompt. Default suggestion:
    `relayfile-<UTC YYYYMMDD-HHMMSS>`.
 4. **Provider choice.** Use `--provider`, else prompt with the catalog
@@ -78,12 +77,13 @@ step **MUST** be idempotent on re-run:
 5. **Local dir.** Use `--local-dir`, else prompt; default
    `./relayfile-mount`. The directory **MUST** be created with `0o755`
    and a `.relay/` subdir with `0o755`.
-6. **Workspace create + join.** `POST /api/v1/workspaces`, then
-   `POST /api/v1/workspaces/{id}/join` with
-   `{agentName: "relayfile-cli", scopes: ["fs:read", "fs:write"]}`.
-   Persist Relayfile VFS credentials to `~/.relayfile/credentials.json`
-   (§5.1) and add the workspace to `~/.relayfile/workspaces.json`,
-   marking it default.
+6. **Workspace create + join.** Resolve the canonical active workspace via
+   `agent-relay workspace active --json`, then `POST
+   /api/v1/workspaces/{cloudWorkspaceId}/join` with `{agentName:
+   "relayfile-cli", scopes: ["fs:read", "fs:write"]}`. Use the returned
+   Relayfile VFS token in memory and add/update local workspace metadata in
+   `~/.relayfile/workspaces.json` without marking a separate Relayfile
+   workspace default.
 7. **Integration connect.** If a provider was chosen and not `none`:
    `POST /api/v1/workspaces/{id}/integrations/connect-session` with
    `{allowedIntegrations: [provider]}`. Print the `connectLink`, open it
@@ -369,18 +369,27 @@ two layers: Cloud login tokens (user identity) and Relayfile VFS tokens
 
 ### 5.1 Credential files
 
-- `~/.relayfile/cloud-credentials.json` (`0600`):
+- `agent-relay cloud session --json`:
   ```json
   {
     "apiUrl": "https://agentrelay.com/cloud",
     "accessToken": "...",
-    "refreshToken": "...",
-    "accessTokenExpiresAt":  "2026-05-03T18:00:00Z",
-    "refreshTokenExpiresAt": "2026-05-09T18:00:00Z",
-    "updatedAt":             "2026-05-02T18:00:00Z"
+    "accessTokenExpiresAt": "2026-05-03T18:00:00Z"
   }
   ```
-- `~/.relayfile/credentials.json` (`0600`):
+- `agent-relay workspace active --json` includes the canonical
+  `relayfileWorkspaceId` used by Relayfile data-plane calls.
+- Relayfile shells out to the external `agent-relay` binary on `PATH`, or to
+  `AGENT_RELAY_BIN` when set. The runtime environment, including sandbox and
+  Daytona/base images, must provide `agent-relay` CLI `8.7.0` or newer before
+  using the Cloud-hosted path. Relayfile must fail fast with an actionable
+  upgrade message when the binary is missing, stale, or lacks the required
+  `cloud session`, `workspace active`, or `workspace switch` commands.
+  The cloud/workforce sandbox image owner must ship that binary update before
+  enabling the unified Relayfile path in production; Relayfile validates the
+  binary but does not mutate the runtime image.
+- `~/.relayfile/credentials.json` (`0600`, self-hosted/API-key
+  compatibility only):
   ```json
   {
     "server": "https://api.relayfile.dev",
@@ -388,22 +397,18 @@ two layers: Cloud login tokens (user identity) and Relayfile VFS tokens
     "updatedAt": "2026-05-02T18:00:00Z"
   }
   ```
-- `~/.relayfile/workspaces.json`: catalog with `default` and per-name
-  `id`, `createdAt`, `lastUsedAt`.
+- `~/.relayfile/workspaces.json`: local metadata catalog with per-name
+  `id`, `localDir`, `createdAt`, and `lastUsedAt`. It is not a separate
+  active workspace pin.
 
 ### 5.2 Cloud token refresh
 
-The CLI **MUST** treat a Cloud access token as expired when
-`now ≥ accessTokenExpiresAt - 60s`. Refresh **MUST** call
-`POST ${apiUrl}/api/v1/auth/token/refresh` with the refresh token and
-**MUST**:
-
-- Persist the new token set atomically (write temp file, rename).
-- Coalesce concurrent refresh attempts inside a single CLI process.
-- Surface a `403 invalid_grant` as `error: cloud session expired. Run
-  'relayfile login' to sign in again.` and exit 10. The mount process
-  **MUST** keep running on the existing VFS token until that token also
-  expires.
+Relayfile **MUST NOT** refresh Cloud tokens itself. When it needs Cloud
+credentials it invokes `agent-relay cloud session --json`; the relay SDK owns
+refresh, timeout, and typed failure behavior. If that command fails because the
+canonical session is expired, Relayfile surfaces an actionable `agent-relay
+login` recovery hint. The mount process **MUST** keep running on the existing
+VFS token until that token also expires.
 
 ### 5.3 Relayfile VFS token rejoin
 
@@ -425,8 +430,9 @@ Triggers:
 
 The rejoin **MUST**:
 
-- Use the Cloud access token (refreshing it first if needed per §5.2).
-- Replace the on-disk `credentials.json` atomically.
+- Use the Cloud access token returned by `agent-relay cloud session --json`.
+- Keep the minted Relayfile runtime token in memory; do not write it to
+  `~/.relayfile/credentials.json`.
 - Update the in-memory token of the running syncer/HTTP client without
   killing the process or losing the websocket.
 
@@ -442,7 +448,7 @@ If the refresh token also expires (default 7 days), the mount **MUST**:
 - Refuse local writes for affected paths and place them in
   `.relay/permissions-denied.log` with reason `cloud_session_expired`.
 - Print one stderr line per minute (capped) directing the user to run
-  `relayfile login`. This is the only condition under which v1 mounts
+  `agent-relay login`. This is the only condition under which v1 mounts
   enter a degraded read-only state.
 
 ---


### PR DESCRIPTION
## Summary

References AgentWorkforce/cloud#2108 and the agreed auth-unification design.

This PR moves Relayfile's Cloud-hosted auth/workspace path onto the canonical Agent Relay session boundary:

- `relayfile login` delegates to `agent-relay login` instead of writing a Relayfile-owned cloud session.
- Cloud credentials are read through `agent-relay cloud session --json` and Relayfile only consumes the short-lived `apiUrl` + `accessToken` output.
- Active workspace resolution uses `agent-relay workspace active --json` and the canonical `relayfileWorkspaceId` descriptor field.
- `relayfile workspace use NAME` keeps Relayfile's UX but delegates to `agent-relay workspace switch NAME`.
- Runtime Relayfile VFS tokens are minted through Cloud `/join` and kept in memory; no `~/.relayfile/cloud-credentials.json` or local workspace default is used as a Cloud session/workspace source of truth.
- Explicit `--token` / `RELAYFILE_TOKEN` and `relayfile login --api-key` remain for CI/self-hosted compatibility.

## CLI preflight / runtime rollout

Relayfile shells out to the external `agent-relay` binary on `PATH`, or to `AGENT_RELAY_BIN` when set. This PR adds a preflight before canonical session/workspace shell-outs:

- `agent-relay --version` must be `>= 8.7.0`.
- `agent-relay cloud session --help`, `agent-relay workspace active --help`, and `agent-relay workspace switch --help` must all succeed.
- stale/missing binaries fail fast with an actionable install/update message before Relayfile attempts `cloud session --json`.

Required rollout step before prod exercises this path: the environment that runs Relayfile, including sandbox / Daytona / base images or any global install mechanism, must install `agent-relay@8.7.0` or newer on `PATH`, or set `AGENT_RELAY_BIN` to a compatible binary. Publishing this PR alone does not update existing runtime images.

## Published CLI live-command evidence

Run against the real published CLI, not the local `agent-relay` on PATH:

```text
npx -y agent-relay@8.7.0 --version
8.7.0

npx -y agent-relay@8.7.0 cloud session --json
{
  "apiUrl": "http://127.0.0.1:<mock-port>",
  "accessToken": "access_live_test",
  "accessTokenExpiresAt": "2099-01-01T00:00:00.000Z"
}

npx -y agent-relay@8.7.0 workspace active --json
{
  "name": "demo",
  "key": "rk_live_test",
  "cloudWorkspaceId": "rw_cloud",
  "relaycastWorkspaceId": "rw_cloud",
  "relayfileWorkspaceId": "rf_workspace",
  "relayauthWorkspaceId": "rw_cloud",
  "organizationId": "org_test",
  "slug": "demo",
  "urls": {
    "relayfileUrl": "https://relayfile.test"
  },
  "apiUrl": "http://127.0.0.1:<mock-port>",
  "provisioned": true
}

npx -y agent-relay@8.7.0 workspace switch --help
Usage: agent-relay workspace switch [options] <name>
```

The live JSON was produced with env-backed credentials plus a temp `AGENT_RELAY_HOME` workspace store and a local mock `/api/v1/workspaces/rk_live_test/resolve` endpoint. This verifies the field names the Go parser consumes from the published binary.

## Validation

- `go test -count=1 ./cmd/relayfile-cli -run 'TestEnsureCloudCredentialsUsesAgentRelaySession|TestEnsureCloudCredentialsRejectsStaleAgentRelayBeforeSessionCommand|TestWorkspaceUseSetsDefaultWorkspace'`
- `go test -count=1 ./cmd/relayfile-cli ./cmd/relayfile-mount`
- `go test -count=1 ./...`
- `git diff --check origin/main...HEAD`
- `rg "agent-relay workspace use|\.agent-relay/cloud-auth.json|file:/Users" cmd docs package.json pnpm-lock.yaml go.mod go.sum` returned no hits
- `git diff --name-only origin/main...HEAD` is exactly the intended Relayfile auth/docs surface; no `.trajectories` or `.agentworkforce/trajectories` artifacts are in the PR diff

TS SDK tests were not run locally in this worktree because the TS workspace deps/types are not installed here; CI should validate that surface.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

