### PR TITLE
feat(mount): --push-local-once teardown drain (stop dropping last-moment writeback drafts)

### DIFF
--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -65,6 +65,7 @@ type mountConfig struct {
 	scopes           []string
 	once             bool
 	flushOutboxOnce  bool
+	pushLocalOnce    bool
 	mode             string
 }
 
@@ -106,6 +107,7 @@ func main() {
 	fuse := flag.Bool("fuse", boolEnv("RELAYFILE_MOUNT_FUSE", false), "shortcut for --mode=fuse")
 	once := flag.Bool("once", false, "run one sync cycle and exit")
 	flushOutboxOnce := flag.Bool("flush-outbox-once", false, "flush durable writeback outbox once and exit without reconciling the local mirror")
+	pushLocalOnce := flag.Bool("push-local-once", false, "ingest pending local writeback drafts (one pushLocal pass) then flush the outbox once and exit; no pullRemote/digest/reconcile — the teardown drain for last-moment drafts")
 	flag.Parse()
 
 	resolvedToken := strings.TrimSpace(*token)
@@ -184,6 +186,7 @@ func main() {
 		scopes:           parseTokenScopes(resolvedToken),
 		once:             *once,
 		flushOutboxOnce:  *flushOutboxOnce,
+		pushLocalOnce:    *pushLocalOnce,
 		mode:             resolvedMode,
 	}
 
@@ -400,6 +403,15 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 	}
 	if _, err := mountsync.StartDiagnostics(rootCtx, cfg.pprofAddr, cfg.memlogInterval, log.Default()); err != nil {
 		return fmt.Errorf("start diagnostics: %w", err)
+	}
+	if cfg.pushLocalOnce {
+		ctx, cancel := context.WithTimeout(rootCtx, cfg.timeout)
+		defer cancel()
+		if err := syncer.PushLocalAndFlushOnce(ctx); err != nil {
+			return fmt.Errorf("push local and flush once: %w", err)
+		}
+		log.Printf("local push + outbox flush completed")
+		return nil
 	}
 	if cfg.flushOutboxOnce {
 		ctx, cancel := context.WithTimeout(rootCtx, cfg.timeout)

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1628,6 +1628,58 @@ func (s *Syncer) FlushOutboxOnce(ctx context.Context) error {
 	return s.saveStateWithoutLocalScan()
 }
 
+// PushLocalAndFlushOnce ingests pending local writeback drafts with a single
+// pushLocal pass, then flushes the durable outbox, and exits — without
+// pullRemote, digest, websocket, or a full reconcile cycle.
+//
+// It is the teardown drain. Local writeback drafts are normally ingested into
+// the outbox by the running daemon's sync cycle (watcher + pushLocal). A draft
+// written after that daemon's last cycle and just before shutdown — e.g. a
+// final fire-and-forget reply right before a one-shot sandbox is torn down — is
+// still on disk but not yet in the outbox, so FlushOutboxOnce (outbox-only, no
+// local scan) silently drops it. Running pushLocal here, in the fresh cleanup
+// process that scans the on-disk mirror, ingests those drafts before flushing.
+//
+// The local scan is the cost (the same O(tree) work FlushOutboxOnce exists to
+// avoid), so callers should invoke this only when pending local writes are
+// detected and keep FlushOutboxOnce for the no-pending-writes fast path. Unlike
+// a full reconcile it still skips pullRemote/digest/websocket, so it cannot
+// reintroduce the pull-side flush-124 stalls.
+func (s *Syncer) PushLocalAndFlushOnce(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.loadState(); err != nil {
+		return err
+	}
+	conflicted, err := s.pushLocal(ctx)
+	if err != nil {
+		s.markSyncError(err)
+		_ = s.saveStateWithoutLocalScan()
+		return err
+	}
+	if err := s.flushOutboxRecords(ctx, conflicted, true); err != nil {
+		s.markSyncError(err)
+		_ = s.saveStateWithoutLocalScan()
+		return err
+	}
+	outbox := s.summarizeOutbox()
+	if outbox.NeedsAttention > 0 {
+		err := fmt.Errorf("outbox needs attention: %d command(s)", outbox.NeedsAttention)
+		s.markSyncError(err)
+		_ = s.saveStateWithoutLocalScan()
+		return err
+	}
+	if outbox.Pending > 0 {
+		err := fmt.Errorf("outbox pending remains: %d command(s)", outbox.Pending)
+		s.markSyncError(err)
+		_ = s.saveStateWithoutLocalScan()
+		return err
+	}
+	s.markSyncSuccess()
+	return s.saveState()
+}
+
 // HandleLocalChange routes a local filesystem event to the appropriate
 // writeback action.
 //

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1646,6 +1646,14 @@ func (s *Syncer) FlushOutboxOnce(ctx context.Context) error {
 // a full reconcile it still skips pullRemote/digest/websocket, so it cannot
 // reintroduce the pull-side flush-124 stalls.
 func (s *Syncer) PushLocalAndFlushOnce(ctx context.Context) error {
+	// Same top-of-cycle invariant as syncReserved: pushLocal scans and mutates
+	// the local mirror, so refuse to run if the mount root was wiped/clobbered
+	// (recovery is gated behind --reset-after-clobber). FlushOutboxOnce skips
+	// this because it is outbox-only and never touches the mirror.
+	if err := s.assertMountRootInvariant(); err != nil {
+		return err
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -2678,6 +2678,55 @@ func TestFlushOutboxOnceFlushesPendingWithoutMirrorScan(t *testing.T) {
 	}
 }
 
+// A draft written but never ingested by a sync cycle (the teardown race: a
+// final fire-and-forget reply right before shutdown) is on disk but not in the
+// outbox. FlushOutboxOnce drops it (outbox-only, no local scan);
+// PushLocalAndFlushOnce ingests it by scanning the on-disk mirror, then flushes.
+func TestPushLocalAndFlushOnceIngestsUnsyncedLocalDraft(t *testing.T) {
+	localDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("seed local command failed: %v", err)
+	}
+
+	// Baseline: FlushOutboxOnce must NOT ingest the unsynced draft (the bug).
+	flushClient := &fakeClient{files: map[string]RemoteFile{}}
+	flushOnly, err := NewSyncer(flushClient, SyncerOptions{
+		WorkspaceID: "ws_push_local_once",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer flushOnly: %v", err)
+	}
+	if err := flushOnly.FlushOutboxOnce(context.Background()); err != nil {
+		t.Fatalf("FlushOutboxOnce failed: %v", err)
+	}
+	if flushClient.bulkWriteCalls != 0 {
+		t.Fatalf("FlushOutboxOnce must not ingest an unsynced local draft, got %d uploads", flushClient.bulkWriteCalls)
+	}
+
+	// Fix: PushLocalAndFlushOnce scans the on-disk mirror, ingests the draft,
+	// uploads it, and drains the outbox.
+	pushClient := &fakeClient{files: map[string]RemoteFile{}}
+	drain, err := NewSyncer(pushClient, SyncerOptions{
+		WorkspaceID: "ws_push_local_once",
+		RemoteRoot:  "/slack/channels/C123/messages",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer drain: %v", err)
+	}
+	if err := drain.PushLocalAndFlushOnce(context.Background()); err != nil {
+		t.Fatalf("PushLocalAndFlushOnce failed: %v", err)
+	}
+	if pushClient.bulkWriteCalls != 1 {
+		t.Fatalf("expected the unsynced draft to be ingested + uploaded once, got %d", pushClient.bulkWriteCalls)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		t.Fatalf("expected outbox drained after push+flush, got %+v", pending)
+	}
+}
+
 func TestFlushOutboxOnceWritesReceiptCapabilityMarkerWithEmptyOutbox(t *testing.T) {
 	localDir := t.TempDir()
 	client := &fakeClient{files: map[string]RemoteFile{}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relayfile",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relayfile",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-KAal1WvVeJvOYut5hmzxtZMT2DV8diHTfCimwURrVLl9Z1TNhxnV1eHYqGl0RSB5gemXlP0V//hPg/5aJA6LrA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.6.tgz",
+      "integrity": "sha512-rNScE8xIM7rkgS1Uo7OanH0ODqHa+31q6CvDIZw1HrmtosrvnUjum2tPC2VO6fGsL5F5sULV3UkKxCjojqXAOQ==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-kx2aPRfltvkWxJKxaVwGBtIjhtBH7Z5eWaM5DwMykHXJdtCMwli5z2M4TACQga7ka++HCeirNu4vv6Yth7GHIQ==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.6.tgz",
+      "integrity": "sha512-JkJXEyfcJqN6ljLaJUVeLXFlDXiAx9CAvQyNBGLMrHMsBx8L6para9NiE8NvvKuBiuq15ZOzqi6LTx3socZdQA==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.5.tgz",
-      "integrity": "sha512-vcSyWc28qbOzt5PyClM1jrLgE2/475nmXevxDwwEveq9wNuyWNtlzVJm/XzFKPoGu1wNJw87ABtxAluyt+jxTA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.6.tgz",
+      "integrity": "sha512-Z7Ds8U1+rLzQcZRGV5srBOYim7rqVsnxTgf3v7Yp1azCUATUnU7daLbO4kk3xhnBkDR2hROgS2TiNShd0jQCQQ==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.5.tgz",
-      "integrity": "sha512-A6dGhA9ZJG387WOztOMNjo1VV9Eu9OXJERjpYhnGQXeYDNW+pl0zUNjY3hdifTzc0AAtVm7ynHIGRKG51/8x9w==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.6.tgz",
+      "integrity": "sha512-FwtHKx6EFbGQRRCa84SMG4xvuCI8gFR0LFyc/9YhmBS6blDXPSqVwxp/gYikxTkeybTmDx7/06Efs4CPkPjbLA==",
       "cpu": [
         "x64"
       ],
@@ -3739,7 +3739,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3761,7 +3760,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3783,7 +3781,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3805,7 +3802,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3827,7 +3823,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3849,7 +3844,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3871,7 +3865,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3893,7 +3886,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3915,7 +3907,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3937,7 +3928,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3959,7 +3949,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5287,7 +5276,7 @@
     },
     "packages/cli": {
       "name": "relayfile",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5299,7 +5288,7 @@
     },
     "packages/core": {
       "name": "@relayfile/core",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -5312,7 +5301,7 @@
     },
     "packages/file-observer": {
       "name": "@relayfile/file-observer",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
@@ -6120,7 +6109,7 @@
     },
     "packages/local-mount": {
       "name": "@relayfile/local-mount",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.6",
@@ -6149,10 +6138,10 @@
     },
     "packages/sdk/typescript": {
       "name": "@relayfile/sdk",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.5",
+        "@relayfile/core": "0.9.6",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -6164,10 +6153,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.5",
-        "@relayfile/mount-darwin-x64": "0.9.5",
-        "@relayfile/mount-linux-arm64": "0.9.5",
-        "@relayfile/mount-linux-x64": "0.9.5"
+        "@relayfile/mount-darwin-arm64": "0.9.6",
+        "@relayfile/mount-darwin-x64": "0.9.6",
+        "@relayfile/mount-linux-arm64": "0.9.6",
+        "@relayfile/mount-linux-x64": "0.9.6"
       }
     }
   }

--- a/packages/sdk/typescript/package-lock.json
+++ b/packages/sdk/typescript/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@relayfile/sdk",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.5",
+        "@relayfile/core": "0.9.6",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -21,10 +21,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.5",
-        "@relayfile/mount-darwin-x64": "0.9.5",
-        "@relayfile/mount-linux-arm64": "0.9.5",
-        "@relayfile/mount-linux-x64": "0.9.5"
+        "@relayfile/mount-darwin-arm64": "0.9.6",
+        "@relayfile/mount-darwin-x64": "0.9.6",
+        "@relayfile/mount-linux-arm64": "0.9.6",
+        "@relayfile/mount-linux-x64": "0.9.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -489,18 +489,18 @@
       "license": "MIT"
     },
     "node_modules/@relayfile/core": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.9.5.tgz",
-      "integrity": "sha512-ZCZ1Rk9tCPgLJXJ/7oiBWDol8DOuJuzaJYgMcHyHbVrtVkhV95Pnr5lBxQfWMYHi9M9wS05nq9MJ8LueBzTiZw==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.9.6.tgz",
+      "integrity": "sha512-Tybhr8mNcBx/HcRP6/fg4eMgz/bxluGcTfmnPrDA7E6rgg6+8cyfda6qrM6w5G+j1LAjXyjCTERplbGsl/2wzg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.5.tgz",
-      "integrity": "sha512-KAal1WvVeJvOYut5hmzxtZMT2DV8diHTfCimwURrVLl9Z1TNhxnV1eHYqGl0RSB5gemXlP0V//hPg/5aJA6LrA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.9.6.tgz",
+      "integrity": "sha512-rNScE8xIM7rkgS1Uo7OanH0ODqHa+31q6CvDIZw1HrmtosrvnUjum2tPC2VO6fGsL5F5sULV3UkKxCjojqXAOQ==",
       "cpu": [
         "arm64"
       ],
@@ -511,9 +511,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.5.tgz",
-      "integrity": "sha512-kx2aPRfltvkWxJKxaVwGBtIjhtBH7Z5eWaM5DwMykHXJdtCMwli5z2M4TACQga7ka++HCeirNu4vv6Yth7GHIQ==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.9.6.tgz",
+      "integrity": "sha512-JkJXEyfcJqN6ljLaJUVeLXFlDXiAx9CAvQyNBGLMrHMsBx8L6para9NiE8NvvKuBiuq15ZOzqi6LTx3socZdQA==",
       "cpu": [
         "x64"
       ],
@@ -524,9 +524,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.5.tgz",
-      "integrity": "sha512-vcSyWc28qbOzt5PyClM1jrLgE2/475nmXevxDwwEveq9wNuyWNtlzVJm/XzFKPoGu1wNJw87ABtxAluyt+jxTA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.9.6.tgz",
+      "integrity": "sha512-Z7Ds8U1+rLzQcZRGV5srBOYim7rqVsnxTgf3v7Yp1azCUATUnU7daLbO4kk3xhnBkDR2hROgS2TiNShd0jQCQQ==",
       "cpu": [
         "arm64"
       ],
@@ -537,9 +537,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.5.tgz",
-      "integrity": "sha512-A6dGhA9ZJG387WOztOMNjo1VV9Eu9OXJERjpYhnGQXeYDNW+pl0zUNjY3hdifTzc0AAtVm7ynHIGRKG51/8x9w==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.9.6.tgz",
+      "integrity": "sha512-FwtHKx6EFbGQRRCa84SMG4xvuCI8gFR0LFyc/9YhmBS6blDXPSqVwxp/gYikxTkeybTmDx7/06Efs4CPkPjbLA==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
## Root cause
Local writeback drafts are ingested into the durable outbox by the running daemon's sync cycle (watcher + `pushLocal`). A draft written **after that cycle and just before shutdown** — e.g. a one-shot deploy sandbox writing a final fire-and-forget Slack reply right before teardown — is on disk but **not yet in the outbox**.

The teardown cleanup runs **`--flush-outbox-once`** (`FlushOutboxOnce`: outbox-only, *deliberately no local scan* — the flush-124 cure), so that draft is never ingested and is **silently dropped**. Symptom downstream: the header message lands, the threaded reply vanishes.

## Fix
Add **`PushLocalAndFlushOnce` / `--push-local-once`**: one `pushLocal` pass (scans the on-disk mirror — in the fresh cleanup process, so it catches drafts the running daemon never ingested) followed by an outbox flush, then exit. It **skips `pullRemote`/digest/websocket**, so it cannot reintroduce the pull-side flush-124 stalls. The only added cost over `--flush-outbox-once` is the local scan, so callers should invoke it **only when pending local writes are detected** and keep `--flush-outbox-once` for the no-pending-writes fast path (the cloud cleanup shell already does that `find -newer` detection — wired in the companion cloud PR).

## Test
`TestPushLocalAndFlushOnceIngestsUnsyncedLocalDraft`: an unsynced on-disk draft is **dropped by `FlushOutboxOnce`** (0 uploads) but **ingested + uploaded + drained by `PushLocalAndFlushOnce`** (1 upload, empty outbox). Full `mountsync` suite + `go vet` pass.

## Rollout
New `relayfile-mount` binary → release → cloud bumps `RELAYFILE_MOUNT_VERSION` + cleanup shell invokes `--push-local-once` on pending writes (companion PR) → snapshot rebuild. Backward-compatible: feature-detected; absent the flag, behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

