### PR TITLE
fix(sdk): normalize change event resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.3.tgz",
-      "integrity": "sha512-dXTnvPA7PmsWQPFvNoAkG5WVfelv+LpCj8p+HlCn9upNooeg/okCIJJD2bv6z02k1UchVsUAtIO8slpz3H0w4A==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.4.tgz",
+      "integrity": "sha512-PMioSG2wTJCVVsbrTIF4rEml5bgDJEBM+cE0jUTvflJfNiYvEDdvjXtA0Q5y2Ee+gEc2IGZ3ztYOmzNeV2+3Cw==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.3.tgz",
-      "integrity": "sha512-+Gg47XGO8p5M8s7uE01blMW5SS9pyVK0z7fpB2X5roM/dq2F24vtd/U8uVlQaEH5RyDGvwTDxiR6vTMTJOMD5g==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.4.tgz",
+      "integrity": "sha512-LWISBqO+Or4MYlLPFISEA0bf5TLgIaxE+FKmqiPodqxQt21I4BnT9nJ02i5exTgz/9n1PdIqtzT5y16ggXh4Mg==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.3.tgz",
-      "integrity": "sha512-+LA45OALeD+Jzbz65JRtCPrO9x/lw5wW681pjo33RtRgNDgeFkEEh/3oefgDPZayLNV9rTpPNO4xgqvHJaU0Iw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.4.tgz",
+      "integrity": "sha512-XaEbra5kEOqFDB+iJzuBmc5HXu20dZe6kQybtjevg5HINtO37yeVzhH9Jni1qiUUS8cuPow78LhRW7aeOwin0A==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.3.tgz",
-      "integrity": "sha512-LLisNh36iDX2LRu6uC8QjMVb4IfkQZSkStdhFISFBH/Pegdi9kgUlUPJ41uSwGm/e/xBcR9OHpGumy3Z6wQmKw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.4.tgz",
+      "integrity": "sha512-zmjXlRDoFzUArsNdecgXG+oPTvbSOjy3Pz7J8YAhyw22X+Ot87FFC96NISRpXFAnpIY1Y8w27JVQRQ0a14xqpA==",
       "cpu": [
         "x64"
       ],
@@ -3739,6 +3739,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3760,6 +3761,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3781,6 +3783,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3802,6 +3805,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3823,6 +3827,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3844,6 +3849,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3865,6 +3871,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3886,6 +3893,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3907,6 +3915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3928,6 +3937,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3949,6 +3959,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5276,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5288,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5301,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6109,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6138,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.3",
+        "@relayfile/core": "0.9.4",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6153,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.3",
-        "@relayfile/mount-darwin-x64": "0.9.3",
-        "@relayfile/mount-linux-arm64": "0.9.3",
-        "@relayfile/mount-linux-x64": "0.9.3"
+        "@relayfile/mount-darwin-arm64": "0.9.4",
+        "@relayfile/mount-darwin-x64": "0.9.4",
+        "@relayfile/mount-linux-arm64": "0.9.4",
+        "@relayfile/mount-linux-x64": "0.9.4"
       }
     }
   }

--- a/packages/sdk/typescript/package-lock.json
+++ b/packages/sdk/typescript/package-lock.json
@@ -1,19 +1,30 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.1.0",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@relayfile/sdk",
-      "version": "0.1.0",
+      "version": "0.9.4",
       "license": "MIT",
