### PR TITLE
fix(auth): strip relay_ag_ token prefix before JWT parse

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_afcsy82z2y6v/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_afcsy82z2y6v/summary.md
@@ -1,0 +1,113 @@
+# Trajectory: Review issue 183 changes and open PR
+
+> **Status:** ✅ Completed
+> **Confidence:** 80%
+> **Started:** May 21, 2026 at 12:18 PM
+> **Completed:** June 15, 2026 at 09:37 AM
+
+---
+
+## Summary
+
+Reviewed PR #280 relay_ag_ token prefix change. Validated diff scope, bot comments, Go auth behavior, contract check, and identified unrelated npm lockfile CI install blocker without editing PR code.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Addressing issue #192 on existing active trajectory
+- **Chose:** Addressing issue #192 on existing active trajectory
+- **Reasoning:** Trail already has an active trajectory in this workspace; preserving it avoids clobbering prior agent context while still recording the issue work.
+
+### Treat truncated export JSON as an export-path degradation
+- **Chose:** Treat truncated export JSON as an export-path degradation
+- **Reasoning:** Issue #192 reports torn 2xx /fs/export bodies; using the existing tree-pull fallback preserves progress without changing generic HTTP JSON handling.
+
+### Opened issue #192 PR from origin/main branch
+- **Chose:** Opened issue #192 PR from origin/main branch
+- **Reasoning:** The previous working branch included unrelated PR follow-up commits; basing codex/issue-192-export-json-fallback on origin/main keeps the review focused on the export fallback fix.
+
+### Checkpoint incremental event pages at the page boundary
+- **Chose:** Checkpoint incremental event pages at the page boundary
+- **Reasoning:** Issue #197 reports that relying on the outer sync error path leaves applied event pages vulnerable to repeated replay after timeout/crash; persisting EventsCursor immediately after each successfully applied ListEvents page makes backlog catch-up resumable.
+
+### Treat per-cycle deadline after incremental page progress as clean completion
+- **Chose:** Treat per-cycle deadline after incremental page progress as clean completion
+- **Reasoning:** A persisted cursor fixes replay, but returning context deadline after progress keeps the daemon reporting failed cycles while catching up; issue #197 explicitly asks deadline exits after checkpointed progress to resume cleanly on the next cycle.
+
+### Address issue #200 with smaller incremental event pages and content-hash skips
+- **Chose:** Address issue #200 with smaller incremental event pages and content-hash skips
+- **Reasoning:** A 50-event page lets cursors advance within the daemon cycle budget, while skipping ReadFile for matching contentHash avoids replaying files already refreshed by full-tree reconciliation.
+
+### Open issue #200 PR from clean origin/main worktree
+- **Chose:** Open issue #200 PR from clean origin/main worktree
+- **Reasoning:** The current workspace contains unrelated uncommitted issue #192 changes, so isolating the PR in a separate worktree avoids mixing unrelated behavior into the review.
+
+### Implement issue #202 in relayfile CLI lifecycle
+- **Chose:** Implement issue #202 in relayfile CLI lifecycle
+- **Reasoning:** runMount already detects stale pidfiles via runningMountDaemons but ignores the stalePID return; stopWorkspaceMountDaemons returns after SIGTERM timeout without force-killing. Fixing those two paths directly addresses the operator recovery failure without touching mount syncer changes already present in the dirty worktree.
+
+### Use a fresh relayfile worktree from origin/main for issue 211
+- **Chose:** Use a fresh relayfile worktree from origin/main for issue 211
+- **Reasoning:** The primary checkout is on a gone branch; isolating the fix avoids disturbing existing local work.
+
+### Implement relayfile CLI cloud workspace join and command token refresh
+- **Chose:** Implement relayfile CLI cloud workspace join and command token refresh
+- **Reasoning:** Issue 211 fails before cloud-managed workspace inspection because tree/read require an existing Relayfile token and do not rejoin on expired scoped tokens.
+
+### Relayfile lazy matcher uses absolute github/repos marker search
+- **Chose:** Relayfile lazy matcher uses absolute github/repos marker search
+- **Reasoning:** Scoped org roots trim away github/repos under the old relative check; marker search preserves nested /relay roots while keeping repo directories eager and content lazy.
+
+### Diagnosed mount writeback as mirror-sync upload without durable ACKed outbox
+- **Chose:** Diagnosed mount writeback as mirror-sync upload without durable ACKed outbox
+- **Reasoning:** Go mount persists Dirty state but has no stable command id, no server upload receipt, and cancellation after /fs/bulk or follow-up ReadFile can leave commands observable only as dirty mirror files; spec added before implementation.
+
+### Implemented mount-side durable outbox before cloud receipt rollout
+- **Chose:** Implemented mount-side durable outbox before cloud receipt rollout
+- **Reasoning:** Phase 1 must improve delivery against current prod cloud, so mount persists command IDs under .relay/outbox, retries with contentIdentity, treats successful bulk responses as upload ACK when revisions are available, and surfaces capped retries as needs-attention without requiring TS receipt fields first.
+
+### Reviewing PR #278 from required workforce diff and metadata
+- **Chose:** Reviewing PR #278 from required workforce diff and metadata
+- **Reasoning:** Current workspace has an unrelated active trajectory; recording the PR review work without further altering historical trajectory state
+
+### Scoped PR review to relayauth bearer prefix parsing
+- **Chose:** Scoped PR review to relayauth bearer prefix parsing
+- **Reasoning:** PR diff only adds relay_ag_ to HTTP auth prefix stripping and matching unit coverage; related review should trace auth callers and token-prefix references without unrelated repo audit.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Addressing issue #192 on existing active trajectory: Addressing issue #192 on existing active trajectory
+- Treat truncated export JSON as an export-path degradation: Treat truncated export JSON as an export-path degradation
+- Issue #192 fix is scoped to mount export fallback; focused and full mountsync tests pass, running full Go test suite for wider confidence.
+- Opened issue #192 PR from origin/main branch: Opened issue #192 PR from origin/main branch
+- Checkpoint incremental event pages at the page boundary: Checkpoint incremental event pages at the page boundary
+- Implemented issue #197 page-boundary cursor persistence and verified mountsync tests. Existing active trajectory belongs to earlier issue #183 work, so leaving it active rather than completing it here.
+- Treat per-cycle deadline after incremental page progress as clean completion: Treat per-cycle deadline after incremental page progress as clean completion
+- Sub-agent review found test durability gaps and status semantics risk for issue #197. Addressed by persisting backlog-draining state, reporting public status as syncing during partial backlog progress, avoiding LastSuccessfulReconcileAt advancement until feed tail, and adding restart-based checkpoint tests.
+- Address issue #200 with smaller incremental event pages and content-hash skips: Address issue #200 with smaller incremental event pages and content-hash skips
+- Issue #200 change implemented in mountsync: smaller incremental event pages plus contentHash-based ReadFile skips; targeted and package tests pass.
+- Open issue #200 PR from clean origin/main worktree: Open issue #200 PR from clean origin/main worktree
+- Implement issue #202 in relayfile CLI lifecycle: Implement issue #202 in relayfile CLI lifecycle
+- Issue #202 CLI stop/start recovery implemented and focused lifecycle tests pass; full CLI package still fails in existing productized cloud mount proof due the dirty mountsync conflict path returning an unhandled PUT /fs/file route.
+- Use a fresh relayfile worktree from origin/main for issue 211: Use a fresh relayfile worktree from origin/main for issue 211
+- Implement relayfile CLI cloud workspace join and command token refresh: Implement relayfile CLI cloud workspace join and command token refresh
+- Relayfile CLI side can cloud-join and refresh tokens; cloud route still needs UUID/app-workspace alias and org-member access for issue 211's live workspace shape.
+- Issue 211 fix split into Relayfile CLI token join/refresh and Cloud app-workspace alias authorization; PRs opened as relayfile#212 and cloud#1248.
+- Self-review and delegated reviews found and fixed canonical workspace retry, default-workspace mutation on command refresh, Cloud active-membership revalidation, direct app-row binding, and OpenAPI join documentation.
+- Reviewed bot feedback on relayfile#212 and cloud#1248; fixed Relayfile scope widening, persisted remapped records, workspace error text, and simplified Cloud join resolution per bot feedback.
+- Cloud PR #1248 CI failure isolated to direct rw_* join reverse-binding lookup hitting DB/SST in offline handler tests. Added best-effort fallback plus anonymous success and private fail-closed route tests; focused join route and handler suite pass locally.
+- Relayfile PR #212 feedback checked against current head. Production fixes for remapped workspace records, retry URL rebuild, least-privilege scopes, and workspace join error text are already present; added CLI tests/assertions to lock down the live feedback before amending.
+- Relayfile lazy matcher uses absolute github/repos marker search: Relayfile lazy matcher uses absolute github/repos marker search
+- Diagnosed mount writeback as mirror-sync upload without durable ACKed outbox: Diagnosed mount writeback as mirror-sync upload without durable ACKed outbox
+- Implemented mount-side durable outbox before cloud receipt rollout: Implemented mount-side durable outbox before cloud receipt rollout
+- Reviewing PR #278 from required workforce diff and metadata: Reviewing PR #278 from required workforce diff and metadata
+- Scoped PR review to relayauth bearer prefix parsing: Scoped PR review to relayauth bearer prefix parsing
+- Go auth verification passed; npm CI install is blocked by an existing SDK lockfile/package version mismatch outside PR #280's diff.

