### PR TITLE
fix(sdk): self-heal WebSocket after involuntary polling fallback

### DIFF
--- a/.agentworkforce/trajectories/active/traj_afcsy82z2y6v/trajectory.json
+++ b/.agentworkforce/trajectories/active/traj_afcsy82z2y6v/trajectory.json
@@ -400,6 +400,18 @@
             "reasoning": "Phase 1 must improve delivery against current prod cloud, so mount persists command IDs under .relay/outbox, retries with contentIdentity, treats successful bulk responses as upload ACK when revisions are available, and surfaces capped retries as needs-attention without requiring TS receipt fields first."
           },
           "significance": "high"
+        },
+        {
+          "ts": 1781508511616,
+          "type": "decision",
+          "content": "Reviewing PR #278 from required workforce diff and metadata: Reviewing PR #278 from required workforce diff and metadata",
+          "raw": {
+            "question": "Reviewing PR #278 from required workforce diff and metadata",
+            "chosen": "Reviewing PR #278 from required workforce diff and metadata",
+            "alternatives": [],
+            "reasoning": "Current workspace has an unrelated active trajectory; recording the PR review work without further altering historical trajectory state"
+          },
+          "significance": "high"
         }
       ]
     }

--- a/.agentworkforce/trajectories/completed/2026-06/traj_bakc54xcb4km/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_bakc54xcb4km/summary.md
@@ -1,0 +1,5 @@
+# Trajectory: Review and fix PR #269
+
+> **Status:** ❌ Abandoned
+> **Started:** June 10, 2026 at 06:02 PM
+> **Completed:** June 15, 2026 at 07:28 AM

--- a/.agentworkforce/trajectories/completed/2026-06/traj_bakc54xcb4km/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_bakc54xcb4km/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Review and fix PR #269"
   },
-  "status": "active",
+  "status": "abandoned",
   "startedAt": "2026-06-10T18:02:24.509Z",
+  "completedAt": "2026-06-15T07:28:06.970Z",
   "agents": [],
   "chapters": [],
   "commits": [],

--- a/.trajectories/active/traj_4pvrlmqfnzng/trajectory.json
+++ b/.trajectories/active/traj_4pvrlmqfnzng/trajectory.json
@@ -1,0 +1,46 @@
+{
+  "id": "traj_4pvrlmqfnzng",
+  "version": 1,
+  "task": {
+    "title": "Review PR #278 in AgentWorkforce/relayfile"
+  },
+  "status": "active",
+  "startedAt": "2026-06-15T07:37:32.072Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-15T07:37:32.451Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_ihldqr43vlno",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-15T07:37:32.451Z",
+      "events": [
+        {
+          "ts": 1781509052452,
+          "type": "reflection",
+          "content": "Validated PR #278 SDK change; no mechanical edits applied. Found one behavior risk around re-probing after permanent WebSocket factory failure; SDK build/typecheck/tests pass, root Node tests pass until missing Go, npm ci blocked by pre-existing lock drift.",
+          "raw": {
+            "confidence": 0.82
+          },
+          "significance": "high",
+          "tags": [
+            "confidence:0.82"
+          ]
+        }
+      ]
+    }
+  ],
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "/home/daytona/workspace",
+  "tags": [],
+  "_trace": {
+    "startRef": "b951fa3b01f705af8555c98a23814a545532b699",
+    "endRef": "b951fa3b01f705af8555c98a23814a545532b699"
+  }
+}

