### PR TITLE
feat(writeback): surface provider-echoed fields (e.g. Slack ts) on op providerResult

### DIFF
--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -2261,6 +2261,24 @@ func (s *Server) handleWritebackAck(w http.ResponseWriter, r *http.Request, work
 		ack.CanonicalPath = canonicalPath
 	}
 
+	// Optional: an external writeback consumer may report fields the provider
+	// echoed back about the written record (e.g. a Slack message `ts`/`channel`).
+	// These are surfaced on the operation's providerResult. Strip the reserved,
+	// server-owned providerRevision at this trust boundary so an untrusted
+	// consumer cannot attempt to overwrite it. (mergeProviderResult also
+	// re-stamps the authoritative value as a backstop; this makes the intent
+	// explicit and keeps the persisted map clean.)
+	if pr, ok := payload["providerResult"].(map[string]any); ok {
+		filtered := make(map[string]any, len(pr))
+		for k, v := range pr {
+			if k == "providerRevision" {
+				continue
+			}
+			filtered[k] = v
+		}
+		ack.ProviderResult = filtered
+	}
+
 	resp, err := s.store.AcknowledgeWriteback(workspaceID, itemID, ack, correlationID)
 	if err != nil {
 		if err == relayfile.ErrNotFound {

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -434,8 +434,8 @@ func TestFileEventsWebSocketEnforcesPathScopedMountGrant(t *testing.T) {
 
 func TestFileEventsWebSocketWritebackMaterializationCarriesAgentWriteOrigin(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{
-		ProviderWriteAction: func(action relayfile.WritebackAction) error {
-			return nil
+		ProviderWriteAction: func(action relayfile.WritebackAction) (map[string]any, error) {
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2883,11 +2883,11 @@ func TestSyncStatusEndpointIncludesProviderFromOperations(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWriteAction: func(action relayfile.WritebackAction) error {
+		ProviderWriteAction: func(action relayfile.WritebackAction) (map[string]any, error) {
 			if action.Type == relayfile.WritebackActionFileDelete {
-				return fmt.Errorf("delete failure for provider discovery")
+				return nil, fmt.Errorf("delete failure for provider discovery")
 			}
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -3934,8 +3934,8 @@ func TestWorkspaceOperationReplayEndpoint(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
-			return fmt.Errorf("forced writeback failure")
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, fmt.Errorf("forced writeback failure")
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4098,8 +4098,8 @@ func TestAdminReplayAndSyncRefresh(t *testing.T) {
 	server := NewServer(relayfile.NewStoreWithOptions(relayfile.StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
-			return fmt.Errorf("forced dead-letter for replay")
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, fmt.Errorf("forced dead-letter for replay")
 		},
 	}))
 

--- a/internal/relayfile/adapters.go
+++ b/internal/relayfile/adapters.go
@@ -30,7 +30,11 @@ type ProviderAdapter interface {
 }
 
 type ProviderWritebackAdapter interface {
-	ApplyWriteback(action WritebackAction) error
+	// ApplyWriteback executes the writeback against the provider. The returned
+	// map, when non-nil, carries provider-echoed fields about the written
+	// record (e.g. a Slack message `ts`) that are surfaced on the operation's
+	// ProviderResult.
+	ApplyWriteback(action WritebackAction) (map[string]any, error)
 }
 
 // ParseGenericEnvelope processes a generic webhook envelope for any provider.

--- a/internal/relayfile/draft_reconcile.go
+++ b/internal/relayfile/draft_reconcile.go
@@ -32,6 +32,11 @@ type WritebackAck struct {
 	// must stay under the same provider root as the draft; otherwise the
 	// service falls back to the ExternalID-derived name.
 	CanonicalPath string
+	// ProviderResult carries additional fields the provider echoed back about
+	// the written record (e.g. a Slack message ts/channel). They are surfaced
+	// verbatim on the operation's providerResult. The reserved server-owned
+	// key providerRevision cannot be overridden via this map.
+	ProviderResult map[string]any
 }
 
 // DraftDisposition reports what the service did to the draft file at ack time.

--- a/internal/relayfile/store.go
+++ b/internal/relayfile/store.go
@@ -402,8 +402,14 @@ type StoreOptions struct {
 	StaleRunningOpThreshold time.Duration
 }
 
-type ProviderWriteFunc func(workspaceID, path, revision string) error
-type ProviderWriteActionFunc func(action WritebackAction) error
+// ProviderWriteFunc and ProviderWriteActionFunc execute a writeback against
+// the external provider. They return an optional providerResult map — the
+// fields the provider echoed back about the written record (e.g. a Slack
+// message `ts`, the created issue id) — which is surfaced verbatim on the
+// operation's ProviderResult so agents can recover server-assigned ids
+// without a second round-trip. A nil map means "nothing to surface".
+type ProviderWriteFunc func(workspaceID, path, revision string) (map[string]any, error)
+type ProviderWriteActionFunc func(action WritebackAction) (map[string]any, error)
 
 type WritebackActionType string
 
@@ -866,8 +872,8 @@ func NewStoreWithOptions(opts StoreOptions) *Store {
 	writer := opts.ProviderWrite
 	legacyWriterConfigured := writer != nil
 	if writer == nil {
-		writer = func(workspaceID, path, revision string) error {
-			return nil
+		writer = func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, nil
 		}
 	}
 	actionWriter := opts.ProviderWriteAction
@@ -3195,7 +3201,10 @@ func (s *Store) GetPendingWritebacks(workspaceID string) []map[string]any {
 // AcknowledgeWriteback acknowledges a writeback item as processed. On a
 // successful ack carrying an ExternalID it also reconciles the agent-authored
 // draft file per the draftFile() rename contract (issue #242); that mutation
-// is classification-exempt and can never enqueue a new writeback.
+// is classification-exempt and can never enqueue a new writeback. Any
+// provider-echoed fields the consumer reports (ack.ExternalID and
+// ack.ProviderResult, e.g. a Slack message ts/channel) are surfaced on the
+// operation's providerResult.
 func (s *Store) AcknowledgeWriteback(workspaceID, itemID string, ack WritebackAck, correlationID string) (map[string]any, error) {
 	if workspaceID == "" || itemID == "" {
 		return nil, ErrInvalidInput
@@ -3221,12 +3230,19 @@ func (s *Store) AcknowledgeWriteback(workspaceID, itemID string, ack WritebackAc
 		op.Status = "succeeded"
 		op.LastError = nil
 		op.CompletedAt = &nowTS
+		// Fold the consumer-reported externalId into the provider-echoed fields
+		// so it lands on providerResult alongside any ts/channel the consumer
+		// sent. mergeProviderResult keeps providerRevision server-owned.
+		echoed := ack.ProviderResult
 		if externalID := strings.TrimSpace(ack.ExternalID); externalID != "" {
-			if op.ProviderResult == nil {
-				op.ProviderResult = map[string]any{}
+			merged := make(map[string]any, len(echoed)+1)
+			for k, v := range echoed {
+				merged[k] = v
 			}
-			op.ProviderResult["externalId"] = externalID
+			merged["externalId"] = externalID
+			echoed = merged
 		}
+		op.ProviderResult = mergeProviderResult(op.Revision, echoed)
 	} else {
 		op.Status = "dead_lettered"
 		if ack.Error != "" {
@@ -3608,6 +3624,21 @@ func (s *Store) enqueueWriteback(task writebackTask) {
 	}()
 }
 
+// mergeProviderResult builds the ProviderResult map stored on a succeeded
+// operation. It overlays any fields the provider echoed back (e.g. a Slack
+// message `ts`), letting agents recover server-assigned ids from
+// GET /ops/{opId} without a second request, then stamps the server-owned
+// providerRevision last so a provider- or caller-supplied value can never
+// overwrite it (keeping providerRevision a stable, server-authoritative field).
+func mergeProviderResult(revision string, providerResult map[string]any) map[string]any {
+	result := make(map[string]any, len(providerResult)+1)
+	for k, v := range providerResult {
+		result[k] = v
+	}
+	result["providerRevision"] = revision
+	return result
+}
+
 func (s *Store) writebackWorker() {
 	for {
 		task, ok := s.writebackQueue.Dequeue(s.queueCtx)
@@ -3960,18 +3991,19 @@ func (s *Store) processWriteback(task writebackTask) {
 
 	// Step 2: execute provider write outside the lock.
 	var err error
+	var providerResult map[string]any
 	if s.providerWriteAction != nil {
-		err = s.providerWriteAction(writeAction)
+		providerResult, err = s.providerWriteAction(writeAction)
 	} else if s.providerWriteConfigured {
-		err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
+		providerResult, err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
 	} else if adapter, ok := s.adapters[writeAction.Provider]; ok {
 		if outbound, ok := adapter.(ProviderWritebackAdapter); ok {
-			err = outbound.ApplyWriteback(writeAction)
+			providerResult, err = outbound.ApplyWriteback(writeAction)
 		} else {
-			err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
+			providerResult, err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
 		}
 	} else {
-		err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
+		providerResult, err = s.providerWrite(task.WorkspaceID, task.Path, task.Revision)
 	}
 
 	// Step 3: persist state update and emit event.
@@ -3999,7 +4031,7 @@ func (s *Store) processWriteback(task writebackTask) {
 		op.Status = "succeeded"
 		op.LastError = nil
 		op.NextAttemptAt = nil
-		op.ProviderResult = map[string]any{"providerRevision": task.Revision}
+		op.ProviderResult = mergeProviderResult(task.Revision, providerResult)
 		op.UpdatedAt = nowTS
 		op.CompletedAt = &nowTS
 		ws.Ops[task.OpID] = op

--- a/internal/relayfile/store_test.go
+++ b/internal/relayfile/store_test.go
@@ -707,9 +707,9 @@ func TestProcessWritebackSkipsNonPendingOperation(t *testing.T) {
 	var writeCalls int32
 	store := NewStoreWithOptions(StoreOptions{
 		DisableWorkers: true,
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			atomic.AddInt32(&writeCalls, 1)
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -1577,9 +1577,9 @@ func TestPendingWritebacksRecoveredOnRestart(t *testing.T) {
 	var writeCalls int32
 	recovered := NewStoreWithOptions(StoreOptions{
 		StateFile: stateFile,
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			atomic.AddInt32(&writeCalls, 1)
-			return nil
+			return nil, nil
 		},
 		WritebackDelay: 5 * time.Millisecond,
 	})
@@ -1598,8 +1598,8 @@ func TestRecoveredWritebackRespectsPersistedNextAttemptAt(t *testing.T) {
 		StateFile:            stateFile,
 		MaxWritebackAttempts: 3,
 		WritebackDelay:       400 * time.Millisecond,
-		ProviderWriteAction: func(action WritebackAction) error {
-			return fmt.Errorf("transient writeback failure")
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
+			return nil, fmt.Errorf("transient writeback failure")
 		},
 	})
 	write, err := store.WriteFile(WriteRequest{
@@ -1629,9 +1629,9 @@ func TestRecoveredWritebackRespectsPersistedNextAttemptAt(t *testing.T) {
 		StateFile:            stateFile,
 		MaxWritebackAttempts: 3,
 		WritebackDelay:       400 * time.Millisecond,
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			atomic.AddInt32(&recoveredCalls, 1)
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(recovered.Close)
@@ -2093,8 +2093,8 @@ func TestGetSyncStatusMarksProviderErrorFromWritebackDeadLetter(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
-			return fmt.Errorf("writeback provider failure")
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, fmt.Errorf("writeback provider failure")
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2138,11 +2138,11 @@ func TestGetSyncStatusIncludesProviderPresentOnlyInOperations(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			if action.Type == WritebackActionFileDelete {
-				return fmt.Errorf("delete failure for provider discovery")
+				return nil, fmt.Errorf("delete failure for provider discovery")
 			}
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2284,11 +2284,11 @@ func TestListSyncStatusesIncludesFailureCodesFromDeadLettersAndOps(t *testing.T)
 				},
 			},
 		},
-		ProviderWrite: func(workspaceID, path, revision string) error {
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
 			if workspaceID == "ws_sync_list_error_op" {
-				return fmt.Errorf("writeback provider failure")
+				return nil, fmt.Errorf("writeback provider failure")
 			}
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2403,8 +2403,8 @@ func TestListOperationsFiltersByStatus(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
-			return fmt.Errorf("forced failure")
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, fmt.Errorf("forced failure")
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2698,8 +2698,8 @@ func TestStoreIngestEnvelopeAndReplayOp(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
-			return fmt.Errorf("forced replay precondition failure")
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
+			return nil, fmt.Errorf("forced replay precondition failure")
 		},
 	})
 	t.Cleanup(store.Close)
@@ -2788,11 +2788,11 @@ func TestReplayOperationResetsAttemptCount(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 1,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
 			if shouldFail.Load() {
-				return fmt.Errorf("forced failure")
+				return nil, fmt.Errorf("forced failure")
 			}
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4368,9 +4368,9 @@ func TestIngressStatusReportsOldestPendingAge(t *testing.T) {
 func TestProviderWriteActionReceivesFileUpsertPayload(t *testing.T) {
 	actions := make(chan WritebackAction, 2)
 	store := NewStoreWithOptions(StoreOptions{
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			actions <- action
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4409,9 +4409,9 @@ func TestProviderWriteActionReceivesFileUpsertPayload(t *testing.T) {
 func TestBulkWriteContentIdentityReachesProviderWriteAction(t *testing.T) {
 	actions := make(chan WritebackAction, 1)
 	store := NewStoreWithOptions(StoreOptions{
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			actions <- action
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4502,9 +4502,9 @@ func TestBulkWriteContentIdentityRetryReturnsExistingOperationWithoutDuplicateDi
 func TestProviderWriteActionReceivesFileDeletePayload(t *testing.T) {
 	actions := make(chan WritebackAction, 10)
 	store := NewStoreWithOptions(StoreOptions{
-		ProviderWriteAction: func(action WritebackAction) error {
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
 			actions <- action
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4559,12 +4559,12 @@ func TestWritebackRetriesThenSucceeds(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 5,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
 			n := attempts.Add(1)
 			if n < 3 {
-				return fmt.Errorf("transient provider error")
+				return nil, fmt.Errorf("transient provider error")
 			}
-			return nil
+			return nil, nil
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4596,9 +4596,9 @@ func TestWritebackDeadLetterAfterMaxAttempts(t *testing.T) {
 	store := NewStoreWithOptions(StoreOptions{
 		MaxWritebackAttempts: 2,
 		WritebackDelay:       5 * time.Millisecond,
-		ProviderWrite: func(workspaceID, path, revision string) error {
+		ProviderWrite: func(workspaceID, path, revision string) (map[string]any, error) {
 			attempts.Add(1)
-			return fmt.Errorf("permanent failure")
+			return nil, fmt.Errorf("permanent failure")
 		},
 	})
 	t.Cleanup(store.Close)
@@ -4705,9 +4705,9 @@ func TestAdapterWritebackHandlerIsUsedWhenLegacyProviderWriteNotConfigured(t *te
 			testAdapter{
 				provider: "external",
 				actions:  []ApplyAction{{Type: ActionIgnored}},
-				writeback: func(action WritebackAction) error {
+				writeback: func(action WritebackAction) (map[string]any, error) {
 					actions <- action
-					return nil
+					return nil, nil
 				},
 			},
 		},
@@ -4932,7 +4932,7 @@ type testAdapter struct {
 	provider      string
 	actions       []ApplyAction
 	parseEnvelope func(req WebhookEnvelopeRequest) ([]ApplyAction, error)
-	writeback     func(action WritebackAction) error
+	writeback     func(action WritebackAction) (map[string]any, error)
 }
 
 func (a testAdapter) Provider() string {
@@ -4946,9 +4946,9 @@ func (a testAdapter) ParseEnvelope(req WebhookEnvelopeRequest) ([]ApplyAction, e
 	return append([]ApplyAction(nil), a.actions...), nil
 }
 
-func (a testAdapter) ApplyWriteback(action WritebackAction) error {
+func (a testAdapter) ApplyWriteback(action WritebackAction) (map[string]any, error) {
 	if a.writeback == nil {
-		return nil
+		return nil, nil
 	}
 	return a.writeback(action)
 }
@@ -5026,5 +5026,98 @@ func TestBulkWriteContentIdentityAppearsInPendingWritebacks(t *testing.T) {
 	}
 	if *rawIdentity != *identity {
 		t.Fatalf("pending content identity = %+v, want %+v", rawIdentity, identity)
+	}
+}
+
+// TestProviderWriteActionSurfacesProviderResult verifies that fields returned
+// by the provider write action (e.g. a Slack message `ts`) are surfaced on the
+// operation's ProviderResult alongside the local providerRevision.
+func TestProviderWriteActionSurfacesProviderResult(t *testing.T) {
+	store := NewStoreWithOptions(StoreOptions{
+		ProviderWriteAction: func(action WritebackAction) (map[string]any, error) {
+			return map[string]any{"ts": "123.45", "channel": "C0001"}, nil
+		},
+	})
+	t.Cleanup(store.Close)
+
+	write, err := store.WriteFile(WriteRequest{
+		WorkspaceID:   "ws_provider_result",
+		Path:          "/external/ProviderResult.md",
+		IfMatch:       "0",
+		ContentType:   "text/markdown",
+		Content:       "# provider result",
+		CorrelationID: "corr_provider_result_1",
+	})
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	waitForOpStatus(t, store, "ws_provider_result", write.OpID, "succeeded")
+
+	op, err := store.GetOperation("ws_provider_result", write.OpID)
+	if err != nil {
+		t.Fatalf("get operation failed: %v", err)
+	}
+	if op.ProviderResult["ts"] != "123.45" {
+		t.Fatalf("expected providerResult.ts to be surfaced, got %v", op.ProviderResult["ts"])
+	}
+	if op.ProviderResult["channel"] != "C0001" {
+		t.Fatalf("expected providerResult.channel to be surfaced, got %v", op.ProviderResult["channel"])
+	}
+	if _, ok := op.ProviderResult["providerRevision"]; !ok {
+		t.Fatalf("expected providerRevision to remain present, got %v", op.ProviderResult)
+	}
+}
+
+// TestExternalWritebackAckSurfacesProviderResult verifies that an external
+// writeback consumer can report provider-echoed fields (e.g. a Slack message
+// `ts`) via the ack, that they land on the operation's ProviderResult, and that
+// a caller-supplied providerRevision cannot overwrite the server-owned value.
+func TestExternalWritebackAckSurfacesProviderResult(t *testing.T) {
+	store := NewStoreWithOptions(StoreOptions{
+		ExternalWritebackMode: true,
+	})
+	t.Cleanup(store.Close)
+
+	write, err := store.WriteFile(WriteRequest{
+		WorkspaceID:   "ws_ext_result",
+		Path:          "/external/ExtResult.md",
+		IfMatch:       "0",
+		ContentType:   "text/markdown",
+		Content:       "# external result",
+		CorrelationID: "corr_ext_result_1",
+	})
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if _, err := store.AcknowledgeWriteback(
+		"ws_ext_result",
+		write.OpID,
+		WritebackAck{
+			Success: true,
+			// A malicious/buggy consumer cannot clobber the server-owned
+			// providerRevision via the echoed fields.
+			ProviderResult: map[string]any{"ts": "678.90", "channel": "C0002", "providerRevision": "spoofed"},
+		},
+		"corr_ext_result_1",
+	); err != nil {
+		t.Fatalf("acknowledge writeback failed: %v", err)
+	}
+
+	op, err := store.GetOperation("ws_ext_result", write.OpID)
+	if err != nil {
+		t.Fatalf("get operation failed: %v", err)
+	}
+	if op.Status != "succeeded" {
+		t.Fatalf("expected op to be succeeded, got %s", op.Status)
+	}
+	if op.ProviderResult["ts"] != "678.90" {
+		t.Fatalf("expected providerResult.ts from ack, got %v", op.ProviderResult["ts"])
+	}
+	if pr, ok := op.ProviderResult["providerRevision"]; !ok {
+		t.Fatalf("expected providerRevision to remain present, got %v", op.ProviderResult)
+	} else if pr == "spoofed" {
+		t.Fatalf("expected server-owned providerRevision to win, but caller value was kept: %v", pr)
 	}
 }

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -1736,6 +1736,17 @@ paths:
                     Must stay under the same provider root as the draft;
                     otherwise the service falls back to the externalId-derived
                     name next to the draft.
+                providerResult:
+                  type: object
+                  additionalProperties: true
+                  description: |
+                    Optional fields the provider echoed back about the written
+                    record (e.g. a Slack message `ts` and `channel`). They are
+                    surfaced verbatim on the operation's providerResult, so an
+                    agent can recover them from GET /ops/{opId} — for example to
+                    reply in a Slack thread using the returned ts as thread_ts.
+                    The reserved key `providerRevision` is server-owned and
+                    cannot be overridden via this map.
       responses:
         '200':
           description: Acknowledgment accepted

--- a/packages/sdk/python/src/relayfile/client.py
+++ b/packages/sdk/python/src/relayfile/client.py
@@ -783,7 +783,13 @@ class RelayFileClient:
         return self._request(
             "POST",
             f"/v1/workspaces/{_enc(input.workspace_id)}/writeback/{_enc(input.item_id)}/ack",
-            json_body={"success": input.success, "error": input.error},
+            json_body={
+                "success": input.success,
+                "error": input.error,
+                "externalId": input.external_id,
+                "canonicalPath": input.canonical_path,
+                "providerResult": input.provider_result,
+            },
             correlation_id=input.correlation_id,
         )
 
@@ -1474,7 +1480,13 @@ class AsyncRelayFileClient:
         return await self._request(
             "POST",
             f"/v1/workspaces/{_enc(input.workspace_id)}/writeback/{_enc(input.item_id)}/ack",
-            json_body={"success": input.success, "error": input.error},
+            json_body={
+                "success": input.success,
+                "error": input.error,
+                "externalId": input.external_id,
+                "canonicalPath": input.canonical_path,
+                "providerResult": input.provider_result,
+            },
             correlation_id=input.correlation_id,
         )
 

--- a/packages/sdk/python/src/relayfile/types.py
+++ b/packages/sdk/python/src/relayfile/types.py
@@ -680,6 +680,18 @@ class AckWritebackInput:
     item_id: str
     success: bool
     error: str | None = None
+    # Provider-assigned id of the created/updated object (e.g. the Slack
+    # message ts). When present on a successful ack, the service reconciles the
+    # agent-authored draft file per the draftFile() rename contract.
+    external_id: str | None = None
+    # Optional canonical projection path for the draft rename. Must stay under
+    # the same provider root as the draft.
+    canonical_path: str | None = None
+    # Optional fields the provider echoed back about the written record (e.g. a
+    # Slack message ts/channel). Surfaced verbatim on the operation's
+    # providerResult (recoverable via get_operation). The reserved key
+    # providerRevision is server-owned and cannot be overridden via this map.
+    provider_result: dict[str, Any] | None = None
     correlation_id: str | None = None
 
 

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -1983,7 +1983,8 @@ export class RelayFileClient {
         success: input.success,
         error: input.error,
         externalId: input.externalId,
-        canonicalPath: input.canonicalPath
+        canonicalPath: input.canonicalPath,
+        providerResult: input.providerResult
       },
       signal: input.signal
     });

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -918,6 +918,14 @@ export interface AckWritebackInput {
    * the externalId-derived name next to the draft.
    */
   canonicalPath?: string;
+  /**
+   * Optional fields the provider echoed back about the written record (e.g. a
+   * Slack message `ts` and `channel`). They are surfaced verbatim on the
+   * operation's providerResult (recoverable via getOp), letting an agent reply
+   * in a Slack thread using the returned ts as thread_ts. The reserved key
+   * `providerRevision` is server-owned and cannot be overridden via this map.
+   */
+  providerResult?: Record<string, unknown>;
   correlationId?: string;
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Problem

Writes to relayfile are queued, async write-backs that **discarded the provider's API response**. The created record's server-assigned id — e.g. a Slack message `ts`, which is needed as `thread_ts` to reply in-thread — was unrecoverable. The only workaround was to watch for the inbound webhook and correlate by content (eventually-consistent and racy).

## Change

Thread the provider response through **both** writeback execution paths so it lands on the operation's existing `ProviderResult`, recoverable via `GET /ops/{opId}` with no second round-trip:

- Widen `ProviderWriteFunc`, `ProviderWriteActionFunc`, and the `ProviderWritebackAdapter.ApplyWriteback` interface from `error` → `(map[string]any, error)`.
- **In-process worker** captures the returned map; new `mergeProviderResult` helper keeps `providerRevision` and overlays provider-echoed fields.
- **External writeback mode**: `AcknowledgeWriteback` accepts a `providerResult` param and the `/writeback/{id}/ack` handler parses it from the body, so a hosted consumer can report the response (additive, optional field).

The read path (`ProviderResult` field, `GET /ops`, OpenAPI, SDK type) is **unchanged** — no migration, no API version bump.

## Tests

- `TestProviderWriteActionSurfacesProviderResult` — in-process: a write action returning `{ts, channel}` surfaces them (plus `providerRevision`) on the op.
- `TestExternalWritebackAckSurfacesProviderResult` — external: ack with `providerResult` lands on the op.
- `go vet ./...` clean; `go test ./internal/relayfile/ ./internal/httpapi/` pass.

## Companion

Paired with AgentWorkforce/cloud PR aliasing the Slack `ts`/`channel` on the hosted path so both backends expose the same field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

