### PR TITLE
fix(writeback): delete dispatches to /fs/file, not /fs (#289)

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3186,7 +3186,7 @@ func dispatchWritebackDelete(commandClient *workspaceCommandClient, remotePath s
 	err := commandClient.deleteWorkspaceJSON(context.Background(), func(workspaceID string) string {
 		query := url.Values{}
 		query.Set("path", remotePath)
-		return fmt.Sprintf("/v1/workspaces/%s/fs?%s", url.PathEscape(workspaceID), query.Encode())
+		return fmt.Sprintf("/v1/workspaces/%s/fs/file?%s", url.PathEscape(workspaceID), query.Encode())
 	}, "*", &result)
 	if err != nil {
 		return writebackDispatchResult{}, err

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2652,7 +2652,7 @@ func TestWritebackDeleteCallsFilesystemDeleteAndPollsOperation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
-		case r.Method == http.MethodDelete && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs":
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs/file":
 			sawDelete.Store(true)
 			if got := r.Header.Get("If-Match"); got != "*" {
 				t.Fatalf("If-Match = %q, want *", got)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.0.tgz",
-      "integrity": "sha512-TOjrJ+aTiAz0xvybaogn6X96vpgDHYqiomvb0ZNTJ61qYtlBK5SU2sSbZfcDbJHmwR905WlFmf/QzwWAhOg40w==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.1.tgz",
+      "integrity": "sha512-wGxB5f83+jY4yBD3Nw8MygRZCztJX2EwnUCC9To6W61rBXOvduZgYrpqBCfQpkQnIfB9G2CEhFy2mHwv8comoA==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.0.tgz",
-      "integrity": "sha512-Y9vfJoXxCVzJiMeTvpWnIRb6Hn2j78UcX359aODMHHdghlm4sVKrsr9kVxPkB9YKrArwa1cAqZR/uAldepmprA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.1.tgz",
+      "integrity": "sha512-qk1wSCbemMgnNO/EW8sibYp+8OV2sngUToMWqa42rmv7U79m55eOdhzafUMPHvBPnnZab4fc2EM4GZtLKSnfMA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.0.tgz",
-      "integrity": "sha512-Qd1oKU0Aph3F2rH3yTCOVk9/iP+XtoCtJEuJ0QPxOw1Vr1JahNw5lqx8QgG45aJliLF3Lv8oAIMaM2DrQh1TJA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.1.tgz",
+      "integrity": "sha512-5EhyzdS3RiiPvYdBWpBvXLJbgb/HH2xTQCbehwdHMv3PVtse90a1+2FellxU+wpL6zmm3m86zw5oHVXaCCATWg==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.0.tgz",
-      "integrity": "sha512-a1ltTvSOyMSnfVUcMqWoxkxbohUOAmfTPJMNMMSX4YUq6mYYAe7NLEACVsWExCHiHZvz8k10Sso3leLq8kR3Lg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.1.tgz",
+      "integrity": "sha512-6XTWqyte++fdJ+sncZKKtAwZzLcwKVMgXuIa36wxizcd06nqfwHMYWmcxWTf2tJKbmDKTCzhUFNO2/bYZVXPGA==",
       "cpu": [
         "x64"
       ],
@@ -5287,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.0",
+        "@relayfile/core": "0.9.1",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.0",
-        "@relayfile/mount-darwin-x64": "0.9.0",
-        "@relayfile/mount-linux-arm64": "0.9.0",
-        "@relayfile/mount-linux-x64": "0.9.0"
+        "@relayfile/mount-darwin-arm64": "0.9.1",
+        "@relayfile/mount-darwin-x64": "0.9.1",
+        "@relayfile/mount-linux-arm64": "0.9.1",
+        "@relayfile/mount-linux-x64": "0.9.1"
       }
     }
   }


### PR DESCRIPTION
## What

`relayfile writeback delete` (#288) built its dispatch URL as `DELETE /v1/workspaces/{id}/fs?path=…`, but the cloud route is `/v1/workspaces/{id}/fs/file?path=…`. Result: every `writeback delete` returned `http 404 not_found: Route not found` — the command was unusable.

## Fix

- `dispatchWritebackDelete` → `/v1/workspaces/%s/fs/file?%s` (matches the cloud route `DELETE /v1/workspaces/:workspaceId/fs/file` and the file's existing `/fs/file` file-delete path at ~L5675).
- Updated `TestWritebackDeleteCallsFilesystemDeleteAndPollsOperation`, whose mock asserted the buggy `/fs` path (so it had been green against the wrong endpoint).

## Test
`go test ./cmd/relayfile-cli/` green (22s).

## Note (separate, still open)
With the endpoint fixed, deleting a **synced** provider record (e.g. a Linear issue) still returns `404 not_found` from the fs layer — the record isn't a deletable file row at the CLI-materialized view path (`/linear/issues/AR-NNN__<uuid>.json`) in either the app-workspace or `rw_` runtime DO. That's a deeper issue (synced-record delete addressing) tracked separately; this PR only fixes the endpoint so `writeback delete` reaches the right handler.

Fixes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