--- a/.agentworkforce/trajectories/completed/2026-06/traj_afcsy82z2y6v/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_afcsy82z2y6v/trajectory.json
@@ -4,8 +4,9 @@
   "task": {
     "title": "Review issue 183 changes and open PR"
   },
-  "status": "active",
+  "status": "completed",
   "startedAt": "2026-05-21T12:18:19.780Z",
+  "completedAt": "2026-06-15T09:37:02.787Z",
   "agents": [
     {
       "name": "default",
@@ -19,6 +20,7 @@
       "title": "Work",
       "agentName": "default",
       "startedAt": "2026-05-21T13:37:43.820Z",
+      "endedAt": "2026-06-15T09:37:02.787Z",
       "events": [
         {
           "ts": 1779370663821,
@@ -412,10 +414,48 @@
             "reasoning": "Current workspace has an unrelated active trajectory; recording the PR review work without further altering historical trajectory state"
           },
           "significance": "high"
+        },
+        {
+          "ts": 1781515881011,
+          "type": "decision",
+          "content": "Scoped PR review to relayauth bearer prefix parsing: Scoped PR review to relayauth bearer prefix parsing",
+          "raw": {
+            "question": "Scoped PR review to relayauth bearer prefix parsing",
+            "chosen": "Scoped PR review to relayauth bearer prefix parsing",
+            "alternatives": [],
+            "reasoning": "PR diff only adds relay_ag_ to HTTP auth prefix stripping and matching unit coverage; related review should trace auth callers and token-prefix references without unrelated repo audit."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1781516167101,
+          "type": "reflection",
+          "content": "Go auth verification passed; npm CI install is blocked by an existing SDK lockfile/package version mismatch outside PR #280's diff.",
+          "raw": {
+            "focalPoints": [
+              "verification",
+              "scope",
+              "ci"
+            ],
+            "adjustments": "Do not auto-edit unrelated lockfile; report as CI blocker/advisory while continuing PR-specific review.",
+            "confidence": 0.8
+          },
+          "significance": "high",
+          "tags": [
+            "focal:verification",
+            "focal:scope",
+            "focal:ci",
+            "confidence:0.8"
+          ]
         }
       ]
     }
   ],
