### PR TITLE
chore(deps): sync package-lock with v0.8.26 mount packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.8.25",
+  "version": "0.8.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.8.25",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.25.tgz",
-      "integrity": "sha512-tlBN14DS/LA9H2bOCBQ6A5LQP7nWQuR1J5m6hXERWqET2XvyNG5QSZTYlibxoW4fCAnk9L26+UueG4D2Q+Y0xg==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.26.tgz",
+      "integrity": "sha512-mxe9n4Evww6kppwMUatUTM32akOwaerQ32t+ehsZZRTum8+L7l+//mwhTYbqmuQto/LoFR9s0d/ABE/3gEE7Pw==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.8.25",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.25.tgz",
-      "integrity": "sha512-Mm7oGxERkkYmcqwQfMGL5AQLWXUyPSaaa8+s766BUMJKodz/QfZ+/epXctpuUbuculRxW8gcqL/1urkhqlKDLA==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.26.tgz",
+      "integrity": "sha512-MzgLu2x3PXFuaoQNw3BYsjze0uensHGSmyxMHo4fCnzG5D6Jfuy3P8ialqz09Q9D4s1zkpOMeagTbv5GTrypJA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.8.25",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.25.tgz",
-      "integrity": "sha512-fzg4NVM2CkBt7ag5zS5kVjF5qP+NLd+bPGYR/OqFaXj8l5rEE/QIh9SMVh9Zu6pfF5gco6vNN445XrV6NNGjHQ==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.26.tgz",
+      "integrity": "sha512-ij+BMfYYV4eTqzExsBwn7GuoQXj09Nr4BlP+BheyhQMHpKi8rkUbK0kbNMzElAswjPMkaOe5edreOb2LspldHw==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.8.25",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.25.tgz",
-      "integrity": "sha512-iXDpEsNiugO+QFc585gfGyPI48a1JpqevBd/qjxs88rOCPtlK8buVcEJb/XnR4hXKvngapgB9xW66bQWEyWlKQ==",
+      "version": "0.8.26",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.26.tgz",
+      "integrity": "sha512-Xmjt4vRsBQzT+ePlepCmf+/wR9nqy+SsUpPCMIENxTeFKZb89m5qaY0+EAm3k/2QYs8n6Z5uxKDZW7720Qv22Q==",
       "cpu": [
         "x64"
       ],
@@ -5287,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.8.25",
+      "version": "0.8.26",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.8.25",
+        "@relayfile/core": "0.8.26",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.8.25",
-        "@relayfile/mount-darwin-x64": "0.8.25",
-        "@relayfile/mount-linux-arm64": "0.8.25",
-        "@relayfile/mount-linux-x64": "0.8.25"
+        "@relayfile/mount-darwin-arm64": "0.8.26",
+        "@relayfile/mount-darwin-x64": "0.8.26",
+        "@relayfile/mount-linux-arm64": "0.8.26",
+        "@relayfile/mount-linux-x64": "0.8.26"
       }
     }
   }


### PR DESCRIPTION
## Problem

The `v0.8.26` release commit (`9bed14b`, current `main` HEAD) bumped `@relayfile/mount-*` to **0.8.26** in the manifests but **did not regenerate `package-lock.json`**, which still pins **0.8.25**. As a result `npm ci` fails at the install step:

```
npm error Invalid: lock file's @relayfile/mount-darwin-arm64@0.8.25 does not satisfy @relayfile/mount-darwin-arm64@0.8.26
```

This red-flags **every** PR (Contract, SDK Typecheck, Provider-backed evals all fail at *Install dependencies*) and `main` HEAD itself — the last green Contract run was on `70865a7`, the commit *before* the release, so CI never ran on the broken release commit.

## Fix

Regenerated with `npm install --package-lock-only`. The only changes are the four `@relayfile/mount-*` platform packages and the SDK version, `0.8.25 → 0.8.26` (24 lines, no transitive churn).

Unblocks all open PRs (including #278) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

