### PR TITLE
fix(cli): delegate relayfile login to agent-relay cloud login

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -711,7 +711,7 @@ Usage:
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
-  login       Sign in via agent-relay login (or --api-key for self-hosted)
+  login       Sign in via agent-relay cloud login (or --api-key for self-hosted)
   workspace   Create, join, select via agent-relay, list, show current, or delete locally tracked workspaces
   integration Connect, discover, list, disconnect, or adopt workspace integrations
   ops         List or replay dead-lettered writeback ops
@@ -1030,7 +1030,7 @@ func runAgentRelayJSON(args []string, out any) error {
 	cmd := exec.CommandContext(ctx, agentRelayBinary(), args...)
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
-		return fmt.Errorf("agent-relay %s timed out; run 'agent-relay login' and try again", strings.Join(args, " "))
+		return fmt.Errorf("agent-relay %s timed out; run 'agent-relay cloud login' and try again", strings.Join(args, " "))
 	}
 	if err != nil {
 		detail := strings.TrimSpace(string(output))
@@ -1049,7 +1049,7 @@ func runAgentRelayLogin(stdin io.Reader, stdout io.Writer, noOpen bool) error {
 	if err := ensureAgentRelayCLICompatible(); err != nil {
 		return err
 	}
-	args := []string{"login"}
+	args := []string{"cloud", "login"}
 	if noOpen {
 		args = append(args, "--no-open")
 	}
@@ -1058,7 +1058,7 @@ func runAgentRelayLogin(stdin io.Reader, stdout io.Writer, noOpen bool) error {
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("agent-relay login failed: %w", err)
+		return fmt.Errorf("agent-relay cloud login failed: %w", err)
 	}
 	return nil
 }
@@ -1182,7 +1182,7 @@ func loadCloudCredentials() (cloudCredentials, error) {
 	payload, err := os.ReadFile(cloudCredentialsPath())
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return creds, fmt.Errorf("legacy cloud credentials not found at %s; run agent-relay login", cloudCredentialsPath())
+			return creds, fmt.Errorf("legacy cloud credentials not found at %s; run agent-relay cloud login", cloudCredentialsPath())
 		}
 		return creds, err
 	}