+      "dependencies": {
+        "@relayfile/core": "0.9.4",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
       "devDependencies": {
         "typescript": "^5.7.3",
         "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.9.4",
+        "@relayfile/mount-darwin-x64": "0.9.4",
+        "@relayfile/mount-linux-arm64": "0.9.4",
+        "@relayfile/mount-linux-x64": "0.9.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -458,12 +469,85 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@relayfile/core": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.9.4.tgz",
+      "integrity": "sha512-Ego3OKu9NGrrlk7SUIHSpUXVtLOx7FmUWpnCcShCMLshHP9NfRERe+/9wJjIM5HJwTfPWDueEYTeS4+Mvoz7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@relayfile/mount-darwin-arm64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.4.tgz",
+      "integrity": "sha512-PMioSG2wTJCVVsbrTIF4rEml5bgDJEBM+cE0jUTvflJfNiYvEDdvjXtA0Q5y2Ee+gEc2IGZ3ztYOmzNeV2+3Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-darwin-x64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.4.tgz",
+      "integrity": "sha512-LWISBqO+Or4MYlLPFISEA0bf5TLgIaxE+FKmqiPodqxQt21I4BnT9nJ02i5exTgz/9n1PdIqtzT5y16ggXh4Mg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-arm64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.4.tgz",
+      "integrity": "sha512-XaEbra5kEOqFDB+iJzuBmc5HXu20dZe6kQybtjevg5HINtO37yeVzhH9Jni1qiUUS8cuPow78LhRW7aeOwin0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-x64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.4.tgz",
+      "integrity": "sha512-zmjXlRDoFzUArsNdecgXG+oPTvbSOjy3Pz7J8YAhyw22X+Ot87FFC96NISRpXFAnpIY1Y8w27JVQRQ0a14xqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -1002,6 +1086,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1132,6 +1225,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1154,6 +1256,27 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -1335,6 +1458,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -1598,6 +1737,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/packages/sdk/typescript/src/client.test.ts
+++ b/packages/sdk/typescript/src/client.test.ts
@@ -773,6 +773,55 @@ describe("RelayFileClient — existing methods", () => {
       });
     });
 