+  "retrospective": {
+    "summary": "Reviewed PR #280 relay_ag_ token prefix change. Validated diff scope, bot comments, Go auth behavior, contract check, and identified unrelated npm lockfile CI install blocker without editing PR code.",
+    "approach": "Standard approach",
+    "confidence": 0.8
+  },
   "commits": [],
   "filesChanged": [],
   "projectId": "/Users/khaliqgant/Projects/AgentWorkforce/relayfile",

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kaeaxmsd3zqo/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kaeaxmsd3zqo/summary.md
@@ -1,0 +1,32 @@
+# Trajectory: Review PR #280 in AgentWorkforce/relayfile
+
+> **Status:** ✅ Completed
+> **Confidence:** 82%
+> **Started:** June 15, 2026 at 09:40 AM
+> **Completed:** June 15, 2026 at 09:45 AM
+
+---
+
+## Summary
+
+Reviewed PR #280 relay_ag_ bearer prefix support. Validated code path, bot comments, Go test/build/vet, contract surface, and reproduced unrelated npm lockfile CI blocker without editing PR code.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Scoped review to relay_ag bearer-prefix handling
+- **Chose:** Scoped review to relay_ag bearer-prefix handling
+- **Reasoning:** The runtime diff only changes internal/httpapi auth prefix stripping and its unit coverage; npm lockfile drift is unrelated and must not be folded into this PR.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Scoped review to relay_ag bearer-prefix handling: Scoped review to relay_ag bearer-prefix handling
+- Runtime Go auth review passed; npm CI install remains blocked by unrelated lockfile drift

