### PR TITLE
test(httpapi): pin bulk-write 202=synchronous contract; clarify OpenAPI spec (#306)

### DIFF
--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1261,6 +1261,147 @@ func TestBulkWriteEndpoint(t *testing.T) {
 	}
 }
 
+// TestBulkWriteReadImmediatelyAfter202 documents the OSS contract for issue #306:
+// a 202 from POST /fs/bulk means every file in the results array is immediately
+// readable — the handler is synchronous so "accepted" and "written" are the same.
+func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		files   []map[string]any
+		want    []string // paths expected to be readable
+		written int
+	}{
+		{
+			name: "single file readable after bulk write",
+			files: []map[string]any{
+				{"path": "/sync/Record.md", "contentType": "text/markdown", "content": "# record"},
+			},
+			want:    []string{"/sync/Record.md"},
+			written: 1,
+		},
+		{
+			name: "multiple files all readable after bulk write",
+			files: []map[string]any{
+				{"path": "/sync/Alpha.md", "contentType": "text/markdown", "content": "# alpha"},
+				{"path": "/sync/Beta.md", "contentType": "text/plain", "content": "beta"},
+				{"path": "/sync/Gamma.json", "contentType": "application/json", "content": `{"ok":true}`},
+			},
+			want:    []string{"/sync/Alpha.md", "/sync/Beta.md", "/sync/Gamma.json"},
+			written: 3,
+		},
+		{
+			name: "partial batch: valid files readable, invalid files reported in errors",
+			files: []map[string]any{
+				{"path": "/sync/Good.md", "contentType": "text/markdown", "content": "# good"},
+				{"path": "/sync/Bad.md", "contentType": "text/markdown", "content": "# bad", "encoding": "utf16"},
+			},
+			want:    []string{"/sync/Good.md"},
+			written: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := NewServer(relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true}))
+			wsID := "ws_read_after_202_" + tc.name[:4]
+			token := mustTestJWT(t, "dev-secret", wsID, "Worker1", []string{"fs:read", "fs:write"}, time.Now().Add(time.Hour))
+
+			bulkResp := doRequest(t, server, request{
+				method: http.MethodPost,
+				path:   "/v1/workspaces/" + wsID + "/fs/bulk",
+				headers: map[string]string{
+					"Authorization":    "Bearer " + token,
+					"X-Correlation-Id": "corr_rar202",
+				},
+				body: map[string]any{"files": tc.files},
+			})
+			if bulkResp.Code != http.StatusAccepted {
+				t.Fatalf("expected 202, got %d: %s", bulkResp.Code, bulkResp.Body.String())
+			}
+			var payload struct {
+				Written int `json:"written"`
+			}
+			if err := json.NewDecoder(bulkResp.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode bulk response: %v", err)
+			}
+			if payload.Written != tc.written {
+				t.Fatalf("expected written=%d, got %d", tc.written, payload.Written)
+			}
+
+			for _, path := range tc.want {
+				file := readFileForTest(t, server, token, wsID, path, "corr_read_after_bulk")
+				if file.Path != path {
+					t.Errorf("path mismatch: want %q got %q", path, file.Path)
+				}
+				if file.Content == "" {
+					t.Errorf("file %q has empty content after bulk write", path)
+				}
+			}
+		})
+	}
+}
+
+// TestBulkWriteResyncPattern documents that sequential bulk writes (simulating a
+// provider re-sync) produce a consistent readable state: both original and updated
+// paths are immediately available after each round, and updated content is reflected.
+// This is the OSS analogue of the full_resync scenario in issue #306: the OSS handler
+// is synchronous, so there is no window between "accepted" and "readable".
+func TestBulkWriteResyncPattern(t *testing.T) {
+	t.Parallel()
+	server := NewServer(relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true}))
+	const wsID = "ws_resync_pattern"
+	token := mustTestJWT(t, "dev-secret", wsID, "Worker1", []string{"fs:read", "fs:write"}, time.Now().Add(time.Hour))
+
+	bulkWrite := func(files []map[string]any) {
+		t.Helper()
+		resp := doRequest(t, server, request{
+			method: http.MethodPost,
+			path:   "/v1/workspaces/" + wsID + "/fs/bulk",
+			headers: map[string]string{
+				"Authorization":    "Bearer " + token,
+				"X-Correlation-Id": "corr_resync",
+			},
+			body: map[string]any{"files": files},
+		})
+		if resp.Code != http.StatusAccepted {
+			t.Fatalf("bulk write: expected 202, got %d: %s", resp.Code, resp.Body.String())
+		}
+	}
+
+	// Round 1: initial provider sync.
+	bulkWrite([]map[string]any{
+		{"path": "/provider/A.md", "contentType": "text/markdown", "content": "v1-A"},
+		{"path": "/provider/B.md", "contentType": "text/markdown", "content": "v1-B"},
+		{"path": "/provider/C.md", "contentType": "text/markdown", "content": "v1-C"},
+	})
+
+	for _, path := range []string{"/provider/A.md", "/provider/B.md", "/provider/C.md"} {
+		f := readFileForTest(t, server, token, wsID, path, "corr_resync_r1")
+		if f.Content == "" {
+			t.Errorf("round 1: %q has empty content", path)
+		}
+	}
+
+	// Round 2: re-sync with updated B, new D — simulates a provider resync batch.
+	bulkWrite([]map[string]any{
+		{"path": "/provider/B.md", "contentType": "text/markdown", "content": "v2-B"},
+		{"path": "/provider/D.md", "contentType": "text/markdown", "content": "v2-D"},
+	})
+
+	updated := readFileForTest(t, server, token, wsID, "/provider/B.md", "corr_resync_r2")
+	if updated.Content != "v2-B" {
+		t.Errorf("expected updated content %q, got %q", "v2-B", updated.Content)
+	}
+	newFile := readFileForTest(t, server, token, wsID, "/provider/D.md", "corr_resync_r2")
+	if newFile.Content != "v2-D" {
+		t.Errorf("expected new file content %q, got %q", "v2-D", newFile.Content)
+	}
+}
+
 func TestExportJSON(t *testing.T) {
 	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
 	t.Cleanup(store.Close)

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1269,12 +1269,14 @@ func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
 
 	cases := []struct {
 		name    string
+		ws      string // stable, unique workspace suffix per case
 		files   []map[string]any
 		want    []string // paths expected to be readable
 		written int
 	}{
 		{
 			name: "single file readable after bulk write",
+			ws:   "single",
 			files: []map[string]any{
 				{"path": "/sync/Record.md", "contentType": "text/markdown", "content": "# record"},
 			},
@@ -1283,6 +1285,7 @@ func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
 		},
 		{
 			name: "multiple files all readable after bulk write",
+			ws:   "multi",
 			files: []map[string]any{
 				{"path": "/sync/Alpha.md", "contentType": "text/markdown", "content": "# alpha"},
 				{"path": "/sync/Beta.md", "contentType": "text/plain", "content": "beta"},
@@ -1293,6 +1296,7 @@ func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
 		},
 		{
 			name: "partial batch: valid files readable, invalid files reported in errors",
+			ws:   "partial",
 			files: []map[string]any{
 				{"path": "/sync/Good.md", "contentType": "text/markdown", "content": "# good"},
 				{"path": "/sync/Bad.md", "contentType": "text/markdown", "content": "# bad", "encoding": "utf16"},
@@ -1306,8 +1310,10 @@ func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			server := NewServer(relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true}))
-			wsID := "ws_read_after_202_" + tc.name[:4]
+			store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
+			t.Cleanup(store.Close)
+			server := NewServer(store)
+			wsID := "ws_read_after_202_" + tc.ws
 			token := mustTestJWT(t, "dev-secret", wsID, "Worker1", []string{"fs:read", "fs:write"}, time.Now().Add(time.Hour))
 
 			bulkResp := doRequest(t, server, request{
@@ -1352,7 +1358,9 @@ func TestBulkWriteReadImmediatelyAfter202(t *testing.T) {
 // is synchronous, so there is no window between "accepted" and "readable".
 func TestBulkWriteResyncPattern(t *testing.T) {
 	t.Parallel()
-	server := NewServer(relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true}))
+	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
+	t.Cleanup(store.Close)
+	server := NewServer(store)
 	const wsID = "ws_resync_pattern"
 	token := mustTestJWT(t, "dev-secret", wsID, "Worker1", []string{"fs:read", "fs:write"}, time.Now().Add(time.Hour))
 

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -174,9 +174,14 @@ paths:
       operationId: bulkWriteFiles
       summary: Write multiple files in a single request
       description: |
-        Writes multiple files atomically within a workspace. Each file is
-        individually permission-checked; files that fail permission checks are
-        reported in the `errors` array while permitted files are written.
+        Writes multiple files within a workspace. Each file is individually
+        permission-checked; files that fail permission checks are reported in
+        the `errors` array while permitted files are written.
+
+        The response is synchronous: a `202` means all files listed in
+        `results` are immediately readable via `GET /fs/file`. The `202`
+        status code is kept for historical reasons and does not imply an
+        asynchronous or queued write.
       security:
         - BearerAuth: [fs:write]
       parameters:
@@ -191,7 +196,9 @@ paths:
               $ref: '#/components/schemas/BulkWriteRequest'
       responses:
         '202':
-          description: Bulk write accepted
+          description: >
+            Bulk write complete. All files in `results` are immediately
+            readable. Files that could not be written appear in `errors`.
           content:
             application/json:
               schema:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,9 +1999,9 @@
       "link": true
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.10.0.tgz",
-      "integrity": "sha512-OE9ubZ0cCAVvKScCF2WrG60Gk9n7d5CFpjZJ/5kGjgG8TTmVZoJrb7ZWRFOBnY4It20MKwP0B9MF5e/MeD+XVQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.10.1.tgz",
+      "integrity": "sha512-A6pLlYHR5seLHR5BIUFhEEt2WFbOG2FgZ2fCKtB+gMvBZuxNPdnFphMLKUak7JDvE5j1/NPmFM4A2E5X1rkR5w==",
       "cpu": [
         "arm64"
       ],
@@ -2012,9 +2012,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.10.0.tgz",
-      "integrity": "sha512-/E4wRLvD3RBQS/QHnUV9MtWEqWlTklJetfw8S+0qNTgmhT/KkgrWKRHj9EXj9Gb8mhxcmnbd0Mz/DyfixmDbBw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.10.1.tgz",
+      "integrity": "sha512-bN5jd8aF8xi9tQ8tCh/TwYg8QlUf4c/KZm+LkAXgZzuGukvuwAJzIfS6gbbfRTi7wkebatbJDTJFYP3cCwMOhQ==",
       "cpu": [
         "x64"
       ],
@@ -2025,9 +2025,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.10.0.tgz",
-      "integrity": "sha512-yQY0P14v6YpeHBncpBIZcztmEJh5haz1K6gbLb60Fe2W6Isx/yDBmMd1h56jK91Cd7TFUchRcqUgrvc2l6CYxg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.10.1.tgz",
+      "integrity": "sha512-AZN8DyRW7AbeNR2QJJwbM4APkDu5fAFB393Rqh2QL+lF69U8usP9w+SAMKCQPfuekJarMgLmnIpgPMRJWAqXCw==",
       "cpu": [
         "arm64"
       ],
@@ -2038,9 +2038,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.0.tgz",
-      "integrity": "sha512-+QYM0VaDQw/FNSp6Cs+Ym80QJA8uDolD3egQB/59AE8ws+WkkVStx2hGfJWg0psbnhMLzOuIPLEfNNRfT6S28g==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.1.tgz",
+      "integrity": "sha512-Gpa/K6z/cWIGIjnL1hLU/m9c7hbb9XjDPrYJEO2G9TNCd8fboUxFMABMqQJTTBzBm8FaT9/qC0WGeOjedQyMsA==",
       "cpu": [
         "x64"
       ],
@@ -6153,10 +6153,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.6",
-        "@relayfile/mount-darwin-x64": "0.9.6",
-        "@relayfile/mount-linux-arm64": "0.9.6",
-        "@relayfile/mount-linux-x64": "0.9.6"
+        "@relayfile/mount-darwin-arm64": "0.10.1",
+        "@relayfile/mount-darwin-x64": "0.10.1",
+        "@relayfile/mount-linux-arm64": "0.10.1",
+        "@relayfile/mount-linux-x64": "0.10.1"
       }
     }
   }

--- a/packages/sdk/typescript/package-lock.json
+++ b/packages/sdk/typescript/package-lock.json
@@ -21,10 +21,10 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.9.6",
-        "@relayfile/mount-darwin-x64": "0.9.6",
-        "@relayfile/mount-linux-arm64": "0.9.6",
-        "@relayfile/mount-linux-x64": "0.9.6"
+        "@relayfile/mount-darwin-arm64": "0.10.1",
+        "@relayfile/mount-darwin-x64": "0.10.1",
+        "@relayfile/mount-linux-arm64": "0.10.1",
+        "@relayfile/mount-linux-x64": "0.10.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@relayfile/mount-darwin-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.10.0.tgz",
-      "integrity": "sha512-OE9ubZ0cCAVvKScCF2WrG60Gk9n7d5CFpjZJ/5kGjgG8TTmVZoJrb7ZWRFOBnY4It20MKwP0B9MF5e/MeD+XVQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-arm64/-/mount-darwin-arm64-0.10.1.tgz",
+      "integrity": "sha512-A6pLlYHR5seLHR5BIUFhEEt2WFbOG2FgZ2fCKtB+gMvBZuxNPdnFphMLKUak7JDvE5j1/NPmFM4A2E5X1rkR5w==",
       "cpu": [
         "arm64"
       ],
@@ -511,9 +511,9 @@
       ]
     },
     "node_modules/@relayfile/mount-darwin-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.10.0.tgz",
