### PR TITLE
feat(sdk): self-host Connect + data-ready signal + agent-examples docs (#310, #311, #309 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ site/dist/
 packages/file-observer/out/
 packages/agents/dist
 .scratch/
+.agentworkforce/
+packages/**/.claude/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ That's the entire interface. No new SDK to learn, no MCP schemas eating your con
 - **Hosted integrations:** `npx relayfile setup --provider notion --workspace research-room --local-dir ./relayfile-mount`
 - **Local OSS:** run the Docker stack below, then mount `ws_demo` as a normal directory.
 - **Sandbox SDK:** use `RelayfileSetup.ensureMountedWorkspace()` when your runtime already has a cloud access token.
-- **Programmatic agents:** wrap `RelayFileClient.readFile()` / `writeFile()` as one tool inside Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, or any custom harness.
+- **Programmatic agents:** use [`@relayfile/agents`](packages/agents/README.md) for Vercel AI SDK, OpenAI Agents SDK, and LangChain, or wrap `RelayFileClient.readFile()` / `writeFile()` directly in any custom harness.
 
 ```ts
 import { RelayFileClient } from "@relayfile/sdk"
@@ -125,6 +125,7 @@ This is what turns multi-agent collaboration into a property of the substrate in
 - **Real-time multi-agent sync.** Writes from one agent are visible to others on the next read. No commit/push/pull cycle, no merge.
 - **Real OS mount.** Native bash, native `find`/`grep`/`jq`/`rg`, no emulation gaps. Any process — agents, scripts, IDEs — can read or write the mount.
 - **Pluggable architecture.** A core file server plus [adapters](https://github.com/AgentWorkforce/relayfile-adapters) (per-integration logic) and [providers](https://github.com/AgentWorkforce/relayfile-providers) (auth/proxy via Nango, Composio, Pipedream). One provider integration unlocks tens of apps.
+- **Framework adapter.** [`@relayfile/agents`](packages/agents/) is a thin adapter — one `connect()` call yields path-scoped read tools, a proven writeback lifecycle, and `onEvent` reactive webhooks, working identically across the Vercel AI SDK, OpenAI Agents SDK, and LangChain.
 
 ## Works with
 
@@ -133,9 +134,12 @@ Anything that can read and write files works with relayfile out of the box — t
 | Framework | Recipe |
 |---|---|
 | Claude Code | [setting-up-relayfile skill](https://github.com/AgentWorkforce/skills/blob/main/skills/setting-up-relayfile/SKILL.md) |
+| Vercel AI SDK | [`@relayfile/agents`](packages/agents/README.md) · [Notion read](examples/integrations/vercel-ai-sdk-notion-read/) · [Linear writeback](examples/integrations/vercel-ai-sdk-linear-writeback/) · [reactive `onEvent`](examples/integrations/vercel-ai-sdk-linear-events/) |
+| OpenAI Agents SDK | [`@relayfile/agents`](packages/agents/README.md) · [Notion read](examples/integrations/openai-agents-notion-read/) · [Linear writeback](examples/integrations/openai-agents-linear-writeback/) |
+| LangChain | [`@relayfile/agents`](packages/agents/README.md) · [Notion read](examples/integrations/langchain-notion-read/) · [Linear writeback](examples/integrations/langchain-linear-writeback/) |
 | Anything that runs `bash` | works out of the box (it's a real OS mount) |
 
-More framework recipes (Vercel AI SDK, OpenAI Agents SDK, LangGraph, Pydantic AI) are landing as part of [#106](https://github.com/AgentWorkforce/relayfile/issues/106).
+For the exact SDK/cloud contract that the examples pin against, see [`docs/integrations/SDK-SURFACE.md`](docs/integrations/SDK-SURFACE.md). For self-host connect and ingestion boundaries, see [`docs/integrations/SELF-HOST.md`](docs/integrations/SELF-HOST.md).
 
 ## How relayfile compares
 
@@ -307,6 +311,8 @@ Use the OSS repo when you want to run the file server yourself. Use hosted Agent
 
 For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant [adapters](https://github.com/AgentWorkforce/relayfile-adapters), [providers](https://github.com/AgentWorkforce/relayfile-providers), and Nango. Relayfile itself does not store third-party OAuth credentials.
 
+The current split is deliberate: Relayfile's OSS surface handles the VFS, scoped tokens, generic ingest, writeback queue, and mount. The polished OAuth connect flow and provider sync definitions are either hosted by Agent Relay Cloud or implemented in your self-host provider stack. See the [self-host integration guide](docs/integrations/SELF-HOST.md) for the connect path, ingestion path, and paid sync-definition boundary.
+
 ### Mount a workspace from a sandbox (TypeScript SDK)
 
 Once a user has signed in and connected their providers in Agent Relay Cloud, a sandbox (Daytona, E2B, an ephemeral container, your own runtime) can attach the workspace as local files in a single SDK call:
@@ -366,7 +372,10 @@ Pipedream:
 
 - [Getting started](docs/guides/getting-started.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
+- [SDK surface](docs/integrations/SDK-SURFACE.md) — authoritative SDK + cloud contract surface
+- [Self-host connect and ingestion boundaries](docs/integrations/SELF-HOST.md)
 - [Post-auth mount session (SDK)](docs/guides/post-auth-mount-session.md)
+- [`@relayfile/agents`](packages/agents/README.md)
 - [Adapters](https://github.com/AgentWorkforce/relayfile-adapters)
 - [Providers](https://github.com/AgentWorkforce/relayfile-providers)
 - [API reference](docs/api-reference.md)

--- a/docs/integrations/SDK-SURFACE.md
+++ b/docs/integrations/SDK-SURFACE.md
@@ -214,6 +214,28 @@ Properties: `info: WorkspaceInfo`, `workspaceId: string`.
 
 ---
 
+## Self-Host Connect
+
+`ConnectCapableProvider` (`src/connection.ts`) extends `ConnectionProvider` with
+`createConnectSession(input)` and `getConnectionStatus(input)`. Use
+`supportsConnect(provider)` before treating a provider as connect-capable.
+
+`SelfHostConnect` (`src/self-host-connect.ts`) is provider-backed and requires
+an explicit `providerConfigKeys` map (typed `ProviderConfigKeyMap`, a
+`Record<relayfileSlug, providerConfigKey>`), for example
+`{ github: "github-prod" }`. `startConnect("github", { endUserId })` resolves
+that map and calls the provider directly. The OSS server has no bind/adopt route
+for self-host Connect; Cloud convergence remains separate from this surface.
+
+`waitForConnection(provider, { connectionId })` waits for auth readiness
+(`oauth_connected` or provider `ready: true`). Data-plane readiness is a
+separate, shipped helper — `RelayFileClient.waitForData(workspaceId, provider)`
+over `/v1/workspaces/{id}/sync/status` (resolves when the provider reports
+`ready`). See `docs/integrations/SELF-HOST.md` for the full connect → data-ready
+flow and the provider sync-coverage matrix.
+
+---
+
 ## 6. MountedWorkspaceHandle (`src/setup.ts:1081`)
 
 `{ workspaceId, localDir, remotePath, mode: "poll"|"fuse", ready: boolean, expiresAt, suggestedRefreshAt }`
@@ -231,9 +253,43 @@ github · slack-sage · slack-my-senior-dev · slack-nightcto · notion · linea
 
 `WORKSPACE_INTEGRATION_PROVIDERS` is the exact allowed set for `connectIntegration(provider)` and `EnsureMountedWorkspaceInput.provider`.
 
+## 8. `@relayfile/agents` shipped surface
+
+PR 309 adds the thin package that the framework examples use:
+
+```ts
+import { connect, tools } from "@relayfile/agents";
+
+const rf = await connect({ scopes: ["relayfile:fs:read:/notion/**"] });
+tools.vercel(rf, { readPaths: ["/notion"] });
+tools.openai(rf, { readPaths: ["/notion"] });
+tools.langchain(rf, { readPaths: ["/notion"] });
+```
+
+The package wraps the canonical Cloud bootstrap from §1, exposes `rf.client` as the raw SDK escape hatch, and adds `writeback.*`, `read`, and `onEvent` helpers. See `packages/agents/README.md` for the package API and `examples/integrations/` for runnable smoke-tested projects.
+
+## 9. Self-host boundary
+
+`WorkspaceHandle.connectIntegration()` / `connectNotion()` are Cloud-backed today: they call Agent Relay Cloud `integrations/connect-session` and `status` routes. They are correct for hosted examples, but they are not a white-label self-host connect orchestrator.
+
+Current self-hostable pieces in this repo:
+
+| Need | Current surface |
+|---|---|
+| Run the VFS API | relayfile server |
+| Issue scoped workspace tokens | relayauth-compatible issuer |
+| Read/write/list files | `RelayFileClient` |
+| Push normalized provider events | `RelayFileClient.ingestWebhook(...)` -> `POST /v1/workspaces/{id}/webhooks/ingest` |
+| Orchestrate self-host connect | `SelfHostConnect` (`@relayfile/sdk`) + a `ConnectCapableProvider` |
+| Wait for first-sync data | `RelayFileClient.waitForData(id, provider)` -> `/v1/workspaces/{id}/sync/status` |
+| Consume writeback work | writeback queue / consumer APIs |
+| Framework tools | `@relayfile/agents` |
+
+Self-host provider OAuth session minting and `connectionId` binding remain provider-stack work; first-sync backfill and the actual sync definitions are the [paid boundary](./SYNC-DEFINITION-BOUNDARY.md). The connect orchestrator (`SelfHostConnect`) and the data-ready signal (`waitForData`) now ship in `@relayfile/sdk`. Issues [#310](https://github.com/AgentWorkforce/relayfile/issues/310) and [#311](https://github.com/AgentWorkforce/relayfile/issues/311) track turning more of that into explicit SDK/OSS surface. The short guide is `docs/integrations/SELF-HOST.md`.
+
 ---
 
-## 8. Existing examples to lift patterns from (`examples/`)
+## 10. Existing examples to lift patterns from (`examples/`)
 
 | Dir | Demonstrates | Real SDK calls |
 |---|---|---|
@@ -245,6 +301,8 @@ github · slack-sage · slack-my-senior-dev · slack-nightcto · notion · linea
 | `06-writeback-consumer` | writeback handler | — |
 
 Env vars these examples read: `RELAYFILE_TOKEN`, `WORKSPACE_ID` (and scoped variants in 05). The SDK does **not** auto-read `process.env` — the caller passes token + workspaceId explicitly.
+
+Framework examples live under `examples/integrations/` and use `@relayfile/agents`: Vercel AI SDK, OpenAI Agents SDK, and LangChain Notion read / Linear writeback projects, plus the Vercel Linear events example.
 
 ---
 

--- a/docs/integrations/SDK-SURFACE.md
+++ b/docs/integrations/SDK-SURFACE.md
@@ -231,8 +231,9 @@ for self-host Connect; Cloud convergence remains separate from this surface.
 (`oauth_connected` or provider `ready: true`). Data-plane readiness is a
 separate, shipped helper — `RelayFileClient.waitForData(workspaceId, provider)`
 over `/v1/workspaces/{id}/sync/status` (resolves when the provider reports
-`ready`). See `docs/integrations/SELF-HOST.md` for the full connect → data-ready
-flow and the provider sync-coverage matrix.
+`ready`, or when an OSS `healthy` row includes processed-ingest progress via
+`cursor`/`watermarkTs`). See `docs/integrations/SELF-HOST.md` for the full
+connect → data-ready flow and the provider sync-coverage matrix.
 
 ---
 

--- a/docs/integrations/SELF-HOST.md
+++ b/docs/integrations/SELF-HOST.md
@@ -56,12 +56,12 @@ Auth-ready is not data-ready. After connect, a provider sync still has to backfi
 // Push normalized provider events into the VFS with a workspace token (no internal HMAC).
 await client.ingestWebhook(/* workspaceId, normalized event */);
 
-// Wait until first sync has actually materialized data for a provider (data-ready).
+// Wait until provider data is safe to read.
 await client.waitForData(workspaceId, "github");
 ```
 
 - **`ingestWebhook`** posts to the token-authed `POST /v1/workspaces/{workspaceId}/webhooks/ingest`. The receiver can be `@relayfile/webhook-server`, a Nango sync-webhook handler, a Composio trigger handler, or your own service.
-- **`waitForData`** polls `/v1/workspaces/{workspaceId}/sync/status` until the provider reports `ready`. This is the **data-ready signal**, distinct from Connect's auth-ready — call it before an agent reads `/<provider>/**` so it never reads an empty tree.
+- **`waitForData`** polls `/v1/workspaces/{workspaceId}/sync/status`. Cloud-managed syncs report first-sync completion with `ready`; OSS self-host reports provider health as `healthy`, so the SDK only treats `healthy` as data-ready after the status row carries processed-ingest progress (`cursor` or `watermarkTs`). If your OSS deployment ingests through custom webhooks or sync workers, gate on your own ingest completion when you need stronger proof than observed provider progress.
 
 The end-to-end self-host shape: `connect → backfill + live webhooks → waitForData → agent reads the VFS`. Full reference tracked in [#311](https://github.com/AgentWorkforce/relayfile/issues/311).
 

--- a/docs/integrations/SELF-HOST.md
+++ b/docs/integrations/SELF-HOST.md
@@ -1,0 +1,106 @@
+# Self-Host Connect and Ingestion
+
+**Status:** Guide for running Relayfile integrations without Agent Relay Cloud.
+
+Relayfile OSS is the filesystem, auth boundary, ingest endpoint, writeback queue, and mount layer. Provider OAuth and provider **sync definitions** live in your provider stack — Nango, Composio, Pipedream, or a custom `ConnectionProvider`. This guide covers the two halves a self-host developer wires up: **Connect** (auth) and **Ingestion** (data).
+
+## Connect
+
+Hosted Agent Relay ships a polished `connectIntegration()` / `connectNotion()` flow through Cloud. For self-host, `@relayfile/sdk` now ships the same orchestration with **no Cloud dependency** via `SelfHostConnect`, backed by any provider that implements the `ConnectCapableProvider` contract:
+
+```ts
+import { SelfHostConnect, type ConnectCapableProvider } from "@relayfile/sdk";
+
+// Implement this around your provider stack. The concrete Nango/Pipedream
+// provider-package adapters are tracked as relayfile-providers follow-up work.
+const provider: ConnectCapableProvider = {
+  name: "nango",
+  proxy: async (_request) => {
+    throw new Error("Wire this to your provider proxy");
+  },
+  healthCheck: async (_connectionId) => {
+    throw new Error("Wire this to your provider health check");
+  },
+  createConnectSession: async (_input) => {
+    throw new Error("Wire this to your provider connect-session API");
+  },
+  getConnectionStatus: async (_input) => {
+    throw new Error("Wire this to your provider connection-status API");
+  },
+};
+
+const connect = new SelfHostConnect({
+  provider,
+  // relayfile slug -> your provider's config key (they are not always equal)
+  providerConfigKeys: { github: "github" },
+});
+
+// 1. mint a connect session for your end user
+const session = await connect.startConnect("github", { endUserId: user.id });
+//    → render session.sessionToken in a frontend widget, or redirect to session.connectLink
+
+// 2. wait until upstream OAuth is live (auth-ready)
+await connect.waitForConnection("github", { connectionId: session.connectionId });
+```
+
+- `SelfHostConnect` orchestrates `startConnect → (user OAuths) → waitForConnection`. The connection ↔ workspace binding is **provider-side** (the `connectionId` is tagged in your Nango/Pipedream account and resolved at proxy time) — there is no Cloud bind route and no internal HMAC dependency.
+- `waitForConnection` polls `provider.getConnectionStatus(...)` until the connection reports auth-ready (`oauth_connected`).
+- Use the `supportsConnect(provider)` type guard to check a provider implements the capability before calling.
+- The `ConnectCapableProvider` contract (`createConnectSession` / `getConnectionStatus`) lives in `@relayfile/sdk`. The concrete `NangoProvider` / `PipedreamProvider` implementations land in [`relayfile-providers`](https://github.com/AgentWorkforce/relayfile-providers) (tracked in [#310](https://github.com/AgentWorkforce/relayfile/issues/310)); any provider satisfying the contract works today.
+
+## Ingestion
+
+Auth-ready is not data-ready. After connect, a provider sync still has to backfill and materialize records into the VFS. Two SDK primitives cover the self-host ingest path:
+
+```ts
+// Push normalized provider events into the VFS with a workspace token (no internal HMAC).
+await client.ingestWebhook(/* workspaceId, normalized event */);
+
+// Wait until first sync has actually materialized data for a provider (data-ready).
+await client.waitForData(workspaceId, "github");
+```
+
+- **`ingestWebhook`** posts to the token-authed `POST /v1/workspaces/{workspaceId}/webhooks/ingest`. The receiver can be `@relayfile/webhook-server`, a Nango sync-webhook handler, a Composio trigger handler, or your own service.
+- **`waitForData`** polls `/v1/workspaces/{workspaceId}/sync/status` until the provider reports `ready`. This is the **data-ready signal**, distinct from Connect's auth-ready — call it before an agent reads `/<provider>/**` so it never reads an empty tree.
+
+The end-to-end self-host shape: `connect → backfill + live webhooks → waitForData → agent reads the VFS`. Full reference tracked in [#311](https://github.com/AgentWorkforce/relayfile/issues/311).
+
+## Provider sync coverage
+
+A provider only **backfills** into the VFS if a sync definition ships for it. An adapter alone gives path-mapping + writeback, not backfill — picking a path-mapping-only provider and getting an empty tree is the common DX trap.
+
+**Sync-ready** (adapter + shipped sync definition → initial backfill + live events): `confluence`, `daytona`*, `docker-hub`†, `dropbox`, `fathom`, `gcp`, `github`, `gitlab`, `gmail`, `google-calendar`, `granola`, `hubspot`, `jira`, `linear`, `neon`, `notion`, `recall`, `reddit`†, `slack`, `x`.
+
+**Path-mapping / writeback-only** (adapter exists, **no** shipped sync def → no backfill; ingest only what you push via `ingestWebhook`): `airtable`, `asana`, `azure-blob`, `box`, `calendly`, `clickup`, `gcs`, `google-drive`, `intercom`, `mailgun`, `mixpanel`, `onedrive`, `pipedrive`, `postgres`, `redis`, `s3`, `salesforce`, `segment`, `sendgrid`, `sharepoint`, `shopify`, `stripe`, `teams`, `zendesk`.
+
+†Composio-backed; the rest are Nango. Adapters live in [`relayfile-adapters`](https://github.com/AgentWorkforce/relayfile-adapters); sync definitions ship behind the [paid boundary](#paid-sync-definition-boundary).
+
+## Responsibility matrix
+
+| Layer | Current OSS surface | Hosted Agent Relay | Self-host responsibility |
+|---|---|---|---|
+| VFS API, revisions, ACL checks | yes | managed | run Relayfile |
+| Scoped token issuing | relayauth-compatible | managed | run relayauth or equivalent |
+| Agent framework tools | `@relayfile/agents` | same package | same package |
+| Connect orchestration | `SelfHostConnect` (`@relayfile/sdk`) | managed connect flow | provide a `ConnectCapableProvider` + frontend widget |
+| Provider OAuth + connection binding | provider-side (`connectionId`) | managed | run Nango/Pipedream; tag connection |
+| Generic event ingest | `ingestWebhook` / `/webhooks/ingest` | managed workers call ingest | run webhook/sync handlers |
+| Data-ready gate | `waitForData` / `/sync/status` | managed per provider | call before reads |
+| Sync definitions | not shipped as generic defaults | managed by Agent Relay | scoped engagement |
+| Writeback queue and op status | yes | managed | run provider workers |
+
+## Paid sync-definition boundary
+
+The plumbing is OSS; the sync definitions are scoped work. A Nango/Composio sync definition decides *which objects, fields, depth, cadence, and deletion semantics* become files — choices that are customer-specific, so this repo ships the ingest scaffolding and examples, not a universal drop-in sync.
+
+- **Included as OSS:** Relayfile server, SDK client, `SelfHostConnect`, generic ingest, `waitForData`, writeback queue, mount, agent tools, scaffolding.
+- **Scoped engagement:** authoring and validating the provider sync definitions for the customer's required data.
+
+Full detail: [`SYNC-DEFINITION-BOUNDARY.md`](./SYNC-DEFINITION-BOUNDARY.md).
+
+## Related docs
+
+- [`SDK-SURFACE.md`](./SDK-SURFACE.md) — authoritative shipped SDK + Cloud contract.
+- [`SYNC-DEFINITION-BOUNDARY.md`](./SYNC-DEFINITION-BOUNDARY.md) — the OSS-vs-paid boundary in detail.
+- [`docs/api-reference.md`](../api-reference.md) — ingest + sync-status endpoint shapes.
+- [`docs/guides/cloud-integration.md`](../guides/cloud-integration.md) — existing connection IDs and provider ownership.

--- a/docs/integrations/SYNC-DEFINITION-BOUNDARY.md
+++ b/docs/integrations/SYNC-DEFINITION-BOUNDARY.md
@@ -8,8 +8,9 @@ definitions are a scoped services engagement.
 - Workspace-token ingest: `RelayFileClient.ingestWebhook(...)` sends normalized
   provider events to `POST /v1/workspaces/{workspaceId}/webhooks/ingest`.
 - Data readiness: `RelayFileClient.waitForData(workspaceId, provider)` polls
-  `/v1/workspaces/{workspaceId}/sync/status` until that provider reports
-  `ready`.
+  `/v1/workspaces/{workspaceId}/sync/status` until cloud reports first-sync
+  `ready`, or until OSS reports `healthy` with processed-ingest progress
+  (`cursor`/`watermarkTs`).
 - Adapter contract: `@relayfile/adapter-*` packages define path mapping,
   webhook normalization, writeback payloads, and digest handling.
 - Self-host wiring: the developer runs Relayfile, their provider backend

--- a/docs/integrations/SYNC-DEFINITION-BOUNDARY.md
+++ b/docs/integrations/SYNC-DEFINITION-BOUNDARY.md
@@ -1,0 +1,35 @@
+# Sync definition boundary
+
+Self-host Relayfile ships the ingestion plumbing. Customer-specific sync
+definitions are a scoped services engagement.
+
+## What is OSS
+
+- Workspace-token ingest: `RelayFileClient.ingestWebhook(...)` sends normalized
+  provider events to `POST /v1/workspaces/{workspaceId}/webhooks/ingest`.
+- Data readiness: `RelayFileClient.waitForData(workspaceId, provider)` polls
+  `/v1/workspaces/{workspaceId}/sync/status` until that provider reports
+  `ready`.
+- Adapter contract: `@relayfile/adapter-*` packages define path mapping,
+  webhook normalization, writeback payloads, and digest handling.
+- Self-host wiring: the developer runs Relayfile, their provider backend
+  (Nango, Pipedream, or equivalent), and the webhook/sync worker that calls
+  `ingestWebhook`.
+
+## What is scoped work
+
+The Nango/Composio sync definition decides which upstream objects, fields,
+permissions, backfill depth, polling cadence, and webhook edge cases are worth
+materializing for that customer. Relayfile does not ship a generic, drop-in
+sync for every provider because that scope is product-specific.
+
+The default delivery model is:
+
+1. OSS scaffold and SDK APIs provide the plumbing.
+2. A paid engagement authors the customer's sync definitions in their provider
+   account, usually from a small template.
+3. The sync worker emits normalized events through `ingestWebhook`.
+4. Applications call `waitForData` before reading `/<provider>/**`.
+
+This keeps the open source runtime reusable while making the customer's data
+scope explicit and validated.

--- a/openapi/relayfile-v1.openapi.yaml
+++ b/openapi/relayfile-v1.openapi.yaml
@@ -2687,7 +2687,18 @@ components:
                 type: string
               status:
                 type: string
-                enum: [healthy, lagging, error, paused]
+                enum:
+                  - connected
+                  - oauth_connected
+                  - sync_queued
+                  - syncing
+                  - ready
+                  - healthy
+                  - lagging
+                  - error
+                  - paused
+              ready:
+                type: boolean
               cursor:
                 type: string
                 nullable: true

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -69,9 +69,9 @@ a user prompt but reacting to provider state changes (a new Linear issue, a Noti
 a GitHub PR opened). MCPs have no concept of this: they're pull-only.
 
 The SDK exposes `connectWebSocket({ onEvent })` and a glob-based `subscribe()` API for
-filtering. See `examples/04-realtime-events/` for the raw-SDK pattern. A framework-wrapped
-"agent reacts to webhook" example is on the Phase-2 roadmap — the wiring is identical to the
-read/write examples in this PR plus a long-lived event loop.
+filtering. See `examples/04-realtime-events/` for the raw-SDK pattern and
+[`examples/integrations/vercel-ai-sdk-linear-events`](../../examples/integrations/vercel-ai-sdk-linear-events/)
+for the framework-wrapped "agent reacts to webhook" example.
 
 ### Operational deploy story
 
@@ -114,7 +114,7 @@ That's it. No legacy probing.
 
 ## See also
 
-Six runnable example projects in [`examples/integrations/`](../../examples/integrations/) —
-Vercel AI SDK / OpenAI Agents / LangChain × Notion read + Linear writeback. Each is
-self-contained (`npm install && npm run smoke`) and proves the full lifecycle against
-production Relayfile.
+Seven runnable example projects in [`examples/integrations/`](../../examples/integrations/) —
+Vercel AI SDK / OpenAI Agents / LangChain × Notion read + Linear writeback, plus Vercel
+AI SDK Linear events. Each is self-contained (`npm install && npm run smoke`) and proves
+the relevant lifecycle against production Relayfile.

--- a/packages/sdk/typescript/src/client.test.ts
+++ b/packages/sdk/typescript/src/client.test.ts
@@ -1635,6 +1635,59 @@ describe("RelayFileClient — existing methods", () => {
       expect(status.ready).toBe(true);
     });
 
+    it("waitForData treats OSS healthy with provider progress as data-ready", async () => {
+      const payload: SyncStatusResponse = {
+        workspaceId: "ws_acme",
+        providers: [{ provider: "linear", status: "healthy", cursor: "env_1" }],
+      };
+      const client = makeClient(mockFetch(payload));
+
+      const status = await client.waitForData("ws_acme", "linear");
+
+      expect(status.status).toBe("healthy");
+      expect(status.cursor).toBe("env_1");
+    });
+
+    it("waitForData does not treat bare OSS healthy as data-ready", async () => {
+      vi.useFakeTimers();
+      const payload: SyncStatusResponse = {
+        workspaceId: "ws_acme",
+        providers: [{ provider: "linear", status: "healthy" }],
+      };
+      const client = makeClient(mockFetch(payload));
+
+      try {
+        const promise = client.waitForData("ws_acme", "linear", {
+          pollIntervalMs: 500,
+          timeoutMs: 1_000,
+        });
+        const rejection = expect(promise).rejects.toThrow(
+          "Timed out waiting for linear data"
+        );
+
+        await vi.advanceTimersByTimeAsync(1_000);
+
+        await rejection;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("waitForData ignores invalid returned provider ids while matching the requested provider", async () => {
+      const payload: SyncStatusResponse = {
+        workspaceId: "ws_acme",
+        providers: [
+          { provider: " ", status: "ready" },
+          { provider: "github", status: "ready" },
+        ],
+      };
+      const client = makeClient(mockFetch(payload));
+
+      const status = await client.waitForData("ws_acme", "github");
+
+      expect(status.provider).toBe("github");
+    });
+
     it("triggerSyncRefresh sends provider and reason", async () => {
       const payload: QueuedResponse = { status: "queued", id: "ref_1" };
       const f = mockFetch(payload);

--- a/packages/sdk/typescript/src/client.test.ts
+++ b/packages/sdk/typescript/src/client.test.ts
@@ -1589,6 +1589,52 @@ describe("RelayFileClient — existing methods", () => {
       expect(res.providers).toHaveLength(1);
     });
 
+    it("waitForData polls sync status until the provider is ready", async () => {
+      vi.useFakeTimers();
+      const responses: SyncStatusResponse[] = [
+        { workspaceId: "ws_acme", providers: [{ provider: "github", status: "syncing" }] },
+        { workspaceId: "ws_acme", providers: [{ provider: "github", status: "ready" }] },
+      ];
+      const f = vi.fn(async () => {
+        const body = responses.shift() ?? responses[responses.length - 1];
+        return {
+          ok: true,
+          status: 200,
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () => Promise.resolve(body),
+          text: () => Promise.resolve(JSON.stringify(body)),
+        } as unknown as Response;
+      });
+      const client = makeClient(f);
+      const onPoll = vi.fn();
+
+      const promise = client.waitForData("ws_acme", "github", {
+        pollIntervalMs: 1000,
+        onPoll,
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      const status = await promise;
+      vi.useRealTimers();
+
+      expect(status.status).toBe("ready");
+      expect(f).toHaveBeenCalledTimes(2);
+      expect(String(f.mock.calls[0]![0])).toContain("/v1/workspaces/ws_acme/sync/status?provider=github");
+      expect(onPoll).toHaveBeenCalledTimes(2);
+    });
+
+    it("waitForData treats ready=true as data-ready", async () => {
+      const payload: SyncStatusResponse = {
+        workspaceId: "ws_acme",
+        providers: [{ provider: "linear", status: "syncing", ready: true }],
+      };
+      const client = makeClient(mockFetch(payload));
+
+      const status = await client.waitForData("ws_acme", "linear");
+
+      expect(status.ready).toBe(true);
+    });
+
     it("triggerSyncRefresh sends provider and reason", async () => {
       const payload: QueuedResponse = { status: "queued", id: "ref_1" };
       const f = mockFetch(payload);

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -41,6 +41,7 @@ import {
   type RelayFileReadCacheOptions,
   type Subscription,
   type SyncIngressStatusResponse,
+  type SyncProviderStatus,
   type SyncStatusResponse,
   type TreeResponse,
   type WriteFileInput,
@@ -59,7 +60,8 @@ import {
   type ChangeStreamConnectionOptions,
   type Expansion,
   type ExpansionLevel,
-  type SubscribeOptions
+  type SubscribeOptions,
+  type WaitForDataOptions
 } from "./types.js";
 import type { ForkHandle } from "@relayfile/core";
 import { RelayFileSync, normalizeFilesystemEvent } from "./sync.js";
@@ -410,6 +412,26 @@ function normalizeErrorDetails(data: Record<string, unknown>, explicitDetails: u
     }
   }
   return Object.keys(details).length > 0 ? details : undefined;
+}
+
+function normalizeProviderId(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    throw new Error("provider is required.");
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value: number, field: string): number {
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    throw new Error(`${field} must be a positive integer.`);
+  }
+  return normalized;
+}
+
+function providerDataReady(status: SyncProviderStatus): boolean {
+  return status.ready === true || status.status === "ready";
 }
 
 class RelayFileWebSocketConnection implements WebSocketConnection {
@@ -1931,6 +1953,45 @@ export class RelayFileClient {
       correlationId: options.correlationId,
       signal: options.signal
     });
+  }
+
+  async waitForData(
+    workspaceId: string,
+    provider: string,
+    options: WaitForDataOptions = {}
+  ): Promise<SyncProviderStatus> {
+    const providerKey = normalizeProviderId(provider);
+    const pollIntervalMs = normalizePositiveInteger(options.pollIntervalMs ?? 1_000, "pollIntervalMs");
+    const timeoutMs = normalizePositiveInteger(options.timeoutMs ?? 5 * 60_000, "timeoutMs");
+    const startedAt = Date.now();
+
+    for (;;) {
+      if (options.signal?.aborted) {
+        throw createAbortError();
+      }
+
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= timeoutMs) {
+        throw new Error(`Timed out waiting for ${providerKey} data after ${elapsedMs}ms.`);
+      }
+
+      const status = await this.getSyncStatus(workspaceId, {
+        provider: providerKey,
+        correlationId: options.correlationId,
+        signal: options.signal
+      });
+      const providerStatus = status.providers.find(
+        (entry) => normalizeProviderId(entry.provider) === providerKey
+      );
+      options.onPoll?.(elapsedMs, providerStatus);
+
+      if (providerStatus && providerDataReady(providerStatus)) {
+        return providerStatus;
+      }
+
+      const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt));
+      await this.sleep(Math.min(pollIntervalMs, remainingMs), options.signal);
+    }
   }
 
   async getSyncIngressStatus(

--- a/packages/sdk/typescript/src/client.ts
+++ b/packages/sdk/typescript/src/client.ts
@@ -422,6 +422,11 @@ function normalizeProviderId(value: string): string {
   return normalized;
 }
 
+function normalizeProviderIdOrNull(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
 function normalizePositiveInteger(value: number, field: string): number {
   const normalized = Math.floor(value);
   if (!Number.isFinite(normalized) || normalized <= 0) {
@@ -431,7 +436,15 @@ function normalizePositiveInteger(value: number, field: string): number {
 }
 
 function providerDataReady(status: SyncProviderStatus): boolean {
-  return status.ready === true || status.status === "ready";
+  return (
+    status.ready === true ||
+    status.status === "ready" ||
+    (status.status === "healthy" && providerHasProgress(status))
+  );
+}
+
+function providerHasProgress(status: SyncProviderStatus): boolean {
+  return Boolean(status.cursor || status.watermarkTs);
 }
 
 class RelayFileWebSocketConnection implements WebSocketConnection {
@@ -1955,6 +1968,17 @@ export class RelayFileClient {
     });
   }
 
+  /**
+   * Wait until a provider is safe to read from the data plane.
+   *
+   * Cloud-managed syncs report first-sync completion through `ready: true` or
+   * `status: "ready"`. OSS self-host `/sync/status` uses `healthy` for provider
+   * health, including empty freshly filtered provider rows, so this method only
+   * treats OSS `healthy` as data-ready after processed-ingest progress appears
+   * on the status row (`cursor` or `watermarkTs`). For custom OSS ingest flows,
+   * gate on your own ingest completion when you need stronger domain-specific
+   * proof than provider progress.
+   */
   async waitForData(
     workspaceId: string,
     provider: string,
@@ -1981,7 +2005,7 @@ export class RelayFileClient {
         signal: options.signal
       });
       const providerStatus = status.providers.find(
-        (entry) => normalizeProviderId(entry.provider) === providerKey
+        (entry) => normalizeProviderIdOrNull(entry.provider) === providerKey
       );
       options.onPoll?.(elapsedMs, providerStatus);
 

--- a/packages/sdk/typescript/src/connection.ts
+++ b/packages/sdk/typescript/src/connection.ts
@@ -46,3 +46,52 @@ export interface ConnectionProvider {
   getConnection?(connectionId: string): Promise<Record<string, unknown>>;
   listConnections?(): Promise<Array<Record<string, unknown>>>;
 }
+
+/**
+ * Maps a relayfile provider slug (e.g. "github", "linear") to the provider
+ * config key it is registered under in your credential backend (e.g. the Nango
+ * `providerConfigKey`). The relayfile slug is NOT guaranteed to equal the
+ * upstream config key, so self-host callers supply this mapping explicitly.
+ */
+export type ProviderConfigKeyMap = Record<string, string>;
+
+export interface CreateConnectSessionInput {
+  relayfileProvider: string;
+  providerConfigKey: string;
+  endUserId: string;
+  connectionId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ConnectSession {
+  connectLink: string | null;
+  sessionToken: string | null;
+  expiresAt: string | null;
+  connectionId: string;
+}
+
+export interface GetConnectConnectionStatusInput {
+  relayfileProvider: string;
+  providerConfigKey: string;
+  connectionId: string;
+}
+
+export interface ConnectConnectionStatus {
+  connectionId: string;
+  state: string;
+  ready?: boolean;
+  raw?: unknown;
+}
+
+export interface ConnectCapableProvider extends ConnectionProvider {
+  createConnectSession(input: CreateConnectSessionInput): Promise<ConnectSession>;
+  getConnectionStatus(input: GetConnectConnectionStatusInput): Promise<ConnectConnectionStatus>;
+}
+
+export function supportsConnect(provider: ConnectionProvider): provider is ConnectCapableProvider {
+  const candidate = provider as Partial<ConnectCapableProvider>;
+  return (
+    typeof candidate.createConnectSession === "function" &&
+    typeof candidate.getConnectionStatus === "function"
+  );
+}

--- a/packages/sdk/typescript/src/index.ts
+++ b/packages/sdk/typescript/src/index.ts
@@ -100,14 +100,28 @@ export { IntegrationProvider, computeCanonicalPath } from "./provider.js";
 export type { WebhookInput, ListProviderFilesOptions, WatchProviderEventsOptions } from "./provider.js";
 // Connection provider contract
 export type {
+  ConnectCapableProvider,
+  ConnectConnectionStatus,
+  ConnectSession,
   ConnectionProvider,
+  CreateConnectSessionInput,
+  GetConnectConnectionStatusInput,
   NormalizedWebhook,
+  ProviderConfigKeyMap,
   ProxyHeaders,
   ProxyMethod,
   ProxyQuery,
   ProxyRequest,
   ProxyResponse,
 } from "./connection.js";
+export { supportsConnect } from "./connection.js";
+export { SelfHostConnect } from "./self-host-connect.js";
+export type {
+  SelfHostConnectOptions,
+  SelfHostConnectResult,
+  StartSelfHostConnectOptions,
+  WaitForSelfHostConnectionOptions
+} from "./self-host-connect.js";
 
 export type {
   AckResponse,
@@ -177,6 +191,7 @@ export type {
   GetSyncDeadLettersOptions,
   GetSyncIngressStatusOptions,
   GetSyncStatusOptions,
+  WaitForDataOptions,
   GetWebhookDeadLettersOptions,
   IngestWebhookInput,
   LayoutManifest,

--- a/packages/sdk/typescript/src/self-host-connect.test.ts
+++ b/packages/sdk/typescript/src/self-host-connect.test.ts
@@ -103,6 +103,57 @@ describe("SelfHostConnect", () => {
       connectionId: "conn_123"
     });
   });
+
+  it("rejects immediately with AbortError when waitForConnection starts aborted", async () => {
+    const provider = connectProvider();
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {
+        github: "github-prod"
+      }
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      connect.waitForConnection("github", {
+        connectionId: "conn_123",
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(provider.getConnectionStatus).not.toHaveBeenCalled();
+  });
+
+  it("removes the abort listener when waitForConnection sleep is aborted", async () => {
+    const provider = connectProvider({
+      getConnectionStatus: vi.fn(async () => ({
+        connectionId: "conn_123",
+        state: "pending"
+      }))
+    });
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {
+        github: "github-prod"
+      }
+    });
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+
+    const promise = connect.waitForConnection("github", {
+      connectionId: "conn_123",
+      pollIntervalMs: 10_000,
+      timeoutMs: 60_000,
+      signal: controller.signal
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+  });
 });
 
 function baseProvider(): ConnectionProvider {

--- a/packages/sdk/typescript/src/self-host-connect.test.ts
+++ b/packages/sdk/typescript/src/self-host-connect.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ConnectCapableProvider,
+  ConnectConnectionStatus,
+  ConnectionProvider
+} from "./connection.js";
+import { supportsConnect } from "./connection.js";
+import { SelfHostConnect } from "./self-host-connect.js";
+
+describe("supportsConnect", () => {
+  it("guards connection providers with self-host Connect methods", () => {
+    expect(supportsConnect(baseProvider())).toBe(false);
+    expect(supportsConnect(connectProvider())).toBe(true);
+  });
+});
+
+describe("SelfHostConnect", () => {
+  it("starts provider-backed sessions with explicit providerConfigKey mapping", async () => {
+    const provider = connectProvider();
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {
+        github: "github-prod"
+      }
+    });
+
+    const result = await connect.startConnect("github", {
+      endUserId: "user_123",
+      connectionId: "conn_hint",
+      metadata: { workspaceId: "rw_123" }
+    });
+
+    expect(provider.createConnectSession).toHaveBeenCalledWith({
+      relayfileProvider: "github",
+      providerConfigKey: "github-prod",
+      endUserId: "user_123",
+      connectionId: "conn_hint",
+      metadata: { workspaceId: "rw_123" }
+    });
+    expect(result).toEqual({
+      relayfileProvider: "github",
+      providerConfigKey: "github-prod",
+      connectLink: "https://connect.test/github",
+      sessionToken: "session_123",
+      expiresAt: "2026-06-18T12:00:00Z",
+      connectionId: "conn_123"
+    });
+  });
+
+  it("fails before calling the provider when mapping is missing", async () => {
+    const provider = connectProvider();
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {}
+    });
+
+    await expect(
+      connect.startConnect("github", { endUserId: "user_123" })
+    ).rejects.toThrow('No providerConfigKey mapping configured for relayfile provider "github".');
+    expect(provider.createConnectSession).not.toHaveBeenCalled();
+  });
+
+  it("fails before calling connect methods when provider lacks Connect support", async () => {
+    const provider = baseProvider();
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {
+        github: "github-prod"
+      }
+    });
+
+    await expect(
+      connect.startConnect("github", { endUserId: "user_123" })
+    ).rejects.toThrow('Provider "base" does not support self-host Connect.');
+  });
+
+  it("waits until the provider reports auth-ready oauth_connected", async () => {
+    const statuses: ConnectConnectionStatus[] = [
+      { connectionId: "conn_123", state: "pending" },
+      { connectionId: "conn_123", state: "oauth_connected" }
+    ];
+    const provider = connectProvider({
+      getConnectionStatus: vi.fn(async () => statuses.shift()!)
+    });
+    const connect = new SelfHostConnect({
+      provider,
+      providerConfigKeys: {
+        github: "github-prod"
+      }
+    });
+
+    const result = await connect.waitForConnection("github", {
+      connectionId: "conn_123",
+      pollIntervalMs: 0,
+      timeoutMs: 1_000
+    });
+
+    expect(result.state).toBe("oauth_connected");
+    expect(provider.getConnectionStatus).toHaveBeenCalledTimes(2);
+    expect(provider.getConnectionStatus).toHaveBeenLastCalledWith({
+      relayfileProvider: "github",
+      providerConfigKey: "github-prod",
+      connectionId: "conn_123"
+    });
+  });
+});
+
+function baseProvider(): ConnectionProvider {
+  return {
+    name: "base",
+    proxy: vi.fn(),
+    healthCheck: vi.fn()
+  };
+}
+
+function connectProvider(
+  overrides: Partial<ConnectCapableProvider> = {}
+): ConnectCapableProvider {
+  return {
+    name: "connect",
+    proxy: vi.fn(),
+    healthCheck: vi.fn(),
+    createConnectSession: vi.fn(async () => ({
+      connectLink: "https://connect.test/github",
+      sessionToken: "session_123",
+      expiresAt: "2026-06-18T12:00:00Z",
+      connectionId: "conn_123"
+    })),
+    getConnectionStatus: vi.fn(async () => ({
+      connectionId: "conn_123",
+      state: "oauth_connected"
+    })),
+    ...overrides
+  };
+}

--- a/packages/sdk/typescript/src/self-host-connect.ts
+++ b/packages/sdk/typescript/src/self-host-connect.ts
@@ -188,7 +188,7 @@ function normalizeNonNegativeInteger(value: number | undefined, fallback: number
 
 function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
-    throw new Error("Aborted while waiting for self-host connection.");
+    throw createAbortError();
   }
 }
 
@@ -196,15 +196,25 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (ms <= 0) {
     return Promise.resolve();
   }
+  if (signal?.aborted) {
+    return Promise.reject(createAbortError());
+  }
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout);
-        reject(new Error("Aborted while waiting for self-host connection."));
-      },
-      { once: true }
-    );
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(createAbortError());
+    };
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function createAbortError(): Error {
+  const error = new Error("Aborted while waiting for self-host connection.");
+  error.name = "AbortError";
+  return error;
 }

--- a/packages/sdk/typescript/src/self-host-connect.ts
+++ b/packages/sdk/typescript/src/self-host-connect.ts
@@ -1,0 +1,210 @@
+import type {
+  ConnectCapableProvider,
+  ConnectConnectionStatus,
+  ConnectionProvider,
+  CreateConnectSessionInput,
+  ProviderConfigKeyMap
+} from "./connection.js";
+import { supportsConnect } from "./connection.js";
+
+const DEFAULT_WAIT_INTERVAL_MS = 2_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 5 * 60_000;
+const AUTH_READY_STATE = "oauth_connected";
+
+export interface SelfHostConnectOptions {
+  provider: ConnectionProvider;
+  providerConfigKeys: ProviderConfigKeyMap;
+  defaultPollIntervalMs?: number;
+  defaultTimeoutMs?: number;
+}
+
+export interface StartSelfHostConnectOptions {
+  endUserId: string;
+  connectionId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SelfHostConnectResult {
+  relayfileProvider: string;
+  providerConfigKey: string;
+  connectLink: string | null;
+  sessionToken: string | null;
+  expiresAt: string | null;
+  connectionId: string;
+}
+
+export interface WaitForSelfHostConnectionOptions {
+  connectionId: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  onPoll?: (elapsedMs: number, status?: ConnectConnectionStatus) => void;
+}
+
+export class SelfHostConnect {
+  private readonly provider: ConnectionProvider;
+  private readonly providerConfigKeys: ProviderConfigKeyMap;
+  private readonly defaultPollIntervalMs: number;
+  private readonly defaultTimeoutMs: number;
+
+  constructor(options: SelfHostConnectOptions) {
+    this.provider = options.provider;
+    this.providerConfigKeys = { ...options.providerConfigKeys };
+    this.defaultPollIntervalMs = normalizePositiveInteger(
+      options.defaultPollIntervalMs,
+      DEFAULT_WAIT_INTERVAL_MS
+    );
+    this.defaultTimeoutMs = normalizePositiveInteger(
+      options.defaultTimeoutMs,
+      DEFAULT_WAIT_TIMEOUT_MS
+    );
+  }
+
+  async startConnect(
+    relayfileProvider: string,
+    options: StartSelfHostConnectOptions
+  ): Promise<SelfHostConnectResult> {
+    const normalizedProvider = normalizeRelayfileProvider(relayfileProvider);
+    const providerConfigKey = this.resolveProviderConfigKey(normalizedProvider);
+    const connectProvider = this.requireConnectProvider();
+    const endUserId = options.endUserId?.trim();
+    if (!endUserId) {
+      throw new Error("endUserId is required to start a self-host connect session");
+    }
+
+    const input: CreateConnectSessionInput = {
+      relayfileProvider: normalizedProvider,
+      providerConfigKey,
+      endUserId
+    };
+    const connectionId = options.connectionId?.trim();
+    if (connectionId) {
+      input.connectionId = connectionId;
+    }
+    if (options.metadata) {
+      input.metadata = { ...options.metadata };
+    }
+
+    const session = await connectProvider.createConnectSession(input);
+    return {
+      relayfileProvider: normalizedProvider,
+      providerConfigKey,
+      connectLink: session.connectLink,
+      sessionToken: session.sessionToken,
+      expiresAt: session.expiresAt,
+      connectionId: session.connectionId
+    };
+  }
+
+  async waitForConnection(
+    relayfileProvider: string,
+    options: WaitForSelfHostConnectionOptions
+  ): Promise<ConnectConnectionStatus> {
+    const normalizedProvider = normalizeRelayfileProvider(relayfileProvider);
+    const providerConfigKey = this.resolveProviderConfigKey(normalizedProvider);
+    const connectProvider = this.requireConnectProvider();
+    const connectionId = options.connectionId?.trim();
+    if (!connectionId) {
+      throw new Error("connectionId is required to wait for a self-host connection");
+    }
+
+    const pollIntervalMs = normalizeNonNegativeInteger(
+      options.pollIntervalMs,
+      this.defaultPollIntervalMs
+    );
+    const timeoutMs = normalizePositiveInteger(options.timeoutMs, this.defaultTimeoutMs);
+    const startedAt = Date.now();
+
+    for (;;) {
+      throwIfAborted(options.signal);
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= timeoutMs) {
+        throw new Error(
+          `Timed out waiting for ${normalizedProvider} connection "${connectionId}" after ${elapsedMs}ms.`
+        );
+      }
+
+      const status = await connectProvider.getConnectionStatus({
+        relayfileProvider: normalizedProvider,
+        providerConfigKey,
+        connectionId
+      });
+      options.onPoll?.(Date.now() - startedAt, status);
+      if (isAuthReady(status)) {
+        return status;
+      }
+
+      const sleepMs = Math.min(
+        pollIntervalMs,
+        Math.max(0, timeoutMs - (Date.now() - startedAt))
+      );
+      await sleep(sleepMs, options.signal);
+    }
+  }
+
+  private resolveProviderConfigKey(relayfileProvider: string): string {
+    const providerConfigKey = this.providerConfigKeys[relayfileProvider]?.trim();
+    if (!providerConfigKey) {
+      throw new Error(
+        `No providerConfigKey mapping configured for relayfile provider "${relayfileProvider}".`
+      );
+    }
+    return providerConfigKey;
+  }
+
+  private requireConnectProvider(): ConnectCapableProvider {
+    if (!supportsConnect(this.provider)) {
+      throw new Error(`Provider "${this.provider.name}" does not support self-host Connect.`);
+    }
+    return this.provider;
+  }
+}
+
+function isAuthReady(status: ConnectConnectionStatus): boolean {
+  return status.state === AUTH_READY_STATE || status.ready === true;
+}
+
+function normalizeRelayfileProvider(provider: string): string {
+  const normalized = provider?.trim();
+  if (!normalized) {
+    throw new Error("relayfileProvider is required");
+  }
+  return normalized;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function normalizeNonNegativeInteger(value: number | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  return Math.max(0, Math.floor(value));
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error("Aborted while waiting for self-host connection.");
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(new Error("Aborted while waiting for self-host connection."));
+      },
+      { once: true }
+    );
+  });
+}

