### PR TITLE
fix(cli): stabilize delegated credentials

### DIFF
--- a/cmd/relayfile-cli/filelock_other.go
+++ b/cmd/relayfile-cli/filelock_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package main
+
+import "os"
+
+func lockFileExclusive(file *os.File) (func(), error) {
+	return func() {}, nil
+}

--- a/cmd/relayfile-cli/filelock_unix.go
+++ b/cmd/relayfile-cli/filelock_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFileExclusive(file *os.File) (func(), error) {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	}, nil
+}

--- a/cmd/relayfile-cli/filelock_windows.go
+++ b/cmd/relayfile-cli/filelock_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFileExclusive(file *os.File) (func(), error) {
+	var overlapped windows.Overlapped
+	handle := windows.Handle(file.Fd())
+	if err := windows.LockFileEx(handle, windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &overlapped); err != nil {
+		return nil, err
+	}
+	return func() {
+		_ = windows.UnlockFileEx(handle, 0, 1, 0, &overlapped)
+	}, nil
+}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -912,7 +912,7 @@ func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	delegatedCredsFile := delegatedCredentialsPath()
+	delegatedCredsFile := delegatedCredentialsPathForRequest(record.ID, record.Scopes)
 	if err := delegatedauth.SaveAtomic(delegatedCredsFile, delegated); err != nil {
 		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
@@ -1245,7 +1245,9 @@ func workspaceRequestMatchesDelegatedCredentials(value, relayfileWorkspaceID str
 	return false
 }
 
-func loadCloudCredentials() (cloudCredentials, error) {
+// loadLegacyCloudCredentials reads the pre-Agent Relay cloud credential store.
+// New cloud auth flows must use cloudCredentialsFromAgentRelay instead.
+func loadLegacyCloudCredentials() (cloudCredentials, error) {
 	var creds cloudCredentials
 	payload, err := os.ReadFile(cloudCredentialsPath())
 	if err != nil {
@@ -1669,27 +1671,30 @@ func delegatedRelayfileTokenViaCloud(cloud cloudCredentials, workspaceID, agentN
 	if bundle.Workspace() == "" {
 		bundle.RelayfileWorkspaceID = workspaceID
 	}
+	if len(bundle.Scopes) == 0 {
+		bundle.Scopes = append([]string(nil), scopes...)
+	}
 	if err := bundle.ValidateForUse(); err != nil {
 		return delegatedauth.Bundle{}, fmt.Errorf("delegated relayfile credential bundle invalid: %w", err)
 	}
 	return bundle, nil
 }
 
-func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes []string) (workspaceRecord, error) {
+func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes []string) (workspaceRecord, string, error) {
 	cloudCreds, err := cloudCredentialsFromAgentRelay()
 	if err != nil {
-		return workspaceRecord{}, err
+		return workspaceRecord{}, "", err
 	}
 	workspace, err := activeWorkspaceFromAgentRelay()
 	if err != nil {
-		return workspaceRecord{}, err
+		return workspaceRecord{}, "", err
 	}
 	if !agentRelayWorkspaceMatches(workspaceValue, workspace) {
-		return workspaceRecord{}, fmt.Errorf("active agent-relay workspace %s does not match requested workspace %q", workspace.Name, workspaceValue)
+		return workspaceRecord{}, "", fmt.Errorf("active agent-relay workspace %s does not match requested workspace %q", workspace.Name, workspaceValue)
 	}
 	cloudWorkspaceID := firstNonEmpty(workspace.CloudWorkspaceID, workspace.ID, workspace.RelayfileWorkspaceID)
 	if cloudWorkspaceID == "" {
-		return workspaceRecord{}, errors.New("agent-relay workspace active --json did not include a cloud workspace id")
+		return workspaceRecord{}, "", errors.New("agent-relay workspace active --json did not include a cloud workspace id")
 	}
 	recordScopes := append([]string(nil), scopes...)
 	if len(recordScopes) == 0 {
@@ -1707,24 +1712,31 @@ func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes [
 	}
 	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, cloudWorkspaceID, record.AgentName, record.Scopes)
 	if err != nil {
-		return workspaceRecord{}, err
+		return workspaceRecord{}, "", err
 	}
-	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegated); err != nil {
-		return workspaceRecord{}, fmt.Errorf("persist delegated relayfile credentials: %w", err)
+	credsPath := delegatedCredentialsPathForRequest(record.ID, record.Scopes)
+	if err := delegatedauth.SaveAtomic(credsPath, delegated); err != nil {
+		return workspaceRecord{}, "", fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
-	return persistDelegatedWorkspace(record, delegated, "", true)
+	persisted, err := persistDelegatedWorkspace(record, delegated, "", true)
+	if err != nil {
+		return workspaceRecord{}, "", err
+	}
+	return persisted, credsPath, nil
 }
 
 func loadOrBootstrapDelegatedCredentials(workspaceValue string, scopes []string) (delegatedauth.Bundle, string, error) {
-	bundle, path, err := loadDelegatedCredentials("")
+	bundle, path, err := loadDelegatedCredentialsForRequest("", workspaceValue, scopes)
 	if err == nil {
 		return bundle, path, nil
 	}
 	if !errors.Is(err, delegatedauth.ErrMissingCredentials) {
 		return delegatedauth.Bundle{}, path, err
 	}
-	if _, bootstrapErr := bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue, scopes); bootstrapErr != nil {
+	if _, bootstrappedPath, bootstrapErr := bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue, scopes); bootstrapErr != nil {
 		return delegatedauth.Bundle{}, path, bootstrapErr
+	} else if strings.TrimSpace(bootstrappedPath) != "" {
+		path = bootstrappedPath
 	}
 	return loadDelegatedCredentials(path)
 }
@@ -2035,7 +2047,7 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "Relayfile now uses the active agent-relay cloud session.")
 		return nil
 	}
-	record, err := bootstrapDelegatedCredentialsFromAgentRelay(strings.TrimSpace(*workspaceFlag), defaultJoinScopes)
+	record, _, err := bootstrapDelegatedCredentialsFromAgentRelay(strings.TrimSpace(*workspaceFlag), defaultJoinScopes)
 	if err != nil {
 		return fmt.Errorf("bootstrap delegated relayfile credentials: %w", err)
 	}
@@ -2166,7 +2178,7 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	if err != nil {
 		return err
 	}
-	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegated); err != nil {
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPathForRequest(record.ID, record.Scopes), delegated); err != nil {
 		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
 	record, err = persistDelegatedWorkspace(record, delegated, record.LocalDir, true)
@@ -3269,19 +3281,19 @@ func waitForWritebackOperation(ctx context.Context, commandClient *workspaceComm
 }
 
 func ensureWritebackDelegatedCredentials(workspaceID string, joinScopes, requiredRelayfileScopes []string) error {
-	if bundle, _, err := loadDelegatedCredentials(""); err == nil &&
+	if bundle, _, err := loadDelegatedCredentialsForRequest("", workspaceID, joinScopes); err == nil &&
 		workspaceRequestMatchesDelegatedCredentials(workspaceID, bundle.Workspace()) &&
 		delegatedBundleHasScopes(bundle, requiredRelayfileScopes) {
 		return nil
 	}
-	if _, err := bootstrapDelegatedCredentialsFromAgentRelay(workspaceID, joinScopes); err != nil {
+	if _, _, err := bootstrapDelegatedCredentialsFromAgentRelay(workspaceID, joinScopes); err != nil {
 		return err
 	}
 	// Re-validate after bootstrap: if Cloud returns a delegated bundle that
 	// omits the compiled relayfile:fs:write:/<provider>/** scope, fail loudly
 	// here rather than proceeding to write receipts and call /fs/bulk with an
 	// under-scoped token.
-	bundle, _, err := loadDelegatedCredentials("")
+	bundle, _, err := loadDelegatedCredentialsForRequest("", workspaceID, joinScopes)
 	if err != nil {
 		return err
 	}
@@ -4545,7 +4557,7 @@ func runWorkspaceJoin(args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegated); err != nil {
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPathForRequest(record.ID, record.Scopes), delegated); err != nil {
 		return fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
 	record, err = persistDelegatedWorkspace(record, delegated, "", true)
@@ -4963,7 +4975,7 @@ func runMount(args []string) error {
 		requestedWorkspace = strings.TrimSpace(fs.Arg(0))
 	}
 	if tokenValue == "" {
-		bundle, path, berr := loadDelegatedCredentials(*credsFile)
+		bundle, path, berr := loadDelegatedCredentialsForRequest(*credsFile, requestedWorkspace, defaultJoinScopes)
 		if berr != nil {
 			return fmt.Errorf("resolve delegated relayfile credentials: %w", berr)
 		}
@@ -5430,7 +5442,6 @@ func (c *workspaceCommandClient) refreshFromDelegated() error {
 	} else if strings.TrimSpace(record.ID) != c.workspaceID {
 		record.RelayWorkspaceID = c.workspaceID
 	}
-	record.Scopes = append([]string(nil), c.scopes...)
 	record.Server = strings.TrimRight(renewed.ServerURL(), "/")
 	record.CloudAPIURL = ""
 	record.LastUsedAt = time.Now().UTC().Format(time.RFC3339)
@@ -6498,17 +6509,81 @@ func delegatedCredentialsPath() string {
 	return filepath.Join(configDir(), "delegated-credentials.json")
 }
 
-func resolveDelegatedCredentialsPath(flagValue string) string {
+func delegatedCredentialsPathForRequest(workspaceValue string, scopes []string) string {
+	workspaceKey := delegatedCredentialsWorkspaceKey(workspaceValue)
+	scopeKey := delegatedCredentialsScopeKey(scopes)
+	return filepath.Join(configDir(), "delegated", workspaceKey, scopeKey+".json")
+}
+
+func delegatedCredentialsWorkspaceKey(workspaceValue string) string {
+	workspaceValue = strings.TrimSpace(workspaceValue)
+	if workspaceValue == "" {
+		workspaceValue = "active"
+	}
+	if record, ok := workspaceRecordByName(workspaceValue); ok && strings.TrimSpace(record.ID) != "" {
+		workspaceValue = record.ID
+	} else if record, ok := workspaceRecordByID(workspaceValue); ok && strings.TrimSpace(record.ID) != "" {
+		workspaceValue = record.ID
+	}
+	sum := sha256.Sum256([]byte(workspaceValue))
+	return hex.EncodeToString(sum[:])[:24]
+}
+
+func delegatedCredentialsScopeKey(scopes []string) string {
+	normalized := normalizedScopeSet(scopes)
+	if len(normalized) == 0 {
+		normalized = normalizedScopeSet(defaultJoinScopes)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(normalized, "\n")))
+	return hex.EncodeToString(sum[:])[:24]
+}
+
+func normalizedScopeSet(scopes []string) []string {
+	seen := map[string]struct{}{}
+	normalized := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		if _, ok := seen[scope]; ok {
+			continue
+		}
+		seen[scope] = struct{}{}
+		normalized = append(normalized, scope)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func explicitDelegatedCredentialsPath(flagValue string) (string, bool) {
 	if value := strings.TrimSpace(flagValue); value != "" {
-		return value
+		return value, true
 	}
 	if value := strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_CREDS_FILE")); value != "" {
-		return value
+		return value, true
 	}
 	if value := strings.TrimSpace(os.Getenv("RELAYFILE_DELEGATED_CREDENTIALS_FILE")); value != "" {
+		return value, true
+	}
+	return "", false
+}
+
+func resolveDelegatedCredentialsPath(flagValue string) string {
+	if value, ok := explicitDelegatedCredentialsPath(flagValue); ok {
 		return value
 	}
 	return delegatedCredentialsPath()
+}
+
+func resolveDelegatedCredentialsPathForRequest(flagValue, workspaceValue string, scopes []string) (string, bool) {
+	if value, ok := explicitDelegatedCredentialsPath(flagValue); ok {
+		return value, true
+	}
+	if strings.TrimSpace(workspaceValue) != "" || len(scopes) > 0 {
+		return delegatedCredentialsPathForRequest(workspaceValue, scopes), false
+	}
+	return delegatedCredentialsPath(), false
 }
 
 func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error) {
@@ -6526,25 +6601,242 @@ func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error)
 	return bundle, resolvedPath, nil
 }
 
+func loadDelegatedCredentialsForRequest(path, workspaceValue string, scopes []string) (delegatedauth.Bundle, string, error) {
+	resolvedPath, explicit := resolveDelegatedCredentialsPathForRequest(path, workspaceValue, scopes)
+	bundle, loadedPath, err := loadDelegatedCredentials(resolvedPath)
+	if err == nil || explicit || resolvedPath == delegatedCredentialsPath() || !errors.Is(err, delegatedauth.ErrMissingCredentials) {
+		return bundle, loadedPath, err
+	}
+	legacyBundle, legacyPath, legacyErr := loadDelegatedCredentials(delegatedCredentialsPath())
+	if legacyErr == nil && delegatedBundleSatisfiesRequestedScopes(legacyBundle, scopes) {
+		return legacyBundle, legacyPath, nil
+	}
+	return bundle, loadedPath, err
+}
+
+func delegatedBundleSatisfiesRequestedScopes(bundle delegatedauth.Bundle, requested []string) bool {
+	requested = normalizedScopeSet(requested)
+	if len(requested) == 0 {
+		return true
+	}
+	available := delegatedBundleAvailableScopes(bundle)
+	if len(available) == 0 {
+		return false
+	}
+	for _, want := range requested {
+		if !scopeSetAllows(available, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func delegatedBundleAvailableScopes(bundle delegatedauth.Bundle) []string {
+	available := append(append([]string(nil), bundle.Scopes...), bundle.RelayfileScopes...)
+	if claims, ok := parseJWTClaims(bundle.BearerToken()); ok {
+		if raw, ok := claims["scopes"]; ok {
+			available = append(available, normalizeScopeClaim(raw)...)
+		} else if raw, ok := claims["scope"]; ok {
+			available = append(available, normalizeScopeClaim(raw)...)
+		}
+	}
+	return normalizedScopeSet(available)
+}
+
+func normalizeScopeClaim(raw any) []string {
+	var scopes []string
+	add := func(scope string) {
+		scope = strings.TrimSpace(scope)
+		if scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	switch value := raw.(type) {
+	case []any:
+		for _, item := range value {
+			if scope, ok := item.(string); ok {
+				add(scope)
+			}
+		}
+	case []string:
+		for _, scope := range value {
+			add(scope)
+		}
+	case string:
+		for _, scope := range strings.FieldsFunc(value, func(r rune) bool {
+			return r == ' ' || r == ',' || r == '\t' || r == '\n' || r == '\r'
+		}) {
+			add(scope)
+		}
+	}
+	return scopes
+}
+
+func scopeSetAllows(available []string, requested string) bool {
+	for _, grant := range available {
+		if scopeAllows(grant, requested) {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeAllows(grant, requested string) bool {
+	grant = strings.TrimSpace(grant)
+	requested = strings.TrimSpace(requested)
+	if grant == "" || requested == "" {
+		return false
+	}
+	if grant == requested {
+		return true
+	}
+	grant = strings.TrimPrefix(grant, "relayfile:")
+	requested = strings.TrimPrefix(requested, "relayfile:")
+	if grant == requested {
+		return true
+	}
+	grantParts := strings.Split(grant, ":")
+	requestParts := strings.Split(requested, ":")
+	if len(grantParts) < 2 || len(requestParts) < 2 {
+		return false
+	}
+	if grantParts[0] != requestParts[0] || grantParts[1] != requestParts[1] {
+		return false
+	}
+	grantPath := ""
+	if len(grantParts) > 2 {
+		grantPath = strings.Join(grantParts[2:], ":")
+	}
+	requestPath := ""
+	if len(requestParts) > 2 {
+		requestPath = strings.Join(requestParts[2:], ":")
+	}
+	if grantPath == "" || grantPath == "*" || grantPath == "/*" || grantPath == "/**" {
+		return true
+	}
+	return grantPath == requestPath
+}
+
 func refreshDelegatedCredentials(path string, bundle delegatedauth.Bundle, force bool) (delegatedauth.Bundle, error) {
 	resolvedPath := resolveDelegatedCredentialsPath(path)
 	if !force && !relayfileTokenNeedsRefresh(bundle.BearerToken()) {
 		return bundle, nil
 	}
-	renewed, changed, err := delegatedauth.RenewFile(context.Background(), nil, resolvedPath, delegatedauth.DefaultRefreshTimeout)
-	if err != nil {
-		if errors.Is(err, delegatedauth.ErrRefreshRejected) {
-			return bundle, ErrDelegatedRelayfileCredentialsExpired
+	var renewed delegatedauth.Bundle
+	attemptedToken := strings.TrimSpace(bundle.BearerToken())
+	if err := withDelegatedCredentialsLock(resolvedPath, func() error {
+		latest, loadErr := delegatedauth.Load(resolvedPath)
+		if loadErr == nil {
+			bundle = latest
+		} else if !errors.Is(loadErr, os.ErrNotExist) {
+			return loadErr
 		}
+		latestToken := strings.TrimSpace(bundle.BearerToken())
+		if latestToken != "" && latestToken != attemptedToken && !relayfileTokenNeedsRefresh(latestToken) {
+			renewed = bundle
+			return nil
+		}
+		if !force && !relayfileTokenNeedsRefresh(bundle.BearerToken()) {
+			renewed = bundle
+			return nil
+		}
+		refreshed, changed, err := delegatedauth.RenewFile(context.Background(), nil, resolvedPath, delegatedauth.DefaultRefreshTimeout)
+		if err != nil {
+			reminted, remintErr := remintDelegatedCredentialsFromCloud(resolvedPath, bundle)
+			if remintErr == nil {
+				renewed = reminted
+				return nil
+			}
+			if errors.Is(err, delegatedauth.ErrRefreshRejected) {
+				return fmt.Errorf("%w; cloud re-mint fallback failed: %v", ErrDelegatedRelayfileCredentialsExpired, remintErr)
+			}
+			return fmt.Errorf("%w; cloud re-mint fallback failed: %v", err, remintErr)
+		}
+		if !changed {
+			renewed = bundle
+			return nil
+		}
+		renewed = refreshed
+		return nil
+	}); err != nil {
 		return bundle, err
-	}
-	if !changed {
-		return bundle, nil
 	}
 	if err := renewed.ValidateForUse(); err != nil {
 		return bundle, err
 	}
 	return renewed, nil
+}
+
+func withDelegatedCredentialsLock(path string, fn func() error) error {
+	lockPath := path + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	return fn()
+}
+
+func remintDelegatedCredentialsFromCloud(path string, bundle delegatedauth.Bundle) (delegatedauth.Bundle, error) {
+	workspaceID := cloudWorkspaceIDForDelegatedBundle(bundle)
+	if workspaceID == "" {
+		return delegatedauth.Bundle{}, errors.New("delegated relayfile credentials missing workspace id")
+	}
+	scopes := delegatedBundleMintScopes(bundle)
+	cloudCreds, err := cloudCredentialsFromAgentRelay()
+	if err != nil {
+		return delegatedauth.Bundle{}, err
+	}
+	renewed, err := delegatedRelayfileTokenViaCloud(cloudCreds, workspaceID, bundle.AgentName, scopes)
+	if err != nil {
+		return delegatedauth.Bundle{}, err
+	}
+	if err := delegatedauth.SaveAtomic(path, renewed); err != nil {
+		return delegatedauth.Bundle{}, fmt.Errorf("persist re-minted delegated relayfile credentials: %w", err)
+	}
+	return renewed, nil
+}
+
+func cloudWorkspaceIDForDelegatedBundle(bundle delegatedauth.Bundle) string {
+	if workspaceID := strings.TrimSpace(bundle.WorkspaceID); workspaceID != "" {
+		return workspaceID
+	}
+	relayWorkspaceID := strings.TrimSpace(bundle.Workspace())
+	if relayWorkspaceID == "" {
+		return ""
+	}
+	if record, ok := workspaceRecordByID(relayWorkspaceID); ok && strings.TrimSpace(record.ID) != "" {
+		return record.ID
+	}
+	if record, ok := workspaceRecordByName(relayWorkspaceID); ok && strings.TrimSpace(record.ID) != "" {
+		return record.ID
+	}
+	catalog, err := loadWorkspaceCatalog()
+	if err == nil {
+		for _, record := range catalog.Workspaces {
+			if strings.TrimSpace(record.RelayWorkspaceID) == relayWorkspaceID && strings.TrimSpace(record.ID) != "" {
+				return strings.TrimSpace(record.ID)
+			}
+		}
+	}
+	return relayWorkspaceID
+}
+
+func delegatedBundleMintScopes(bundle delegatedauth.Bundle) []string {
+	if len(bundle.Scopes) > 0 {
+		return append([]string(nil), bundle.Scopes...)
+	}
+	if len(bundle.RelayfileScopes) > 0 {
+		return append([]string(nil), bundle.RelayfileScopes...)
+	}
+	return append([]string(nil), defaultJoinScopes...)
 }
 
 func agentRelayCloudAuthPath() string {
@@ -6582,7 +6874,9 @@ func removeCredentialFile(path string) error {
 	return nil
 }
 
-func saveCloudCredentials(creds cloudCredentials) error {
+// saveLegacyCloudCredentials is retained for stale-store cleanup tests only.
+// Relayfile no longer owns the canonical cloud session.
+func saveLegacyCloudCredentials(creds cloudCredentials) error {
 	if err := ensureConfigDir(); err != nil {
 		return err
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1696,10 +1696,11 @@ func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes [
 	if cloudWorkspaceID == "" {
 		return workspaceRecord{}, "", errors.New("agent-relay workspace active --json did not include a cloud workspace id")
 	}
-	recordScopes := append([]string(nil), scopes...)
-	if len(recordScopes) == 0 {
-		recordScopes = append([]string(nil), defaultJoinScopes...)
+	mintScopes := append([]string(nil), scopes...)
+	if len(mintScopes) == 0 {
+		mintScopes = append([]string(nil), defaultJoinScopes...)
 	}
+	recordScopes := delegatedWorkspaceCatalogScopes(cloudWorkspaceID, workspace, mintScopes)
 	now := time.Now().UTC().Format(time.RFC3339)
 	record := workspaceRecord{
 		Name:             firstNonEmpty(workspace.Name, workspace.Slug, workspace.Key, cloudWorkspaceID, workspace.RelayfileWorkspaceID),
@@ -1710,11 +1711,11 @@ func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes [
 		AgentName:        "relayfile-cli",
 		Scopes:           recordScopes,
 	}
-	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, cloudWorkspaceID, record.AgentName, record.Scopes)
+	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, cloudWorkspaceID, record.AgentName, mintScopes)
 	if err != nil {
 		return workspaceRecord{}, "", err
 	}
-	credsPath := delegatedCredentialsPathForRequest(record.ID, record.Scopes)
+	credsPath := delegatedCredentialsPathForRequest(record.ID, mintScopes)
 	if err := delegatedauth.SaveAtomic(credsPath, delegated); err != nil {
 		return workspaceRecord{}, "", fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
@@ -1723,6 +1724,26 @@ func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes [
 		return workspaceRecord{}, "", err
 	}
 	return persisted, credsPath, nil
+}
+
+func delegatedWorkspaceCatalogScopes(cloudWorkspaceID string, workspace agentRelayActiveWorkspace, fallback []string) []string {
+	candidates := []string{
+		cloudWorkspaceID,
+		workspace.RelayfileWorkspaceID,
+		workspace.Name,
+		workspace.Slug,
+		workspace.Key,
+		workspace.ID,
+	}
+	for _, candidate := range candidates {
+		if record, ok := workspaceRecordByID(candidate); ok && len(record.Scopes) > 0 {
+			return append([]string(nil), record.Scopes...)
+		}
+		if record, ok := workspaceRecordByName(candidate); ok && len(record.Scopes) > 0 {
+			return append([]string(nil), record.Scopes...)
+		}
+	}
+	return append([]string(nil), fallback...)
 }
 
 func loadOrBootstrapDelegatedCredentials(workspaceValue string, scopes []string) (delegatedauth.Bundle, string, error) {
@@ -3311,14 +3332,7 @@ func delegatedBundleHasScopes(bundle delegatedauth.Bundle, required []string) bo
 		if want == "" {
 			continue
 		}
-		found := false
-		for _, got := range available {
-			if strings.TrimSpace(got) == want {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !scopeSetAllows(available, want) {
 			return false
 		}
 	}
@@ -3626,18 +3640,12 @@ func runWritebackSkipStuck(args []string, stdout io.Writer) error {
 		return errors.New("workspace has no local mirror")
 	}
 
-	creds, err := loadCredentials()
+	commandClient, err := prepareWorkspaceCommandClient(workspaceID, "", "", defaultJoinScopes)
 	if err != nil {
 		return err
 	}
-	tokenValue := resolveToken("", creds)
-	if tokenValue == "" {
-		return errors.New("token is required; set RELAYFILE_TOKEN or pass explicit relayfile credentials")
-	}
-	server := strings.TrimSpace(record.Server)
-	if server == "" {
-		server = resolveServer("", creds)
-	}
+	tokenValue := commandClient.client.token
+	server := strings.TrimSpace(commandClient.client.baseURL)
 	timeout := durationEnv("RELAYFILE_MOUNT_TIMEOUT", defaultMountTimeout)
 	if timeout <= 0 {
 		timeout = defaultMountTimeout
@@ -3646,7 +3654,7 @@ func runWritebackSkipStuck(args []string, stdout io.Writer) error {
 		Transport: newWritebackFailureTransport(record.LocalDir, log.Default(), mountsync.NewSyncTransport()),
 	})
 	remoteRoot := readMountRemoteRoot(record.LocalDir)
-	websocketDisabled := true
+	websocketDisabled := false
 	syncer, err := mountsync.NewSyncer(client, mountsync.SyncerOptions{
 		WorkspaceID: workspaceID,
 		RemoteRoot:  remoteRoot,
@@ -3925,14 +3933,14 @@ func resolveWorkspaceLikeStatus(value string) (string, workspaceRecord, error) {
 	}
 	if candidate != "" {
 		if local, ok := workspaceRecordByName(candidate); ok {
-			workspaceID := strings.TrimSpace(local.ID)
+			workspaceID := firstNonBlank(strings.TrimSpace(local.RelayWorkspaceID), strings.TrimSpace(local.ID))
 			if workspaceID == "" {
 				workspaceID = local.Name
 			}
 			return workspaceID, local, nil
 		}
 		if local, ok := workspaceRecordByID(candidate); ok {
-			return strings.TrimSpace(local.ID), local, nil
+			return firstNonBlank(strings.TrimSpace(local.RelayWorkspaceID), strings.TrimSpace(local.ID)), local, nil
 		}
 	}
 
@@ -4806,9 +4814,12 @@ func readLocalMountCursorHealth(localDir string) (stuckCount int, backlogDrainin
 		if json.Unmarshal(payload, &state) != nil {
 			continue
 		}
-		return len(state.IncrementalReadNotReadySince), state.IncrementalBacklogDraining
+		if count := len(state.IncrementalReadNotReadySince); count > stuckCount {
+			stuckCount = count
+		}
+		backlogDraining = backlogDraining || state.IncrementalBacklogDraining
 	}
-	return 0, false
+	return stuckCount, backlogDraining
 }
 
 func countJSONFiles(dir string) int {
@@ -6580,10 +6591,22 @@ func resolveDelegatedCredentialsPathForRequest(flagValue, workspaceValue string,
 	if value, ok := explicitDelegatedCredentialsPath(flagValue); ok {
 		return value, true
 	}
+	workspaceValue = resolveDelegatedCredentialsWorkspaceValue(workspaceValue)
 	if strings.TrimSpace(workspaceValue) != "" || len(scopes) > 0 {
 		return delegatedCredentialsPathForRequest(workspaceValue, scopes), false
 	}
 	return delegatedCredentialsPath(), false
+}
+
+func resolveDelegatedCredentialsWorkspaceValue(workspaceValue string) string {
+	workspaceValue = strings.TrimSpace(workspaceValue)
+	if workspaceValue != "" && !strings.EqualFold(workspaceValue, "active") {
+		return workspaceValue
+	}
+	if name, _ := activeWorkspaceName(""); strings.TrimSpace(name) != "" {
+		return strings.TrimSpace(name)
+	}
+	return workspaceValue
 }
 
 func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error) {
@@ -6777,10 +6800,11 @@ func withDelegatedCredentialsLock(path string, fn func() error) error {
 		return err
 	}
 	defer file.Close()
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+	unlock, err := lockFileExclusive(file)
+	if err != nil {
 		return err
 	}
-	defer syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	defer unlock()
 	return fn()
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -316,7 +316,7 @@ func TestWorkspaceJoinStoresDelegatedRelayfileCredentials(t *testing.T) {
 	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected workspace join not to persist relayfile token credentials, got err=%v", err)
 	}
-	delegated, err := delegatedauth.Load(delegatedCredentialsPath())
+	delegated, err := delegatedauth.Load(delegatedCredentialsPathForRequest("ws_cloud", defaultInspectScopes))
 	if err != nil {
 		t.Fatalf("expected delegated credentials to be stored: %v", err)
 	}
@@ -2300,6 +2300,20 @@ func testJWTWithWorkspaceAndAgent(workspaceID, agentName string) string {
 	return header + "." + payload + ".sig"
 }
 
+func testJWTWithWorkspaceAndScopes(workspaceID, agentName string, scopes []string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(map[string]any{
+		"workspace_id": workspaceID,
+		"agent_name":   agentName,
+		"aud":          "relayfile",
+		"scopes":       scopes,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
 func testJWTWithWorkspaceAgentAndExpiry(workspaceID, agentName string, exp time.Time) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload, err := json.Marshal(map[string]any{
@@ -2339,8 +2353,11 @@ func writeDelegatedCredentialsForTest(t *testing.T, bundle delegatedauth.Bundle)
 	if bundle.RelayfileWorkspaceID == "" && bundle.WorkspaceID == "" {
 		bundle.RelayfileWorkspaceID = "ws_test"
 	}
+	if len(bundle.Scopes) == 0 && len(bundle.RelayfileScopes) == 0 {
+		bundle.Scopes = append([]string(nil), defaultJoinScopes...)
+	}
 	if bundle.AccessToken == "" && bundle.Token == "" && bundle.RelayfileToken == "" {
-		bundle.AccessToken = testJWTWithWorkspace(bundle.Workspace())
+		bundle.AccessToken = testJWTWithWorkspaceAndScopes(bundle.Workspace(), "test", bundle.Scopes)
 	}
 	if bundle.RefreshToken == "" && bundle.RelayfileRefreshToken == "" {
 		bundle.RefreshToken = "refresh_test"
@@ -2389,7 +2406,7 @@ func TestWritebackPushPostsBulkAndWritesAckedReceipt(t *testing.T) {
 		t.Fatalf("write local payload failed: %v", err)
 	}
 
-	if err := saveCloudCredentials(cloudCredentials{
+	if err := saveLegacyCloudCredentials(cloudCredentials{
 		APIURL:      "https://legacy-cloud-credentials.invalid",
 		AccessToken: "legacy_token_must_not_be_used",
 	}); err != nil {
@@ -3807,7 +3824,7 @@ func TestOpsReplayPostsToCloudAndRemovesLocalRecord(t *testing.T) {
 func TestLoginWithExplicitTokenPersistsServerCreds(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-	if err := saveCloudCredentials(cloudCredentials{
+	if err := saveLegacyCloudCredentials(cloudCredentials{
 		APIURL:      "https://cloud.relayfile.test",
 		AccessToken: "stale_cloud_token",
 	}); err != nil {
@@ -3852,7 +3869,7 @@ func TestLoginWithExplicitTokenPersistsServerCreds(t *testing.T) {
 func TestLoginDelegatesToAgentRelay(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-	if err := saveCloudCredentials(cloudCredentials{
+	if err := saveLegacyCloudCredentials(cloudCredentials{
 		APIURL:      "https://cloud.relayfile.test",
 		AccessToken: "stale_cloud_token",
 	}); err != nil {
@@ -3935,7 +3952,7 @@ exit 2
 	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected stale relayfile credentials removed, got err=%v", err)
 	}
-	delegated, err := delegatedauth.Load(delegatedCredentialsPath())
+	delegated, err := delegatedauth.Load(delegatedCredentialsPathForRequest("ws_123", defaultJoinScopes))
 	if err != nil {
 		t.Fatalf("expected delegated credentials to be stored: %v", err)
 	}
@@ -4000,7 +4017,7 @@ func TestPrepareWorkspaceCommandClientBootstrapsDelegatedCredentialsDespiteStale
 	if _, err := os.Stat(credentialsPath()); !os.IsNotExist(err) {
 		t.Fatalf("expected legacy relayfile credentials removed, got err=%v", err)
 	}
-	delegated, err := delegatedauth.Load(delegatedCredentialsPath())
+	delegated, err := delegatedauth.Load(delegatedCredentialsPathForRequest("cloud-prod", defaultInspectScopes))
 	if err != nil {
 		t.Fatalf("expected delegated credentials to be stored: %v", err)
 	}
@@ -4050,7 +4067,8 @@ func TestWorkspaceCommandClientRefreshesExpiredDelegatedAccessToken(t *testing.T
 		}
 	}))
 	defer server.Close()
-	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegatedauth.Bundle{
+	credsPath := delegatedCredentialsPathForRequest("ws_refresh", defaultInspectScopes)
+	if err := delegatedauth.SaveAtomic(credsPath, delegatedauth.Bundle{
 		RelayfileURL:          server.URL,
 		RelayauthURL:          server.URL,
 		RelayfileWorkspaceID:  "ws_refresh",
@@ -4072,12 +4090,248 @@ func TestWorkspaceCommandClientRefreshesExpiredDelegatedAccessToken(t *testing.T
 	if !sawStatus {
 		t.Fatalf("expected status data-plane call")
 	}
-	renewed, err := delegatedauth.Load(delegatedCredentialsPath())
+	renewed, err := delegatedauth.Load(credsPath)
 	if err != nil {
 		t.Fatalf("load renewed delegated credentials failed: %v", err)
 	}
 	if renewed.RotationToken() != "refresh_new" {
 		t.Fatalf("expected rotated refresh token, got %#v", renewed)
+	}
+}
+
+func TestLoadDelegatedCredentialsForRequestIgnoresInsufficientLegacyBundle(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPath(), delegatedauth.Bundle{
+		RelayfileURL:         "https://relayfile.test",
+		RelayfileWorkspaceID: "ws_cloud",
+		AccessToken:          testJWTWithWorkspaceAndScopes("ws_cloud", "relayfile-cli", []string{"relayfile:fs:read:*"}),
+		RefreshToken:         "refresh_read",
+		RelayfileScopes:      append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("save legacy delegated credentials failed: %v", err)
+	}
+
+	var sawBootstrap bool
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_cloud/relayfile/delegated-token":
+			sawBootstrap = true
+			var body cloudRelayfileDelegatedTokenRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode delegated-token body: %v", err)
+			}
+			if got, want := strings.Join(body.Scopes, ","), strings.Join(defaultJoinScopes, ","); got != want {
+				t.Fatalf("delegated-token scopes = %q, want %q", got, want)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_cloud", "rf_join", "refresh_join")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "cloud-prod", "ws_cloud", "ws_cloud")
+
+	bundle, path, err := loadOrBootstrapDelegatedCredentials("cloud-prod", defaultJoinScopes)
+	if err != nil {
+		t.Fatalf("loadOrBootstrapDelegatedCredentials failed: %v", err)
+	}
+	if !sawBootstrap {
+		t.Fatalf("expected insufficient legacy delegated bundle to be ignored")
+	}
+	if path == delegatedCredentialsPath() {
+		t.Fatalf("expected scoped delegated credential path, got legacy path")
+	}
+	if bundle.BearerToken() != "rf_join" {
+		t.Fatalf("expected bootstrapped bundle, got %#v", bundle)
+	}
+}
+
+func TestRefreshDelegatedCredentialsFallsBackToCloudRemint(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	expired := testJWTWithWorkspaceAgentAndExpiry("ws_relay", "relayfile-cli", time.Now().Add(-time.Minute))
+	reminted := testJWTWithWorkspaceAgentAndExpiry("ws_relay", "relayfile-cli", time.Now().Add(time.Hour))
+	var sawRemint bool
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_cloud/relayfile/delegated-token":
+			sawRemint = true
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+				t.Fatalf("unexpected remint Authorization: %q", got)
+			}
+			var body cloudRelayfileDelegatedTokenRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode remint body: %v", err)
+			}
+			if got, want := strings.Join(body.Scopes, ","), "relayfile:fs:read:*"; got != want {
+				t.Fatalf("remint scopes = %q, want %q", got, want)
+			}
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_relay", reminted, "refresh_new")
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	installFakeAgentRelaySession(t, server.URL, "cld_access", "demo", "ws_cloud", "ws_relay")
+
+	path := delegatedCredentialsPathForRequest("ws_cloud", defaultInspectScopes)
+	if err := delegatedauth.SaveAtomic(path, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_relay",
+		WorkspaceID:          "ws_cloud",
+		AccessToken:          expired,
+		RefreshToken:         "refresh_old",
+		AgentName:            "relayfile-cli",
+		Scopes:               append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+
+	renewed, err := refreshDelegatedCredentials(path, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_relay",
+		WorkspaceID:          "ws_cloud",
+		AccessToken:          expired,
+		RefreshToken:         "refresh_old",
+		AgentName:            "relayfile-cli",
+		Scopes:               append([]string(nil), defaultInspectScopes...),
+	}, false)
+	if err != nil {
+		t.Fatalf("refreshDelegatedCredentials failed: %v", err)
+	}
+	if !sawRemint {
+		t.Fatalf("expected cloud delegated-token re-mint")
+	}
+	if renewed.BearerToken() != reminted || renewed.RotationToken() != "refresh_new" {
+		t.Fatalf("unexpected renewed bundle: %#v", renewed)
+	}
+	persisted, err := delegatedauth.Load(path)
+	if err != nil {
+		t.Fatalf("load persisted remint failed: %v", err)
+	}
+	if persisted.BearerToken() != reminted {
+		t.Fatalf("expected reminted token persisted, got %#v", persisted)
+	}
+}
+
+func TestRefreshDelegatedCredentialsSurfacesRemintFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	installFakeAgentRelay(t, `
+if [ "$*" = "cloud session --json" ]; then
+  echo "no active cloud session" >&2
+  exit 2
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	expired := testJWTWithWorkspaceAgentAndExpiry("ws_refresh", "relayfile-cli", time.Now().Add(-time.Minute))
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/tokens/refresh":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"code":"delegation_expired"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	path := delegatedCredentialsPathForRequest("ws_refresh", defaultInspectScopes)
+	bundle := delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayauthURL:         server.URL,
+		RelayfileWorkspaceID: "ws_refresh",
+		AccessToken:          expired,
+		RefreshToken:         "refresh_old",
+		Scopes:               append([]string(nil), defaultInspectScopes...),
+	}
+	if err := delegatedauth.SaveAtomic(path, bundle); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+
+	_, err := refreshDelegatedCredentials(path, bundle, false)
+	if err == nil {
+		t.Fatal("expected refresh failure")
+	}
+	if !errors.Is(err, ErrDelegatedRelayfileCredentialsExpired) {
+		t.Fatalf("expected delegated expiry sentinel, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no active cloud session") {
+		t.Fatalf("expected remint failure detail, got %v", err)
+	}
+}
+
+func TestWorkspaceCommandRefreshPreservesCatalogDefaultScopes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_refresh",
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	expired := testJWTWithWorkspaceAgentAndExpiry("ws_refresh", "relayfile-cli", time.Now().Add(-time.Minute))
+	renewedAccessToken := testJWTWithWorkspaceAgentAndExpiry("ws_refresh", "relayfile-cli", time.Now().Add(time.Hour))
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/tokens/refresh":
+			_ = json.NewEncoder(w).Encode(delegatedauth.TokenPair{
+				AccessToken:           renewedAccessToken,
+				RefreshToken:          "refresh_new",
+				AccessTokenExpiresAt:  time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+				RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			})
+		case "/v1/workspaces/ws_refresh/sync/status":
+			if got, want := r.Header.Get("Authorization"), "Bearer "+renewedAccessToken; got != want {
+				t.Fatalf("unexpected status Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_refresh","providers":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPathForRequest("ws_refresh", defaultInspectScopes), delegatedauth.Bundle{
+		RelayfileURL:          server.URL,
+		RelayauthURL:          server.URL,
+		RelayfileWorkspaceID:  "ws_refresh",
+		AccessToken:           expired,
+		RefreshToken:          "refresh_old",
+		AccessTokenExpiresAt:  time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+		RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		Scopes:                append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"status", "ws_refresh"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run status failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	record, ok := workspaceRecordByID("ws_refresh")
+	if !ok {
+		t.Fatalf("expected workspace record")
+	}
+	if got, want := strings.Join(record.Scopes, ","), strings.Join(defaultJoinScopes, ","); got != want {
+		t.Fatalf("workspace scopes were clobbered: got %q want %q", got, want)
 	}
 }
 
@@ -4125,7 +4379,7 @@ func TestDelegatedRelayfileTokenViaCloudDefaultsToCoarseScopes(t *testing.T) {
 func TestEnsureCloudCredentialsUsesAgentRelaySession(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
-	if err := saveCloudCredentials(cloudCredentials{
+	if err := saveLegacyCloudCredentials(cloudCredentials{
 		APIURL:      "https://stale-cloud.test",
 		AccessToken: "stale_cloud_token",
 	}); err != nil {
@@ -4150,7 +4404,7 @@ exit 2
 	if creds.AccessToken != "agent_cloud_token" {
 		t.Fatalf("expected agent-relay access token, got %q", creds.AccessToken)
 	}
-	stale, err := loadCloudCredentials()
+	stale, err := loadLegacyCloudCredentials()
 	if err != nil {
 		t.Fatalf("loadCloudCredentials failed: %v", err)
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/agentworkforce/relayfile/internal/delegatedauth"
+	"github.com/agentworkforce/relayfile/internal/mountsync"
 )
 
 func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
@@ -2370,6 +2371,144 @@ func writeDelegatedCredentialsForTest(t *testing.T, bundle delegatedauth.Bundle)
 		t.Fatalf("save delegated credentials failed: %v", err)
 	}
 	return path
+}
+
+func TestDelegatedBundleHasScopesAllowsBroadWildcardGrant(t *testing.T) {
+	bundle := delegatedauth.Bundle{
+		RelayfileScopes: []string{"relayfile:fs:write:/**"},
+	}
+	if !delegatedBundleHasScopes(bundle, []string{"relayfile:fs:write:/github/**"}) {
+		t.Fatal("expected broad write scope to satisfy provider write scope")
+	}
+	if delegatedBundleHasScopes(bundle, []string{"relayfile:fs:read:/github/**"}) {
+		t.Fatal("did not expect write scope to satisfy read scope")
+	}
+}
+
+func TestReadLocalMountCursorHealthAggregatesStateFiles(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), []byte(`{"incrementalReadNotReadySince":{"a":"now"},"incrementalBacklogDraining":false}`), 0o644); err != nil {
+		t.Fatalf("write public state failed: %v", err)
+	}
+	privateDir := filepath.Join(localDir, mountsync.DefaultMountStateDirName)
+	if err := os.MkdirAll(privateDir, 0o755); err != nil {
+		t.Fatalf("mkdir private state failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(privateDir, "state.json"), []byte(`{"incrementalReadNotReadySince":{"a":"now","b":"now"},"incrementalBacklogDraining":true}`), 0o644); err != nil {
+		t.Fatalf("write private state failed: %v", err)
+	}
+
+	stuck, backlog := readLocalMountCursorHealth(localDir)
+	if stuck != 2 || !backlog {
+		t.Fatalf("cursor health = %d/%v, want 2/true", stuck, backlog)
+	}
+}
+
+func TestResolveWorkspaceLikeStatusPrefersRelayWorkspaceID(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:             "demo",
+		ID:               "ws_cloud",
+		RelayWorkspaceID: "rw_cloud",
+		LocalDir:         t.TempDir(),
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	workspaceID, _, err := resolveWorkspaceLikeStatus("demo")
+	if err != nil {
+		t.Fatalf("resolveWorkspaceLikeStatus failed: %v", err)
+	}
+	if workspaceID != "rw_cloud" {
+		t.Fatalf("workspaceID = %q, want rw_cloud", workspaceID)
+	}
+}
+
+func TestLoadDelegatedCredentialsForActiveWorkspaceUsesCatalogDefault(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:      "cloud-prod",
+		ID:        "ws_cloud",
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		Scopes:    append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	if _, err := setDefaultWorkspace("cloud-prod"); err != nil {
+		t.Fatalf("setDefaultWorkspace failed: %v", err)
+	}
+	path := delegatedCredentialsPathForRequest("cloud-prod", defaultInspectScopes)
+	if err := delegatedauth.SaveAtomic(path, delegatedauth.Bundle{
+		RelayfileURL:         "https://relayfile.test",
+		RelayfileWorkspaceID: "ws_cloud",
+		AccessToken:          testJWTWithWorkspaceAndScopes("ws_cloud", "relayfile-cli", defaultInspectScopes),
+		RefreshToken:         "refresh_read",
+		Scopes:               append([]string(nil), defaultInspectScopes...),
+	}); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+
+	_, loadedPath, err := loadDelegatedCredentialsForRequest("", "active", defaultInspectScopes)
+	if err != nil {
+		t.Fatalf("loadDelegatedCredentialsForRequest failed: %v", err)
+	}
+	if loadedPath != path {
+		t.Fatalf("loadedPath = %q, want %q", loadedPath, path)
+	}
+}
+
+func TestWritebackSkipStuckUsesDelegatedCredentialsWithoutLegacyCredentials(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_demo",
+		LocalDir:   localDir,
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/workspaces/ws_demo/fs/export":
+			_, _ = w.Write([]byte(`[]`))
+		case "/v1/workspaces/ws_demo/fs/events":
+			_, _ = w.Write([]byte(`{"events":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPathForRequest("ws_demo", defaultJoinScopes), delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_demo",
+		AccessToken:          testJWTWithWorkspaceAndScopes("ws_demo", "relayfile-cli", defaultJoinScopes),
+		RefreshToken:         "refresh_join",
+		RelayauthURL:         server.URL,
+		Scopes:               append([]string(nil), defaultJoinScopes...),
+	}); err != nil {
+		t.Fatalf("save delegated credentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"writeback", "skip-stuck", "demo", "--json"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("writeback skip-stuck failed without legacy credentials: %v\n%s", err, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), `"workspace": "ws_demo"`) {
+		t.Fatalf("unexpected skip-stuck output: %s", stdout.String())
+	}
 }
 
 func TestWritebackPushPostsBulkAndWritesAckedReceipt(t *testing.T) {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -999,6 +999,7 @@ type Syncer struct {
 	skipStuckMode     bool
 	skipStuckMax      int
 	skipStuckCount    int
+	syncActive        bool
 	oversizedLogged   map[string]struct{}
 	quarantinedPaths  map[string]struct{}
 	lazyRepos         bool
@@ -1553,6 +1554,11 @@ func (s *Syncer) BacklogDraining() bool {
 // events skipped along with any reconcile error.
 func (s *Syncer) SkipStuck(ctx context.Context, max int) (int, error) {
 	s.mu.Lock()
+	if s.syncActive {
+		s.mu.Unlock()
+		return 0, errors.New("sync already in progress")
+	}
+	s.syncActive = true
 	s.skipStuckMode = true
 	s.skipStuckMax = max
 	s.skipStuckCount = 0
@@ -1561,9 +1567,10 @@ func (s *Syncer) SkipStuck(ctx context.Context, max int) (int, error) {
 		s.mu.Lock()
 		s.skipStuckMode = false
 		s.skipStuckMax = 0
+		s.syncActive = false
 		s.mu.Unlock()
 	}()
-	err := s.sync(ctx, true)
+	err := s.syncReserved(ctx, true)
 	s.mu.Lock()
 	count := s.skipStuckCount
 	s.mu.Unlock()
@@ -2487,6 +2494,22 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 }
 
 func (s *Syncer) sync(ctx context.Context, forcePoll bool) error {
+	s.mu.Lock()
+	if s.syncActive {
+		s.mu.Unlock()
+		return errors.New("sync already in progress")
+	}
+	s.syncActive = true
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.syncActive = false
+		s.mu.Unlock()
+	}()
+	return s.syncReserved(ctx, forcePoll)
+}
+
+func (s *Syncer) syncReserved(ctx context.Context, forcePoll bool) error {
 	// Top-of-cycle invariant: the mount root must exist and be a
 	// directory. If a previous cycle, an external process, or a cloud
 	// clobber wiped it out, refuse to continue rather than recreating

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2066,18 +2066,34 @@ func outboxRecordsAsBulkFiles(records []outboxRecord) []BulkWriteFile {
 	files := make([]BulkWriteFile, 0, len(records))
 	for _, record := range records {
 		files = append(files, BulkWriteFile{
-			Path:        record.RemotePath,
-			ContentType: record.ContentType,
-			Content:     record.Content,
-			Encoding:    record.Encoding,
-			ContentIdentity: &ContentIdentity{
-				Kind:       "mount-command",
-				Key:        record.CommandID,
-				TTLSeconds: 7 * 24 * 60 * 60,
-			},
+			Path:            record.RemotePath,
+			ContentType:     record.ContentType,
+			Content:         record.Content,
+			Encoding:        record.Encoding,
+			ContentIdentity: outboxRecordContentIdentity(record),
 		})
 	}
 	return files
+}
+
+// outboxRecordContentIdentity derives the server-side dedupe key for a durable
+// outbox record. Writeback "create draft" paths must dedupe on
+// (workspace, path, content hash) — the same identity used by the in-flight
+// `bulkWriteFilesForPending` path and by the CLI's direct `relayfile writeback
+// push`. Keying those on the per-record commandId instead would mint a second
+// idempotency key for identical content, so a direct push racing a mount-daemon
+// flush of the same pending receipt could create duplicate provider
+// drafts/tickets. Non-draft mount commands keep the commandId identity, which is
+// stable across reconnect/restart.
+func outboxRecordContentIdentity(record outboxRecord) *ContentIdentity {
+	if identity := mountWritebackCreateDraftContentIdentity(record.WorkspaceID, record.RemotePath, record.Hash); identity != nil {
+		return identity
+	}
+	return &ContentIdentity{
+		Kind:       "mount-command",
+		Key:        record.CommandID,
+		TTLSeconds: 7 * 24 * 60 * 60,
+	}
 }
 
 func bulkWriteFilesForPending(workspaceID string, pending []pendingBulkWrite) []BulkWriteFile {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -1989,14 +1989,21 @@ func TestBulkWrite_FlushSendsContentIdentity(t *testing.T) {
 	if len(acked) != 1 {
 		t.Fatalf("expected one acked outbox record, got %+v", acked)
 	}
-	if identity.Kind != "mount-command" {
-		t.Fatalf("flushed identity kind = %q, want mount-command", identity.Kind)
+	// A draft-create flush must dedupe on the create-draft identity
+	// (workspace:path:hash) — the same key the in-flight pending path and the
+	// CLI's direct `writeback push` use — so a daemon flush of a pending push
+	// receipt collides with the direct push instead of minting a second
+	// idempotency key (which would create duplicate provider drafts).
+	remotePath := acked[0].RemotePath
+	want := newMountWritebackCreateDraftContentIdentity(workspaceID, remotePath, acked[0].Hash)
+	if identity.Kind != mountWritebackCreateDraftContentIdentityKind {
+		t.Fatalf("flushed identity kind = %q, want %q", identity.Kind, mountWritebackCreateDraftContentIdentityKind)
 	}
-	if identity.Key != acked[0].CommandID {
-		t.Fatalf("flushed identity key = %q, want persisted command id %q", identity.Key, acked[0].CommandID)
+	if identity.Key != want.Key {
+		t.Fatalf("flushed identity key = %q, want create-draft key %q", identity.Key, want.Key)
 	}
-	if identity.TTLSeconds != 7*24*60*60 {
-		t.Fatalf("flushed identity ttl = %d, want 604800", identity.TTLSeconds)
+	if identity.TTLSeconds != mountWritebackCreateDraftContentIdentityTTLSeconds {
+		t.Fatalf("flushed identity ttl = %d, want %d", identity.TTLSeconds, mountWritebackCreateDraftContentIdentityTTLSeconds)
 	}
 }
 
@@ -2120,6 +2127,46 @@ func TestOutboxFlushUsesIndependentDeadlineNotPerCycleCtx(t *testing.T) {
 	}
 	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
 		t.Fatalf("expected pending outbox empty after ack, got %+v", pending)
+	}
+}
+
+func TestOutboxRecordContentIdentityDraftMatchesDirectPush(t *testing.T) {
+	const (
+		workspaceID = "ws_test"
+		contentHash = "751f9591557700f69b5ceefcdec7ead8563a10f0a712c501a5028699be021511"
+		draftPath   = "/slack/channels/C123/messages/messages 5ab77d67-1111-2222-3333-444455556666.json"
+	)
+
+	// A draft "create" outbox record must dedupe on the create-draft identity
+	// (workspace:path:hash) so a mount-daemon flush of the CLI's pending receipt
+	// collides with the CLI's direct `writeback push`, not on the per-record
+	// commandId. Otherwise the server sees two idempotency keys for identical
+	// content and can mint duplicate provider drafts.
+	if !isMountWritebackCreateDraftPath(draftPath) {
+		t.Fatalf("expected %q to be recognized as a create-draft path", draftPath)
+	}
+	draftRecord := outboxRecord{
+		CommandID:   "mountcmd_should_not_be_used",
+		WorkspaceID: workspaceID,
+		RemotePath:  draftPath,
+		Hash:        contentHash,
+	}
+	got := outboxRecordContentIdentity(draftRecord)
+	want := newMountWritebackCreateDraftContentIdentity(workspaceID, draftPath, contentHash)
+	if got == nil || got.Kind != want.Kind || got.Key != want.Key || got.TTLSeconds != want.TTLSeconds {
+		t.Fatalf("draft record identity = %+v, want %+v", got, want)
+	}
+
+	// Non-draft mount commands keep the stable commandId identity.
+	plainRecord := outboxRecord{
+		CommandID:   "mountcmd_abc123",
+		WorkspaceID: workspaceID,
+		RemotePath:  "/slack/channels/C123/messages/command.json",
+		Hash:        contentHash,
+	}
+	plain := outboxRecordContentIdentity(plainRecord)
+	if plain == nil || plain.Kind != "mount-command" || plain.Key != plainRecord.CommandID {
+		t.Fatalf("plain record identity = %+v, want mount-command keyed by commandId", plain)
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7653,6 +7653,31 @@ func TestSkipStuckDropsConsecutiveUnreadableEvents(t *testing.T) {
 	assertLocalFileContent(t, filepath.Join(localDir, "Docs", "004.md"), "# 004")
 }
 
+func TestSkipStuckRefusesConcurrentSync(t *testing.T) {
+	syncer, err := NewSyncer(&fakeClient{files: map[string]RemoteFile{}}, SyncerOptions{
+		WorkspaceID: "ws_skip_stuck_busy",
+		RemoteRoot:  "/",
+		LocalRoot:   t.TempDir(),
+		WebSocket:   boolPtr(false),
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	syncer.mu.Lock()
+	syncer.syncActive = true
+	syncer.mu.Unlock()
+
+	skipped, err := syncer.SkipStuck(context.Background(), 0)
+	if err == nil || !strings.Contains(err.Error(), "sync already in progress") {
+		t.Fatalf("expected concurrent sync error, skipped=%d err=%v", skipped, err)
+	}
+	syncer.mu.Lock()
+	defer syncer.mu.Unlock()
+	if syncer.skipStuckMode || syncer.skipStuckMax != 0 {
+		t.Fatalf("skip-stuck state leaked after refusal: mode=%v max=%d", syncer.skipStuckMode, syncer.skipStuckMax)
+	}
+}
+
 func TestPullRemoteIncrementalCreatedThreadReply404RetriesWithoutAdvancingCursor(t *testing.T) {
 	const replyPath = "/slack/channels/C123ABC__proj-cloud/threads/1780871788_370329/replies/1780914176_827829.json"
 	client := &fakeClient{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.2.tgz",
-      "integrity": "sha512-v+73fozoCx5/De9Pju6gbhmtiFeha6IkjYgerzI7CegYBpVmKOsdKPEBk+TanT6nan08YEWJqOdXk2T7a4Aslg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.3.tgz",
+      "integrity": "sha512-dXTnvPA7PmsWQPFvNoAkG5WVfelv+LpCj8p+HlCn9upNooeg/okCIJJD2bv6z02k1UchVsUAtIO8slpz3H0w4A==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.2.tgz",
-      "integrity": "sha512-sC7hU3ZTN7hCU43BbsVX7CdadculLR2byjvpCrSYZRljI56KXk/w7HDq6Q+1xoa/tQ4XxFqmW9/zdiAcxp76bQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.3.tgz",
+      "integrity": "sha512-+Gg47XGO8p5M8s7uE01blMW5SS9pyVK0z7fpB2X5roM/dq2F24vtd/U8uVlQaEH5RyDGvwTDxiR6vTMTJOMD5g==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.2.tgz",
-      "integrity": "sha512-/Llov8pGpC5fRNIoaocq6LlY8Y1z9ihP3nBFzyJlOxdzuAxZyGYq2jcO4xQfz+t349xw+EP6oKnnKGoW871fsA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.3.tgz",
+      "integrity": "sha512-+LA45OALeD+Jzbz65JRtCPrO9x/lw5wW681pjo33RtRgNDgeFkEEh/3oefgDPZayLNV9rTpPNO4xgqvHJaU0Iw==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.2.tgz",
-      "integrity": "sha512-7cpka0EWT7/ueAS9zGZFKHmjWmkj9NXi87mGZOFYVcK8uXWma1XVfr0eY/LU+sY5Pap606WfgPbSLOmpyb0vTg==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.3.tgz",
+      "integrity": "sha512-LLisNh36iDX2LRu6uC8QjMVb4IfkQZSkStdhFISFBH/Pegdi9kgUlUPJ41uSwGm/e/xBcR9OHpGumy3Z6wQmKw==",
       "cpu": [
         "x64"
       ],
@@ -3739,7 +3739,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3761,7 +3760,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3783,7 +3781,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3805,7 +3802,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3827,7 +3823,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3849,7 +3844,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3871,7 +3865,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3893,7 +3886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3915,7 +3907,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3937,7 +3928,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3959,7 +3949,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5287,7 +5276,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5288,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5301,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6109,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6138,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.2",
+        "@relayfile/core": "0.9.3",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6153,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.2",
-        "@relayfile/mount-darwin-x64": "0.9.2",
-        "@relayfile/mount-linux-arm64": "0.9.2",
-        "@relayfile/mount-linux-x64": "0.9.2"
+        "@relayfile/mount-darwin-arm64": "0.9.3",
+        "@relayfile/mount-darwin-x64": "0.9.3",
+        "@relayfile/mount-linux-arm64": "0.9.3",
+        "@relayfile/mount-linux-x64": "0.9.3"
       }
     }
   }


### PR DESCRIPTION
## Summary
- quarantine legacy relayfile cloud credential helpers behind explicit legacy names
- store delegated relayfile bundles by workspace and normalized scope set, with legacy global-file fallback
- serialize delegated refresh across processes and fall back to Agent Relay cloud re-mint when token rotation cannot run
- preserve workspace catalog default scopes when command-specific delegated refreshes run

Fixes #291

## Validation
- npm ci
- go test ./cmd/relayfile-cli ./internal/mountsync ./internal/delegatedauth
- go test ./cmd/relayfile-cli
- GOOS=windows GOARCH=amd64 go test -c ./cmd/relayfile-cli -o /private/tmp/relayfile-cli-windows.test.exe
- go test ./...

## Notes
- No OpenAPI contract changes; HTTP server surface was not changed.
- .agentworkforce trajectory output remains untracked locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->