-      "integrity": "sha512-/E4wRLvD3RBQS/QHnUV9MtWEqWlTklJetfw8S+0qNTgmhT/KkgrWKRHj9EXj9Gb8mhxcmnbd0Mz/DyfixmDbBw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-darwin-x64/-/mount-darwin-x64-0.10.1.tgz",
+      "integrity": "sha512-bN5jd8aF8xi9tQ8tCh/TwYg8QlUf4c/KZm+LkAXgZzuGukvuwAJzIfS6gbbfRTi7wkebatbJDTJFYP3cCwMOhQ==",
       "cpu": [
         "x64"
       ],
@@ -524,9 +524,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-arm64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.10.0.tgz",
-      "integrity": "sha512-yQY0P14v6YpeHBncpBIZcztmEJh5haz1K6gbLb60Fe2W6Isx/yDBmMd1h56jK91Cd7TFUchRcqUgrvc2l6CYxg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-arm64/-/mount-linux-arm64-0.10.1.tgz",
+      "integrity": "sha512-AZN8DyRW7AbeNR2QJJwbM4APkDu5fAFB393Rqh2QL+lF69U8usP9w+SAMKCQPfuekJarMgLmnIpgPMRJWAqXCw==",
       "cpu": [
         "arm64"
       ],
@@ -537,9 +537,9 @@
       ]
     },
     "node_modules/@relayfile/mount-linux-x64": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.0.tgz",
