### PR TITLE
Add CLI writeback update and delete

### DIFF
--- a/.agentworkforce/trajectories/completed/2026-06/traj_eckqqrcw2iiw/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_eckqqrcw2iiw/summary.md
@@ -1,0 +1,37 @@
+# Trajectory: Agree CLI writeback contract for relayfile#287
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 16, 2026 at 08:34 PM
+> **Completed:** June 16, 2026 at 08:47 PM
+
+---
+
+## Summary
+
+Implemented relayfile CLI writeback update/delete support, canonical push updates, and failed-op handling for false-success prevention. Validated with full Go suite and OpenAPI contract check.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification
+- **Chose:** Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification
+- **Reasoning:** Relayfile currently models provider mutations as file_upsert/file_delete operations; adapter classification by VFS path preserves existing store semantics while enabling CLI update/delete commands.
+
+### Adapter rejection contract requires non-nil errors for non-OK writeback outcomes
+- **Chose:** Adapter rejection contract requires non-nil errors for non-OK writeback outcomes
+- **Reasoning:** The relayfile CLI observes operation state from /ops/{opId}; if adapters return nil for rejected statuses, relayfile marks the operation succeeded and false-success cannot be fixed at the CLI layer.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification: Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification
+- Adapter rejection contract requires non-nil errors for non-OK writeback outcomes: Adapter rejection contract requires non-nil errors for non-OK writeback outcomes
+- Phase 1 CLI implementation underway: command routing and tests added for canonical update/delete; validating build and behavior now

