### PR TITLE
fix(cli): allow update without returned op id

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3099,7 +3099,7 @@ func runWritebackFileMutation(mode writebackCommandMode, args []string, stdout i
 	revision := firstNonBlank(dispatch.Revision, "")
 	opID := strings.TrimSpace(dispatch.OpID)
 	dispatchStatus := firstNonBlank(dispatch.State, "succeeded")
-	if (mode == writebackCommandUpdate || mode == writebackCommandDelete) && opID == "" {
+	if mode == writebackCommandDelete && opID == "" {
 		err := fmt.Errorf("writeback %s did not return an operation id; provider writeback was not dispatched", mode)
 		failed := pendingReceipt
 		failed.Status = "failed"

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3113,6 +3113,21 @@ func runWritebackFileMutation(mode writebackCommandMode, args []string, stdout i
 		}
 		return err
 	}
+	if mode == writebackCommandUpdate && opID == "" && !isSuccessfulWritebackDispatchStatus(dispatchStatus) {
+		err := fmt.Errorf("writeback update did not return an operation id; provider writeback status %q cannot be tracked", dispatchStatus)
+		receipt := pendingReceipt
+		receipt.Status = "pending"
+		receipt.LastAttemptAt = time.Now().UTC().Format(time.RFC3339Nano)
+		receipt.AttemptCount = 1
+		receipt.LastError = sanitizeCLIReceiptError(err)
+		receipt.DispatchStatus = dispatchStatus
+		receipt.NeedsAttention = true
+		receipt.CorrelationID = firstNonBlank(dispatch.CorrelationID, receipt.CorrelationID)
+		if receiptErr := writeWritebackPushReceipt(resolved.MountRoot, receipt); receiptErr != nil {
+			return fmt.Errorf("%w; additionally failed to write pending receipt: %v", err, receiptErr)
+		}
+		return err
+	}
 	if opID == "" && isTerminalWritebackOpStatus(dispatchStatus) {
 		err := fmt.Errorf("writeback operation %s", dispatchStatus)
 		failed := pendingReceipt
@@ -3263,6 +3278,15 @@ type writebackOperationStatus struct {
 func isTerminalWritebackOpStatus(status string) bool {
 	switch strings.TrimSpace(status) {
 	case "failed", "dead_lettered", "canceled":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSuccessfulWritebackDispatchStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "succeeded", "completed":
 		return true
 	default:
 		return false

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2837,6 +2837,83 @@ func TestWritebackUpdateCanonicalPathAllowsMissingOperationAndSendsIntent(t *tes
 	}
 }
 
+func TestWritebackUpdateMissingOperationIDPendingStateNeedsAttention(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceID = "ws_demo"
+	const remotePath = "/linear/issues/AR-295__00000000-0000-0000-0000-000000000295.json"
+	localDir := t.TempDir()
+	if err := ensureMirrorLayout(localDir); err != nil {
+		t.Fatalf("ensureMirrorLayout failed: %v", err)
+	}
+	if err := writeMirrorStateFile(localDir, syncStateFile{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/linear/issues",
+		Mode:        defaultMountMode,
+	}); err != nil {
+		t.Fatalf("writeMirrorStateFile failed: %v", err)
+	}
+
+	localPath := filepath.Join(localDir, "AR-295__00000000-0000-0000-0000-000000000295.json")
+	content := []byte(`{"priority":2}` + "\n")
+	if err := os.WriteFile(localPath, content, 0o644); err != nil {
+		t.Fatalf("write local payload failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/workspaces/"+workspaceID+"/fs/bulk":
+			var req bulkWriteRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode bulk request failed: %v", err)
+			}
+			if len(req.Files) != 1 || req.Files[0].WritebackIntent != "update" {
+				t.Fatalf("unexpected bulk request: %+v", req.Files)
+			}
+			_, _ = io.WriteString(w, `{"written":1,"errorCount":0,"correlationId":"corr_update_295","results":[{"path":"`+remotePath+`","revision":"rev_295","writeback":{"provider":"linear","state":"pending"}}]}`)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	err := run([]string{"writeback", "update", localPath, "--server", server.URL, "--token", "rf_write", "--timeout", "1s"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected missing operation id tracking error")
+	}
+	if got := err.Error(); !strings.Contains(got, "cannot be tracked") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "failed")); got != 0 {
+		t.Fatalf("failed receipt count = %d, want 0", got)
+	}
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "acked")); got != 0 {
+		t.Fatalf("acked receipt count = %d, want 0", got)
+	}
+	pendingDir := filepath.Join(localDir, ".relay", "outbox", "pending")
+	entries, err := os.ReadDir(pendingDir)
+	if err != nil {
+		t.Fatalf("read pending dir failed: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("pending receipt count = %d, want 1", len(entries))
+	}
+	payload, err := os.ReadFile(filepath.Join(pendingDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read pending receipt failed: %v", err)
+	}
+	var receipt writebackPushReceipt
+	if err := json.Unmarshal(payload, &receipt); err != nil {
+		t.Fatalf("decode pending receipt failed: %v", err)
+	}
+	if receipt.Status != "pending" || receipt.OpID != "" || receipt.DispatchStatus != "pending" || !receipt.NeedsAttention {
+		t.Fatalf("unexpected receipt: %+v", receipt)
+	}
+}
+
 func TestWritebackUpdateRejectsDraftPath(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2745,7 +2745,7 @@ func TestWritebackPushCanonicalPathPostsBulkWithoutContentIdentity(t *testing.T)
 	}
 }
 
-func TestWritebackUpdateCanonicalPathRequiresOperationAndSendsIntent(t *testing.T) {
+func TestWritebackUpdateCanonicalPathAllowsMissingOperationAndSendsIntent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
 
@@ -2804,20 +2804,36 @@ func TestWritebackUpdateCanonicalPathRequiresOperationAndSendsIntent(t *testing.
 
 	var stdout bytes.Buffer
 	err := run([]string{"writeback", "update", localPath, "--server", server.URL, "--token", "rf_write", "--timeout", "1s"}, strings.NewReader(""), &stdout, &stdout)
-	if err == nil {
-		t.Fatal("expected missing operation id error")
-	}
-	if got := err.Error(); !strings.Contains(got, "provider writeback was not dispatched") {
-		t.Fatalf("unexpected error: %v", err)
+	if err != nil {
+		t.Fatalf("writeback update failed: %v\n%s", err, stdout.String())
 	}
 	if !sawBulk.Load() {
 		t.Fatal("expected bulk write request")
 	}
-	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "failed")); got != 1 {
-		t.Fatalf("failed receipt count = %d, want 1", got)
+	if got := stdout.String(); !strings.Contains(got, "Updated ") || !strings.Contains(got, " -> "+remotePath) {
+		t.Fatalf("unexpected stdout: %s", got)
 	}
-	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "acked")); got != 0 {
-		t.Fatalf("acked receipt count = %d, want 0", got)
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "failed")); got != 0 {
+		t.Fatalf("failed receipt count = %d, want 0", got)
+	}
+	if got := countJSONFiles(filepath.Join(localDir, ".relay", "outbox", "acked")); got != 1 {
+		t.Fatalf("acked receipt count = %d, want 1", got)
+	}
+	ackedDir := filepath.Join(localDir, ".relay", "outbox", "acked")
+	entries, err := os.ReadDir(ackedDir)
+	if err != nil {
+		t.Fatalf("read acked dir failed: %v", err)
+	}
+	payload, err := os.ReadFile(filepath.Join(ackedDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read acked receipt failed: %v", err)
+	}
+	var receipt writebackPushReceipt
+	if err := json.Unmarshal(payload, &receipt); err != nil {
+		t.Fatalf("decode acked receipt failed: %v", err)
+	}
+	if receipt.Status != "acked" || receipt.OpID != "" || receipt.DispatchStatus != "succeeded" || receipt.Revision != "rev_292" {
+		t.Fatalf("unexpected receipt: %+v", receipt)
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.3.tgz",
-      "integrity": "sha512-dXTnvPA7PmsWQPFvNoAkG5WVfelv+LpCj8p+HlCn9upNooeg/okCIJJD2bv6z02k1UchVsUAtIO8slpz3H0w4A==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.4.tgz",
+      "integrity": "sha512-PMioSG2wTJCVVsbrTIF4rEml5bgDJEBM+cE0jUTvflJfNiYvEDdvjXtA0Q5y2Ee+gEc2IGZ3ztYOmzNeV2+3Cw==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.3.tgz",
-      "integrity": "sha512-+Gg47XGO8p5M8s7uE01blMW5SS9pyVK0z7fpB2X5roM/dq2F24vtd/U8uVlQaEH5RyDGvwTDxiR6vTMTJOMD5g==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.4.tgz",
+      "integrity": "sha512-LWISBqO+Or4MYlLPFISEA0bf5TLgIaxE+FKmqiPodqxQt21I4BnT9nJ02i5exTgz/9n1PdIqtzT5y16ggXh4Mg==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.3.tgz",
-      "integrity": "sha512-+LA45OALeD+Jzbz65JRtCPrO9x/lw5wW681pjo33RtRgNDgeFkEEh/3oefgDPZayLNV9rTpPNO4xgqvHJaU0Iw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.4.tgz",
+      "integrity": "sha512-XaEbra5kEOqFDB+iJzuBmc5HXu20dZe6kQybtjevg5HINtO37yeVzhH9Jni1qiUUS8cuPow78LhRW7aeOwin0A==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.3.tgz",
-      "integrity": "sha512-LLisNh36iDX2LRu6uC8QjMVb4IfkQZSkStdhFISFBH/Pegdi9kgUlUPJ41uSwGm/e/xBcR9OHpGumy3Z6wQmKw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.4.tgz",
+      "integrity": "sha512-zmjXlRDoFzUArsNdecgXG+oPTvbSOjy3Pz7J8YAhyw22X+Ot87FFC96NISRpXFAnpIY1Y8w27JVQRQ0a14xqpA==",
       "cpu": [
         "x64"
       ],
@@ -3739,6 +3739,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3760,6 +3761,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3781,6 +3783,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3802,6 +3805,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3823,6 +3827,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3844,6 +3849,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3865,6 +3871,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3886,6 +3893,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3907,6 +3915,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3928,6 +3937,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3949,6 +3959,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5276,7 +5287,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5288,7 +5299,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5301,7 +5312,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6109,7 +6120,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6138,10 +6149,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.3",
+        "@relayfile/core": "0.9.4",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6153,10 +6164,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.3",
-        "@relayfile/mount-darwin-x64": "0.9.3",
-        "@relayfile/mount-linux-arm64": "0.9.3",
-        "@relayfile/mount-linux-x64": "0.9.3"
+        "@relayfile/mount-darwin-arm64": "0.9.4",
+        "@relayfile/mount-darwin-x64": "0.9.4",
+        "@relayfile/mount-linux-arm64": "0.9.4",
+        "@relayfile/mount-linux-x64": "0.9.4"
       }
     }
   }

--- a/packages/sdk/typescript/package-lock.json
+++ b/packages/sdk/typescript/package-lock.json
@@ -1,19 +1,30 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.1.0",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@relayfile/sdk",
-      "version": "0.1.0",
+      "version": "0.9.4",
       "license": "MIT",
+      "dependencies": {
+        "@relayfile/core": "0.9.4",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
       "devDependencies": {
         "typescript": "^5.7.3",
         "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.9.4",
+        "@relayfile/mount-darwin-x64": "0.9.4",
+        "@relayfile/mount-linux-arm64": "0.9.4",
+        "@relayfile/mount-linux-x64": "0.9.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -458,12 +469,85 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@relayfile/core": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.9.4.tgz",
+      "integrity": "sha512-Ego3OKu9NGrrlk7SUIHSpUXVtLOx7FmUWpnCcShCMLshHP9NfRERe+/9wJjIM5HJwTfPWDueEYTeS4+Mvoz7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@relayfile/mount-darwin-arm64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.4.tgz",
+      "integrity": "sha512-PMioSG2wTJCVVsbrTIF4rEml5bgDJEBM+cE0jUTvflJfNiYvEDdvjXtA0Q5y2Ee+gEc2IGZ3ztYOmzNeV2+3Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-darwin-x64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.4.tgz",
+      "integrity": "sha512-LWISBqO+Or4MYlLPFISEA0bf5TLgIaxE+FKmqiPodqxQt21I4BnT9nJ02i5exTgz/9n1PdIqtzT5y16ggXh4Mg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-arm64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.4.tgz",
+      "integrity": "sha512-XaEbra5kEOqFDB+iJzuBmc5HXu20dZe6kQybtjevg5HINtO37yeVzhH9Jni1qiUUS8cuPow78LhRW7aeOwin0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@relayfile/mount-linux-x64": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.4.tgz",
+      "integrity": "sha512-zmjXlRDoFzUArsNdecgXG+oPTvbSOjy3Pz7J8YAhyw22X+Ot87FFC96NISRpXFAnpIY1Y8w27JVQRQ0a14xqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -1002,6 +1086,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1132,6 +1225,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1154,6 +1256,27 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -1335,6 +1458,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -1598,6 +1737,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Stop treating a missing `opId` as a failed dispatch for successful `writeback update` bulk writes
- Keep `writeback delete` strict when its delete response omits `opId`
- Update the writeback update regression to assert successful exit, acked receipt, and preserved update intent when the bulk response has no `opId`

Fixes #295

## Verification
- `go test ./cmd/relayfile-cli -run 'TestWriteback(Update|Delete)'`
- `go test ./cmd/relayfile-cli`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