-      "integrity": "sha512-+QYM0VaDQw/FNSp6Cs+Ym80QJA8uDolD3egQB/59AE8ws+WkkVStx2hGfJWg0psbnhMLzOuIPLEfNNRfT6S28g==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.1.tgz",
+      "integrity": "sha512-Gpa/K6z/cWIGIjnL1hLU/m9c7hbb9XjDPrYJEO2G9TNCd8fboUxFMABMqQJTTBzBm8FaT9/qC0WGeOjedQyMsA==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
## Summary

- Adds `TestBulkWriteReadImmediatelyAfter202` (table-driven, 3 subtests): single file, multi-file batch, and partial batch with encoding errors — each bulk write is immediately followed by `GET /fs/file` on every path in `results` to assert synchronous readability.
- Adds `TestBulkWriteResyncPattern`: simulates a provider re-sync (write batch 1, then a second overlapping batch), verifies updated content and new paths are readable instantly after each round.
- Clarifies the OpenAPI `/fs/bulk` endpoint description: the `202` response is synchronous — "accepted" and "written" happen in the same call. The `202` status code is historical, not an indicator of async/queued work. Updates the `202` response description from the misleading "Bulk write accepted" to an explicit statement that all `results` paths are immediately readable.

## Context

Issue #306 identified a cloud DO bug where provider sync writes were 202-accepted but temporarily unreadable due to shard resolver bypass + clear-pass ordering. This PR documents and pins the **OSS server's correct contract** — `handleBulkWrite` calls `store.BulkWrite()` inline with no async gap — so any future refactor that breaks synchronous readability will be caught immediately.

The cloud-side fix (shard resolver and clear-pass ordering) is tracked separately in the paired Cloud PR.

## Test plan

- [x] `go test ./internal/httpapi/ -run TestBulkWrite` — all pass
- [x] `scripts/check-contract-surface.sh` — contract check passes
- [ ] Verify Cloud PR cross-references this PR once opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