--- a/.agentworkforce/trajectories/completed/2026-06/traj_eckqqrcw2iiw/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_eckqqrcw2iiw/trajectory.json
@@ -1,0 +1,85 @@
+{
+  "id": "traj_eckqqrcw2iiw",
+  "version": 1,
+  "task": {
+    "title": "Agree CLI writeback contract for relayfile#287"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-16T18:34:06.128Z",
+  "completedAt": "2026-06-16T18:47:56.009Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-16T18:37:58.677Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_aqwdp1mhrtww",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-16T18:37:58.677Z",
+      "endedAt": "2026-06-16T18:47:56.009Z",
+      "events": [
+        {
+          "ts": 1781635078678,
+          "type": "decision",
+          "content": "Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification: Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification",
+          "raw": {
+            "question": "Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification",
+            "chosen": "Phase 0 writeback contract accepts draft-create and canonical-update/delete path classification",
+            "alternatives": [],
+            "reasoning": "Relayfile currently models provider mutations as file_upsert/file_delete operations; adapter classification by VFS path preserves existing store semantics while enabling CLI update/delete commands."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1781635124214,
+          "type": "decision",
+          "content": "Adapter rejection contract requires non-nil errors for non-OK writeback outcomes: Adapter rejection contract requires non-nil errors for non-OK writeback outcomes",
+          "raw": {
+            "question": "Adapter rejection contract requires non-nil errors for non-OK writeback outcomes",
+            "chosen": "Adapter rejection contract requires non-nil errors for non-OK writeback outcomes",
+            "alternatives": [],
+            "reasoning": "The relayfile CLI observes operation state from /ops/{opId}; if adapters return nil for rejected statuses, relayfile marks the operation succeeded and false-success cannot be fixed at the CLI layer."
+          },
+          "significance": "high"
+        },
+        {
+          "ts": 1781635458919,
+          "type": "reflection",
+          "content": "Phase 1 CLI implementation underway: command routing and tests added for canonical update/delete; validating build and behavior now",
+          "raw": {
+            "focalPoints": [
+              "cli-writeback",
+              "false-success",
+              "canonical-paths"
+            ],
+            "confidence": 0.7
+          },
+          "significance": "high",
+          "tags": [
+            "focal:cli-writeback",
+            "focal:false-success",
+            "focal:canonical-paths",
+            "confidence:0.7"
+          ]
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Implemented relayfile CLI writeback update/delete support, canonical push updates, and failed-op handling for false-success prevention. Validated with full Go suite and OpenAPI contract check.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [],
+  "filesChanged": [],
+  "projectId": "AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "d9c07630e3a850b4c5dcbf4267ef618d3a04cece",
+    "endRef": "d9c07630e3a850b4c5dcbf4267ef618d3a04cece"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow.trace.json
@@ -1,0 +1,849 @@
+{
+  "version": "1.0.0",
+  "id": "c029e369-573a-4692-96b2-c7f6eb06ad52",
+  "timestamp": "2026-06-16T19:38:52.894Z",
+  "trajectory": "traj_gpadho1tfnow",
+  "files": [
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-06/traj_gaeqizrg7xrp/summary.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 31,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-06/traj_gaeqizrg7xrp/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 53,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-06/traj_n21cpwtav76z/summary.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 31,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": ".agentworkforce/trajectories/completed/2026-06/traj_n21cpwtav76z/trajectory.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 53,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/httpapi/server.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2261,
+              "end_line": 2284,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/httpapi/server_test.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 434,
+              "end_line": 441,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2883,
+              "end_line": 2893,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 3934,
+              "end_line": 3941,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4098,
+              "end_line": 4105,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/relayfile/adapters.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 30,
+              "end_line": 40,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/relayfile/draft_reconcile.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 32,
+              "end_line": 42,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/relayfile/store.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 402,
+              "end_line": 415,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 872,
+              "end_line": 879,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 3201,
+              "end_line": 3210,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 3230,
+              "end_line": 3248,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 3624,
+              "end_line": 3644,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 3991,
+              "end_line": 4009,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4031,
+              "end_line": 4037,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "internal/relayfile/store_test.go",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 707,
+              "end_line": 715,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 1577,
+              "end_line": 1585,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 1598,
+              "end_line": 1605,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 1629,
+              "end_line": 1637,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2093,
+              "end_line": 2100,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2138,
+              "end_line": 2148,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2284,
+              "end_line": 2294,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2403,
+              "end_line": 2410,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2698,
+              "end_line": 2705,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2788,
+              "end_line": 2798,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4368,
+              "end_line": 4376,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4409,
+              "end_line": 4417,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4502,
+              "end_line": 4510,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4559,
+              "end_line": 4570,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4596,
+              "end_line": 4604,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4705,
+              "end_line": 4713,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4932,
+              "end_line": 4938,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 4946,
+              "end_line": 4954,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 5028,
+              "end_line": 5123,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "openapi/relayfile-v1.openapi.yaml",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1736,
+              "end_line": 1752,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package-lock.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 12,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 830,
+              "end_line": 836,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 1999,
+              "end_line": 2007,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2012,
+              "end_line": 2020,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2025,
+              "end_line": 2033,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 2038,
+              "end_line": 2046,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 5287,
+              "end_line": 5293,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 5299,
+              "end_line": 5305,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 5312,
+              "end_line": 5318,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 6120,
+              "end_line": 6126,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 6149,
+              "end_line": 6158,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 6164,
+              "end_line": 6173,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 8,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 412,
+              "end_line": 419,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/core/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 388,
+              "end_line": 395,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/core/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/file-observer/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 387,
+              "end_line": 394,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/file-observer/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/local-mount/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 411,
+              "end_line": 418,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/local-mount/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-darwin-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-darwin-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-linux-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-linux-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/python/src/relayfile/client.py",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 783,
+              "end_line": 795,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 1480,
+              "end_line": 1492,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/python/src/relayfile/types.py",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 680,
+              "end_line": 697,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 409,
+              "end_line": 416,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 59,
+              "end_line": 73,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/src/client.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1983,
+              "end_line": 1990,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/src/types.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 918,
+              "end_line": 931,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/conformance.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 23,
+              "end_line": 33,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 63,
+              "end_line": 81,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 155,
+              "end_line": 184,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 448,
+              "end_line": 458,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 466,
+              "end_line": 472,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 502,
+              "end_line": 508,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 548,
+              "end_line": 554,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 596,
+              "end_line": 602,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 653,
+              "end_line": 756,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "scripts/e2e.ts",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 9,
+              "end_line": 15,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 21,
+              "end_line": 46,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 141,
+              "end_line": 171,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            },
+            {
+              "start_line": 604,
+              "end_line": 684,
+              "revision": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow/summary.md
@@ -1,0 +1,38 @@
+# Trajectory: Fix relayfile PR conflicts for writeback update delete
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 16, 2026 at 09:24 PM
+> **Completed:** June 16, 2026 at 09:38 PM
+
+---
+
+## Summary
+
+Resolved relayfile#288 conflicts by rebasing onto origin/main, dropping duplicate pre-squash AR-272 commits already upstream, and validating the resulting update/delete CLI delta.
+
+**Approach:** Standard approach
+
+---
+
+## Key Decisions
+
+### Rebased PR by skipping duplicate pre-squash AR-272 commits
+- **Chose:** Rebased PR by skipping duplicate pre-squash AR-272 commits
+- **Reasoning:** origin/main already contains the direct writeback push work via PR #282, so replaying the older branch commits caused conflicts and stale lockfile changes; keeping only the new update/delete commit preserves PR #288's intended delta.
+
+---
+
+## Chapters
+
+### 1. Work
+*Agent: default*
+
+- Rebased PR by skipping duplicate pre-squash AR-272 commits: Rebased PR by skipping duplicate pre-squash AR-272 commits
+
+---
+
+## Artifacts
+
+**Commits:** c77f016, 4b27c4a, bd458a7, ed0a507, e17c4b6, 6fb0441
+**Files changed:** 33

--- a/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_gpadho1tfnow/trajectory.json
@@ -1,0 +1,95 @@
+{
+  "id": "traj_gpadho1tfnow",
+  "version": 1,
+  "task": {
+    "title": "Fix relayfile PR conflicts for writeback update delete"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-16T19:24:08.463Z",
+  "completedAt": "2026-06-16T19:38:52.710Z",
+  "agents": [
+    {
+      "name": "default",
+      "role": "lead",
+      "joinedAt": "2026-06-16T19:35:01.067Z"
+    }
+  ],
+  "chapters": [
+    {
+      "id": "chap_bk2jsns57bps",
+      "title": "Work",
+      "agentName": "default",
+      "startedAt": "2026-06-16T19:35:01.067Z",
+      "endedAt": "2026-06-16T19:38:52.710Z",
+      "events": [
+        {
+          "ts": 1781638501067,
+          "type": "decision",
+          "content": "Rebased PR by skipping duplicate pre-squash AR-272 commits: Rebased PR by skipping duplicate pre-squash AR-272 commits",
+          "raw": {
+            "question": "Rebased PR by skipping duplicate pre-squash AR-272 commits",
+            "chosen": "Rebased PR by skipping duplicate pre-squash AR-272 commits",
+            "alternatives": [],
+            "reasoning": "origin/main already contains the direct writeback push work via PR #282, so replaying the older branch commits caused conflicts and stale lockfile changes; keeping only the new update/delete commit preserves PR #288's intended delta."
+          },
+          "significance": "high"
+        }
+      ]
+    }
+  ],
+  "retrospective": {
+    "summary": "Resolved relayfile#288 conflicts by rebasing onto origin/main, dropping duplicate pre-squash AR-272 commits already upstream, and validating the resulting update/delete CLI delta.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "c77f016",
+    "4b27c4a",
+    "bd458a7",
+    "ed0a507",
+    "e17c4b6",
+    "6fb0441"
+  ],
+  "filesChanged": [
+    ".agentworkforce/trajectories/completed/2026-06/traj_gaeqizrg7xrp/summary.md",
+    ".agentworkforce/trajectories/completed/2026-06/traj_gaeqizrg7xrp/trajectory.json",
+    ".agentworkforce/trajectories/completed/2026-06/traj_n21cpwtav76z/summary.md",
+    ".agentworkforce/trajectories/completed/2026-06/traj_n21cpwtav76z/trajectory.json",
+    "internal/httpapi/server.go",
+    "internal/httpapi/server_test.go",
+    "internal/relayfile/adapters.go",
+    "internal/relayfile/draft_reconcile.go",
+    "internal/relayfile/store.go",
+    "internal/relayfile/store_test.go",
+    "openapi/relayfile-v1.openapi.yaml",
+    "package-lock.json",
+    "package.json",
+    "packages/cli/CHANGELOG.md",
+    "packages/cli/package.json",
+    "packages/core/CHANGELOG.md",
+    "packages/core/package.json",
+    "packages/file-observer/CHANGELOG.md",
+    "packages/file-observer/package.json",
+    "packages/local-mount/CHANGELOG.md",
+    "packages/local-mount/package.json",
+    "packages/mount-darwin-arm64/package.json",
+    "packages/mount-darwin-x64/package.json",
+    "packages/mount-linux-arm64/package.json",
+    "packages/mount-linux-x64/package.json",
+    "packages/sdk/python/src/relayfile/client.py",
+    "packages/sdk/python/src/relayfile/types.py",
+    "packages/sdk/typescript/CHANGELOG.md",
+    "packages/sdk/typescript/package.json",
+    "packages/sdk/typescript/src/client.ts",
+    "packages/sdk/typescript/src/types.ts",
+    "scripts/conformance.ts",
+    "scripts/e2e.ts"
+  ],
+  "projectId": "AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "96c3bb0278de5c8163a7c026211a475bc0b75934",
+    "endRef": "c77f0162b7439e55f7b7f919d6bbbf86916be1f6",
+    "traceId": "c029e369-573a-4692-96b2-c7f6eb06ad52"
+  }
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux.trace.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux.trace.json
@@ -1,0 +1,293 @@
+{
+  "version": "1.0.0",
+  "id": "da3b5aea-81d2-4f85-b77d-4c00bf604ba1",
+  "timestamp": "2026-06-16T19:57:09.915Z",
+  "trajectory": "traj_x7bgqmh9orux",
+  "files": [
+    {
+      "path": "package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 2,
+              "end_line": 8,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 416,
+              "end_line": 423,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/cli/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/core/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 392,
+              "end_line": 399,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/core/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/file-observer/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 391,
+              "end_line": 398,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/file-observer/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/local-mount/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 415,
+              "end_line": 422,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/local-mount/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-darwin-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-darwin-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-linux-arm64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/mount-linux-x64/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/CHANGELOG.md",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 8,
+              "end_line": 17,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 413,
+              "end_line": 420,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "packages/sdk/typescript/package.json",
+      "conversations": [
+        {
+          "contributor": {
+            "type": "ai"
+          },
+          "ranges": [
+            {
+              "start_line": 1,
+              "end_line": 6,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            },
+            {
+              "start_line": 59,
+              "end_line": 73,
+              "revision": "03ef54f52b7853949b4780e882f5c54b57b31217"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux/summary.md
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux/summary.md
@@ -1,0 +1,21 @@
+# Trajectory: Fix relayfile PR npm lockfile CI failure
+
+> **Status:** ✅ Completed
+> **Confidence:** 90%
+> **Started:** June 16, 2026 at 09:54 PM
+> **Completed:** June 16, 2026 at 09:57 PM
+
+---
+
+## Summary
+
+Rebased relayfile#288 onto v0.9.0 and refreshed package-lock.json so npm ci accepts @relayfile/mount-* 0.9.0 dependencies. Validated npm ci, Go tests, and contract check.
+
+**Approach:** Standard approach
+
+---
+
+## Artifacts
+
+**Commits:** 03ef54f, 996a48e
+**Files changed:** 15

--- a/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux/trajectory.json
+++ b/.agentworkforce/trajectories/completed/2026-06/traj_x7bgqmh9orux/trajectory.json
@@ -1,0 +1,45 @@
+{
+  "id": "traj_x7bgqmh9orux",
+  "version": 1,
+  "task": {
+    "title": "Fix relayfile PR npm lockfile CI failure"
+  },
+  "status": "completed",
+  "startedAt": "2026-06-16T19:54:21.219Z",
+  "completedAt": "2026-06-16T19:57:09.845Z",
+  "agents": [],
+  "chapters": [],
+  "retrospective": {
+    "summary": "Rebased relayfile#288 onto v0.9.0 and refreshed package-lock.json so npm ci accepts @relayfile/mount-* 0.9.0 dependencies. Validated npm ci, Go tests, and contract check.",
+    "approach": "Standard approach",
+    "confidence": 0.9
+  },
+  "commits": [
+    "03ef54f",
+    "996a48e"
+  ],
+  "filesChanged": [
+    "package.json",
+    "packages/cli/CHANGELOG.md",
+    "packages/cli/package.json",
+    "packages/core/CHANGELOG.md",
+    "packages/core/package.json",
+    "packages/file-observer/CHANGELOG.md",
+    "packages/file-observer/package.json",
+    "packages/local-mount/CHANGELOG.md",
+    "packages/local-mount/package.json",
+    "packages/mount-darwin-arm64/package.json",
+    "packages/mount-darwin-x64/package.json",
+    "packages/mount-linux-arm64/package.json",
+    "packages/mount-linux-x64/package.json",
+    "packages/sdk/typescript/CHANGELOG.md",
+    "packages/sdk/typescript/package.json"
+  ],
+  "projectId": "AgentWorkforce/relayfile",
+  "tags": [],
+  "_trace": {
+    "startRef": "5039b4faf12e7c845c211851072baf10c431454f",
+    "endRef": "03ef54f52b7853949b4780e882f5c54b57b31217",
+    "traceId": "da3b5aea-81d2-4f85-b77d-4c00bf604ba1"
+  }
+}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -155,6 +155,16 @@ type bulkWriteError struct {
 	Message string `json:"message"`
 }
 
+type writeQueuedResponse struct {
+	OpID           string `json:"opId"`
+	Status         string `json:"status"`
+	TargetRevision string `json:"targetRevision"`
+	Writeback      struct {
+		Provider string `json:"provider"`
+		State    string `json:"state"`
+	} `json:"writeback"`
+}
+
 type contentIdentity struct {
 	Kind       string `json:"kind"`
 	Key        string `json:"key"`
@@ -686,6 +696,10 @@ func printWritebackUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, "Usage: relayfile writeback status [WORKSPACE] [--json]")
 	case "push":
 		fmt.Fprintln(w, "Usage: relayfile writeback push LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]")
+	case "update":
+		fmt.Fprintln(w, "Usage: relayfile writeback update LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]")
+	case "delete":
+		fmt.Fprintln(w, "Usage: relayfile writeback delete LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]")
 	case "retry":
 		fmt.Fprintln(w, "Usage: relayfile writeback retry --opId OP [WORKSPACE]")
 	case "skip-stuck":
@@ -698,6 +712,8 @@ func printWritebackUsage(w io.Writer, subcommand string) {
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]
   relayfile writeback push LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
+  relayfile writeback update LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
+  relayfile writeback delete LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
   relayfile writeback skip-stuck [WORKSPACE] [--workspace WS] [--max N] [--json]
   relayfile writeback sweep-drafts [WORKSPACE] [--path-prefix PREFIX] [--pattern GLOB ...] [--apply] [--json]`)
 	}
@@ -741,6 +757,8 @@ Usage:
   relayfile writeback status [WORKSPACE] [--json]
   relayfile writeback retry --opId OP [WORKSPACE]
   relayfile writeback push LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
+  relayfile writeback update LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
+  relayfile writeback delete LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]
   relayfile writeback skip-stuck [WORKSPACE] [--workspace WS] [--max N] [--json]
   relayfile digest rebuild --window today|yesterday|YYYY-MM-DD|this-week|last-week [--workspace NAME] [--json]
   relayfile pull [--workspace NAME] [--provider PROVIDER] [--reason TEXT]
@@ -2861,6 +2879,7 @@ type writebackPushReceipt struct {
 	CommandID       string           `json:"commandId"`
 	WorkspaceID     string           `json:"workspaceId"`
 	RemotePath      string           `json:"remotePath"`
+	Action          string           `json:"action,omitempty"`
 	ContentType     string           `json:"contentType"`
 	Content         string           `json:"content"`
 	Encoding        string           `json:"encoding,omitempty"`
@@ -2908,6 +2927,14 @@ type workspaceHealthReport struct {
 
 var errWritebackFailuresPresent = errors.New("writeback failures present")
 
+type writebackCommandMode string
+
+const (
+	writebackCommandPush   writebackCommandMode = "push"
+	writebackCommandUpdate writebackCommandMode = "update"
+	writebackCommandDelete writebackCommandMode = "delete"
+)
+
 func deadLetterDirFor(localDir string) string {
 	return filepath.Join(localDir, ".relay", "dead-letter")
 }
@@ -2917,7 +2944,22 @@ func deadLetterErrorPathFor(localDir, opID string) string {
 }
 
 func runWritebackPush(args []string, stdout io.Writer) error {
+	return runWritebackFileMutation(writebackCommandPush, args, stdout)
+}
+
+func runWritebackUpdate(args []string, stdout io.Writer) error {
+	return runWritebackFileMutation(writebackCommandUpdate, args, stdout)
+}
+
+func runWritebackDelete(args []string, stdout io.Writer) error {
+	return runWritebackFileMutation(writebackCommandDelete, args, stdout)
+}
+
+func runWritebackFileMutation(mode writebackCommandMode, args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("writeback push", flag.ContinueOnError)
+	if mode != writebackCommandPush {
+		fs = flag.NewFlagSet("writeback "+string(mode), flag.ContinueOnError)
+	}
 	fs.SetOutput(io.Discard)
 	workspaceName := fs.String("workspace", "", "workspace name or id")
 	server := fs.String("server", "", "relayfile server URL override")
@@ -2934,23 +2976,15 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return errors.New("usage: relayfile writeback push LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]")
+		return fmt.Errorf("usage: relayfile writeback %s LOCAL_PATH [--workspace WS] [--json] [--timeout 90s]", mode)
 	}
 
 	resolved, err := resolveWritebackPushPath(fs.Arg(0), strings.TrimSpace(*workspaceName))
 	if err != nil {
 		return err
 	}
-	raw, err := os.ReadFile(resolved.LocalPath)
-	if err != nil {
-		return err
-	}
-	content, encoding := encodeLocalWritebackContent(raw)
-	contentType := detectContentType(resolved.LocalPath, raw)
-	contentHash := hashBytes(raw)
-	identity := writebackPushContentIdentity(resolved.WorkspaceID, resolved.RemotePath, contentHash)
-	if identity == nil {
-		return fmt.Errorf("writeback push currently supports only draft writeback paths and factory-create-*.json files; %s has no content identity for double-dispatch dedupe", resolved.RemotePath)
+	if mode != writebackCommandPush && !isCanonicalWritebackTargetPath(resolved.RemotePath) {
+		return fmt.Errorf("writeback %s requires a canonical provider record path, got %s", mode, resolved.RemotePath)
 	}
 	joinScopes := writebackPushJoinScopes(resolved.RemotePath)
 	requiredRelayfileScopes := writebackPushRequiredRelayfileScopes(resolved.RemotePath)
@@ -2966,16 +3000,34 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 
 	now := time.Now().UTC()
 	firstSeenAt := now.Format(time.RFC3339Nano)
-	commandID := newWritebackPushCommandID(resolved.WorkspaceID, resolved.RemotePath, contentHash, firstSeenAt)
+	raw := []byte(nil)
+	content := ""
+	encoding := ""
+	contentType := ""
+	contentHash := ""
+	var identity *contentIdentity
+	exists := mode != writebackCommandDelete
+	if exists {
+		raw, err = os.ReadFile(resolved.LocalPath)
+		if err != nil {
+			return err
+		}
+		content, encoding = encodeLocalWritebackContent(raw)
+		contentType = detectContentType(resolved.LocalPath, raw)
+		contentHash = hashBytes(raw)
+		identity = writebackPushContentIdentity(resolved.WorkspaceID, resolved.RemotePath, contentHash)
+	}
+	commandID := newWritebackPushCommandID(resolved.WorkspaceID, resolved.RemotePath, string(mode)+":"+contentHash, firstSeenAt)
 	pendingReceipt := writebackPushReceipt{
 		CommandID:       commandID,
 		WorkspaceID:     resolved.WorkspaceID,
 		RemotePath:      resolved.RemotePath,
+		Action:          string(mode),
 		ContentType:     contentType,
 		Content:         content,
 		Encoding:        encoding,
 		Hash:            contentHash,
-		Exists:          true,
+		Exists:          exists,
 		Status:          "pending",
 		FirstSeenAt:     firstSeenAt,
 		CorrelationID:   commandID,
@@ -2985,17 +3037,19 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 		return err
 	}
 
-	file := bulkWriteFile{
-		Path:            resolved.RemotePath,
-		ContentType:     contentType,
-		Content:         content,
-		Encoding:        encoding,
-		ContentIdentity: identity,
+	dispatch := writebackDispatchResult{}
+	if mode == writebackCommandDelete {
+		dispatch, err = dispatchWritebackDelete(commandClient, resolved.RemotePath)
+	} else {
+		file := bulkWriteFile{
+			Path:            resolved.RemotePath,
+			ContentType:     contentType,
+			Content:         content,
+			Encoding:        encoding,
+			ContentIdentity: identity,
+		}
+		dispatch, err = dispatchWritebackUpsert(commandClient, file)
 	}
-	var response bulkWriteResponse
-	err = commandClient.postWorkspaceJSON(context.Background(), func(workspaceID string) string {
-		return fmt.Sprintf("/v1/workspaces/%s/fs/bulk", url.PathEscape(workspaceID))
-	}, bulkWriteRequest{Files: []bulkWriteFile{file}}, &response)
 	if err != nil {
 		failed := pendingReceipt
 		failed.Status = "failed"
@@ -3008,29 +3062,22 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 		}
 		return err
 	}
-	result := firstBulkWriteResultForPath(response.Results, resolved.RemotePath)
-	if response.ErrorCount > 0 {
-		reason := firstBulkWriteErrorForPath(response.Errors, resolved.RemotePath)
-		if reason == "" {
-			reason = fmt.Sprintf("bulk write returned %d error(s)", response.ErrorCount)
-		}
+	revision := firstNonBlank(dispatch.Revision, "")
+	opID := strings.TrimSpace(dispatch.OpID)
+	dispatchStatus := firstNonBlank(dispatch.State, "succeeded")
+	if opID == "" && isTerminalWritebackOpStatus(dispatchStatus) {
+		err := fmt.Errorf("writeback operation %s", dispatchStatus)
 		failed := pendingReceipt
 		failed.Status = "failed"
 		failed.LastAttemptAt = time.Now().UTC().Format(time.RFC3339Nano)
 		failed.AttemptCount = 1
-		failed.LastError = sanitizeCLIReceiptError(errors.New(reason))
-		failed.DispatchStatus = "failed"
-		failed.CorrelationID = firstNonBlank(response.CorrelationID, failed.CorrelationID)
+		failed.LastError = sanitizeCLIReceiptError(err)
+		failed.DispatchStatus = dispatchStatus
+		failed.CorrelationID = firstNonBlank(dispatch.CorrelationID, failed.CorrelationID)
 		if receiptErr := writeWritebackPushReceipt(resolved.MountRoot, failed); receiptErr != nil {
-			return fmt.Errorf("%s; additionally failed to write failure receipt: %v", reason, receiptErr)
+			return fmt.Errorf("%w; additionally failed to write failure receipt: %v", err, receiptErr)
 		}
-		return errors.New(reason)
-	}
-	revision := firstNonBlank(result.Revision, "")
-	opID := strings.TrimSpace(result.OpID)
-	dispatchStatus := "succeeded"
-	if result.Writeback != nil && strings.TrimSpace(result.Writeback.State) != "" {
-		dispatchStatus = strings.TrimSpace(result.Writeback.State)
+		return err
 	}
 	if opID != "" {
 		waitTimeout := *timeout
@@ -3052,7 +3099,7 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 			receipt.LastAttemptAt = time.Now().UTC().Format(time.RFC3339Nano)
 			receipt.AttemptCount = 1
 			receipt.LastError = sanitizeCLIReceiptError(err)
-			receipt.CorrelationID = firstNonBlank(response.CorrelationID, receipt.CorrelationID)
+			receipt.CorrelationID = firstNonBlank(dispatch.CorrelationID, receipt.CorrelationID)
 			if isTerminalWritebackOpStatus(op.Status) {
 				receipt.Status = "failed"
 				receipt.DispatchStatus = firstNonBlank(strings.TrimSpace(op.Status), "failed")
@@ -3077,19 +3124,82 @@ func runWritebackPush(args []string, stdout io.Writer) error {
 	acked.DispatchStatus = dispatchStatus
 	acked.AckedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	acked.Revision = revision
-	acked.CorrelationID = firstNonBlank(response.CorrelationID, acked.CorrelationID)
+	acked.CorrelationID = firstNonBlank(dispatch.CorrelationID, acked.CorrelationID)
 	if err := writeWritebackPushReceipt(resolved.MountRoot, acked); err != nil {
 		return err
 	}
 	if *jsonOutput {
 		return writeJSON(stdout, acked.withoutBody())
 	}
-	fmt.Fprintf(stdout, "Pushed %s -> %s", resolved.LocalPath, resolved.RemotePath)
+	switch mode {
+	case writebackCommandUpdate:
+		fmt.Fprintf(stdout, "Updated %s -> %s", resolved.LocalPath, resolved.RemotePath)
+	case writebackCommandDelete:
+		fmt.Fprintf(stdout, "Deleted %s", resolved.RemotePath)
+	default:
+		fmt.Fprintf(stdout, "Pushed %s -> %s", resolved.LocalPath, resolved.RemotePath)
+	}
 	if opID != "" {
 		fmt.Fprintf(stdout, " (%s)", opID)
 	}
 	fmt.Fprintln(stdout)
 	return nil
+}
+
+type writebackDispatchResult struct {
+	OpID          string
+	Revision      string
+	State         string
+	CorrelationID string
+}
+
+func dispatchWritebackUpsert(commandClient *workspaceCommandClient, file bulkWriteFile) (writebackDispatchResult, error) {
+	var response bulkWriteResponse
+	err := commandClient.postWorkspaceJSON(context.Background(), func(workspaceID string) string {
+		return fmt.Sprintf("/v1/workspaces/%s/fs/bulk", url.PathEscape(workspaceID))
+	}, bulkWriteRequest{Files: []bulkWriteFile{file}}, &response)
+	if err != nil {
+		return writebackDispatchResult{}, err
+	}
+	if response.ErrorCount > 0 {
+		reason := firstBulkWriteErrorForPath(response.Errors, file.Path)
+		if reason == "" {
+			reason = fmt.Sprintf("bulk write returned %d error(s)", response.ErrorCount)
+		}
+		return writebackDispatchResult{CorrelationID: response.CorrelationID}, errors.New(reason)
+	}
+	result := firstBulkWriteResultForPath(response.Results, file.Path)
+	state := "succeeded"
+	if result.Writeback != nil && strings.TrimSpace(result.Writeback.State) != "" {
+		state = strings.TrimSpace(result.Writeback.State)
+	}
+	return writebackDispatchResult{
+		OpID:          strings.TrimSpace(result.OpID),
+		Revision:      result.Revision,
+		State:         state,
+		CorrelationID: response.CorrelationID,
+	}, nil
+}
+
+func dispatchWritebackDelete(commandClient *workspaceCommandClient, remotePath string) (writebackDispatchResult, error) {
+	var result writeQueuedResponse
+	err := commandClient.deleteWorkspaceJSON(context.Background(), func(workspaceID string) string {
+		query := url.Values{}
+		query.Set("path", remotePath)
+		return fmt.Sprintf("/v1/workspaces/%s/fs?%s", url.PathEscape(workspaceID), query.Encode())
+	}, "*", &result)
+	if err != nil {
+		return writebackDispatchResult{}, err
+	}
+	state := result.Writeback.State
+	if strings.TrimSpace(state) == "" {
+		state = result.Status
+	}
+	return writebackDispatchResult{
+		OpID:     strings.TrimSpace(result.OpID),
+		Revision: result.TargetRevision,
+		State:    state,
+	}, nil
 }
 
 type writebackOperationStatus struct {
@@ -3329,6 +3439,15 @@ func isWritebackDraftPath(remotePath string) bool {
 		relayfile.IsDraftFilePath(remotePath)
 }
 
+func isCanonicalWritebackTargetPath(remotePath string) bool {
+	remotePath = normalizeWritebackFailurePath(remotePath)
+	if remotePath == "" || remotePath == "/" || isWritebackDraftPath(remotePath) {
+		return false
+	}
+	base := path.Base(remotePath)
+	return strings.HasSuffix(base, ".json")
+}
+
 func newWritebackPushCommandID(workspaceID, remotePath, hash, firstSeenAt string) string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		strings.TrimSpace(workspaceID),
@@ -3423,13 +3542,17 @@ func sanitizeCLIReceiptError(err error) string {
 
 func runWriteback(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("writeback subcommand is required: list, push, status, retry, or sweep-drafts")
+		return errors.New("writeback subcommand is required: list, push, update, delete, status, retry, or sweep-drafts")
 	}
 	switch args[0] {
 	case "list":
 		return runWritebackList(args[1:], stdout)
 	case "push":
 		return runWritebackPush(args[1:], stdout)
+	case "update":
+		return runWritebackUpdate(args[1:], stdout)
+	case "delete":
+		return runWritebackDelete(args[1:], stdout)
 	case "status":
 		return runWritebackStatus(args[1:], stdout)
 	case "retry":
@@ -5342,6 +5465,17 @@ func (c *workspaceCommandClient) postWorkspaceJSON(ctx context.Context, pathForW
 	return c.client.postJSON(ctx, pathForWorkspace(c.workspaceID), body, out)
 }
 
+func (c *workspaceCommandClient) deleteWorkspaceJSON(ctx context.Context, pathForWorkspace func(string) string, ifMatch string, out any) error {
+	err := c.client.deleteJSON(ctx, pathForWorkspace(c.workspaceID), ifMatch, out)
+	if err == nil || c.directToken || !isAPIAuthError(err) {
+		return err
+	}
+	if refreshErr := c.refreshFromDelegated(); refreshErr != nil {
+		return err
+	}
+	return c.client.deleteJSON(ctx, pathForWorkspace(c.workspaceID), ifMatch, out)
+}
+
 func isAPIAuthError(err error) bool {
 	if err == nil {
 		return false
@@ -6152,11 +6286,28 @@ func (c *apiClient) postJSON(ctx context.Context, path string, input, out any) e
 	return json.Unmarshal(body, out)
 }
 
+func (c *apiClient) deleteJSON(ctx context.Context, path string, ifMatch string, out any) error {
+	body, _, err := c.doWithHeaders(ctx, http.MethodDelete, path, nil, map[string]string{
+		"If-Match": ifMatch,
+	})
+	if err != nil {
+		return err
+	}
+	if out == nil || len(body) == 0 {
+		return nil
+	}
+	return json.Unmarshal(body, out)
+}
+
 func (c *apiClient) getBytes(ctx context.Context, path string) ([]byte, string, error) {
 	return c.do(ctx, http.MethodGet, path, nil)
 }
 
 func (c *apiClient) do(ctx context.Context, method, path string, body []byte) ([]byte, string, error) {
+	return c.doWithHeaders(ctx, method, path, body, nil)
+}
+
+func (c *apiClient) doWithHeaders(ctx context.Context, method, path string, body []byte, headers map[string]string) ([]byte, string, error) {
 	var reader io.Reader
 	if len(body) > 0 {
 		reader = bytes.NewReader(body)
@@ -6169,6 +6320,11 @@ func (c *apiClient) do(ctx context.Context, method, path string, body []byte) ([
 	req.Header.Set("X-Correlation-Id", correlationID())
 	if len(body) > 0 {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		if strings.TrimSpace(value) != "" {
+			req.Header.Set(key, value)
+		}
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -193,6 +193,8 @@ func TestHelpFlagPrintsUsageForCommandsAndSubcommands(t *testing.T) {
 		{name: "writeback group", args: []string{"writeback", "-h"}, want: "relayfile writeback retry --opId OP"},
 		{name: "writeback list", args: []string{"writeback", "list", "-h"}, want: writebackListUsage},
 		{name: "writeback status", args: []string{"writeback", "status", "-h"}, want: "Usage: relayfile writeback status"},
+		{name: "writeback update", args: []string{"writeback", "update", "-h"}, want: "Usage: relayfile writeback update"},
+		{name: "writeback delete", args: []string{"writeback", "delete", "-h"}, want: "Usage: relayfile writeback delete"},
 		{name: "writeback retry", args: []string{"writeback", "retry", "-h"}, want: "Usage: relayfile writeback retry --opId OP"},
 		{name: "digest group", args: []string{"digest", "-h"}, want: "today|yesterday|YYYY-MM-DD|this-week|last-week"},
 		{name: "digest rebuild", args: []string{"digest", "rebuild", "-h"}, want: digestRebuildUsage},
@@ -2514,7 +2516,80 @@ func TestWritebackPushPostsBulkAndWritesAckedReceipt(t *testing.T) {
 	}
 }
 
-func TestWritebackPushRejectsPathWithoutContentIdentity(t *testing.T) {
+func TestWritebackPushCanonicalPathPostsBulkWithoutContentIdentity(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceID = "ws_demo"
+	const remotePath = "/linear/issues/AR-272__00000000-0000-0000-0000-000000000272.json"
+	const opID = "op_update_272"
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := writeMirrorStateFile(localDir, syncStateFile{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/linear/issues",
+		Mode:        defaultMountMode,
+	}); err != nil {
+		t.Fatalf("writeMirrorStateFile failed: %v", err)
+	}
+
+	localPath := filepath.Join(localDir, "AR-272__00000000-0000-0000-0000-000000000272.json")
+	content := []byte(`{"title":"updated title","stateId":"state_1"}` + "\n")
+	if err := os.WriteFile(localPath, content, 0o644); err != nil {
+		t.Fatalf("write local payload failed: %v", err)
+	}
+
+	var sawBulk atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs/bulk":
+			sawBulk.Store(true)
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_write" {
+				t.Fatalf("unexpected bulk Authorization: %q", got)
+			}
+			var req bulkWriteRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode bulk request failed: %v", err)
+			}
+			if len(req.Files) != 1 {
+				t.Fatalf("bulk files = %d, want 1", len(req.Files))
+			}
+			file := req.Files[0]
+			if file.Path != remotePath {
+				t.Fatalf("bulk path = %q, want %q", file.Path, remotePath)
+			}
+			if file.Content != string(content) {
+				t.Fatalf("bulk content = %q, want %q", file.Content, string(content))
+			}
+			if file.ContentIdentity != nil {
+				t.Fatalf("canonical update must not carry draft content identity: %+v", file.ContentIdentity)
+			}
+			_, _ = io.WriteString(w, `{"written":1,"errorCount":0,"correlationId":"corr_update_272","results":[{"path":"`+remotePath+`","revision":"rev_2","opId":"`+opID+`","writeback":{"provider":"linear","state":"pending"}}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/"+workspaceID+"/ops/"+opID:
+			_, _ = io.WriteString(w, `{"opId":"`+opID+`","path":"`+remotePath+`","status":"succeeded","revision":"rev_2"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	err := run([]string{"writeback", "push", localPath, "--server", server.URL, "--token", "rf_write", "--timeout", "1s"}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("writeback push canonical failed: %v\n%s", err, stdout.String())
+	}
+	if !sawBulk.Load() {
+		t.Fatal("expected bulk write request")
+	}
+	if got := stdout.String(); !strings.Contains(got, "Pushed ") || !strings.Contains(got, opID) {
+		t.Fatalf("unexpected stdout: %s", got)
+	}
+}
+
+func TestWritebackUpdateRejectsDraftPath(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -2530,24 +2605,131 @@ func TestWritebackPushRejectsPathWithoutContentIdentity(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("writeMirrorStateFile failed: %v", err)
 	}
-
-	localPath := filepath.Join(localDir, "comment-ar-272-test.json")
-	if err := os.WriteFile(localPath, []byte(`{"body":"synthetic comment"}`+"\n"), 0o644); err != nil {
+	localPath := filepath.Join(localDir, "factory-create-ar-272-test.json")
+	if err := os.WriteFile(localPath, []byte(`{"title":"draft"}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write local payload failed: %v", err)
 	}
 
 	var stdout bytes.Buffer
-	err := run([]string{"writeback", "push", localPath}, strings.NewReader(""), &stdout, &stdout)
+	err := run([]string{"writeback", "update", localPath, "--token", "rf_write"}, strings.NewReader(""), &stdout, &stdout)
 	if err == nil {
-		t.Fatal("expected unsupported path error")
+		t.Fatal("expected draft path rejection")
 	}
-	if got := err.Error(); !strings.Contains(got, "supports only draft writeback paths and factory-create-*.json") {
+	if got := err.Error(); !strings.Contains(got, "requires a canonical provider record path") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, state := range []string{"pending", "acked", "failed"} {
 		if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", state)); got != 0 {
 			t.Fatalf("%s receipt count = %d, want 0", state, got)
 		}
+	}
+}
+
+func TestWritebackDeleteCallsFilesystemDeleteAndPollsOperation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceID = "ws_demo"
+	const remotePath = "/linear/issues/AR-272__00000000-0000-0000-0000-000000000272.json"
+	const opID = "op_delete_272"
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := writeMirrorStateFile(localDir, syncStateFile{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/linear/issues",
+		Mode:        defaultMountMode,
+	}); err != nil {
+		t.Fatalf("writeMirrorStateFile failed: %v", err)
+	}
+	localPath := filepath.Join(localDir, "AR-272__00000000-0000-0000-0000-000000000272.json")
+	if err := os.WriteFile(localPath, []byte(`{"title":"delete me"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write local payload failed: %v", err)
+	}
+
+	var sawDelete atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs":
+			sawDelete.Store(true)
+			if got := r.Header.Get("If-Match"); got != "*" {
+				t.Fatalf("If-Match = %q, want *", got)
+			}
+			if got := r.URL.Query().Get("path"); got != remotePath {
+				t.Fatalf("delete path = %q, want %q", got, remotePath)
+			}
+			_, _ = io.WriteString(w, `{"opId":"`+opID+`","status":"queued","targetRevision":"rev_3","writeback":{"provider":"linear","state":"pending"}}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/"+workspaceID+"/ops/"+opID:
+			_, _ = io.WriteString(w, `{"opId":"`+opID+`","path":"`+remotePath+`","status":"succeeded","revision":"rev_3"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	if err := run([]string{"writeback", "delete", localPath, "--server", server.URL, "--token", "rf_write", "--timeout", "1s"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("writeback delete failed: %v\n%s", err, stdout.String())
+	}
+	if !sawDelete.Load() {
+		t.Fatal("expected delete request")
+	}
+	if got := stdout.String(); !strings.Contains(got, "Deleted "+remotePath) || !strings.Contains(got, opID) {
+		t.Fatalf("unexpected stdout: %s", got)
+	}
+}
+
+func TestWritebackUpdateFailsWhenOperationFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceID = "ws_demo"
+	const remotePath = "/linear/issues/AR-272__00000000-0000-0000-0000-000000000272.json"
+	const opID = "op_failed_272"
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := writeMirrorStateFile(localDir, syncStateFile{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/linear/issues",
+		Mode:        defaultMountMode,
+	}); err != nil {
+		t.Fatalf("writeMirrorStateFile failed: %v", err)
+	}
+	localPath := filepath.Join(localDir, "AR-272__00000000-0000-0000-0000-000000000272.json")
+	if err := os.WriteFile(localPath, []byte(`{"stateId":"missing"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write local payload failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs/bulk":
+			_, _ = io.WriteString(w, `{"written":1,"errorCount":0,"correlationId":"corr_failed_272","results":[{"path":"`+remotePath+`","revision":"rev_4","opId":"`+opID+`","writeback":{"provider":"linear","state":"pending"}}]}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/workspaces/"+workspaceID+"/ops/"+opID:
+			_, _ = io.WriteString(w, `{"opId":"`+opID+`","path":"`+remotePath+`","status":"failed","revision":"rev_4","lastError":"ADAPTER_ERROR: not found"}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	err := run([]string{"writeback", "update", localPath, "--server", server.URL, "--token", "rf_write", "--timeout", "1s"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected failed operation error")
+	}
+	if got := err.Error(); !strings.Contains(got, "writeback operation "+opID+" failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "failed")); got != 1 {
+		t.Fatalf("failed receipt count = %d, want 1", got)
+	}
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "acked")); got != 0 {
+		t.Fatalf("acked receipt count = %d, want 0", got)
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.8.30",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -830,7 +830,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.8.30",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.8.30.tgz",
-      "integrity": "sha512-XYIJ1aiay6u9QdpGeDoWNA+Q0jboHbsOjCi37kBHpEapbuUXpqSW9HH5vAmpIPxzaFvsmYvTkTkjHPS9RLlnUA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.0.tgz",
+      "integrity": "sha512-TOjrJ+aTiAz0xvybaogn6X96vpgDHYqiomvb0ZNTJ61qYtlBK5SU2sSbZfcDbJHmwR905WlFmf/QzwWAhOg40w==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.8.30",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.8.30.tgz",
-      "integrity": "sha512-i8SJtwzUeZGSSghmHD8CFe3AK+TIPez7DnpMm7XvYJi7qFqdlPb3Xz8YMo7ANBKD0PrANexvxW71NeYzpZ4IEg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.0.tgz",
+      "integrity": "sha512-Y9vfJoXxCVzJiMeTvpWnIRb6Hn2j78UcX359aODMHHdghlm4sVKrsr9kVxPkB9YKrArwa1cAqZR/uAldepmprA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.8.30",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.8.30.tgz",
-      "integrity": "sha512-PkBSEqKSak1dBLnZE9iBpsefNlaBVI83DjhXP9VAjnRBDN2jqEy8QrcztbmimgbRp3h960PONVtobLGAqQ90tg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.0.tgz",
+      "integrity": "sha512-Qd1oKU0Aph3F2rH3yTCOVk9/iP+XtoCtJEuJ0QPxOw1Vr1JahNw5lqx8QgG45aJliLF3Lv8oAIMaM2DrQh1TJA==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.8.30",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.8.30.tgz",
-      "integrity": "sha512-rjcETwjE80U29CueveHsW/VXvEW68+W8ePqq9IG3OTQZomgYSbXaYb/JS/SWGn0ywUeZaZi0wPlcNEnVNtflfQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.0.tgz",
+      "integrity": "sha512-a1ltTvSOyMSnfVUcMqWoxkxbohUOAmfTPJMNMMSX4YUq6mYYAe7NLEACVsWExCHiHZvz8k10Sso3leLq8kR3Lg==",
       "cpu": [
         "x64"
       ],
@@ -5287,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.8.30",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.8.30",
+        "@relayfile/core": "0.9.0",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.8.30",
-        "@relayfile/mount-darwin-x64": "0.8.30",
-        "@relayfile/mount-linux-arm64": "0.8.30",
-        "@relayfile/mount-linux-x64": "0.8.30"
+        "@relayfile/mount-darwin-arm64": "0.9.0",
+        "@relayfile/mount-darwin-x64": "0.9.0",
+        "@relayfile/mount-linux-arm64": "0.9.0",
+        "@relayfile/mount-linux-x64": "0.9.0"
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `relayfile writeback update` and `relayfile writeback delete` commands
- allow `writeback push` to upsert canonical provider record paths without draft content identity
- fail CLI writeback receipts on terminal failed/dead-lettered/canceled operation states to prevent false success

## Contract compatibility
- uses existing `/fs/bulk`, `/fs` DELETE, and `/ops/{opId}` surfaces
- emits `file_upsert` for draft creates and canonical updates
- emits `file_delete` for canonical deletes and rejects draft delete targets client-side
- compatible with relayfile-adapters#201 mounted path contract

## Validation
- `go test ./...`
- `scripts/check-contract-surface.sh`

Related: relayfile#287, relayfile-adapters#201

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

