### PR TITLE
fix(cli): delegate relayfile login to agent-relay cloud login

### DIFF
--- a/cmd/relayfile-cli/background_test.go
+++ b/cmd/relayfile-cli/background_test.go
@@ -582,7 +582,7 @@ func TestRestartClearsStaleDaemonPID(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected restart to reach mount and fail without credentials")
 	}
-	if !strings.Contains(err.Error(), "agent-relay cloud session") {
+	if !strings.Contains(err.Error(), "delegated relayfile credentials") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if strings.Contains(stdout.String(), "Stopped background mount") {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -711,7 +711,7 @@ Usage:
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
-  login       Sign in via agent-relay login (or --api-key for self-hosted)
+  login       Sign in via agent-relay cloud login (or --api-key for self-hosted)
   workspace   Create, join, select via agent-relay, list, show current, or delete locally tracked workspaces
   integration Connect, discover, list, disconnect, or adopt workspace integrations
   ops         List or replay dead-lettered writeback ops
@@ -1030,7 +1030,7 @@ func runAgentRelayJSON(args []string, out any) error {
 	cmd := exec.CommandContext(ctx, agentRelayBinary(), args...)
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("agent-relay %s timed out; run 'agent-relay login' and try again", strings.Join(args, " "))
+		return fmt.Errorf("agent-relay %s timed out; run 'agent-relay cloud login' and try again", strings.Join(args, " "))
 	}
 	if err != nil {
 		detail := strings.TrimSpace(string(output))
@@ -1049,7 +1049,7 @@ func runAgentRelayLogin(stdin io.Reader, stdout io.Writer, noOpen bool) error {
 	if err := ensureAgentRelayCLICompatible(); err != nil {
 		return err
 	}
-	args := []string{"login"}
+	args := []string{"cloud", "login"}
 	if noOpen {
 		args = append(args, "--no-open")
 	}
@@ -1058,7 +1058,7 @@ func runAgentRelayLogin(stdin io.Reader, stdout io.Writer, noOpen bool) error {
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("agent-relay login failed: %w", err)
+		return fmt.Errorf("agent-relay cloud login failed: %w", err)
 	}
 	return nil
 }
@@ -1182,7 +1182,7 @@ func loadCloudCredentials() (cloudCredentials, error) {
 	payload, err := os.ReadFile(cloudCredentialsPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return creds, fmt.Errorf("legacy cloud credentials not found at %s; run agent-relay login", cloudCredentialsPath())
+			return creds, fmt.Errorf("legacy cloud credentials not found at %s; run agent-relay cloud login", cloudCredentialsPath())
 		}
 		return creds, err
 	}
@@ -1199,9 +1199,9 @@ func loadCloudCredentials() (cloudCredentials, error) {
 // access tokens. The mount loop uses this to enter the read-only degraded
 // state described in the productized cloud-mount contract acceptance test
 // A9 ("Cloud refresh token expired").
-var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay login' to sign in again.")
+var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay cloud login' to sign in again.")
 
-var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile credentials expired or revoked. Re-bootstrap relayfile credentials with agent-relay login.")
+var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile credentials expired or revoked. Re-bootstrap relayfile credentials with agent-relay cloud login.")
 
 func isMountCredentialExpired(err error) bool {
 	return errors.Is(err, ErrCloudRefreshExpired) || errors.Is(err, ErrDelegatedRelayfileCredentialsExpired)
@@ -1901,7 +1901,7 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 
 	if (strings.TrimSpace(*cloudAPIURL) != "" && strings.TrimRight(strings.TrimSpace(*cloudAPIURL), "/") != defaultCloudAPIURL) ||
 		strings.TrimSpace(*cloudToken) != "" || *loginTimeout != 5*time.Minute || *skipWorkspace || strings.TrimSpace(*workspaceFlag) != "" {
-		fmt.Fprintln(stdout, "warning: relayfile login delegates to agent-relay login; relayfile cloud/workspace refresh flags are deprecated and ignored")
+		fmt.Fprintln(stdout, "warning: relayfile login delegates to agent-relay cloud login; relayfile cloud/workspace refresh flags are deprecated and ignored")
 	}
 	if err := runAgentRelayLogin(stdin, stdout, *noOpen); err != nil {
 		return err
@@ -4925,7 +4925,7 @@ func latestCredentialModTime(paths ...string) (time.Time, bool) {
 
 func cloudCredentialAuthLine(now time.Time) string {
 	if _, err := cloudCredentialsFromAgentRelay(); err != nil {
-		return "auth: agent-relay session unavailable - run 'agent-relay login'"
+		return "auth: agent-relay session unavailable - run 'agent-relay cloud login'"
 	}
 	return "auth: agent-relay session ok"
 }
@@ -7868,7 +7868,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	degraded := false
 	var lastDegradedNotice time.Time
 	const degradedRecoveryInterval = time.Minute
-	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay login"
+	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay cloud login"
 
 	enterDegraded := func() {
 		if !degraded {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/agentworkforce/relayfile/internal/delegatedauth"
 	"github.com/agentworkforce/relayfile/internal/mountsync"
 	"github.com/agentworkforce/relayfile/internal/writeback"
 	"github.com/fsnotify/fsnotify"
@@ -235,18 +236,9 @@ type cloudWorkspaceCreateResponse struct {
 	Name         string `json:"name,omitempty"`
 }
 
-type cloudWorkspaceJoinRequest struct {
+type cloudRelayfileDelegatedTokenRequest struct {
 	AgentName string   `json:"agentName,omitempty"`
 	Scopes    []string `json:"scopes,omitempty"`
-}
-
-type cloudWorkspaceJoinResponse struct {
-	WorkspaceID      string `json:"workspaceId"`
-	Token            string `json:"token"`
-	RelayfileURL     string `json:"relayfileUrl"`
-	WSURL            string `json:"wsUrl,omitempty"`
-	RelaycastAPIKey  string `json:"relaycastApiKey,omitempty"`
-	RelaycastBaseURL string `json:"relaycastBaseUrl,omitempty"`
 }
 
 type cloudConnectSessionRequest struct {
@@ -847,11 +839,16 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 		return err
 	}
 
-	joined, err := joinWorkspaceViaCloud(tokenSet, record.ID, record.AgentName, record.Scopes)
+	controlToken := tokenSet.AccessToken
+	delegated, err := delegatedRelayfileTokenViaCloud(tokenSet, record.ID, record.AgentName, record.Scopes)
 	if err != nil {
 		return err
 	}
-	record, err = persistJoinedWorkspace(record, joined, tokenSet.APIURL, absLocalDir, true)
+	delegatedCredsFile := delegatedCredentialsPath()
+	if err := delegatedauth.SaveAtomic(delegatedCredsFile, delegated); err != nil {
+		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
+	}
+	record, err = persistDelegatedWorkspace(record, delegated, absLocalDir, true)
 	if err != nil {
 		return err
 	}
@@ -865,19 +862,19 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	if selectedProvider != "" && selectedProvider != "none" && selectedProvider != "skip" {
 		createdConnection := false
 		if createdWorkspace {
-			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
+			if err := connectCloudIntegration(tokenSet.APIURL, record.ID, controlToken, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout); err != nil {
 				return err
 			}
 			createdConnection = true
 		} else {
 			var err error
-			createdConnection, err = ensureCloudIntegration(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout)
+			createdConnection, err = ensureCloudIntegration(tokenSet.APIURL, record.ID, controlToken, selectedProvider, requestedBackend, absLocalDir, *connectTimeout, !*noOpen, stdout)
 			if err != nil {
 				return err
 			}
 		}
 		if createdConnection && isAtlassianProvider(selectedProvider) {
-			if err := runAtlassianSitePicker(tokenSet.APIURL, record.ID, joined.Token, selectedProvider, stdin, stdout); err != nil {
+			if err := runAtlassianSitePicker(tokenSet.APIURL, record.ID, controlToken, selectedProvider, stdin, stdout); err != nil {
 				return err
 			}
 		}
@@ -890,8 +887,8 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	}
 
 	mountArgs := []string{
-		"--server", strings.TrimRight(joined.RelayfileURL, "/"),
-		"--token", joined.Token,
+		"--server", strings.TrimRight(delegated.ServerURL(), "/"),
+		"--creds-file", delegatedCredsFile,
 		record.ID,
 		localDir,
 	}
@@ -1151,6 +1148,35 @@ func agentRelayWorkspaceMatches(value string, workspace agentRelayActiveWorkspac
 	return false
 }
 
+func workspaceRequestMatchesDelegatedCredentials(value, relayfileWorkspaceID string) bool {
+	value = strings.TrimSpace(value)
+	relayfileWorkspaceID = strings.TrimSpace(relayfileWorkspaceID)
+	if value == "" {
+		return true
+	}
+	if relayfileWorkspaceID == "" {
+		return false
+	}
+	if value == relayfileWorkspaceID {
+		return true
+	}
+	if id, ok := catalogWorkspaceID(value); ok && strings.TrimSpace(id) == relayfileWorkspaceID {
+		return true
+	}
+	for _, lookup := range []func(string) (workspaceRecord, bool){workspaceRecordByName, workspaceRecordByID} {
+		record, ok := lookup(value)
+		if !ok {
+			continue
+		}
+		for _, candidate := range []string{record.ID, record.RelayWorkspaceID, record.Name} {
+			if strings.TrimSpace(candidate) == relayfileWorkspaceID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func loadCloudCredentials() (cloudCredentials, error) {
 	var creds cloudCredentials
 	payload, err := os.ReadFile(cloudCredentialsPath())
@@ -1174,6 +1200,12 @@ func loadCloudCredentials() (cloudCredentials, error) {
 // state described in the productized cloud-mount contract acceptance test
 // A9 ("Cloud refresh token expired").
 var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay login' to sign in again.")
+
+var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile credentials expired or revoked. Re-bootstrap relayfile credentials with agent-relay login.")
+
+func isMountCredentialExpired(err error) bool {
+	return errors.Is(err, ErrCloudRefreshExpired) || errors.Is(err, ErrDelegatedRelayfileCredentialsExpired)
+}
 
 func providerPromptText(entries []integrationCatalogEntry) string {
 	ids := make([]string, 0, len(entries)+1)
@@ -1543,43 +1575,7 @@ func ensureWorkspaceForSetup(cloud cloudCredentials, name, localDir string) (wor
 	return record, true, nil
 }
 
-func persistJoinedWorkspace(record workspaceRecord, joined cloudWorkspaceJoinResponse, cloudAPIURL, localDir string, setDefault bool) (workspaceRecord, error) {
-	serverURL := strings.TrimRight(strings.TrimSpace(joined.RelayfileURL), "/")
-	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
-		if strings.TrimSpace(record.ID) == "" {
-			record.ID = joinedWorkspaceID
-		} else {
-			record.RelayWorkspaceID = joinedWorkspaceID
-		}
-	}
-	record.Server = serverURL
-	record.LocalDir = localDir
-	record.CloudAPIURL = cloudAPIURL
-	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
-	if record.AgentName == "" {
-		record.AgentName = "relayfile-cli"
-	}
-	if len(record.Scopes) == 0 {
-		record.Scopes = append([]string(nil), defaultJoinScopes...)
-	}
-	persisted, err := upsertWorkspaceDetails(record)
-	if err != nil {
-		return workspaceRecord{}, err
-	}
-	return persisted, nil
-}
-
-func relayWorkspaceIDForRecord(record workspaceRecord, joined cloudWorkspaceJoinResponse) string {
-	if relayID := strings.TrimSpace(joined.WorkspaceID); relayID != "" {
-		return relayID
-	}
-	if relayID := strings.TrimSpace(record.RelayWorkspaceID); relayID != "" {
-		return relayID
-	}
-	return strings.TrimSpace(record.ID)
-}
-
-func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string, scopes []string) (cloudWorkspaceJoinResponse, error) {
+func delegatedRelayfileTokenViaCloud(cloud cloudCredentials, workspaceID, agentName string, scopes []string) (delegatedauth.Bundle, error) {
 	if agentName == "" {
 		agentName = "relayfile-cli"
 	}
@@ -1588,25 +1584,49 @@ func joinWorkspaceViaCloud(cloud cloudCredentials, workspaceID, agentName string
 	}
 	client, err := newAPIClient(cloud.APIURL, cloud.AccessToken)
 	if err != nil {
-		return cloudWorkspaceJoinResponse{}, err
+		return delegatedauth.Bundle{}, err
 	}
-	var joined cloudWorkspaceJoinResponse
-	if err := client.postJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/join", url.PathEscape(workspaceID)), cloudWorkspaceJoinRequest{
-		AgentName: agentName,
-		Scopes:    scopes,
-	}, &joined); err != nil {
-		return cloudWorkspaceJoinResponse{}, fmt.Errorf("join cloud workspace: %w", err)
+	var bundle delegatedauth.Bundle
+	if err := client.postJSON(
+		context.Background(),
+		fmt.Sprintf("/api/v1/workspaces/%s/relayfile/delegated-token", url.PathEscape(workspaceID)),
+		cloudRelayfileDelegatedTokenRequest{
+			AgentName: agentName,
+			Scopes:    scopes,
+		},
+		&bundle,
+	); err != nil {
+		return delegatedauth.Bundle{}, fmt.Errorf("mint delegated relayfile credentials: %w", err)
 	}
-	if strings.TrimSpace(joined.WorkspaceID) == "" {
-		joined.WorkspaceID = workspaceID
+	if bundle.Workspace() == "" {
+		bundle.RelayfileWorkspaceID = workspaceID
 	}
-	if strings.TrimSpace(joined.Token) == "" {
-		return cloudWorkspaceJoinResponse{}, errors.New("cloud join response missing token")
+	if err := bundle.ValidateForUse(); err != nil {
+		return delegatedauth.Bundle{}, fmt.Errorf("delegated relayfile credential bundle invalid: %w", err)
 	}
-	if strings.TrimSpace(joined.RelayfileURL) == "" {
-		return cloudWorkspaceJoinResponse{}, errors.New("cloud join response missing relayfileUrl")
+	return bundle, nil
+}
+
+func persistDelegatedWorkspace(record workspaceRecord, bundle delegatedauth.Bundle, localDir string, setDefault bool) (workspaceRecord, error) {
+	relayWorkspaceID := bundle.Workspace()
+	if relayWorkspaceID != "" {
+		if strings.TrimSpace(record.ID) == "" {
+			record.ID = relayWorkspaceID
+		} else if strings.TrimSpace(record.ID) != relayWorkspaceID {
+			record.RelayWorkspaceID = relayWorkspaceID
+		}
 	}
-	return joined, nil
+	record.Server = strings.TrimRight(bundle.ServerURL(), "/")
+	record.LocalDir = localDir
+	record.CloudAPIURL = ""
+	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	if record.AgentName == "" {
+		record.AgentName = "relayfile-cli"
+	}
+	if len(record.Scopes) == 0 {
+		record.Scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	return upsertWorkspaceDetails(record)
 }
 
 func ensureCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider, requestedBackend, localDir string, timeout time.Duration, shouldOpenBrowser bool, stdout io.Writer) (bool, error) {
@@ -2007,19 +2027,22 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
+	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
 	if err != nil {
 		return err
 	}
-	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir, true)
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegated); err != nil {
+		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
+	}
+	record, err = persistDelegatedWorkspace(record, delegated, record.LocalDir, true)
 	if err != nil {
 		return err
 	}
-	createdConnection, err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, joined.Token, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout)
+	createdConnection, err := ensureCloudIntegration(cloudCreds.APIURL, record.ID, cloudCreds.AccessToken, provider, requestedBackend, record.LocalDir, *timeout, !*noOpen, stdout)
 	if err != nil {
 		return err
 	}
-	relayWorkspaceID := relayWorkspaceIDForRecord(record, joined)
+	relayWorkspaceID := delegated.Workspace()
 	if relayWorkspaceID != "" && relayWorkspaceID != record.ID {
 		fmt.Fprintf(stdout, "Workspace: %s (Relayfile runtime: %s)\n", record.ID, relayWorkspaceID)
 	}
@@ -2031,11 +2054,11 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	// to dive into the Nango dashboard. For other providers this is a
 	// no-op so we preserve the existing flow.
 	if createdConnection && isAtlassianProvider(provider) {
-		if err := runAtlassianSitePicker(cloudCreds.APIURL, record.ID, joined.Token, provider, stdin, stdout); err != nil {
+		if err := runAtlassianSitePicker(cloudCreds.APIURL, record.ID, cloudCreds.AccessToken, provider, stdin, stdout); err != nil {
 			return err
 		}
 	}
-	return waitForInitialSync(joined.RelayfileURL, joined.Token, relayWorkspaceID, provider, record.LocalDir, *timeout, stdout)
+	return waitForInitialSync(delegated.ServerURL(), delegated.BearerToken(), relayWorkspaceID, provider, record.LocalDir, *timeout, stdout)
 }
 
 func isAtlassianProvider(provider string) bool {
@@ -2368,11 +2391,7 @@ func runIntegrationList(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
-	if err != nil {
-		return err
-	}
-	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	client, err := newAPIClient(cloudCreds.APIURL, cloudCreds.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -2383,8 +2402,7 @@ func runIntegrationList(args []string, stdout io.Writer) error {
 	if *jsonOutput {
 		return writeJSON(stdout, entries)
 	}
-	relayWorkspaceID := relayWorkspaceIDForRecord(record, joined)
-	if relayWorkspaceID != "" && relayWorkspaceID != record.ID {
+	if relayWorkspaceID := strings.TrimSpace(record.RelayWorkspaceID); relayWorkspaceID != "" && relayWorkspaceID != record.ID {
 		fmt.Fprintf(stdout, "Workspace: %s (Relayfile runtime: %s)\n", record.ID, relayWorkspaceID)
 	}
 	if len(entries) == 0 {
@@ -2434,11 +2452,7 @@ func runIntegrationDisconnect(args []string, stdin io.Reader, stdout io.Writer) 
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
-	if err != nil {
-		return err
-	}
-	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	client, err := newAPIClient(cloudCreds.APIURL, cloudCreds.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -2511,11 +2525,7 @@ func runIntegrationAdopt(args []string, stdin io.Reader, stdout io.Writer) error
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
-	if err != nil {
-		return err
-	}
-	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	client, err := newAPIClient(cloudCreds.APIURL, cloudCreds.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -2660,11 +2670,7 @@ func runIntegrationSetMetadata(args []string, stdin io.Reader, stdout io.Writer)
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
-	if err != nil {
-		return err
-	}
-	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	client, err := newAPIClient(cloudCreds.APIURL, cloudCreds.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -3419,11 +3425,7 @@ func runOpsReplay(args []string, stdin io.Reader, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, record.ID, record.AgentName, record.Scopes)
-	if err != nil {
-		return err
-	}
-	client, err := newAPIClient(cloudCreds.APIURL, joined.Token)
+	client, err := newAPIClient(cloudCreds.APIURL, cloudCreds.AccessToken)
 	if err != nil {
 		return err
 	}
@@ -3615,11 +3617,14 @@ func runWorkspaceJoin(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
+	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
 	if err != nil {
 		return err
 	}
-	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, "", true)
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegated); err != nil {
+		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
+	}
+	record, err = persistDelegatedWorkspace(record, delegated, "", true)
 	if err != nil {
 		return err
 	}
@@ -3825,6 +3830,7 @@ func runMount(args []string) error {
 
 	server := fs.String("server", resolveServer("", credentials{}), "relayfile server URL")
 	token := fs.String("token", strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")), "bearer token")
+	credsFile := fs.String("creds-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_CREDS_FILE")), "delegated relayfile credentials file")
 	remotePath := fs.String("remote-path", envOrDefault("RELAYFILE_REMOTE_PATH", "/"), "remote root path")
 	eventProvider := fs.String("provider", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_PROVIDER")), "event provider filter")
 	stateFile := fs.String("state-file", strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_STATE_FILE")), "state file path")
@@ -3852,6 +3858,7 @@ func runMount(args []string) error {
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"server":              true,
 		"token":               true,
+		"creds-file":          true,
 		"remote-path":         true,
 		"provider":            true,
 		"state-file":          true,
@@ -3897,45 +3904,32 @@ func runMount(args []string) error {
 	tokenValue := strings.TrimSpace(*token)
 	canonicalWorkspaceID := ""
 	requestedWorkspace := ""
-	activeWorkspace := agentRelayActiveWorkspace{}
-	usesAgentRelayWorkspace := false
+	delegatedCredsPath := resolveDelegatedCredentialsPath(*credsFile)
+	usesDelegatedWorkspace := false
 	if fs.NArg() > 0 {
 		requestedWorkspace = strings.TrimSpace(fs.Arg(0))
 	}
 	if tokenValue == "" {
-		cloudCreds, cerr := ensureCloudCredentials("", "", 0, false, io.Discard)
-		if cerr != nil {
-			return fmt.Errorf("resolve agent-relay cloud session: %w", cerr)
+		bundle, path, berr := loadDelegatedCredentials(*credsFile)
+		if berr != nil {
+			return fmt.Errorf("resolve delegated relayfile credentials: %w", berr)
 		}
-		resolvedActiveWorkspace, werr := activeWorkspaceFromAgentRelay()
-		if werr != nil {
-			return fmt.Errorf("resolve active agent-relay workspace: %w", werr)
+		delegatedCredsPath = path
+		bundle, berr = refreshDelegatedCredentials(path, bundle, false)
+		if berr != nil {
+			return fmt.Errorf("refresh delegated relayfile credentials: %w", berr)
 		}
-		activeWorkspace = resolvedActiveWorkspace
-		usesAgentRelayWorkspace = true
-		if requestedWorkspace != "" && !agentRelayWorkspaceMatches(requestedWorkspace, activeWorkspace) {
+		canonicalWorkspaceID = bundle.Workspace()
+		if requestedWorkspace != "" && !workspaceRequestMatchesDelegatedCredentials(requestedWorkspace, canonicalWorkspaceID) {
 			return fmt.Errorf(
-				"relayfile mount without --token uses active agent-relay workspace %s (%s); pass --token for explicit workspace %q or run 'agent-relay workspace switch %s'",
-				defaultIfBlank(activeWorkspace.Name, activeWorkspace.RelayfileWorkspaceID),
-				activeWorkspace.RelayfileWorkspaceID,
-				requestedWorkspace,
+				"relayfile mount without --token uses delegated relayfile workspace %s; pass --token for explicit workspace %q or re-bootstrap delegated credentials for that workspace",
+				canonicalWorkspaceID,
 				requestedWorkspace,
 			)
 		}
-		cloudWorkspaceID := firstNonEmpty(activeWorkspace.CloudWorkspaceID, activeWorkspace.ID, activeWorkspace.Key, activeWorkspace.RelayfileWorkspaceID)
-		if cloudWorkspaceID == "" {
-			return errors.New("agent-relay workspace active --json did not include cloudWorkspaceId")
-		}
-		joined, jerr := joinWorkspaceViaCloud(cloudCreds, cloudWorkspaceID, "relayfile-cli", defaultJoinScopes)
-		if jerr != nil {
-			return fmt.Errorf("mint relayfile runtime credentials: %w", jerr)
-		}
-		tokenValue = joined.Token
-		*server = strings.TrimRight(joined.RelayfileURL, "/")
-		canonicalWorkspaceID = strings.TrimSpace(activeWorkspace.RelayfileWorkspaceID)
-		if canonicalWorkspaceID == "" {
-			canonicalWorkspaceID = strings.TrimSpace(joined.WorkspaceID)
-		}
+		tokenValue = bundle.BearerToken()
+		*server = strings.TrimRight(bundle.ServerURL(), "/")
+		usesDelegatedWorkspace = true
 	}
 	var err error
 	switch fs.NArg() {
@@ -3976,7 +3970,7 @@ func runMount(args []string) error {
 	} else if record, ok := workspaceRecordByName(workspaceID); ok && strings.TrimSpace(record.ID) == "" {
 		recordedLocalDir = strings.TrimSpace(record.LocalDir)
 	}
-	if recordedLocalDir == "" && usesAgentRelayWorkspace && requestedWorkspace != "" && agentRelayWorkspaceMatches(requestedWorkspace, activeWorkspace) {
+	if recordedLocalDir == "" && usesDelegatedWorkspace && requestedWorkspace != "" && workspaceRequestMatchesDelegatedCredentials(requestedWorkspace, canonicalWorkspaceID) {
 		if record, ok := workspaceRecordByName(requestedWorkspace); ok {
 			recordedLocalDir = strings.TrimSpace(record.LocalDir)
 		}
@@ -4152,7 +4146,11 @@ func runMount(args []string) error {
 	}
 	_, _ = upsertWorkspaceDetails(record)
 
-	return runMountLoop(rootCtx, syncer, absLocalDir, workspaceID, strings.TrimRight(strings.TrimSpace(*server), "/"), *timeout, *interval, *intervalJitter, *websocketEnabled, *once, *daemonized, pidFile, logFile)
+	loopDelegatedCredsPath := ""
+	if usesDelegatedWorkspace {
+		loopDelegatedCredsPath = delegatedCredsPath
+	}
+	return runMountLoop(rootCtx, syncer, absLocalDir, workspaceID, strings.TrimRight(strings.TrimSpace(*server), "/"), loopDelegatedCredsPath, *timeout, *interval, *intervalJitter, *websocketEnabled, *once, *daemonized, pidFile, logFile)
 }
 
 func shouldRegisterMountPID(daemonized, once bool) bool {
@@ -4224,29 +4222,76 @@ type workspaceCommandClient struct {
 	client      *apiClient
 	scopes      []string
 	directToken bool
+	credsFile   string
 }
 
 func prepareWorkspaceCommandClient(workspaceValue, serverFlag, tokenFlag string, requestedScopes []string) (*workspaceCommandClient, error) {
 	creds, _ := loadCredentials()
 	tokenValue := resolveToken(tokenFlag, creds)
-	directToken := strings.TrimSpace(tokenFlag) != "" || strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")) != ""
-	workspaceID, err := resolveWorkspaceIDWithToken(workspaceValue, tokenValue)
-	if err != nil {
-		return nil, err
+	directToken := strings.TrimSpace(tokenFlag) != "" || strings.TrimSpace(os.Getenv("RELAYFILE_TOKEN")) != "" || strings.TrimSpace(creds.Token) != ""
+	credsFile := ""
+	var bundle delegatedauth.Bundle
+	var err error
+	if !directToken && strings.TrimSpace(tokenValue) == "" {
+		bundle, credsFile, err = loadDelegatedCredentials("")
+		if err != nil {
+			return nil, fmt.Errorf("resolve delegated relayfile credentials: %w", err)
+		}
+		bundle, err = refreshDelegatedCredentials(credsFile, bundle, false)
+		if err != nil {
+			return nil, fmt.Errorf("refresh delegated relayfile credentials: %w", err)
+		}
+		tokenValue = bundle.BearerToken()
+		if strings.TrimSpace(serverFlag) == "" {
+			serverFlag = bundle.ServerURL()
+		}
+	}
+	workspaceID := ""
+	if credsFile != "" {
+		workspaceID = bundle.Workspace()
+		if !workspaceRequestMatchesDelegatedCredentials(workspaceValue, workspaceID) {
+			return nil, fmt.Errorf(
+				"delegated relayfile credentials are for workspace %s; pass --token for explicit workspace %q or re-bootstrap delegated credentials for that workspace",
+				workspaceID,
+				workspaceValue,
+			)
+		}
+	} else {
+		workspaceID, err = resolveWorkspaceIDWithToken(workspaceValue, tokenValue)
+		if err != nil {
+			return nil, err
+		}
 	}
 	record := workspaceRecordForCommand(workspaceValue, workspaceID)
+	if credsFile != "" {
+		if strings.TrimSpace(record.ID) == "" {
+			record.ID = workspaceID
+		} else if strings.TrimSpace(record.ID) != workspaceID {
+			record.RelayWorkspaceID = workspaceID
+		}
+		record.Server = strings.TrimRight(bundle.ServerURL(), "/")
+		record.CloudAPIURL = ""
+		record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	}
 	scopes := effectiveCommandScopes(record, requestedScopes)
 	commandClient := &workspaceCommandClient{
 		workspaceID: workspaceID,
 		record:      record,
 		scopes:      scopes,
 		directToken: directToken,
+		credsFile:   credsFile,
+	}
+	if credsFile != "" {
+		persisted, err := upsertWorkspaceDetails(record)
+		if err != nil {
+			return nil, err
+		}
+		commandClient.record = persisted
 	}
 
-	tokenWorkspaceID := workspaceIDFromToken(tokenValue)
-	shouldJoin := !directToken && (strings.TrimSpace(tokenValue) == "" || relayfileTokenNeedsRefresh(tokenValue) || (tokenWorkspaceID != "" && tokenWorkspaceID != workspaceID))
-	if shouldJoin {
-		if err := commandClient.refreshFromCloud(); err == nil {
+	shouldRefreshDelegated := !directToken && credsFile != "" && (strings.TrimSpace(tokenValue) == "" || relayfileTokenNeedsRefresh(tokenValue))
+	if shouldRefreshDelegated {
+		if err := commandClient.refreshFromDelegated(); err == nil {
 			return commandClient, nil
 		} else if strings.TrimSpace(tokenValue) == "" {
 			return nil, err
@@ -4302,32 +4347,40 @@ func effectiveCommandScopes(record workspaceRecord, requestedScopes []string) []
 	return append([]string(nil), defaultJoinScopes...)
 }
 
-func (c *workspaceCommandClient) refreshFromCloud() error {
+func (c *workspaceCommandClient) refreshFromDelegated() error {
 	if c == nil {
 		return errors.New("workspace command client is nil")
 	}
-	cloudCreds, err := ensureCloudCredentials("", "", 0, false, io.Discard)
+	if strings.TrimSpace(c.credsFile) == "" {
+		return delegatedauth.ErrMissingCredentials
+	}
+	bundle, _, err := loadDelegatedCredentials(c.credsFile)
 	if err != nil {
 		return err
 	}
-	joined, err := joinWorkspaceViaCloud(cloudCreds, c.workspaceID, c.record.AgentName, c.scopes)
+	if bundle.Workspace() != "" && bundle.Workspace() != c.workspaceID {
+		return fmt.Errorf("delegated relayfile credentials are for workspace %s, expected %s", bundle.Workspace(), c.workspaceID)
+	}
+	renewed, err := refreshDelegatedCredentials(c.credsFile, bundle, true)
 	if err != nil {
 		return err
 	}
-	requestedWorkspaceID := c.workspaceID
-	if joinedWorkspaceID := strings.TrimSpace(joined.WorkspaceID); joinedWorkspaceID != "" {
-		c.workspaceID = joinedWorkspaceID
-	}
+	c.workspaceID = renewed.Workspace()
 	record := c.record
 	if strings.TrimSpace(record.ID) == "" {
-		record.ID = strings.TrimSpace(requestedWorkspaceID)
+		record.ID = c.workspaceID
+	} else if strings.TrimSpace(record.ID) != c.workspaceID {
+		record.RelayWorkspaceID = c.workspaceID
 	}
 	record.Scopes = append([]string(nil), c.scopes...)
-	record, err = persistJoinedWorkspace(record, joined, cloudCreds.APIURL, record.LocalDir, false)
+	record.Server = strings.TrimRight(renewed.ServerURL(), "/")
+	record.CloudAPIURL = ""
+	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
+	record, err = upsertWorkspaceDetails(record)
 	if err != nil {
 		return err
 	}
-	client, err := newAPIClient(strings.TrimRight(joined.RelayfileURL, "/"), joined.Token)
+	client, err := newAPIClient(strings.TrimRight(renewed.ServerURL(), "/"), renewed.BearerToken())
 	if err != nil {
 		return err
 	}
@@ -4341,7 +4394,7 @@ func (c *workspaceCommandClient) getWorkspaceBytes(ctx context.Context, pathForW
 	if err == nil || c.directToken || !isAPIAuthError(err) {
 		return body, contentType, err
 	}
-	if refreshErr := c.refreshFromCloud(); refreshErr != nil {
+	if refreshErr := c.refreshFromDelegated(); refreshErr != nil {
 		return body, contentType, err
 	}
 	return c.client.getBytes(ctx, pathForWorkspace(c.workspaceID))
@@ -4352,7 +4405,7 @@ func (c *workspaceCommandClient) getWorkspaceJSON(ctx context.Context, pathForWo
 	if err == nil || c.directToken || !isAPIAuthError(err) {
 		return err
 	}
-	if refreshErr := c.refreshFromCloud(); refreshErr != nil {
+	if refreshErr := c.refreshFromDelegated(); refreshErr != nil {
 		return err
 	}
 	return c.client.getJSON(ctx, pathForWorkspace(c.workspaceID), out)
@@ -5337,6 +5390,59 @@ func credentialsPath() string {
 
 func cloudCredentialsPath() string {
 	return filepath.Join(configDir(), "cloud-credentials.json")
+}
+
+func delegatedCredentialsPath() string {
+	return filepath.Join(configDir(), "delegated-credentials.json")
+}
+
+func resolveDelegatedCredentialsPath(flagValue string) string {
+	if value := strings.TrimSpace(flagValue); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_CREDS_FILE")); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(os.Getenv("RELAYFILE_DELEGATED_CREDENTIALS_FILE")); value != "" {
+		return value
+	}
+	return delegatedCredentialsPath()
+}
+
+func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error) {
+	resolvedPath := resolveDelegatedCredentialsPath(path)
+	bundle, err := delegatedauth.Load(resolvedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return delegatedauth.Bundle{}, resolvedPath, fmt.Errorf("%w: %s not found", delegatedauth.ErrMissingCredentials, resolvedPath)
+		}
+		return delegatedauth.Bundle{}, resolvedPath, err
+	}
+	if err := bundle.ValidateForUse(); err != nil {
+		return delegatedauth.Bundle{}, resolvedPath, err
+	}
+	return bundle, resolvedPath, nil
+}
+
+func refreshDelegatedCredentials(path string, bundle delegatedauth.Bundle, force bool) (delegatedauth.Bundle, error) {
+	resolvedPath := resolveDelegatedCredentialsPath(path)
+	if !force && !relayfileTokenNeedsRefresh(bundle.BearerToken()) {
+		return bundle, nil
+	}
+	renewed, changed, err := delegatedauth.RenewFile(context.Background(), nil, resolvedPath, delegatedauth.DefaultRefreshTimeout)
+	if err != nil {
+		if errors.Is(err, delegatedauth.ErrRefreshRejected) {
+			return bundle, ErrDelegatedRelayfileCredentialsExpired
+		}
+		return bundle, err
+	}
+	if !changed {
+		return bundle, nil
+	}
+	if err := renewed.ValidateForUse(); err != nil {
+		return bundle, err
+	}
+	return renewed, nil
 }
 
 func agentRelayCloudAuthPath() string {
@@ -7747,7 +7853,7 @@ func spawnBackgroundMountProcess(originalArgs []string, localDir, pidFile, logFi
 	return nil
 }
 
-func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, workspaceID, serverURL string, timeout, interval time.Duration, intervalJitter float64, websocketEnabled, once, daemonized bool, pidFile, logFile string) error {
+func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, workspaceID, serverURL, delegatedCredsFile string, timeout, interval time.Duration, intervalJitter float64, websocketEnabled, once, daemonized bool, pidFile, logFile string) error {
 	interval = enforcePollIntervalFloor(interval)
 	httpClient, _ := syncerClient(syncer)
 	record, _ := workspaceRecordByID(workspaceID)
@@ -7762,7 +7868,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	degraded := false
 	var lastDegradedNotice time.Time
 	const degradedRecoveryInterval = time.Minute
-	const degradedStallReason = "cloud session expired — run 'agent-relay login' to refresh"
+	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay login"
 
 	enterDegraded := func() {
 		if !degraded {
@@ -7777,7 +7883,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			degraded = false
 			stallReason = ""
 			lastDegradedNotice = time.Time{}
-			log.Printf("mount exiting degraded state; cloud session restored")
+			log.Printf("mount exiting degraded state; delegated relayfile credentials restored")
 		}
 	}
 	maybePrintRecovery := func() {
@@ -7798,22 +7904,24 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		if !force && !relayfileTokenNeedsRefresh(httpClient.Token()) {
 			return nil
 		}
-		cloudCreds, err := ensureCloudCredentials("", "", 0, false, io.Discard)
-		if err != nil {
-			if errors.Is(err, ErrCloudRefreshExpired) {
-				return err
-			}
-			log.Printf("agent-relay cloud session refresh failed: %v", err)
+		if strings.TrimSpace(delegatedCredsFile) == "" {
 			return nil
 		}
-		joined, err := joinWorkspaceViaCloud(cloudCreds, workspaceID, record.AgentName, record.Scopes)
+		bundle, _, err := loadDelegatedCredentials(delegatedCredsFile)
 		if err != nil {
 			return err
 		}
-		httpClient.SetToken(joined.Token)
+		if bundle.Workspace() != "" && bundle.Workspace() != workspaceID {
+			return fmt.Errorf("delegated relayfile credentials are for workspace %s, expected %s", bundle.Workspace(), workspaceID)
+		}
+		renewed, err := refreshDelegatedCredentials(delegatedCredsFile, bundle, force)
+		if err != nil {
+			return err
+		}
+		httpClient.SetToken(renewed.BearerToken())
 		syncer.ResetWebSocket()
-		record.Server = strings.TrimRight(joined.RelayfileURL, "/")
-		record.CloudAPIURL = cloudCreds.APIURL
+		record.Server = strings.TrimRight(renewed.ServerURL(), "/")
+		record.CloudAPIURL = ""
 		if _, err := upsertWorkspaceDetails(record); err != nil {
 			return err
 		}
@@ -7893,7 +8001,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			// still missing/expired, stay degraded and emit the
 			// recovery notice on the configured cadence.
 			if err := refreshMountAuth(true); err != nil {
-				if errors.Is(err, ErrCloudRefreshExpired) {
+				if isMountCredentialExpired(err) {
 					maybePrintRecovery()
 					writeSnapshot()
 					return err
@@ -7911,7 +8019,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			return syncer.SyncOnce(ctx)
 		})
 		if err != nil {
-			if errors.Is(err, ErrCloudRefreshExpired) {
+			if isMountCredentialExpired(err) {
 				enterDegraded()
 				maybePrintRecovery()
 				writeSnapshot()
@@ -7950,7 +8058,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 
 	watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
 		if degraded {
-			// Local edit observed while we have no usable cloud session.
+			// Local edit observed while delegated credentials are unusable.
 			// Leave the dirty state in place so the next successful cycle
 			// after re-login picks it up; do not attempt to push now.
 			maybePrintRecovery()
@@ -7959,7 +8067,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		if err := withAuthRefresh(func(ctx context.Context) error {
 			return syncer.HandleLocalChange(ctx, relativePath, op)
 		}); err != nil {
-			if errors.Is(err, ErrCloudRefreshExpired) {
+			if isMountCredentialExpired(err) {
 				enterDegraded()
 				maybePrintRecovery()
 				writeSnapshot()

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/agentworkforce/relayfile/internal/delegatedauth"
 )
 
 func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
@@ -276,28 +278,28 @@ exit 2
 	}
 }
 
-func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
+func TestWorkspaceJoinStoresDelegatedRelayfileCredentials(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	var seenJoin bool
+	var seenBootstrap bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/workspaces/ws_cloud/join" {
+		if r.URL.Path != "/api/v1/workspaces/ws_cloud/relayfile/delegated-token" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		seenJoin = true
+		seenBootstrap = true
 		if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
-			t.Fatalf("unexpected join Authorization: %q", got)
+			t.Fatalf("unexpected bootstrap Authorization: %q", got)
 		}
-		var body cloudWorkspaceJoinRequest
+		var body cloudRelayfileDelegatedTokenRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode join body: %v", err)
+			t.Fatalf("decode bootstrap body: %v", err)
 		}
 		if got, want := strings.Join(body.Scopes, ","), "relayfile:fs:read:*"; got != want {
-			t.Fatalf("join scopes = %q, want %q", got, want)
+			t.Fatalf("bootstrap scopes = %q, want %q", got, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"workspaceId":"ws_cloud","token":"rf_read","relayfileUrl":"https://relayfile.test"}`))
+		writeDelegatedBundleResponse(t, w, "https://relayfile.test", "ws_cloud", "rf_read", "refresh_read")
 	}))
 	defer server.Close()
 	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "ws_cloud")
@@ -306,11 +308,18 @@ func TestWorkspaceJoinMintsReadOnlyCloudToken(t *testing.T) {
 	if err := run([]string{"workspace", "join", "ws_cloud", "--name", "cloud-prod", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run workspace join failed: %v", err)
 	}
-	if !seenJoin {
-		t.Fatalf("expected cloud join call")
+	if !seenBootstrap {
+		t.Fatalf("expected delegated-token bootstrap call")
 	}
 	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected workspace join not to persist relayfile token credentials, got err=%v", err)
+	}
+	delegated, err := delegatedauth.Load(delegatedCredentialsPath())
+	if err != nil {
+		t.Fatalf("expected delegated credentials to be stored: %v", err)
+	}
+	if delegated.BearerToken() != "rf_read" || delegated.RotationToken() != "refresh_read" {
+		t.Fatalf("unexpected delegated credentials: %#v", delegated)
 	}
 	record, ok := workspaceRecordByID("ws_cloud")
 	if !ok {
@@ -329,35 +338,21 @@ func TestTreeJoinsCloudWorkspaceWithoutServerCredentials(t *testing.T) {
 	clearRelayfileEnv(t)
 
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
-		Name:      "cloud-prod",
-		ID:        "ws_cloud",
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		AgentName: "relayfile-cli",
-		Scopes:    append([]string(nil), defaultJoinScopes...),
+		Name:             "cloud-prod",
+		ID:               "ws_cloud",
+		RelayWorkspaceID: "rw_cloud",
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		AgentName:        "relayfile-cli",
+		Scopes:           append([]string(nil), defaultJoinScopes...),
 	}); err != nil {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
 
-	var joinCount int
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_cloud/join":
-			joinCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
-				t.Fatalf("unexpected join Authorization: %q", got)
-			}
-			var body cloudWorkspaceJoinRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("decode join body: %v", err)
-			}
-			if got, want := strings.Join(body.Scopes, ","), "relayfile:fs:read:*"; got != want {
-				t.Fatalf("join scopes = %q, want %q", got, want)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case "/v1/workspaces/rw_cloud/fs/tree":
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_delegated" {
 				t.Fatalf("unexpected tree Authorization: %q", got)
 			}
 			if got := r.URL.Query().Get("path"); got != "/google-mail" {
@@ -370,43 +365,38 @@ func TestTreeJoinsCloudWorkspaceWithoutServerCredentials(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "rw_cloud",
+		AccessToken:           "rf_delegated",
+		RefreshToken:          "refresh_delegated",
+		AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
 
 	var stdout bytes.Buffer
 	if err := run([]string{"tree", "ws_cloud", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run tree failed: %v", err)
-	}
-	if joinCount != 1 {
-		t.Fatalf("expected 1 join, got %d", joinCount)
 	}
 	if got := stdout.String(); !strings.Contains(got, "Tree /google-mail") {
 		t.Fatalf("unexpected stdout: %q", got)
 	}
 }
 
-func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *testing.T) {
+func TestTreeRefreshesDelegatedWorkspaceTokenAndRetriesCanonicalWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	if err := saveCloudCredentials(cloudCredentials{
-		APIURL:      "http://placeholder.test",
-		AccessToken: "cld_access",
-	}); err != nil {
-		t.Fatalf("saveCloudCredentials failed: %v", err)
-	}
-	oldToken := testJWTWithWorkspaceAndAgent("ws_cloud", "old")
-	if err := saveCredentials(credentials{
-		Server: "http://placeholder.test",
-		Token:  oldToken,
-	}); err != nil {
-		t.Fatalf("saveCredentials failed: %v", err)
-	}
+	oldToken := testJWTWithWorkspaceAgentAndExpiry("ws_cloud", "old", time.Now().Add(-time.Minute))
+	newToken := testJWTWithWorkspaceAndAgent("rw_cloud", "new")
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
-		Name:      "cloud-prod",
-		ID:        "ws_cloud",
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		AgentName: "relayfile-cli",
-		Scopes:    append([]string(nil), defaultInspectScopes...),
+		Name:             "cloud-prod",
+		ID:               "ws_cloud",
+		RelayWorkspaceID: "rw_cloud",
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		AgentName:        "relayfile-cli",
+		Scopes:           append([]string(nil), defaultInspectScopes...),
 	}); err != nil {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
@@ -414,26 +404,32 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 		t.Fatalf("setDefaultWorkspace failed: %v", err)
 	}
 
-	var joinCount int
+	var refreshCount int
 	var treeCount int
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_cloud/join":
-			joinCount++
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_new","relayfileUrl":"` + server.URL + `"}`))
-		case "/v1/workspaces/ws_cloud/fs/tree":
-			treeCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer "+oldToken {
-				t.Fatalf("expected first tree to use old token, got %q", got)
+		case "/v1/tokens/refresh":
+			refreshCount++
+			var body struct {
+				RefreshToken string `json:"refreshToken"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode refresh body: %v", err)
+			}
+			if body.RefreshToken != "refresh_old" {
+				t.Fatalf("unexpected refresh token %q", body.RefreshToken)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"message":"Token has expired"}`))
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"accessToken":           newToken,
+				"refreshToken":          "refresh_new",
+				"accessTokenExpiresAt":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				"refreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			})
 		case "/v1/workspaces/rw_cloud/fs/tree":
 			treeCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_new" {
+			if got := r.Header.Get("Authorization"); got != "Bearer "+newToken {
 				t.Fatalf("unexpected refreshed tree Authorization: %q", got)
 			}
 			if got := r.URL.Query().Get("path"); got != "/google-mail" {
@@ -446,23 +442,22 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 		}
 	}))
 	defer server.Close()
-
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	creds.Server = server.URL
-	if err := saveCredentials(creds); err != nil {
-		t.Fatalf("saveCredentials(server URL) failed: %v", err)
-	}
-	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "rw_cloud",
+		AccessToken:           oldToken,
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
 
 	var stdout bytes.Buffer
 	if err := run([]string{"tree", "cloud-prod", "/google-mail"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run tree failed: %v", err)
 	}
-	if joinCount != 1 || treeCount != 2 {
-		t.Fatalf("joinCount/treeCount = %d/%d, want 1/2", joinCount, treeCount)
+	if refreshCount != 1 || treeCount != 1 {
+		t.Fatalf("refreshCount/treeCount = %d/%d, want 1/1", refreshCount, treeCount)
 	}
 	record, ok := workspaceRecordByName("cloud-prod")
 	if !ok {
@@ -477,8 +472,8 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 	if record.Server != server.URL {
 		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)
 	}
-	if record.CloudAPIURL != server.URL {
-		t.Fatalf("workspace record CloudAPIURL = %q, want %q", record.CloudAPIURL, server.URL)
+	if record.CloudAPIURL != "" {
+		t.Fatalf("workspace record CloudAPIURL = %q, want empty", record.CloudAPIURL)
 	}
 	if record.LastUsedAt == "" {
 		t.Fatal("workspace record LastUsedAt was not refreshed")
@@ -495,23 +490,19 @@ func TestTreeRefreshesExpiredCloudWorkspaceTokenAndRetriesCanonicalWorkspace(t *
 	}
 }
 
-func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
+func TestReadRefreshesDelegatedWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	oldToken := testJWTWithWorkspaceAndAgent("ws_cloud", "old")
-	if err := saveCredentials(credentials{
-		Server: "http://placeholder.test",
-		Token:  oldToken,
-	}); err != nil {
-		t.Fatalf("saveCredentials failed: %v", err)
-	}
+	oldToken := testJWTWithWorkspaceAgentAndExpiry("rw_cloud", "old", time.Now().Add(-time.Minute))
+	newToken := testJWTWithWorkspaceAndAgent("rw_cloud", "new")
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
-		Name:      "cloud-prod",
-		ID:        "ws_cloud",
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		AgentName: "relayfile-cli",
-		Scopes:    append([]string(nil), defaultInspectScopes...),
+		Name:             "cloud-prod",
+		ID:               "ws_cloud",
+		RelayWorkspaceID: "rw_cloud",
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		AgentName:        "relayfile-cli",
+		Scopes:           append([]string(nil), defaultInspectScopes...),
 	}); err != nil {
 		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
 	}
@@ -527,29 +518,22 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	}
 
 	var readCount int
-	var joinCount int
+	var refreshCount int
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_cloud/join":
-			joinCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
-				t.Fatalf("unexpected join Authorization: %q", got)
-			}
+		case "/v1/tokens/refresh":
+			refreshCount++
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"workspaceId":"rw_cloud","token":"rf_new","relayfileUrl":"` + server.URL + `"}`))
-		case "/v1/workspaces/ws_cloud/fs/file":
-			readCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer "+oldToken {
-				t.Fatalf("expected first read to use old token, got %q", got)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			_, _ = w.Write([]byte(`{"message":"Token has expired"}`))
-			return
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"accessToken":           newToken,
+				"refreshToken":          "refresh_new",
+				"accessTokenExpiresAt":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				"refreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			})
 		case "/v1/workspaces/rw_cloud/fs/file":
 			readCount++
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_new" {
+			if got := r.Header.Get("Authorization"); got != "Bearer "+newToken {
 				t.Fatalf("unexpected refreshed read Authorization: %q", got)
 			}
 			if got := r.URL.Query().Get("path"); got != "/google-mail/msg.json" {
@@ -562,23 +546,22 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-
-	creds, err := loadCredentials()
-	if err != nil {
-		t.Fatalf("loadCredentials failed: %v", err)
-	}
-	creds.Server = server.URL
-	if err := saveCredentials(creds); err != nil {
-		t.Fatalf("saveCredentials(server URL) failed: %v", err)
-	}
-	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "rw_cloud")
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "rw_cloud",
+		AccessToken:           oldToken,
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
 
 	var stdout bytes.Buffer
 	if err := run([]string{"read", "cloud-prod", "/google-mail/msg.json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run read failed: %v", err)
 	}
-	if joinCount != 1 || readCount != 2 {
-		t.Fatalf("joinCount/readCount = %d/%d, want 1/2", joinCount, readCount)
+	if refreshCount != 1 || readCount != 1 {
+		t.Fatalf("refreshCount/readCount = %d/%d, want 1/1", refreshCount, readCount)
 	}
 	record, ok := workspaceRecordByName("cloud-prod")
 	if !ok {
@@ -593,8 +576,8 @@ func TestReadRefreshesCloudWorkspaceTokenAfterUnauthorized(t *testing.T) {
 	if record.Server != server.URL {
 		t.Fatalf("workspace record Server = %q, want %q", record.Server, server.URL)
 	}
-	if record.CloudAPIURL != server.URL {
-		t.Fatalf("workspace record CloudAPIURL = %q, want %q", record.CloudAPIURL, server.URL)
+	if record.CloudAPIURL != "" {
+		t.Fatalf("workspace record CloudAPIURL = %q, want empty", record.CloudAPIURL)
 	}
 	if record.LastUsedAt == "" {
 		t.Fatal("workspace record LastUsedAt was not refreshed")
@@ -1052,21 +1035,21 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 				t.Fatalf("expected workspace name demo, got %q", body.Name)
 			}
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","relayfileUrl":"https://relayfile.test","createdAt":"2026-05-01T00:00:00Z","name":"demo"}`))
-		case "/api/v1/workspaces/ws_123/join":
-			seen["join"] = true
+		case "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			seen["delegated"] = true
 			if r.Method != http.MethodPost {
-				t.Fatalf("expected join POST, got %s", r.Method)
+				t.Fatalf("expected delegated-token POST, got %s", r.Method)
 			}
 			if got := r.Header.Get("Authorization"); got != "Bearer cld_test" {
-				t.Fatalf("unexpected join Authorization: %q", got)
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
 			}
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+			writeDelegatedBundleResponse(t, w, "https://relayfile.test", "ws_123", "rf_join", "refresh_join")
 		case "/api/v1/workspaces/ws_123/integrations/connect-session":
 			seen["connect"] = true
 			if r.Method != http.MethodPost {
 				t.Fatalf("expected connect POST, got %s", r.Method)
 			}
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_test" {
 				t.Fatalf("unexpected connect Authorization: %q", got)
 			}
 			var body cloudConnectSessionRequest
@@ -1079,7 +1062,7 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 			_, _ = w.Write([]byte(`{"token":"session_token","expiresAt":"2026-05-01T01:00:00Z","connectLink":"https://connect.test/github","connectionId":"conn_123"}`))
 		case "/api/v1/workspaces/ws_123/integrations/github/status":
 			seen["status"] = true
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_test" {
 				t.Fatalf("unexpected status Authorization: %q", got)
 			}
 			if got := r.URL.Query().Get("connectionId"); got != "conn_123" {
@@ -1106,7 +1089,7 @@ func TestSetupCreatesWorkspaceConnectsIntegrationAndSkipsMount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run setup failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"create", "join", "connect", "status"} {
+	for _, key := range []string{"create", "delegated", "connect", "status"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
@@ -1145,9 +1128,9 @@ func TestSetupJiraRunsSitePickerAfterFreshConnect(t *testing.T) {
 		case "/api/v1/workspaces":
 			seen["create"] = true
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","relayfileUrl":"https://relayfile.test","createdAt":"2026-05-01T00:00:00Z","name":"demo"}`))
-		case "/api/v1/workspaces/ws_123/join":
-			seen["join"] = true
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws","relaycastApiKey":"rc_test"}`))
+		case "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			seen["delegated"] = true
+			writeDelegatedBundleResponse(t, w, "https://relayfile.test", "ws_123", "rf_join", "refresh_join")
 		case "/api/v1/workspaces/ws_123/integrations/connect-session":
 			seen["connect"] = true
 			_, _ = w.Write([]byte(`{"connectionId":"conn_jira","connectLink":"","backend":"nango"}`))
@@ -1188,7 +1171,7 @@ func TestSetupJiraRunsSitePickerAfterFreshConnect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run setup failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"create", "join", "connect", "status", "accessible-resources", "metadata"} {
+	for _, key := range []string{"create", "delegated", "connect", "status", "accessible-resources", "metadata"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
@@ -1219,15 +1202,15 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_123/join":
-			seen["join"] = true
+		case "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			seen["delegated"] = true
 			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
-				t.Fatalf("unexpected join Authorization: %q", got)
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
 			}
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_123", "rf_join", "refresh_join")
 		case "/api/v1/workspaces/ws_123/integrations/connect-session":
 			seen["connect"] = true
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
 				t.Fatalf("unexpected connect Authorization: %q", got)
 			}
 			var body cloudConnectSessionRequest
@@ -1243,12 +1226,18 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789","backend":"composio"}`))
 		case "/api/v1/workspaces/ws_123/integrations/notion/status":
 			seen["status"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
 			if got := r.URL.Query().Get("connectionId"); got != "conn_789" {
 				t.Fatalf("unexpected connectionId: %q", got)
 			}
 			_, _ = w.Write([]byte(`{"ready":true}`))
 		case "/v1/workspaces/ws_123/sync/status":
 			seen["sync"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -1269,7 +1258,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	if err != nil {
 		t.Fatalf("run integration connect failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"join", "connect", "status", "sync"} {
+	for _, key := range []string{"delegated", "connect", "status", "sync"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
@@ -1744,21 +1733,25 @@ func TestMountWithoutTokenRejectsWorkspaceOutsideAgentRelayActive(t *testing.T) 
 
 	joinCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/workspaces/rw_active/join" {
-			joinCalls++
-			_, _ = w.Write([]byte(`{"workspaceId":"rw_active","token":"` + testJWTWithWorkspace("rw_active") + `","relayfileUrl":"` + r.Host + `"}`))
-			return
-		}
+		joinCalls++
 		t.Fatalf("unexpected path: %s", r.URL.Path)
 	}))
 	defer server.Close()
-	installFakeAgentRelaySession(t, server.URL, "cld_access", "active", "rw_active", "rw_active")
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "rw_active",
+		AccessToken:           testJWTWithWorkspace("rw_active"),
+		RefreshToken:          "refresh_active",
+		AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
 
 	err := run([]string{"mount", "stale", localDir, "--once", "--websocket=false"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected mount to reject stale workspace")
 	}
-	if !strings.Contains(err.Error(), "uses active agent-relay workspace active (rw_active)") {
+	if !strings.Contains(err.Error(), "uses delegated relayfile workspace rw_active") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if joinCalls != 0 {
@@ -2062,12 +2055,12 @@ func TestLogsPrintsTailForWorkspace(t *testing.T) {
 	}
 }
 
-func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
+func TestMountOnceRefreshesDelegatedWorkspaceTokenBeforeSync(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
 	localDir := t.TempDir()
-	oldToken := testJWTWithWorkspaceAndAgent("ws_refresh", "old")
+	oldToken := testJWTWithWorkspaceAgentAndExpiry("ws_refresh", "old", time.Now().Add(-time.Minute))
 	newToken := testJWTWithWorkspaceAndAgent("ws_refresh", "new")
 	if _, err := upsertWorkspaceDetails(workspaceRecord{
 		Name:       "demo",
@@ -2083,35 +2076,38 @@ func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
 
 	eventCalls := 0
 	exportCalls := 0
-	joinCalls := 0
+	refreshCalls := 0
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_refresh/join":
-			joinCalls++
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
-				t.Fatalf("unexpected join Authorization: %q", got)
+		case "/v1/tokens/refresh":
+			refreshCalls++
+			var body struct {
+				RefreshToken string `json:"refreshToken"`
 			}
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_refresh","token":"` + newToken + `","relayfileUrl":"` + server.URL + `"}`))
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode refresh body: %v", err)
+			}
+			if body.RefreshToken != "refresh_old" {
+				t.Fatalf("unexpected refresh token %q", body.RefreshToken)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"accessToken":           newToken,
+				"refreshToken":          "refresh_new",
+				"accessTokenExpiresAt":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				"refreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			})
 		case "/v1/workspaces/ws_refresh/fs/events":
 			eventCalls++
 			gotAuth := r.Header.Get("Authorization")
-			if gotAuth != "Bearer "+oldToken && gotAuth != "Bearer "+newToken {
+			if gotAuth != "Bearer "+newToken {
 				t.Fatalf("unexpected events Authorization: %q", gotAuth)
 			}
 			_, _ = w.Write([]byte(`{"events":[]}`))
 		case "/v1/workspaces/ws_refresh/fs/export":
 			exportCalls++
 			gotAuth := r.Header.Get("Authorization")
-			if exportCalls == 1 {
-				if gotAuth != "Bearer "+oldToken {
-					t.Fatalf("unexpected initial export Authorization: %q", gotAuth)
-				}
-				w.WriteHeader(http.StatusUnauthorized)
-				_, _ = w.Write([]byte(`{"code":"unauthorized","message":"expired"}`))
-				return
-			}
 			if gotAuth != "Bearer "+newToken {
 				t.Fatalf("unexpected refreshed export Authorization: %q", gotAuth)
 			}
@@ -2123,22 +2119,106 @@ func TestMountOnceRejoinsWorkspaceTokenAfterUnauthorized(t *testing.T) {
 		}
 	}))
 	defer server.Close()
-	installFakeAgentRelaySession(t, server.URL, "cld_access", "demo", "ws_refresh", "ws_refresh")
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "ws_refresh",
+		AccessToken:           oldToken,
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
 
 	if err := run([]string{
 		"mount", "ws_refresh", localDir,
 		"--server", server.URL,
-		"--token", oldToken,
 		"--once",
 		"--websocket=false",
 	}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
 		t.Fatalf("run mount failed: %v", err)
 	}
-	if joinCalls != 1 || exportCalls != 2 {
-		t.Fatalf("expected 1 join and 2 export calls, got join=%d events=%d export=%d", joinCalls, eventCalls, exportCalls)
+	if refreshCalls != 1 || exportCalls != 1 {
+		t.Fatalf("expected 1 refresh and 1 export call, got refresh=%d events=%d export=%d", refreshCalls, eventCalls, exportCalls)
 	}
 	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected refreshed relayfile token not to be persisted, got err=%v", err)
+	}
+}
+
+func TestMountSkipsDataPlaneWhenDelegatedRefreshRejected(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	oldToken := testJWTWithWorkspaceAgentAndExpiry("ws_refresh", "old", time.Now().Add(-time.Minute))
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_refresh",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	refreshCalls := 0
+	dataPlaneCalls := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/tokens/refresh":
+			refreshCalls++
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"code":"delegation_expired","message":"delegation expired"}`))
+		case "/v1/workspaces/ws_refresh/fs/events", "/v1/workspaces/ws_refresh/fs/export", "/v1/workspaces/ws_refresh/sync/status":
+			dataPlaneCalls++
+			t.Fatalf("data-plane call should be skipped after rejected refresh: %s", r.URL.Path)
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	credsPath := writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayfileWorkspaceID:  "ws_refresh",
+		AccessToken:           oldToken,
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	})
+	before, err := os.ReadFile(credsPath)
+	if err != nil {
+		t.Fatalf("read delegated credentials before mount failed: %v", err)
+	}
+
+	err = run([]string{
+		"mount", "ws_refresh", localDir,
+		"--server", server.URL,
+		"--once",
+		"--websocket=false",
+	}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("expected mount to fail fast after rejected delegated refresh")
+	}
+	if !errors.Is(err, ErrDelegatedRelayfileCredentialsExpired) {
+		t.Fatalf("expected delegated credential expiry error, got %v", err)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", refreshCalls)
+	}
+	if dataPlaneCalls != 0 {
+		t.Fatalf("dataPlaneCalls = %d, want 0", dataPlaneCalls)
+	}
+	after, err := os.ReadFile(credsPath)
+	if err != nil {
+		t.Fatalf("read delegated credentials after mount failed: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("delegated credentials changed after rejected refresh\nbefore:\n%s\nafter:\n%s", before, after)
 	}
 }
 
@@ -2150,6 +2230,8 @@ func clearRelayfileEnv(t *testing.T) {
 	t.Setenv("RELAYFILE_WORKSPACE", "")
 	t.Setenv("RELAYFILE_CLOUD_API_URL", "")
 	t.Setenv("RELAYFILE_CLOUD_TOKEN", "")
+	t.Setenv("RELAYFILE_MOUNT_CREDS_FILE", "")
+	t.Setenv("RELAYFILE_DELEGATED_CREDENTIALS_FILE", "")
 	t.Setenv("AGENT_RELAY_BIN", "")
 }
 
@@ -2209,6 +2291,61 @@ func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"workspace_id":"` + workspaceID + `","agent_name":"` + agentName + `","aud":"relayfile"}`))
 	return header + "." + payload + ".sig"
+}
+
+func testJWTWithWorkspaceAgentAndExpiry(workspaceID, agentName string, exp time.Time) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]any{
+		"workspace_id": workspaceID,
+		"agent_name":   agentName,
+		"aud":          "relayfile",
+		"iat":          exp.Add(-time.Hour).Unix(),
+		"exp":          exp.Unix(),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func writeDelegatedBundleResponse(t *testing.T, w http.ResponseWriter, relayfileURL, workspaceID, accessToken, refreshToken string) {
+	t.Helper()
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"relayfileUrl":                   relayfileURL,
+		"relayauthUrl":                   relayfileURL,
+		"relayfileWorkspaceId":           workspaceID,
+		"relayfileToken":                 accessToken,
+		"relayfileTokenExpiresAt":        time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"relayfileRefreshToken":          refreshToken,
+		"relayfileRefreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		"relayfileScopes":                []string{"relayfile:fs:read:*", "relayfile:fs:write:*"},
+		"delegationNotAfter":             time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		"relayfileMountPaths":            []string{"/"},
+	})
+}
+
+func writeDelegatedCredentialsForTest(t *testing.T, bundle delegatedauth.Bundle) string {
+	t.Helper()
+	if bundle.RelayfileURL == "" && bundle.BaseURL == "" && bundle.Server == "" {
+		bundle.RelayfileURL = defaultServerURL
+	}
+	if bundle.RelayfileWorkspaceID == "" && bundle.WorkspaceID == "" {
+		bundle.RelayfileWorkspaceID = "ws_test"
+	}
+	if bundle.AccessToken == "" && bundle.Token == "" && bundle.RelayfileToken == "" {
+		bundle.AccessToken = testJWTWithWorkspace(bundle.Workspace())
+	}
+	if bundle.RefreshToken == "" && bundle.RelayfileRefreshToken == "" {
+		bundle.RefreshToken = "refresh_test"
+	}
+	if bundle.RelayauthURL == "" && bundle.RefreshURL == "" {
+		bundle.RelayauthURL = bundle.ServerURL()
+	}
+	path := delegatedCredentialsPath()
+	if err := delegatedauth.SaveAtomic(path, bundle); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+	return path
 }
 
 func TestStatusSurfacesDegradedStallReason(t *testing.T) {
@@ -3018,15 +3155,12 @@ func TestOpsReplayPostsToCloudAndRemovesLocalRecord(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/api/v1/workspaces/ws_demo/join":
-			seen["join"] = true
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_join","relayfileUrl":"https://relayfile.test"}`))
 		case "/api/v1/workspaces/ws_demo/ops/op_abc/replay":
 			seen["replay"] = true
 			if r.Method != http.MethodPost {
 				t.Fatalf("unexpected replay method: %s", r.Method)
 			}
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_token" {
 				t.Fatalf("unexpected replay Authorization: %q", got)
 			}
 			_, _ = w.Write([]byte(`{"status":"queued","id":"op_abc"}`))
@@ -3046,7 +3180,7 @@ func TestOpsReplayPostsToCloudAndRemovesLocalRecord(t *testing.T) {
 	}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run ops replay failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"join", "replay"} {
+	for _, key := range []string{"replay"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
@@ -3468,9 +3602,8 @@ func TestWorkspaceListNamesOnlyRestoresBareOutput(t *testing.T) {
 	}
 }
 
-// adoptTestServer wires the cloud endpoints the adopt verb exercises:
-// workspace join (mints the relayfile JWT for the workspace), and the new
-// POST .../adopt route.
+// adoptTestServer wires the cloud endpoint the adopt verb exercises:
+// POST .../adopt.
 // Each test injects its own adopt handler so it can simulate the four
 // distinct outcomes — success (fresh insert), success (replacement),
 // 409 refusal, 404 missing-connection — without rebuilding the rest of
@@ -3482,35 +3615,6 @@ func newAdoptTestServer(t *testing.T, adoptHandler func(http.ResponseWriter, *ht
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
-			if r.Method != http.MethodPost {
-				t.Errorf("expected join POST, got %s", r.Method)
-				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-				return
-			}
-			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
-				t.Errorf("unexpected join Authorization: %q", got)
-				http.Error(w, "unauthorized", http.StatusUnauthorized)
-				return
-			}
-			var body cloudWorkspaceJoinRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Errorf("decode join body failed: %v", err)
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			if body.AgentName != "relayfile-cli" {
-				t.Errorf("unexpected join agentName: %q", body.AgentName)
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			if len(body.Scopes) != len(defaultJoinScopes) || body.Scopes[0] != defaultJoinScopes[0] || body.Scopes[1] != defaultJoinScopes[1] {
-				t.Errorf("unexpected join scopes: %#v", body.Scopes)
-				http.Error(w, "bad request", http.StatusBadRequest)
-				return
-			}
-			seen["join"]++
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/adopt" && r.Method == http.MethodPost:
 			seen["adopt"]++
 			adoptHandler(w, r)
@@ -3566,7 +3670,7 @@ func TestIntegrationAdoptForwardsConnectionIdAndPersistsLocalState(t *testing.T)
 		if body["providerConfigKey"] != "github-relay" {
 			t.Fatalf("unexpected providerConfigKey: %q", body["providerConfigKey"])
 		}
-		if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+		if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
 			t.Fatalf("unexpected Authorization: %q", got)
 		}
 		_, _ = w.Write([]byte(`{"ok":true,"connectionId":"conn_adopt_new"}`))
@@ -3766,9 +3870,6 @@ func newSetMetadataTestServer(t *testing.T, metadataHandler func(http.ResponseWr
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
-			seen["join"]++
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
 		case strings.HasSuffix(r.URL.Path, "/metadata") && r.Method == http.MethodPut:
 			seen["metadata"]++
 			metadataHandler(w, r)
@@ -3796,6 +3897,9 @@ func TestIntegrationSetMetadataHappyPath(t *testing.T) {
 		}
 		if r.URL.Path != "/api/v1/workspaces/ws_123/integrations/jira/metadata" {
 			t.Fatalf("unexpected metadata path: %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+			t.Fatalf("unexpected metadata Authorization: %q", got)
 		}
 		_, _ = w.Write([]byte(`{"ok":true,"metadata":{"cloudId":"cloud-1","baseUrl":"https://foo.atlassian.net"}}`))
 	})
@@ -3874,7 +3978,7 @@ func TestIntegrationSetMetadataRejectsNestedKey(t *testing.T) {
 }
 
 // newConnectJiraTestServer stubs the cloud routes the
-// `integration connect jira` path touches: refresh+join, the
+// `integration connect jira` path touches: delegated-token bootstrap, the
 // connect-session POST, the status GET (which the wait loop polls), the
 // accessible-resources GET (post-OAuth picker), and the metadata PUT.
 // `sites` controls how many sites accessible-resources returns; `chosen`
@@ -3886,17 +3990,29 @@ func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, cho
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
-			seen["join"]++
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			seen["delegated"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_123", "rf_join", "refresh_join")
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/connect-session" && r.Method == http.MethodPost:
 			seen["connect-session"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected connect-session Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"connectionId":"conn_jira","connectLink":"","backend":"nango"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/status":
 			seen["status"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"jira","backend":"nango"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/accessible-resources":
 			seen["accessible-resources"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected accessible-resources Authorization: %q", got)
+			}
 			payload := struct {
 				OK        bool                      `json:"ok"`
 				Resources []accessibleResourceEntry `json:"resources"`
@@ -3904,6 +4020,9 @@ func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, cho
 			_ = json.NewEncoder(w).Encode(payload)
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/metadata" && r.Method == http.MethodPut:
 			seen["metadata"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected metadata Authorization: %q", got)
+			}
 			var body map[string]map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode metadata body failed: %v", err)
@@ -3916,6 +4035,9 @@ func newConnectJiraTestServer(t *testing.T, sites []accessibleResourceEntry, cho
 			// waitForInitialSync calls the relayfile data plane; stub it
 			// out with a "complete" reading so the test doesn't hang.
 			seen["sync-status"]++
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"jira","status":"ready","lagSeconds":0}]}`))
 		case strings.HasPrefix(r.URL.Path, "/v1/workspaces/ws_123/fs/tree"):
 			_, _ = w.Write([]byte(`{"entries":[]}`))
@@ -4084,14 +4206,23 @@ func TestIntegrationConnectJiraAlreadyConnectedSkipsPicker(t *testing.T) {
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_123", "rf_join", "refresh_join")
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/jira/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
 			if got := r.URL.Query().Get("connectionId"); got != "conn_jira" {
 				t.Fatalf("unexpected connectionId: %q", got)
 			}
 			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"jira","backend":"nango"}`))
 		case r.URL.Path == "/v1/workspaces/ws_123/sync/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"jira","status":"ready","lagSeconds":0}]}`))
 		case strings.Contains(r.URL.Path, "/accessible-resources"):
 			t.Fatalf("accessible-resources must not be called for already-connected jira, hit: %s", r.URL.Path)
@@ -4128,13 +4259,25 @@ func TestIntegrationConnectNonAtlassianSkipsPicker(t *testing.T) {
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.URL.Path == "/api/v1/workspaces/ws_123/join":
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case r.URL.Path == "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_123", "rf_join", "refresh_join")
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/connect-session":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected connect-session Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"connectionId":"conn_github","connectLink":"","backend":"nango"}`))
 		case r.URL.Path == "/api/v1/workspaces/ws_123/integrations/github/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"github","backend":"nango"}`))
 		case r.URL.Path == "/v1/workspaces/ws_123/sync/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"github","status":"ready","lagSeconds":0}]}`))
 		case strings.Contains(r.URL.Path, "/accessible-resources"):
 			t.Fatalf("accessible-resources must not be called for non-Atlassian providers, hit: %s", r.URL.Path)
@@ -4172,13 +4315,25 @@ func TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForS
 		w.Header().Set("Content-Type", "application/json")
 		seen[r.URL.Path]++
 		switch r.URL.Path {
-		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/join":
-			_, _ = w.Write([]byte(`{"workspaceId":"rw_7ccfea89","token":"rf_join","relayfileUrl":"` + server.URL + `"}`))
+		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/relayfile/delegated-token":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "rw_7ccfea89", "rf_join", "refresh_join")
 		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/connect-session":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected connect-session Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"connectionId":"conn_slack","connectLink":"","backend":"nango"}`))
 		case "/api/v1/workspaces/50587328-441d-4acb-b8f3-dbe1b3c5de99/integrations/slack/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_new" {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"ready":true,"state":"ready","provider":"slack","backend":"nango"}`))
 		case "/v1/workspaces/rw_7ccfea89/sync/status":
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
 			_, _ = w.Write([]byte(`{"workspaceId":"rw_7ccfea89","providers":[{"provider":"slack","status":"ready","lagSeconds":0}]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)

--- a/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
+++ b/cmd/relayfile-cli/productized_cloud_mount_e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentworkforce/relayfile/internal/delegatedauth"
 	"github.com/agentworkforce/relayfile/internal/mountsync"
 	"github.com/fsnotify/fsnotify"
 )
@@ -50,8 +51,8 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 		t.Fatalf("setup failed: %v\noutput:\n%s", err, setupOut.String())
 	}
 	assertFileContentEventually(t, filepath.Join(localDir, "github", "repos", "acme", "api", "pulls", "42", "metadata.json"), `{"title":"Initial PR"}`)
-	if cloud.JoinCount() != 1 {
-		t.Fatalf("expected one workspace join after setup, got %d", cloud.JoinCount())
+	if cloud.TokenMintCount() != 1 {
+		t.Fatalf("expected one delegated token mint after setup, got %d", cloud.TokenMintCount())
 	}
 
 	relay.SetProviderStatus("notion", "syncing", 4)
@@ -97,6 +98,15 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 	if runtimeToken == "" {
 		t.Fatalf("expected setup/connect/list to mint a relayfile runtime token")
 	}
+	delegatedCredsFile := writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:          relay.URL(),
+		RelayfileWorkspaceID:  cloud.workspaceID,
+		AccessToken:           runtimeToken,
+		RefreshToken:          "refresh_productized_1",
+		AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          cloud.URL(),
+	})
 
 	prevLogWriter := log.Writer()
 	log.SetOutput(io.Discard)
@@ -141,6 +151,7 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 			localDir,
 			record.ID,
 			relay.URL(),
+			delegatedCredsFile,
 			500*time.Millisecond,
 			100*time.Millisecond,
 			0,
@@ -201,12 +212,10 @@ func TestProductizedCloudMountE2EProof(t *testing.T) {
 		t.Fatalf("expected github and notion providers in status, got %v", providers)
 	}
 
-	installFakeAgentRelaySession(t, cloud.URL(), cloud.refreshedToken, "demo", cloud.workspaceID, cloud.workspaceID)
 	currentToken := runtimeToken
-	joinCountBeforeRefresh := cloud.JoinCount()
 	relay.RejectToken(currentToken)
-	waitForCondition(t, 12*time.Second, "cloud token refresh + workspace rejoin", func() bool {
-		return cloud.JoinCount() > joinCountBeforeRefresh && cloud.LastRelayfileToken() != currentToken
+	waitForCondition(t, 12*time.Second, "delegated relayfile token refresh", func() bool {
+		return cloud.RefreshCount() > 0 && cloud.LastRelayfileToken() != currentToken
 	})
 
 	relay.UpsertFile("/github/repos/acme/api/pulls/42/after-refresh.md", "text/markdown", "# After refresh\n")
@@ -559,7 +568,8 @@ type productizedCloudMock struct {
 	workspaceID        string
 	initialAccessToken string
 	refreshedToken     string
-	joinCount          int
+	tokenMintCount     int
+	refreshCount       int
 	lastRelayfileToken string
 	providers          map[string]string
 }
@@ -586,10 +596,10 @@ func (m *productizedCloudMock) URL() string {
 	return m.server.URL
 }
 
-func (m *productizedCloudMock) JoinCount() int {
+func (m *productizedCloudMock) TokenMintCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.joinCount
+	return m.tokenMintCount
 }
 
 func (m *productizedCloudMock) LastRelayfileToken() string {
@@ -598,12 +608,20 @@ func (m *productizedCloudMock) LastRelayfileToken() string {
 	return m.lastRelayfileToken
 }
 
+func (m *productizedCloudMock) RefreshCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.refreshCount
+}
+
 func (m *productizedCloudMock) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == "/api/v1/workspaces" && r.Method == http.MethodPost:
 		m.serveCreateWorkspace(w, r)
-	case strings.HasSuffix(r.URL.Path, "/join") && r.Method == http.MethodPost:
-		m.serveJoinWorkspace(w, r)
+	case r.URL.Path == "/v1/tokens/refresh" && r.Method == http.MethodPost:
+		m.serveRefreshToken(w, r)
+	case strings.HasSuffix(r.URL.Path, "/relayfile/delegated-token") && r.Method == http.MethodPost:
+		m.serveDelegatedRelayfileToken(w, r)
 	case strings.HasSuffix(r.URL.Path, "/integrations/connect-session") && r.Method == http.MethodPost:
 		m.serveConnectSession(w, r)
 	case strings.Contains(r.URL.Path, "/integrations/") && strings.HasSuffix(r.URL.Path, "/status") && r.Method == http.MethodGet:
@@ -618,6 +636,31 @@ func (m *productizedCloudMock) serveHTTP(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+func (m *productizedCloudMock) serveRefreshToken(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		RefreshToken string `json:"refreshToken"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		m.t.Fatalf("decode relayauth refresh body failed: %v", err)
+	}
+	if strings.TrimSpace(body.RefreshToken) == "" {
+		m.t.Fatalf("refresh token missing")
+	}
+	m.mu.Lock()
+	m.refreshCount++
+	token := fmt.Sprintf("rf_token_refresh_%d", m.refreshCount)
+	m.lastRelayfileToken = token
+	m.mu.Unlock()
+
+	m.relay.ActivateToken(token)
+	writeMockJSON(w, http.StatusOK, map[string]string{
+		"accessToken":           token,
+		"refreshToken":          fmt.Sprintf("refresh_productized_%d", m.refreshCount+1),
+		"accessTokenExpiresAt":  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"refreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+	})
+}
+
 func (m *productizedCloudMock) serveCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	if got := bearerToken(r); got != m.initialAccessToken {
 		m.t.Fatalf("unexpected create workspace token: %q", got)
@@ -630,27 +673,45 @@ func (m *productizedCloudMock) serveCreateWorkspace(w http.ResponseWriter, r *ht
 	})
 }
 
-func (m *productizedCloudMock) serveJoinWorkspace(w http.ResponseWriter, r *http.Request) {
+func (m *productizedCloudMock) serveDelegatedRelayfileToken(w http.ResponseWriter, r *http.Request) {
 	got := bearerToken(r)
 	if got != m.initialAccessToken && got != m.refreshedToken {
-		m.t.Fatalf("unexpected join token: %q", got)
+		m.t.Fatalf("unexpected delegated-token auth token: %q", got)
+	}
+	var body cloudRelayfileDelegatedTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		m.t.Fatalf("decode delegated-token body failed: %v", err)
+	}
+	if strings.TrimSpace(body.AgentName) == "" {
+		m.t.Fatalf("delegated-token agentName missing")
+	}
+	if len(body.Scopes) == 0 {
+		m.t.Fatalf("delegated-token scopes missing")
 	}
 	m.mu.Lock()
-	m.joinCount++
-	token := fmt.Sprintf("rf_token_%d", m.joinCount)
+	m.tokenMintCount++
+	token := fmt.Sprintf("rf_token_%d", m.tokenMintCount)
+	refreshToken := fmt.Sprintf("refresh_productized_%d", m.tokenMintCount)
 	m.lastRelayfileToken = token
 	m.mu.Unlock()
 
 	m.relay.ActivateToken(token)
-	writeMockJSON(w, http.StatusOK, cloudWorkspaceJoinResponse{
-		WorkspaceID:  m.workspaceID,
-		Token:        token,
-		RelayfileURL: m.relay.URL(),
+	writeMockJSON(w, http.StatusOK, map[string]any{
+		"relayfileUrl":                   m.relay.URL(),
+		"relayauthUrl":                   m.URL(),
+		"relayfileWorkspaceId":           m.workspaceID,
+		"relayfileToken":                 token,
+		"relayfileTokenExpiresAt":        time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		"relayfileRefreshToken":          refreshToken,
+		"relayfileRefreshTokenExpiresAt": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		"relayfileScopes":                body.Scopes,
+		"delegationNotAfter":             time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		"relayfileMountPaths":            []string{"/"},
 	})
 }
 
 func (m *productizedCloudMock) serveConnectSession(w http.ResponseWriter, r *http.Request) {
-	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+	if got := bearerToken(r); got != m.initialAccessToken && got != m.refreshedToken {
 		m.t.Fatalf("unexpected connect-session auth token: %q", got)
 	}
 	var body cloudConnectSessionRequest
@@ -672,14 +733,14 @@ func (m *productizedCloudMock) serveConnectSession(w http.ResponseWriter, r *htt
 }
 
 func (m *productizedCloudMock) serveIntegrationStatus(w http.ResponseWriter, r *http.Request) {
-	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+	if got := bearerToken(r); got != m.initialAccessToken && got != m.refreshedToken {
 		m.t.Fatalf("unexpected integration status auth token: %q", got)
 	}
 	writeMockJSON(w, http.StatusOK, cloudIntegrationReadyResponse{Ready: true})
 }
 
 func (m *productizedCloudMock) serveIntegrationList(w http.ResponseWriter, r *http.Request) {
-	if got := bearerToken(r); !strings.HasPrefix(got, "rf_token_") {
+	if got := bearerToken(r); got != m.initialAccessToken && got != m.refreshedToken {
 		m.t.Fatalf("unexpected integration list auth token: %q", got)
 	}
 	m.mu.Lock()

--- a/cmd/relayfile-cli/setup_e2e_test.go
+++ b/cmd/relayfile-cli/setup_e2e_test.go
@@ -32,9 +32,9 @@ func signedExpJWT(t *testing.T, expIn time.Duration) string {
 }
 
 // TestA8RelayfileTokenNeedsRefreshDetectsNearExpiry covers the predicate
-// the mount loop uses (in withAuthRefresh) to decide when to call
-// joinWorkspaceViaCloud — the trigger half of contract acceptance test
-// A8 ("Token refresh: VFS token expires mid-mount").
+// the mount loop uses to decide when to rotate delegated relayfile credentials
+// — the trigger half of contract acceptance test A8 ("Token refresh: VFS token
+// expires mid-mount").
 func TestA8RelayfileTokenNeedsRefreshDetectsNearExpiry(t *testing.T) {
 	cases := []struct {
 		name string
@@ -64,30 +64,30 @@ func TestA8RelayfileTokenNeedsRefreshDetectsNearExpiry(t *testing.T) {
 	}
 }
 
-// TestA8JoinWorkspaceMintsFreshRelayfileToken covers the action half of A8:
-// when the cloud access token is valid and we call joinWorkspaceViaCloud,
-// the cloud responds with a brand-new relayfile token + URL without the
-// CLI dropping the websocket. We verify the call shape (token bearer, body)
-// and that the returned credentials are well-formed.
-func TestA8JoinWorkspaceMintsFreshRelayfileToken(t *testing.T) {
+// TestA8DelegatedTokenBootstrapMintsRelayfileTokenPair covers the action half
+// of A8: when the cloud access token is valid, relayfile requests a delegated
+// relayfile TokenPair bundle rather than the legacy access-only /join response.
+// We verify the call shape (cloud bearer, body) and that the returned
+// credentials are well-formed for direct relayauth rotation.
+func TestA8DelegatedTokenBootstrapMintsRelayfileTokenPair(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
-	var joinCalls int32
-	var seenBody cloudWorkspaceJoinRequest
+	var mintCalls int32
+	var seenBody cloudRelayfileDelegatedTokenRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path != "/api/v1/workspaces/ws_demo/join" {
+		if r.URL.Path != "/api/v1/workspaces/ws_demo/relayfile/delegated-token" {
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
-			t.Fatalf("unexpected join Authorization: %q", got)
+			t.Fatalf("unexpected delegated-token Authorization: %q", got)
 		}
-		atomic.AddInt32(&joinCalls, 1)
+		atomic.AddInt32(&mintCalls, 1)
 		if err := json.NewDecoder(r.Body).Decode(&seenBody); err != nil {
-			t.Fatalf("decode join body failed: %v", err)
+			t.Fatalf("decode delegated-token body failed: %v", err)
 		}
-		_, _ = w.Write([]byte(`{"workspaceId":"ws_demo","token":"rf_new_token","relayfileUrl":"https://relayfile.test","wsUrl":"wss://relayfile.test/ws"}`))
+		writeDelegatedBundleResponse(t, w, "https://relayfile.test", "ws_demo", "rf_new_token", "refresh_new_token")
 	}))
 	defer server.Close()
 
@@ -96,21 +96,25 @@ func TestA8JoinWorkspaceMintsFreshRelayfileToken(t *testing.T) {
 		AccessToken:          "cld_access",
 		AccessTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
 	}
-	joined, err := joinWorkspaceViaCloud(creds, "ws_demo", "relayfile-cli", append([]string(nil), defaultJoinScopes...))
+	bundle, err := delegatedRelayfileTokenViaCloud(creds, "ws_demo", "relayfile-cli", append([]string(nil), defaultJoinScopes...))
 	if err != nil {
-		t.Fatalf("joinWorkspaceViaCloud failed: %v", err)
+		t.Fatalf("delegatedRelayfileTokenViaCloud failed: %v", err)
 	}
-	if atomic.LoadInt32(&joinCalls) != 1 {
-		t.Fatalf("expected exactly 1 /join call, got %d", joinCalls)
+	if atomic.LoadInt32(&mintCalls) != 1 {
+		t.Fatalf("expected exactly 1 delegated-token call, got %d", mintCalls)
 	}
-	if joined.Token != "rf_new_token" {
-		t.Fatalf("expected fresh relayfile token, got %q", joined.Token)
+	if bundle.BearerToken() != "rf_new_token" || bundle.RotationToken() != "refresh_new_token" {
+		t.Fatalf("expected delegated relayfile token pair, got %+v", bundle)
 	}
-	if joined.RelayfileURL == "" || joined.WSURL == "" {
-		t.Fatalf("expected join response to include relayfileUrl and wsUrl, got %+v", joined)
+	refreshEndpoint, err := bundle.RefreshEndpoint()
+	if err != nil {
+		t.Fatalf("RefreshEndpoint failed: %v", err)
+	}
+	if bundle.ServerURL() != "https://relayfile.test" || refreshEndpoint != "https://relayfile.test/v1/tokens/refresh" {
+		t.Fatalf("expected relayfile and relayauth endpoints, got %+v", bundle)
 	}
 	if seenBody.AgentName != "relayfile-cli" {
-		t.Fatalf("expected agent name in join body, got %+v", seenBody)
+		t.Fatalf("expected agent name in delegated-token body, got %+v", seenBody)
 	}
 }
 

--- a/cmd/relayfile-cli/writeback_daemon_test.go
+++ b/cmd/relayfile-cli/writeback_daemon_test.go
@@ -87,6 +87,7 @@ func TestWritebackDaemonDeadLettersHTTP400(t *testing.T) {
 			localDir,
 			workspaceID,
 			server.URL,
+			"",
 			100*time.Millisecond,
 			time.Hour,
 			0,

--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/agentworkforce/relayfile/internal/delegatedauth"
 	"github.com/agentworkforce/relayfile/internal/mountsync"
 	"github.com/fsnotify/fsnotify"
 )
@@ -485,7 +486,15 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 }
 
 type mountCredsFile struct {
-	Token string `json:"token"`
+	Token                   string `json:"token"`
+	AccessToken             string `json:"accessToken,omitempty"`
+	RelayfileToken          string `json:"relayfileToken,omitempty"`
+	RefreshToken            string `json:"refreshToken,omitempty"`
+	RelayfileRefreshToken   string `json:"relayfileRefreshToken,omitempty"`
+	RelayauthURL            string `json:"relayauthUrl,omitempty"`
+	RefreshURL              string `json:"refreshUrl,omitempty"`
+	AccessTokenExpiresAt    string `json:"accessTokenExpiresAt,omitempty"`
+	RelayfileTokenExpiresAt string `json:"relayfileTokenExpiresAt,omitempty"`
 }
 
 func readMountCredsToken(path string) (string, error) {
@@ -501,11 +510,20 @@ func readMountCredsToken(path string) (string, error) {
 	if err := json.Unmarshal(payload, &creds); err != nil {
 		return "", err
 	}
-	token := strings.TrimSpace(creds.Token)
+	token := firstNonEmpty(creds.Token, creds.AccessToken, creds.RelayfileToken)
 	if token == "" {
 		return "", errors.New("missing token")
 	}
 	return token, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func installCredsFileRefresh(client *mountsync.HTTPClient, cfg mountConfig) {
@@ -514,6 +532,15 @@ func installCredsFileRefresh(client *mountsync.HTTPClient, cfg mountConfig) {
 		return
 	}
 	client.SetTokenRefreshFunc(func(currentToken string) (string, bool, error) {
+		bundle, loadErr := delegatedauth.Load(credsFile)
+		if loadErr == nil && bundle.RotationToken() != "" {
+			renewed, changed, err := delegatedauth.RenewFile(context.Background(), nil, credsFile, delegatedauth.DefaultRefreshTimeout)
+			if err != nil {
+				log.Printf("relayfile delegated credential refresh failed: %v", err)
+				return "", false, err
+			}
+			return renewed.BearerToken(), changed || renewed.BearerToken() != strings.TrimSpace(currentToken), nil
+		}
 		token, err := readMountCredsToken(credsFile)
 		if err != nil {
 			log.Printf("relayfile creds-file refresh failed: %v", err)

--- a/internal/delegatedauth/delegatedauth.go
+++ b/internal/delegatedauth/delegatedauth.go
@@ -1,0 +1,297 @@
+package delegatedauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const DefaultRefreshTimeout = 10 * time.Second
+
+var (
+	ErrMissingCredentials = errors.New("delegated relayfile credentials are required")
+	ErrRefreshRejected    = errors.New("delegated relayfile credential refresh rejected")
+)
+
+// Bundle is the relayfile-owned delegated credential. It deliberately stores
+// only relayauth/relayfile material, never a user cloud-session token.
+type Bundle struct {
+	RelayfileURL string `json:"relayfileUrl,omitempty"`
+	BaseURL      string `json:"baseUrl,omitempty"`
+	Server       string `json:"server,omitempty"`
+
+	RelayfileWorkspaceID string `json:"relayfileWorkspaceId,omitempty"`
+	WorkspaceID          string `json:"workspaceId,omitempty"`
+
+	AccessToken    string `json:"accessToken,omitempty"`
+	Token          string `json:"token,omitempty"`
+	RelayfileToken string `json:"relayfileToken,omitempty"`
+
+	RefreshToken          string `json:"refreshToken,omitempty"`
+	RelayfileRefreshToken string `json:"relayfileRefreshToken,omitempty"`
+
+	AccessTokenExpiresAt        string `json:"accessTokenExpiresAt,omitempty"`
+	RelayfileTokenExpiresAt     string `json:"relayfileTokenExpiresAt,omitempty"`
+	RefreshTokenExpiresAt       string `json:"refreshTokenExpiresAt,omitempty"`
+	RelayfileRefreshTokenExpiry string `json:"relayfileRefreshTokenExpiresAt,omitempty"`
+	DelegationNotAfter          string `json:"delegationNotAfter,omitempty"`
+
+	RelayauthURL string `json:"relayauthUrl,omitempty"`
+	RefreshURL   string `json:"refreshUrl,omitempty"`
+
+	Scopes          []string `json:"scopes,omitempty"`
+	RelayfileScopes []string `json:"relayfileScopes,omitempty"`
+	RelayfilePaths  []string `json:"relayfileMountPaths,omitempty"`
+	AgentName       string   `json:"agentName,omitempty"`
+	UpdatedAt       string   `json:"updatedAt,omitempty"`
+}
+
+type TokenPair struct {
+	AccessToken           string `json:"accessToken"`
+	RefreshToken          string `json:"refreshToken"`
+	AccessTokenExpiresAt  string `json:"accessTokenExpiresAt"`
+	RefreshTokenExpiresAt string `json:"refreshTokenExpiresAt"`
+	DelegationNotAfter    string `json:"delegationNotAfter,omitempty"`
+}
+
+func (b Bundle) ServerURL() string {
+	return firstNonEmpty(b.RelayfileURL, b.BaseURL, b.Server)
+}
+
+func (b Bundle) Workspace() string {
+	return firstNonEmpty(b.RelayfileWorkspaceID, b.WorkspaceID)
+}
+
+func (b Bundle) BearerToken() string {
+	return firstNonEmpty(b.AccessToken, b.Token, b.RelayfileToken)
+}
+
+func (b Bundle) BearerExpiresAt() string {
+	return firstNonEmpty(b.AccessTokenExpiresAt, b.RelayfileTokenExpiresAt)
+}
+
+func (b Bundle) RotationToken() string {
+	return firstNonEmpty(b.RefreshToken, b.RelayfileRefreshToken)
+}
+
+func (b Bundle) RotationExpiresAt() string {
+	return firstNonEmpty(b.RefreshTokenExpiresAt, b.RelayfileRefreshTokenExpiry)
+}
+
+func (b Bundle) RefreshEndpoint() (string, error) {
+	if endpoint := strings.TrimSpace(b.RefreshURL); endpoint != "" {
+		if err := requireAbsoluteURL(endpoint, "refreshUrl"); err != nil {
+			return "", err
+		}
+		return endpoint, nil
+	}
+	base := strings.TrimRight(strings.TrimSpace(b.RelayauthURL), "/")
+	if base == "" {
+		return "", errors.New("delegated relayfile credentials missing relayauthUrl or refreshUrl")
+	}
+	if err := requireAbsoluteURL(base, "relayauthUrl"); err != nil {
+		return "", err
+	}
+	return base + "/v1/tokens/refresh", nil
+}
+
+func requireAbsoluteURL(raw, field string) error {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", field, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%s must be an absolute URL", field)
+	}
+	return nil
+}
+
+func (b Bundle) ValidateForUse() error {
+	if b.BearerToken() == "" {
+		return errors.New("delegated relayfile credentials missing access token")
+	}
+	if b.Workspace() == "" {
+		return errors.New("delegated relayfile credentials missing relayfileWorkspaceId")
+	}
+	if b.ServerURL() == "" {
+		return errors.New("delegated relayfile credentials missing relayfileUrl")
+	}
+	return nil
+}
+
+func Load(path string) (Bundle, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return Bundle{}, errors.New("credential path is required")
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return Bundle{}, err
+	}
+	var bundle Bundle
+	if err := json.Unmarshal(payload, &bundle); err != nil {
+		return Bundle{}, err
+	}
+	return bundle, nil
+}
+
+func SaveAtomic(path string, bundle Bundle) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return errors.New("credential path is required")
+	}
+	bundle.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	payload, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".relayfile-credentials-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(payload); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return os.Chmod(path, 0o600)
+}
+
+func RenewFile(ctx context.Context, client *http.Client, path string, timeout time.Duration) (Bundle, bool, error) {
+	bundle, err := Load(path)
+	if err != nil {
+		return Bundle{}, false, err
+	}
+	renewed, changed, err := Renew(ctx, client, bundle, timeout)
+	if err != nil || !changed {
+		return renewed, changed, err
+	}
+	if err := SaveAtomic(path, renewed); err != nil {
+		return Bundle{}, false, fmt.Errorf("persist rotated delegated relayfile credentials: %w", err)
+	}
+	return renewed, true, nil
+}
+
+func Renew(ctx context.Context, client *http.Client, bundle Bundle, timeout time.Duration) (Bundle, bool, error) {
+	refreshToken := bundle.RotationToken()
+	if refreshToken == "" {
+		return bundle, false, errors.New("delegated relayfile credentials missing refresh token")
+	}
+	endpoint, err := bundle.RefreshEndpoint()
+	if err != nil {
+		return bundle, false, err
+	}
+	if timeout <= 0 {
+		timeout = DefaultRefreshTimeout
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	body, err := json.Marshal(map[string]string{"refreshToken": refreshToken})
+	if err != nil {
+		return bundle, false, err
+	}
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return bundle, false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(reqCtx.Err(), context.DeadlineExceeded) {
+			return bundle, false, fmt.Errorf("%w: refresh timed out", ErrRefreshRejected)
+		}
+		return bundle, false, err
+	}
+	defer resp.Body.Close()
+	payload, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if readErr != nil {
+		return bundle, false, readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return bundle, false, refreshHTTPError(resp.StatusCode, payload)
+	}
+	var pair TokenPair
+	if err := json.Unmarshal(payload, &pair); err != nil {
+		return bundle, false, fmt.Errorf("parse delegated relayfile refresh response: %w", err)
+	}
+	if strings.TrimSpace(pair.AccessToken) == "" || strings.TrimSpace(pair.RefreshToken) == "" {
+		return bundle, false, errors.New("delegated relayfile refresh response missing token pair")
+	}
+	renewed := bundle
+	renewed.AccessToken = strings.TrimSpace(pair.AccessToken)
+	renewed.Token = ""
+	renewed.RelayfileToken = ""
+	renewed.RefreshToken = strings.TrimSpace(pair.RefreshToken)
+	renewed.RelayfileRefreshToken = ""
+	renewed.AccessTokenExpiresAt = strings.TrimSpace(pair.AccessTokenExpiresAt)
+	renewed.RelayfileTokenExpiresAt = ""
+	renewed.RefreshTokenExpiresAt = strings.TrimSpace(pair.RefreshTokenExpiresAt)
+	renewed.RelayfileRefreshTokenExpiry = ""
+	if strings.TrimSpace(pair.DelegationNotAfter) != "" {
+		renewed.DelegationNotAfter = strings.TrimSpace(pair.DelegationNotAfter)
+	}
+	return renewed, true, nil
+}
+
+func refreshHTTPError(status int, payload []byte) error {
+	var parsed struct {
+		Code    string `json:"code"`
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(payload, &parsed)
+	detail := firstNonEmpty(parsed.Code, parsed.Error, parsed.Message, http.StatusText(status))
+	switch parsed.Code {
+	case "delegation_expired", "workspace_token_revoked":
+		return fmt.Errorf("%w: %s", ErrRefreshRejected, parsed.Code)
+	default:
+		return fmt.Errorf("%w: relayauth refresh failed with status %d (%s)", ErrRefreshRejected, status, detail)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/delegatedauth/delegatedauth_test.go
+++ b/internal/delegatedauth/delegatedauth_test.go
@@ -1,0 +1,125 @@
+package delegatedauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenewFileRotatesAndPersistsDelegatedTokenPair(t *testing.T) {
+	var sawRefresh string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/tokens/refresh" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		var body struct {
+			RefreshToken string `json:"refreshToken"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode refresh body: %v", err)
+		}
+		sawRefresh = body.RefreshToken
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(TokenPair{
+			AccessToken:           "access_new",
+			RefreshToken:          "refresh_new",
+			AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			DelegationNotAfter:    time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339),
+		})
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "creds", "delegated.json")
+	original := Bundle{
+		RelayfileURL:          "https://relayfile.test",
+		RelayfileWorkspaceID:  "rw_test",
+		AccessToken:           "access_old",
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	}
+	if err := SaveAtomic(path, original); err != nil {
+		t.Fatalf("SaveAtomic failed: %v", err)
+	}
+
+	renewed, changed, err := RenewFile(context.Background(), server.Client(), path, time.Second)
+	if err != nil {
+		t.Fatalf("RenewFile failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected changed=true")
+	}
+	if sawRefresh != "refresh_old" {
+		t.Fatalf("refresh token sent = %q, want refresh_old", sawRefresh)
+	}
+	if renewed.BearerToken() != "access_new" || renewed.RotationToken() != "refresh_new" {
+		t.Fatalf("unexpected renewed bundle: %#v", renewed)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rotated file failed: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential mode = %o, want 0600", got)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load rotated file failed: %v", err)
+	}
+	if loaded.BearerToken() != "access_new" || loaded.RotationToken() != "refresh_new" {
+		t.Fatalf("rotated file did not persist new pair: %#v", loaded)
+	}
+}
+
+func TestRenewFileRejectedRefreshDoesNotOverwriteCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"code":"delegation_expired","message":"delegation expired"}`))
+	}))
+	defer server.Close()
+
+	path := filepath.Join(t.TempDir(), "delegated.json")
+	original := Bundle{
+		RelayfileURL:          "https://relayfile.test",
+		RelayfileWorkspaceID:  "rw_test",
+		AccessToken:           "access_old",
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+		RelayauthURL:          server.URL,
+	}
+	if err := SaveAtomic(path, original); err != nil {
+		t.Fatalf("SaveAtomic failed: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read before failed: %v", err)
+	}
+
+	_, changed, err := RenewFile(context.Background(), server.Client(), path, time.Second)
+	if err == nil {
+		t.Fatal("expected rejected refresh error")
+	}
+	if !strings.Contains(err.Error(), "delegation_expired") {
+		t.Fatalf("expected delegation_expired error, got %v", err)
+	}
+	if changed {
+		t.Fatal("expected changed=false after rejected refresh")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after failed: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("credentials changed after rejected refresh\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- `relayfile login` delegates to `agent-relay cloud login` (not `agent-relay login`, which is not a top-level command)
- Updates all error hint strings to reference `agent-relay cloud login`

## Root cause
relayfile#273 wired the delegation correctly in concept but used the wrong subcommand path. `agent-relay cloud login` is nested under the `cloud` namespace; calling `agent-relay login` returns `error: unknown command 'login'`.

## Validation
- `go build ./cmd/relayfile-cli/...` ✅
- `agent-relay cloud login --help` confirms the subcommand exists at this path

Closes: follow-up to relayfile#273 / cloud#2108

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