+    it("listChangesSince normalizes retained flat filesystem events into ChangeEvents", async () => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.includes("/fs/changes?since=")) {
+          return {
+            ok: true,
+            status: 200,
+            headers: new Headers({ "content-type": "application/json" }),
+            json: async () => ({
+              events: [
+                {
+                  eventId: "evt_slack_reply_1",
+                  type: "file.updated",
+                  path: "/slack/channels/C1/messages/m1.json",
+                  revision: "rev_1",
+                  provider: "slack",
+                  timestamp: "2026-05-11T00:00:00.000Z",
+                },
+              ],
+            }),
+            text: async () => "",
+          } as unknown as Response;
+        }
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+      const client = makeClient(fetchImpl as unknown as typeof fetch, {
+        token: makeWorkspaceToken("ws_acme", "support-agent"),
+      });
+
+      const result = await client.listChangesSince("2026-05-11T00:00:00.000Z");
+
+      expect(result.events[0]).toMatchObject({
+        id: "evt_slack_reply_1",
+        workspace: "ws_acme",
+        type: "relayfile.changed",
+        occurredAt: "2026-05-11T00:00:00.000Z",
+        resource: {
+          path: "/slack/channels/C1/messages/m1.json",
+          provider: "slack",
+        },
+        summary: {
+          title: "m1",
+        },
+      });
+      await expect(result.events[0]!.expand("summary")).resolves.toMatchObject({
+        level: "summary",
+        path: "/slack/channels/C1/messages/m1.json",
+      });
+    });
+
     it("getResourceAtEvent falls back to the retained change-log endpoint when the cache is cold", async () => {
       const fetchImpl = vi.fn(async (url: string) => {
         if (url.includes("/fs/changes/resource?eventId=evt_rest_1")) {
@@ -1255,6 +1304,44 @@ describe("RelayFileClient — existing methods", () => {
       const url = f.mock.calls[0]![0] as string;
       expect(url).toContain("provider=github");
       expect(url).toContain("limit=10");
+    });
+
+    it("normalizes envelope-style events into filesystem events", async () => {
+      const f = mockFetch({
+        events: [
+          {
+            id: "evt_envelope_1",
+            type: "relayfile.changed",
+            occurredAt: "2026-05-11T00:00:00.000Z",
+            digest: "sha256:envelope",
+            resource: {
+              path: "/slack/channels/C1/messages/m1.json",
+              provider: "slack",
+            },
+          },
+        ],
+        nextCursor: "evt_envelope_1",
+      });
+      const client = makeClient(f);
+
+      const result = await client.getEvents("ws_acme");
+
+      expect(result).toEqual({
+        events: [
+          {
+            eventId: "evt_envelope_1",
+            type: "file.updated",
+            path: "/slack/channels/C1/messages/m1.json",
+            revision: "sha256:envelope",
+            contentHash: "sha256:envelope",
+            origin: undefined,
+            provider: "slack",
+            correlationId: undefined,
+            timestamp: "2026-05-11T00:00:00.000Z",
+          },
+        ],
+        nextCursor: "evt_envelope_1",
+      });
     });
   });
 

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -61,7 +61,7 @@ import {
   type SubscribeOptions
 } from "./types.js";
 import type { ForkHandle } from "@relayfile/core";
-import { RelayFileSync } from "./sync.js";
+import { RelayFileSync, normalizeFilesystemEvent } from "./sync.js";
 import {
   InvalidStateError,
   PayloadTooLargeError,
@@ -372,7 +372,7 @@ class RelayFileWebSocketConnection implements WebSocketConnection {
         if (raw.path !== undefined && typeof raw.path !== "string") {
           throw new Error("Invalid WebSocket event: 'path' must be a string.");
         }
-        parsed = raw as FilesystemEvent;
+        parsed = normalizeFilesystemEvent(raw as Parameters<typeof normalizeFilesystemEvent>[0]);
       } catch (error) {
         const parseError = error instanceof Error ? error : new Error("Failed to parse WebSocket event payload.");
         for (const handler of this.handlers.error) {
@@ -1151,23 +1151,66 @@ function toChangeEvent(
   };
 }
 
-function normalizeWireChangeEvent(payload: unknown): ChangeEventWireShape {
+function normalizeWireChangeEvent(payload: unknown, workspaceId?: string): ChangeEventWireShape {
   const data = (payload ?? {}) as Record<string, unknown>;
   const resource = (data.resource ?? {}) as Record<string, unknown>;
   const summary = (data.summary ?? {}) as Record<string, unknown>;
+  const path = typeof resource.path === "string"
+    ? resource.path
+    : typeof data.path === "string"
+      ? data.path
+      : "";
+  const inferredResource = inferResourceMetadata(path, resource);
+  const occurredAt = typeof data.occurredAt === "string"
+    ? data.occurredAt
+    : typeof data.timestamp === "string"
+      ? data.timestamp
+      : typeof data.ts === "string"
+        ? data.ts
+        : new Date().toISOString();
+  const eventId = typeof data.id === "string"
+    ? data.id
+    : typeof data.eventId === "string"
+      ? data.eventId
+      : [
+          "relayfile",
+          workspaceId ?? "",
+          typeof data.type === "string" ? data.type : "relayfile.changed",
+          path,
+          typeof data.revision === "string" ? data.revision : "",
+          occurredAt
+        ].join(":");
+  const provider = typeof resource.provider === "string"
+    ? resource.provider
+    : typeof data.provider === "string"
+      ? data.provider
+      : inferredResource.provider;
   return {
-    id: typeof data.id === "string" ? data.id : "",
-    workspace: typeof data.workspace === "string" ? data.workspace : "",
+    id: eventId,
+    workspace: typeof data.workspace === "string" ? data.workspace : workspaceId ?? "",
     agentId: typeof data.agentId === "string" ? data.agentId : undefined,
     type: "relayfile.changed",
-    occurredAt: typeof data.occurredAt === "string" ? data.occurredAt : new Date().toISOString(),
+    occurredAt,
     resource: {
-      path: typeof resource.path === "string" ? resource.path : "",
-      kind: typeof resource.kind === "string" ? resource.kind : "relayfile.resource",
-      id: typeof resource.id === "string" ? resource.id : "",
-      provider: typeof resource.provider === "string" ? resource.provider : "relayfile"
+      path,
+      kind: typeof resource.kind === "string"
+        ? resource.kind
+        : typeof data.kind === "string"
+          ? data.kind
+          : typeof data.resourceType === "string"
+            ? data.resourceType
+            : inferredResource.kind,
+      id: typeof resource.id === "string"
+        ? resource.id
+        : typeof data.resourceId === "string"
+          ? data.resourceId
+          : typeof data.providerObjectId === "string"
+            ? data.providerObjectId
+            : inferredResource.id,
+      provider
     },
     summary: {
+      ...buildChangeSummary(path, data),
       ...(typeof summary.title === "string" ? { title: summary.title } : {}),
       ...(typeof summary.status === "string" ? { status: summary.status } : {}),
       ...(typeof summary.priority === "string" ? { priority: summary.priority } : {}),
@@ -1457,12 +1500,16 @@ export class RelayFileClient {
       cursor: options.cursor,
       limit: options.limit
     });
-    return this.request<EventFeedResponse>({
+    const response = await this.request<EventFeedResponse>({
       method: "GET",
       path: `/v1/workspaces/${encodeURIComponent(workspaceId)}/fs/events${query}`,
       correlationId: options.correlationId,
       signal: options.signal
     });
+    return {
+      events: (response.events ?? []).map((event) => normalizeFilesystemEvent(event as Parameters<typeof normalizeFilesystemEvent>[0])),
+      nextCursor: response.nextCursor ?? null
+    };
   }
 
   subscribe(
@@ -1538,7 +1585,7 @@ export class RelayFileClient {
       });
       records = mergeChangeRecords([
         ...cached,
-        ...(payload.events ?? []).map((event) => this.cacheWireChangeEvent(workspaceId, normalizeWireChangeEvent(event), effectiveContext))
+        ...(payload.events ?? []).map((event) => this.cacheWireChangeEvent(workspaceId, normalizeWireChangeEvent(event, workspaceId), effectiveContext))
       ]);
     } catch (error) {
       if (cached.length === 0) {
@@ -1568,7 +1615,7 @@ export class RelayFileClient {
       });
       records = mergeChangeRecords([
         ...cached,
-        ...(payload.events ?? []).map((event) => this.cacheWireChangeEvent(workspaceId, normalizeWireChangeEvent(event), effectiveContext))
+        ...(payload.events ?? []).map((event) => this.cacheWireChangeEvent(workspaceId, normalizeWireChangeEvent(event, workspaceId), effectiveContext))
       ]).slice(-safeLimit);
     } catch (error) {
       if (cached.length === 0) {

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -165,6 +165,7 @@ const DEFAULT_CHANGE_COALESCE_MS = 200;
 const DEFAULT_CHANGE_LOG_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CHANGE_LOG_MAX_ENTRIES = 10_000;
 const CLIENT_TOKEN_STREAM_KEY = "__client__";
+const STABLE_FALLBACK_CHANGE_TIMESTAMP = "1970-01-01T00:00:00.000Z";
 
 type JsonObject = Record<string, unknown>;
 
@@ -1167,7 +1168,7 @@ function normalizeWireChangeEvent(payload: unknown, workspaceId?: string): Chang
       ? data.timestamp
       : typeof data.ts === "string"
         ? data.ts
-        : new Date().toISOString();
+        : STABLE_FALLBACK_CHANGE_TIMESTAMP;
   const eventId = typeof data.id === "string"
     ? data.id
     : typeof data.eventId === "string"

--- a/packages/sdk/typescript/src/sync.test.ts
+++ b/packages/sdk/typescript/src/sync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { RelayFileClient } from "./client.js";
-import { RelayFileSync, normalizeError } from "./sync.js";
+import { RelayFileSync, normalizeError, normalizeFilesystemEvent } from "./sync.js";
 import type { FilesystemEvent } from "./types.js";
 
 class MockWebSocket {
@@ -103,6 +103,22 @@ describe("RelayFileSync", () => {
     await sync.stop();
   });
 
+  it("normalizes malformed filesystem events with stable fallbacks", () => {
+    const first = normalizeFilesystemEvent(null);
+    const second = normalizeFilesystemEvent({ type: "relayfile.changed", resource: { path: "/linear/issues/ENG-1.json" } });
+    const third = normalizeFilesystemEvent({ type: "relayfile.changed", resource: { path: "/linear/issues/ENG-1.json" } });
+
+    expect(first).toMatchObject({
+      eventId: "ws:file.updated:::1970-01-01T00:00:00.000Z",
+      type: "file.updated",
+      path: "",
+      revision: "",
+      timestamp: "1970-01-01T00:00:00.000Z"
+    });
+    expect(second.eventId).toBe(third.eventId);
+    expect(second.timestamp).toBe("1970-01-01T00:00:00.000Z");
+  });
+
   it("preserves contentHash from WebSocket event payloads", async () => {
     const sockets: MockWebSocket[] = [];
     const sync = new RelayFileSync({
@@ -176,6 +192,46 @@ describe("RelayFileSync", () => {
 
     expect(sockets).toHaveLength(2);
     expect(sockets[1]!.url).toBe("wss://relay.test/v1/workspaces/ws_acme/fs/ws?token=ws_token&cursor=evt_11&path=%2Fslack%2Fchannels%2FC1%2F**");
+
+    await sync.stop();
+    vi.useRealTimers();
+  });
+
+  it("advances reconnect cursor from normalized envelope ids", async () => {
+    vi.useFakeTimers();
+    const sockets: MockWebSocket[] = [];
+    const sync = new RelayFileSync({
+      client: makeClient(),
+      workspaceId: "ws_acme",
+      baseUrl: "https://relay.test",
+      token: "ws_token",
+      reconnect: { minDelayMs: 1, maxDelayMs: 1 },
+      webSocketFactory: (url) => {
+        const socket = new MockWebSocket(url);
+        sockets.push(socket);
+        return socket;
+      }
+    });
+
+    sync.start();
+    expect(sockets[0]!.url).toBe("wss://relay.test/v1/workspaces/ws_acme/fs/ws?token=ws_token&from=now");
+    sockets[0]!.emit("open", {});
+    sockets[0]!.emit("message", {
+      data: JSON.stringify({
+        id: "evt_envelope_12",
+        type: "relayfile.changed",
+        resource: {
+          path: "/slack/channels/C1/messages/2.json"
+        },
+        occurredAt: "2026-03-26T00:00:00Z"
+      })
+    });
+    sockets[0]!.emit("close", { code: 1006, reason: "lost" });
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(sockets).toHaveLength(2);
+    expect(sockets[1]!.url).toBe("wss://relay.test/v1/workspaces/ws_acme/fs/ws?token=ws_token&cursor=evt_envelope_12");
 
     await sync.stop();
     vi.useRealTimers();

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -136,15 +136,22 @@ interface RelayFileSyncReconnectConfig {
 
 interface RelayFileSyncWireEvent {
   type: string;
+  id?: string;
   eventId?: string;
   path?: string;
   revision?: string;
+  digest?: string;
   contentHash?: string;
   origin?: EventOrigin;
   provider?: string;
   correlationId?: string;
   timestamp?: string;
   ts?: string;
+  occurredAt?: string;
+  resource?: {
+    path?: unknown;
+    provider?: unknown;
+  };
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
@@ -240,26 +247,57 @@ function createAbortError(): Error {
 }
 
 function buildEventId(message: RelayFileSyncWireEvent): string {
+  const path = readWirePath(message);
+  const timestamp = readWireTimestamp(message);
+  const type = readWireString(message.type) ?? "file.updated";
   return [
     "ws",
-    message.type,
-    message.path ?? "",
-    message.revision ?? "",
-    message.timestamp ?? message.ts ?? ""
+    normalizeFilesystemEventType(type),
+    path,
+    readWireString(message.revision) ?? "",
+    timestamp
   ].join(":");
 }
 
-function normalizeFilesystemEvent(message: RelayFileSyncWireEvent): FilesystemEvent {
+function readWireString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readWirePath(message: RelayFileSyncWireEvent): string {
+  return readWireString(message.path) ?? readWireString(message.resource?.path) ?? "";
+}
+
+function readWireProvider(message: RelayFileSyncWireEvent): string | undefined {
+  return readWireString(message.provider) ?? readWireString(message.resource?.provider);
+}
+
+function readWireTimestamp(message: RelayFileSyncWireEvent): string {
+  return readWireString(message.timestamp)
+    ?? readWireString(message.ts)
+    ?? readWireString(message.occurredAt)
+    ?? new Date().toISOString();
+}
+
+function normalizeFilesystemEventType(type: string): FilesystemEvent["type"] {
+  return type === "relayfile.changed" || type === "relayfile.changed.summary"
+    ? "file.updated"
+    : type as FilesystemEvent["type"];
+}
+
+export function normalizeFilesystemEvent(message: RelayFileSyncWireEvent): FilesystemEvent {
+  const path = readWirePath(message);
+  const type = readWireString(message.type) ?? "file.updated";
+  const digest = readWireString(message.digest);
   return {
-    eventId: message.eventId ?? buildEventId(message),
-    type: message.type as FilesystemEvent["type"],
-    path: message.path ?? "",
-    revision: message.revision ?? "",
-    contentHash: message.contentHash,
+    eventId: readWireString(message.eventId) ?? readWireString(message.id) ?? buildEventId(message),
+    type: normalizeFilesystemEventType(type),
+    path,
+    revision: readWireString(message.revision) ?? digest ?? "",
+    contentHash: readWireString(message.contentHash) ?? digest,
     origin: message.origin,
-    provider: message.provider,
-    correlationId: message.correlationId,
-    timestamp: message.timestamp ?? message.ts ?? new Date().toISOString()
+    provider: readWireProvider(message),
+    correlationId: readWireString(message.correlationId),
+    timestamp: readWireTimestamp(message)
   };
 }
 

--- a/packages/sdk/typescript/src/sync.ts
+++ b/packages/sdk/typescript/src/sync.ts
@@ -168,6 +168,7 @@ const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
 // for long-running consumers like the factory daemon.
 const DEFAULT_WS_REPROBE_MIN_DELAY_MS = 5000;
 const DEFAULT_WS_REPROBE_MAX_DELAY_MS = 300000;
+const STABLE_FALLBACK_TIMESTAMP = "1970-01-01T00:00:00.000Z";
 // Cap on the dedupe cache used in polling mode. Sized large enough that no
 // realistic workspace burst can churn through it within one poll interval
 // (the events API is itself capped at ~1000 per page), small enough to keep
@@ -246,15 +247,15 @@ function createAbortError(): Error {
   return err;
 }
 
-function buildEventId(message: RelayFileSyncWireEvent): string {
+function buildEventId(message?: RelayFileSyncWireEvent | null): string {
   const path = readWirePath(message);
   const timestamp = readWireTimestamp(message);
-  const type = readWireString(message.type) ?? "file.updated";
+  const type = readWireString(message?.type) ?? "file.updated";
   return [
     "ws",
     normalizeFilesystemEventType(type),
     path,
-    readWireString(message.revision) ?? "",
+    readWireString(message?.revision) ?? "",
     timestamp
   ].join(":");
 }
@@ -263,19 +264,19 @@ function readWireString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-function readWirePath(message: RelayFileSyncWireEvent): string {
-  return readWireString(message.path) ?? readWireString(message.resource?.path) ?? "";
+function readWirePath(message?: RelayFileSyncWireEvent | null): string {
+  return readWireString(message?.path) ?? readWireString(message?.resource?.path) ?? "";
 }
 
-function readWireProvider(message: RelayFileSyncWireEvent): string | undefined {
-  return readWireString(message.provider) ?? readWireString(message.resource?.provider);
+function readWireProvider(message?: RelayFileSyncWireEvent | null): string | undefined {
+  return readWireString(message?.provider) ?? readWireString(message?.resource?.provider);
 }
 
-function readWireTimestamp(message: RelayFileSyncWireEvent): string {
-  return readWireString(message.timestamp)
-    ?? readWireString(message.ts)
-    ?? readWireString(message.occurredAt)
-    ?? new Date().toISOString();
+function readWireTimestamp(message?: RelayFileSyncWireEvent | null): string {
+  return readWireString(message?.timestamp)
+    ?? readWireString(message?.ts)
+    ?? readWireString(message?.occurredAt)
+    ?? STABLE_FALLBACK_TIMESTAMP;
 }
 
 function normalizeFilesystemEventType(type: string): FilesystemEvent["type"] {
@@ -284,19 +285,19 @@ function normalizeFilesystemEventType(type: string): FilesystemEvent["type"] {
     : type as FilesystemEvent["type"];
 }
 
-export function normalizeFilesystemEvent(message: RelayFileSyncWireEvent): FilesystemEvent {
+export function normalizeFilesystemEvent(message?: RelayFileSyncWireEvent | null): FilesystemEvent {
   const path = readWirePath(message);
-  const type = readWireString(message.type) ?? "file.updated";
-  const digest = readWireString(message.digest);
+  const type = readWireString(message?.type) ?? "file.updated";
+  const digest = readWireString(message?.digest);
   return {
-    eventId: readWireString(message.eventId) ?? readWireString(message.id) ?? buildEventId(message),
+    eventId: readWireString(message?.eventId) ?? readWireString(message?.id) ?? buildEventId(message),
     type: normalizeFilesystemEventType(type),
     path,
-    revision: readWireString(message.revision) ?? digest ?? "",
-    contentHash: readWireString(message.contentHash) ?? digest,
-    origin: message.origin,
+    revision: readWireString(message?.revision) ?? digest ?? "",
+    contentHash: readWireString(message?.contentHash) ?? digest,
+    origin: message?.origin,
     provider: readWireProvider(message),
-    correlationId: readWireString(message.correlationId),
+    correlationId: readWireString(message?.correlationId),
     timestamp: readWireTimestamp(message)
   };
 }
@@ -872,6 +873,14 @@ export class RelayFileSync {
       this.emit("error", new Error("Invalid WebSocket payload: 'revision' must be a string."));
       return;
     }
+    if (parsed.resource !== undefined && (typeof parsed.resource !== "object" || parsed.resource === null)) {
+      this.emit("error", new Error("Invalid WebSocket payload: 'resource' must be an object."));
+      return;
+    }
+    if (parsed.resource?.path !== undefined && typeof parsed.resource.path !== "string") {
+      this.emit("error", new Error("Invalid WebSocket payload: 'resource.path' must be a string."));
+      return;
+    }
     if (parsed.timestamp !== undefined && typeof parsed.timestamp !== "string") {
       this.emit("error", new Error("Invalid WebSocket payload: 'timestamp' must be a string."));
       return;
@@ -891,8 +900,8 @@ export class RelayFileSync {
     }
 
     const normalized = normalizeFilesystemEvent(parsed);
-    if (parsed.eventId) {
-      this.cursor = parsed.eventId;
+    if (normalized.eventId) {
+      this.cursor = normalized.eventId;
     }
     debugLog("event", { type: normalized.type, path: normalized.path, revision: normalized.revision });
     this.emitFilesystemEvent(normalized);


### PR DESCRIPTION
## Summary
- Normalize retained change-log payloads from flat filesystem events into `ChangeEvent` envelopes with required `resource.path`
- Normalize envelope-style events at low-level event feed/WebSocket boundaries so polling and raw WS paths keep a usable filesystem path
- Add regressions for retained flat events and envelope-style event feed responses

Fixes #296

## Verification
- `npm --prefix packages/sdk/typescript test`
- `npm --prefix packages/sdk/typescript run typecheck`
- `npm --prefix packages/sdk/typescript run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