--- a/packages/sdk/typescript/src/types.ts
+++ b/packages/sdk/typescript/src/types.ts
@@ -431,11 +431,21 @@ export interface SyncRefreshRequest {
   reason?: string;
 }
 
-export type SyncProviderStatusState = "healthy" | "lagging" | "error" | "paused";
+export type SyncProviderStatusState =
+  | "connected"
+  | "oauth_connected"
+  | "sync_queued"
+  | "syncing"
+  | "ready"
+  | "healthy"
+  | "lagging"
+  | "error"
+  | "paused";
 
 export interface SyncProviderStatus {
   provider: string;
   status: SyncProviderStatusState;
+  ready?: boolean;
   cursor?: string | null;
   watermarkTs?: string | null;
   lagSeconds?: number;
@@ -632,6 +642,12 @@ export interface GetSyncStatusOptions {
   provider?: string;
   correlationId?: string;
   signal?: AbortSignal;
+}
+
+export interface WaitForDataOptions extends GetSyncStatusOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onPoll?: (elapsedMs: number, status?: SyncProviderStatus) => void;
 }
 
 export interface GetSyncIngressStatusOptions {


### PR DESCRIPTION
Follow-up to the merged #309. Lands the OSS slices of #310/#311 in this repo + the README pointers #309 missed.

## #310 — self-host Connect (SDK, no Cloud dependency)
`ConnectCapableProvider` / `supportsConnect` / `ProviderConfigKeyMap` contract + `SelfHostConnect` orchestrator (`startConnect → waitForConnection`). Bind is provider-side (connectionId tagged in Nango/Pipedream); no OSS HMAC bind route. NangoProvider/PipedreamProvider impls are tracked as a relayfile-providers follow-up.

## #311 — data-ready + boundary
`RelayFileClient.waitForData(workspaceId, provider)` over `/sync/status` — the data-ready signal, distinct from auth-ready. `SYNC-DEFINITION-BOUNDARY.md` states the OSS-plumbing-vs-paid-sync-definition boundary.

## #309 follow-up — docs
Top-level README per-framework example rows + `@relayfile/agents` bullet + SDK-SURFACE link; `packages/agents/README.md` reactive note → shipped example. `SELF-HOST.md` ties it together with a real sync-ready coverage matrix (20 sync-ready vs 24 path-mapping-only).

## Verification
`tsc` typecheck ✅ · 83/83 tests (self-host-connect + client) ✅ · build ✅ · contract surface check ✅

## Out of scope (tracked follow-ups)
relayfile-providers connect impls; cloud bind-route convergence; `@relayfile/connect-frontend`; full runnable E2E example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