@@ -1199,9 +1199,9 @@ func loadCloudCredentials() (cloudCredentials, error) {
 // access tokens. The mount loop uses this to enter the read-only degraded
 // state described in the productized cloud-mount contract acceptance test
 // A9 ("Cloud refresh token expired").
-var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay login' to sign in again.")
+var ErrCloudRefreshExpired = errors.New("cloud session expired. Run 'agent-relay cloud login' to sign in again.")
 
-var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile credentials expired or revoked. Re-bootstrap relayfile credentials with agent-relay login.")
+var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile credentials expired or revoked. Re-bootstrap relayfile credentials with agent-relay cloud login.")
 
 func isMountCredentialExpired(err error) bool {
 	return errors.Is(err, ErrCloudRefreshExpired) || errors.Is(err, ErrDelegatedRelayfileCredentialsExpired)
@@ -1901,7 +1901,7 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 
 	if (strings.TrimSpace(*cloudAPIURL) != "" && strings.TrimRight(strings.TrimSpace(*cloudAPIURL), "/") != defaultCloudAPIURL) ||
 		strings.TrimSpace(*cloudToken) != "" || *loginTimeout != 5*time.Minute || *skipWorkspace || strings.TrimSpace(*workspaceFlag) != "" {
-		fmt.Fprintln(stdout, "warning: relayfile login delegates to agent-relay login; relayfile cloud/workspace refresh flags are deprecated and ignored")
+		fmt.Fprintln(stdout, "warning: relayfile login delegates to agent-relay cloud login; relayfile cloud/workspace refresh flags are deprecated and ignored")
 	}
 	if err := runAgentRelayLogin(stdin, stdout, *noOpen); err != nil {
 		return err
@@ -4925,7 +4925,7 @@ func latestCredentialModTime(paths ...string) (time.Time, bool) {
 
 func cloudCredentialAuthLine(now time.Time) string {
 	if _, err := cloudCredentialsFromAgentRelay(); err != nil {
-		return "auth: agent-relay session unavailable - run 'agent-relay login'"
+		return "auth: agent-relay session unavailable - run 'agent-relay cloud login'"
 	}
 	return "auth: agent-relay session ok"
 }
@@ -7868,7 +7868,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	degraded := false
 	var lastDegradedNotice time.Time
 	const degradedRecoveryInterval = time.Minute
-	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay login"
+	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay cloud login"
 
 	enterDegraded := func() {
 		if !degraded {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1435,7 +1435,7 @@ exit 1
 	if err := run([]string{"status", "demo"}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("run status failed: %v", err)
 	}
-	if got := stdout.String(); !strings.Contains(got, "auth: agent-relay session unavailable - run 'agent-relay login'") {
+	if got := stdout.String(); !strings.Contains(got, "auth: agent-relay session unavailable - run 'agent-relay cloud login'") {
 		t.Fatalf("expected agent-relay unavailable auth line, got %q", got)
 	}
 }
@@ -3254,7 +3254,7 @@ func TestLoginDelegatesToAgentRelay(t *testing.T) {
 	t.Setenv("AGENT_RELAY_LOG", logPath)
 	installFakeAgentRelay(t, `
 printf '%s\n' "$*" >> "$AGENT_RELAY_LOG"
-if [ "$*" = "login --no-open" ]; then
+if [ "$*" = "cloud login --no-open" ]; then
   echo "agent-relay login ok"
   exit 0
 fi
@@ -3281,8 +3281,8 @@ exit 2
 	if err != nil {
 		t.Fatalf("read fake agent-relay log failed: %v", err)
 	}
-	if strings.TrimSpace(string(logBytes)) != "login --no-open" {
-		t.Fatalf("expected agent-relay login --no-open, got %q", string(logBytes))
+	if strings.TrimSpace(string(logBytes)) != "cloud login --no-open" {
+		t.Fatalf("expected agent-relay cloud login --no-open, got %q", string(logBytes))
 	}
 	if _, err := os.Stat(cloudCredentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected stale relayfile cloud credentials removed, got err=%v", err)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.8.23",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.23.tgz",
-      "integrity": "sha512-WXOWY2xbQKPkcqjFV5f0ARX2DtHNuvnh09QtQClXpxTcrAKZpV/CKtguxiJQXSVUzhzvGACEetMdkkCx3DdfJw==",
+      "version": "0.8.24",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.24.tgz",
+      "integrity": "sha512-EsARUK2Bvbh9MJDZoAmR+pbxE66K8XMgZ6F68eQJ3tSkYE0dZIWmFFfxcSTjYSHERDCyV1GROy2uawFdTzjRmQ==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.8.23",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.23.tgz",
-      "integrity": "sha512-cZY6GPZyBjsOQbUoPtmr6DoFkNiDoBD3AbIajd0Sf/AfNTCEXKCZ3op0K+41PyaK244c90RmJ6sW9I1YaaxtDA==",
+      "version": "0.8.24",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.24.tgz",
+      "integrity": "sha512-5q25rMxMMwsD6iFmfHKvOeUdB0TwxHSlcy7kGJmuddlHPubwEjcEJJLsJpE54PYw9P2G2izojtrMUkoGgE42KA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.8.23",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.23.tgz",
-      "integrity": "sha512-Ew7uwks1CmzhkRenihIQhBp+XjXyVTRDBTXPKbW62hHntqKORyduk+xN0jS+wh9rDxwM/WVrDKXLo8RcaZ0w6A==",
+      "version": "0.8.24",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.24.tgz",
+      "integrity": "sha512-Yphi3S93h2XRhWyKMz9xU4XDQ4taj3B1imQANphEIKyUevgiCbXym3hjvbok6mriZON67azlzxv1IRWs0+F7hg==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.8.23",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.23.tgz",
-      "integrity": "sha512-sq6k4CVQYAtrfEVS2WDzXXw8Ewt6NjijukztJsOu//gJimmGi3RSUuifBcTlGna+UQaR9zY70MUQ4NjzUZ4Vvg==",
+      "version": "0.8.24",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.24.tgz",
+      "integrity": "sha512-pfpCN6yCxSY3phwGXcqDHGEA6CfgG1q/iDCAcBxB+YV+ZN1MimllA2frWLPYMysAlypvytGBxiiy2uRuyOo3kA==",
       "cpu": [
         "x64"
       ],
@@ -5287,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.8.23",
+      "version": "0.8.24",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.8.23",
+        "@relayfile/core": "0.8.24",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.8.23",
-        "@relayfile/mount-darwin-x64": "0.8.23",
-        "@relayfile/mount-linux-arm64": "0.8.23",
-        "@relayfile/mount-linux-x64": "0.8.23"
+        "@relayfile/mount-darwin-arm64": "0.8.24",
+        "@relayfile/mount-darwin-x64": "0.8.24",
+        "@relayfile/mount-linux-arm64": "0.8.24",
+        "@relayfile/mount-linux-x64": "0.8.24"
       }
     }
   }


### PR DESCRIPTION
## Summary
- `relayfile login` delegates to `agent-relay cloud login` (not `agent-relay login`, which is not a top-level command)
- Updates all error hint strings to reference `agent-relay cloud login`

## Root cause
relayfile#273 wired the delegation correctly in concept but used the wrong subcommand path. `agent-relay cloud login` is nested under the `cloud` namespace; calling `agent-relay login` returns `error: unknown command 'login'`.

## Validation
- `go build ./cmd/relayfile-cli/...` ✅

Closes: follow-up to relayfile#273 / cloud#2108

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