--- a/.agentworkforce/trajectories/completed/2026-06/traj_kaeaxmsd3zqo/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_kaeaxmsd3zqo/trajectory.json
@@ -1,0 +1,74 @@
+{
+  "id": "traj_kaeaxmsd3zqo",
+  "version": 1,
+  "task": {
+    "title": "Review PR #280 in AgentWorkforce/relayfile"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-15T09:40:35.364Z",
+  "completedAt": "2026-06-15T09:45:27.379Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-15T09:44:11.497Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_dmrvhn4vt5b9",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-15T09:44:11.497Z",
+      "endedAt": "2026-06-15T09:45:27.379Z",
+      "events": [
+        {
+          "ts": 1781516651499,
+          "type": "decision",
+          "content": "Scoped review to relay_ag bearer-prefix handling: Scoped review to relay_ag bearer-prefix handling",
+          "raw": {
+            "question": "Scoped review to relay_ag bearer-prefix handling",
+            "chosen": "Scoped review to relay_ag bearer-prefix handling",
+            "alternatives": [],
+            "reasoning": "The runtime diff only changes internal/httpapi auth prefix stripping and its unit coverage; npm lockfile drift is unrelated and must not be folded into this PR."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1781516694139,
+          "type": "reflection",
+          "content": "Runtime Go auth review passed; npm CI install remains blocked by unrelated lockfile drift",
+          "raw": {
+            "focalPoints": [
+              "verification",
+              "ci",
+              "scope"
+            ],
+            "adjustments": "Report npm blocker as advisory and leave files unchanged because it is outside PR #280 diff.",
+            "confidence": 0.82
+          },
+          "significance": "high",
+          "tags": [
+            "focal:verification",
+            "focal:ci",
+            "focal:scope",
+            "confidence:0.82"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Reviewed PR #280 relay_ag_ bearer prefix support. Validated code path, bot comments, Go test/build/vet, contract surface, and reproduced unrelated npm lockfile CI blocker without editing PR code.",
+    "approach": "Standard approach",
+    "confidence": 0.82
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "6f56294b76f29606def313e5c63300f6c425eeb4",
+    "endRef": "6f56294b76f29606def313e5c63300f6c425eeb4"
+  }
+}

--- a/internal/httpapi/auth.go
+++ b/internal/httpapi/auth.go
@@ -132,11 +132,14 @@ func authorizeBearer(authHeader string, verifier *bearerVerifier, workspaceID, r
 //
 // Keep this in sync with the prefixes minted by relayauth's
 // `packages/server/src/routes/tokens.ts` (`relay_pa_*` for path-access,
-// `relay_ws_*` for workspace, `relay_id_*` for identity).
+// `relay_ws_*` for workspace, `relay_id_*` for identity, `relay_ag_*` for
+// agent — the delegated-token / `relayfile workspace join` chain issues
+// `relay_ag_` access tokens via `/v1/tokens/agent`).
 var relayauthTokenPrefixes = []string{
 	"relay_pa_",
 	"relay_ws_",
 	"relay_id_",
+	"relay_ag_",
 }
 
 // stripRelayauthTokenPrefix removes the leading `relay_<class>_` prefix

--- a/internal/httpapi/auth_test.go
+++ b/internal/httpapi/auth_test.go
@@ -399,6 +399,7 @@ func TestParseBearerStripsRelayauthTokenPrefixes(t *testing.T) {
 		"relay_pa_",
 		"relay_ws_",
 		"relay_id_",
+		"relay_ag_",
 	}
 	for _, prefix := range prefixes {
 		prefix := prefix // capture

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.8.26",
+  "version": "0.8.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.8.26",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.26.tgz",
-      "integrity": "sha512-mxe9n4Evww6kppwMUatUTM32akOwaerQ32t+ehsZZRTum8+L7l+//mwhTYbqmuQto/LoFR9s0d/ABE/3gEE7Pw==",
+      "version": "0.8.27",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.27.tgz",
+      "integrity": "sha512-J/Y5vasUkUVWvlDwye4F1LF1QYdiZd5ZvhcIZwtbNnoYGl6klPK8xTnLkx4lgbxeGbjnkkC1dOZlcB9cthKTLQ==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.8.26",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.26.tgz",
-      "integrity": "sha512-MzgLu2x3PXFuaoQNw3BYsjze0uensHGSmyxMHo4fCnzG5D6Jfuy3P8ialqz09Q9D4s1zkpOMeagTbv5GTrypJA==",
+      "version": "0.8.27",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.27.tgz",
+      "integrity": "sha512-WXTC+rjjN6qa02D+HMNcwTc2JWNTj4oXRqGEmJZNTZlhVzK88kwuRqnoDxLjDEwZ7d5HYAyQHX3coVEdkYetuw==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.8.26",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.26.tgz",
-      "integrity": "sha512-ij+BMfYYV4eTqzExsBwn7GuoQXj09Nr4BlP+BheyhQMHpKi8rkUbK0kbNMzElAswjPMkaOe5edreOb2LspldHw==",
+      "version": "0.8.27",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.27.tgz",
+      "integrity": "sha512-6xriucInU5mMVki7kHNDMRC33o9xBFbWpg7i06I9PAm6ArEE45lWWrPGQ3TNWDJ2pCbasTrFweikkBfHExRd7w==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.8.26",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.26.tgz",
-      "integrity": "sha512-Xmjt4vRsBQzT+ePlepCmf+/wR9nqy+SsUpPCMIENxTeFKZb89m5qaY0+EAm3k/2QYs8n6Z5uxKDZW7720Qv22Q==",
+      "version": "0.8.27",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.27.tgz",
+      "integrity": "sha512-53abVBh/xv87hUTm5hMtmebpjsO0MyAWMNO6RE5qJtY+VGgrLBOqujzPCx4TAcAI4TtYXWX6bXiI2HyoNi7BBQ==",
       "cpu": [
         "x64"
       ],
@@ -5276,7 +5276,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5288,7 +5288,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5301,7 +5301,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6109,7 +6109,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6138,10 +6138,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.8.26",
+      "version": "0.8.27",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.8.26",
+        "@relayfile/core": "0.8.27",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6153,10 +6153,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.8.26",
-        "@relayfile/mount-darwin-x64": "0.8.26",
-        "@relayfile/mount-linux-arm64": "0.8.26",
-        "@relayfile/mount-linux-x64": "0.8.26"
+        "@relayfile/mount-darwin-arm64": "0.8.27",
+        "@relayfile/mount-darwin-x64": "0.8.27",
+        "@relayfile/mount-linux-arm64": "0.8.27",
+        "@relayfile/mount-linux-x64": "0.8.27"
       }
     }
   }

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -129,6 +129,14 @@ async function api(method: string, path: string, body?: unknown, headers?: Recor
   return { status: resp.status, data };
 }
 
+function apiFileContent(data: { content?: string; encoding?: string }): string {
+  const content = data.content ?? '';
+  if (data.encoding === 'base64') {
+    return Buffer.from(content, 'base64').toString('utf8');
+  }
+  return content;
+}
+
 // ---------------------------------------------------------------------------
 // Wait helpers
 // ---------------------------------------------------------------------------
@@ -360,7 +368,8 @@ ${B}${CYAN}╔══════════════════════
       // Verify via API
       const resp = await api('GET', `/v1/workspaces/${WORKSPACE}/fs/file?path=${encodeURIComponent('/src/new-feature.ts')}`);
       assert(resp.status === 200, `API read new-feature.ts failed: ${resp.status} ${JSON.stringify(resp.data)}`);
-      assert(resp.data.content.includes('feature = true'), `API content mismatch: ${resp.data.content}`);
+      const apiContent = apiFileContent(resp.data);
+      assert(apiContent.includes('feature = true'), `API content mismatch: ${resp.data.content}`);
 
       // Wait for Agent B daemon to pull
       log('⏳', 'Waiting for Agent B to pull...');


### PR DESCRIPTION
Mirrors the prod fix in cloud#2171 for the Go daemon (used in local/non-prod per the deploy topology).

`relayauthTokenPrefixes` was missing `relay_ag_` — the prefix relayauth's `/v1/tokens/agent` mints for the AR-264 delegated-token / `relayfile workspace join` chain. An unstripped `relay_ag_<jwt>` made `parseBearer` parse `relay_ag_<header_b64>` as the JWT header → 401 `invalid jwt header`. Added `relay_ag_` to the list + the parameterised parse test. `go build` + `go test ./internal/httpapi/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