--- a/.trajectories/index.json
+++ b/.trajectories/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lastUpdated": "2026-06-14T19:15:24.280Z",
+  "lastUpdated": "2026-06-15T07:44:13.407Z",
   "trajectories": {
     "traj_7c0yqouml6gq": {
       "title": "Review PR #277 in AgentWorkforce/relayfile",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3739,7 +3739,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3761,7 +3760,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3783,7 +3781,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3805,7 +3802,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3827,7 +3823,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3849,7 +3844,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3871,7 +3865,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3893,7 +3886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3915,7 +3907,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3937,7 +3928,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3959,7 +3949,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -649,6 +649,63 @@ describe("RelayFileSync", () => {
     await sync.stop();
   });
 
+  it("re-probes the WebSocket and recovers after an involuntary polling fallback", async () => {
+    // Regression (relayfile-ws-self-heal-latch): a single pre-open WS failure
+    // used to latch the SDK into polling for the life of the process —
+    // pollLoop() ran `while(!stopped)` forever, so the reconnect path in its
+    // .finally() was unreachable. A long-running consumer (the factory daemon)
+    // stayed on 5s polling until restart. The poll loop now yields after a
+    // backoff window so the WS is re-probed; once the transient clears the
+    // socket re-opens and push delivery resumes — with no restart.
+    vi.useFakeTimers();
+    try {
+      const sockets: MockWebSocket[] = [];
+      const fallback = vi.fn();
+      const sync = new RelayFileSync({
+        client: makeClient(),
+        workspaceId: "ws_acme",
+        baseUrl: "https://relay.test",
+        token: "ws_token",
+        pollIntervalMs: 1000,
+        reconnect: { minDelayMs: 5, maxDelayMs: 5 },
+        onPollingFallback: fallback,
+        webSocketFactory: (url) => {
+          const socket = new MockWebSocket(url);
+          sockets.push(socket);
+          return socket;
+        }
+      });
+
+      sync.start();
+      expect(sockets).toHaveLength(1);
+
+      // Pre-open failure → after the grace window, drop to polling. No eager
+      // WS retry (retrying the same failing handshake in a loop is pointless).
+      sockets[0]!.emit("error", { type: "error" });
+      await vi.advanceTimersByTimeAsync(300);
+      expect(fallback).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "forced-polling-pre-open" })
+      );
+      expect(sync.getState()).toBe("polling");
+      expect(sockets).toHaveLength(1);
+
+      // Advance past the 5s re-probe window: the poll loop yields and the
+      // reconnect path opens a fresh socket. THIS is what the old code could
+      // never do — it stayed in pollLoop forever.
+      await vi.advanceTimersByTimeAsync(5000 + 50);
+      expect(sockets.length).toBeGreaterThanOrEqual(2);
+
+      // The endpoint has recovered — the re-probed socket opens and push
+      // delivery resumes.
+      sockets[sockets.length - 1]!.emit("open", {});
+      expect(sync.getState()).toBe("open");
+
+      await sync.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does NOT double-recover when a normal close follows the ws error", async () => {
     // Companion to the above: when the error IS followed by a close (the
     // well-behaved path), the close handler must clear the grace timer so

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -150,6 +150,16 @@ const DEFAULT_POLL_INTERVAL_MS = 5000;
 const DEFAULT_PING_INTERVAL_MS = 30000;
 const DEFAULT_RECONNECT_MIN_DELAY_MS = 250;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
+// When involuntary polling is active but the WebSocket transport is still
+// viable (baseUrl present, reconnect enabled, not caller-forced), the poll
+// loop yields after a backoff window so the SDK can re-probe the WS and climb
+// back to push delivery. Backoff grows on repeated pre-open failures so we
+// never tight-loop a handshake that keeps rejecting, yet always recover once
+// the transient (cold DO, proxy blip, brief auth gap) clears. Without this a
+// single pre-open failure latches the process into polling forever — fatal
+// for long-running consumers like the factory daemon.
+const DEFAULT_WS_REPROBE_MIN_DELAY_MS = 5000;
+const DEFAULT_WS_REPROBE_MAX_DELAY_MS = 300000;
 // Cap on the dedupe cache used in polling mode. Sized large enough that no
 // realistic workspace burst can churn through it within one poll interval
 // (the events API is itself capped at ~1000 per page), small enough to keep
@@ -327,6 +337,14 @@ export class RelayFileSync {
   // (no broadcasts and no pings yet) would falsely trip the watchdog.
   private lastPingSentAt = 0;
   private reconnectAttempts = 0;
+  // Tracks how many times involuntary polling has yielded to re-probe the
+  // WebSocket without a successful open in between. Drives re-probe backoff;
+  // reset to 0 once a socket actually reaches OPEN.
+  private pollingReprobeAttempts = 0;
+  // Whether the *current* polling session should periodically yield to
+  // re-probe the WS. False for explicit/caller-forced polling (preferPolling
+  // or no baseUrl) — that polling is intentional and stays put.
+  private pollingReprobeEnabled = false;
   private readonly abortHandler?: () => void;
 
   constructor(options: RelayFileSyncOptions) {
@@ -544,6 +562,9 @@ export class RelayFileSync {
       }
       this.currentSocketHasOpened = true;
       this.reconnectAttempts = 0;
+      // A real OPEN means the transport is healthy again — start the next
+      // potential degradation from a fresh (short) re-probe backoff.
+      this.pollingReprobeAttempts = 0;
       // Reset frame/ping bookkeeping for the freshly opened socket so the
       // watchdog has a clean baseline. lastPingSentAt=0 disables the pong
       // timeout until we actually send our first ping.
@@ -663,6 +684,15 @@ export class RelayFileSync {
       }
     }
     this.setState("polling");
+    // Involuntary polling (anything but "explicit") should not be a one-way
+    // door: if the WS transport is viable, the poll loop will yield after a
+    // backoff window so the .finally() below can re-open the socket. Explicit
+    // polling (preferPolling / no baseUrl) is intentional and stays put.
+    this.pollingReprobeEnabled =
+      reason !== "explicit" &&
+      !!this.baseUrl &&
+      this.reconnect.enabled &&
+      !this.preferPolling;
     this.pollingPromise = this.pollLoop().finally(() => {
       this.pollingPromise = undefined;
       if (!this.stopped && !this.shouldUsePolling()) {
@@ -673,9 +703,30 @@ export class RelayFileSync {
 
   private async pollLoop(): Promise<void> {
     let retryAttempt = 0;
+    // When re-probing is enabled, fix a deadline at which this poll session
+    // yields back to the WebSocket. Computed once per session from the running
+    // attempt count so repeated failures back off (5s, 10s, 20s … capped 5m).
+    // `undefined` => never yield (explicit polling, or WS not viable).
+    const reprobeDeadlineAt = this.pollingReprobeEnabled
+      ? Date.now() + this.computeReprobeDelayMs(this.pollingReprobeAttempts)
+      : undefined;
     while (!this.stopped) {
       if (this.signal?.aborted) {
         throw createAbortError();
+      }
+      // Backoff window elapsed: exit the loop so startPolling()'s .finally
+      // runs scheduleReconnect() → openWebSocket(). The cursor advanced by
+      // this session carries into the WS URL, so the re-opened socket resumes
+      // exactly where polling left off (no gap, no replay). If the re-open
+      // fails pre-open again, forceReconnect → startPolling restarts this loop
+      // with an incremented attempt and a longer window.
+      if (reprobeDeadlineAt !== undefined && Date.now() >= reprobeDeadlineAt) {
+        this.pollingReprobeAttempts += 1;
+        debugLog("polling yielding to WS re-probe", {
+          workspaceId: this.workspaceId,
+          attempt: this.pollingReprobeAttempts,
+        });
+        return;
       }
       try {
         // The current server implementation paginates events from oldest to
@@ -936,6 +987,15 @@ export class RelayFileSync {
   private computeReconnectDelayMs(attempt: number): number {
     const uncapped = this.reconnect.minDelayMs * Math.pow(2, Math.max(0, attempt - 1));
     return Math.min(this.reconnect.maxDelayMs, uncapped);
+  }
+
+  // How long involuntary polling runs before yielding to re-probe the WS.
+  // attempt 0 → 5s, 1 → 10s, 2 → 20s … capped at 5m. The first re-probe after
+  // a fresh degradation is fast (transients usually clear within seconds); a
+  // persistently rejecting handshake backs off so we never hammer it.
+  private computeReprobeDelayMs(attempt: number): number {
+    const uncapped = DEFAULT_WS_REPROBE_MIN_DELAY_MS * Math.pow(2, Math.max(0, attempt));
+    return Math.min(DEFAULT_WS_REPROBE_MAX_DELAY_MS, uncapped);
   }
 
   private async sleep(delayMs: number): Promise<void> {


### PR DESCRIPTION
## Problem

A single **pre-open** WebSocket handshake failure — cold Workspace DO, proxy blip, brief auth gap — permanently latched `RelayFileSync` into HTTP polling for the life of the process. `pollLoop()` ran `while(!this.stopped)` forever, so the reconnect path in `startPolling().finally` was unreachable and `scheduleReconnect` additionally bailed `if(this.pollingPromise) return`. **There was no path back to the WebSocket.** Long-running consumers (the factory daemon) stayed on 5s polling until restart — that's what surfaced as `forced-polling-pre-open: ws-error-pre-open` in the field.

The pre-open fallback itself was deliberate (don't tight-loop a failing handshake), but it overshot: it never retried at all.

## Fix

`pollLoop()` now fixes a capped-backoff **re-probe deadline** (`computeReprobeDelayMs`: 5s → 10s → 20s … cap 5m, from `pollingReprobeAttempts`) and `return`s when it elapses. That lets the existing `startPolling().finally → scheduleReconnect → openWebSocket(true)` path re-open the socket. If the re-open fails pre-open again, it falls back with a longer window; once a socket reaches OPEN the attempt counter resets.

- **No gap:** `this.cursor` advances during polling and is used in the WS upgrade URL, so the re-opened socket resumes exactly where polling stopped.
- **Scoped:** re-probe engages only for *involuntary* polling — `reason !== "explicit" && baseUrl && reconnect.enabled && !preferPolling`. Explicit/`preferPolling` polling is unchanged.

## Tests

Adds a `sync.test.ts` case asserting **recovery** (return to `'open'` after a pre-open failure, no restart) — not just *entry* into polling, which the prior test asserted and which cemented the bug. Full SDK suite: **195/195**.

## Adversarial review

Verified via a 5-lens adversarial pass (event-loss, duplicates, timer races, removed-net regression, backoff/lifecycle). No correctness findings against the transition logic.

## Downstream

This is the root fix. The consumer-side companion (pear factory bridge) is **AgentWorkforce/pear** — it removes a now-redundant bridge-level polling fallback that was defeating this self-heal. That PR should land after this is published and pear bumps `@relayfile/sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

