### PR TITLE
fix(release): regenerate lockfiles before tagging (#308)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,21 @@ jobs:
       is_prerelease: ${{ steps.bump.outputs.is_prerelease }}
 
     steps:
+      - name: Validate release mode
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event.inputs.package }}" != "all" ] && [ "${{ github.event.inputs.dry_run }}" != "true" ]; then
+            cat >&2 <<'EOF'
+          ERROR: the publish workflow version-bumps every @relayfile package, and
+          release lockfile regeneration needs every @relayfile/mount-* package at
+          the new version to have been published so npm can resolve tarball
+          integrity metadata. Run the release with package=all, or split
+          single-package releases into a workflow that does not rewrite all
+          package manifests and lockfiles.
+          EOF
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -499,6 +514,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -536,6 +557,14 @@ jobs:
           ( cd packages/cli/bin && sha256sum relayfile-cli-* ) >> checksums.txt
           cat checksums.txt
 
+      - name: Regenerate release lockfiles
+        run: |
+          set -euo pipefail
+          npm install --package-lock-only --ignore-scripts
+          npm install --prefix packages/sdk/typescript --package-lock-only --ignore-scripts
+          npm ci --dry-run
+          npm ci --prefix packages/sdk/typescript --dry-run
+
       - name: Commit version bump and create tag
         env:
           NEW_VERSION: ${{ needs.build.outputs.new_version }}
@@ -544,9 +573,9 @@ jobs:
           git config user.email "actions@github.com"
 
           git add \
-            package.json \
+            package.json package-lock.json \
             packages/core/package.json packages/core/CHANGELOG.md \
-            packages/sdk/typescript/package.json packages/sdk/typescript/CHANGELOG.md \
+            packages/sdk/typescript/package.json packages/sdk/typescript/package-lock.json packages/sdk/typescript/CHANGELOG.md \
             packages/agents/package.json packages/agents/CHANGELOG.md \
             packages/cli/package.json packages/cli/CHANGELOG.md \
             packages/file-observer/package.json packages/file-observer/CHANGELOG.md \
@@ -625,20 +654,22 @@ jobs:
     steps:
       - name: Summary
         run: |
-          echo "## Publish Summary" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Package**: \`${{ github.event.inputs.package }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Version**: \`${{ needs.build.outputs.new_version }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**NPM Tag**: \`${{ github.event.inputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Prerelease**: \`${{ needs.build.outputs.is_prerelease }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Dry Run**: \`${{ github.event.inputs.dry_run }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Provenance**: \`enabled\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "### Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Stage | Status |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Build & Version | ${{ needs.build.result == 'success' && 'SUCCESS' || 'FAILURE' }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Publish All | ${{ needs.publish-packages.result == 'success' && 'SUCCESS' || (needs.publish-packages.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Publish Single | ${{ needs.publish-single.result == 'success' && 'SUCCESS' || (needs.publish-single.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Build Mount Binaries | ${{ needs.build-mount-binaries.result == 'success' && 'SUCCESS' || (needs.build-mount-binaries.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Create Release | ${{ needs.create-release.result == 'success' && 'SUCCESS' || (needs.create-release.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Publish Summary"
+            echo ""
+            echo "**Package**: \`${{ github.event.inputs.package }}\`"
+            echo "**Version**: \`${{ needs.build.outputs.new_version }}\`"
+            echo "**NPM Tag**: \`${{ github.event.inputs.tag }}\`"
+            echo "**Prerelease**: \`${{ needs.build.outputs.is_prerelease }}\`"
+            echo "**Dry Run**: \`${{ github.event.inputs.dry_run }}\`"
+            echo "**Provenance**: \`enabled\`"
+            echo ""
+            echo "### Results"
+            echo "| Stage | Status |"
+            echo "|-------|--------|"
+            echo "| Build & Version | ${{ needs.build.result == 'success' && 'SUCCESS' || 'FAILURE' }} |"
+            echo "| Publish All | ${{ needs.publish-packages.result == 'success' && 'SUCCESS' || (needs.publish-packages.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |"
+            echo "| Publish Single | ${{ needs.publish-single.result == 'success' && 'SUCCESS' || (needs.publish-single.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |"
+            echo "| Build Mount Binaries | ${{ needs.build-mount-binaries.result == 'success' && 'SUCCESS' || (needs.build-mount-binaries.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |"
+            echo "| Create Release | ${{ needs.create-release.result == 'success' && 'SUCCESS' || (needs.create-release.result == 'skipped' && 'SKIPPED' || 'FAILURE') }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/memory/INCIDENT-20260618T181011Z.md
+++ b/memory/INCIDENT-20260618T181011Z.md
@@ -1,0 +1,18 @@
+# relayfile mount-root invariant incident
+
+- timestamp: 20260618T181011Z
+- local root: /home/daytona/workspace/memory/workspace
+- invariant: mount root must always be a directory
+- detected kind: missing
+- reason: local root does not exist
+
+## Recovery
+
+The mount root is gone. Confirm whether the directory was deleted
+by another process (rm -rf, git clean -fdx, sync tool, etc.).
+To recreate a clean mount, pass `--reset-after-clobber` to
+`relayfile mount` (or set `RELAYFILE_RESET_AFTER_CLOBBER=1`).
+The daemon will refuse to start without this acknowledgment.
+
+See `docs/architecture/mount-invariants.md` for the protected
+invariants and the full recovery procedure.

--- a/packages/sdk/typescript/package-lock.json
+++ b/packages/sdk/typescript/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@relayfile/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@relayfile/sdk",
-      "version": "0.9.6",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
-        "@relayfile/core": "0.9.6",
+        "@relayfile/core": "0.10.1",
         "ignore": "^7.0.5",
         "tar": "^7.5.10"
       },
@@ -489,9 +489,9 @@
       "license": "MIT"
     },
     "node_modules/@relayfile/core": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.9.6.tgz",
-      "integrity": "sha512-Tybhr8mNcBx/HcRP6/fg4eMgz/bxluGcTfmnPrDA7E6rgg6+8cyfda6qrM6w5G+j1LAjXyjCTERplbGsl/2wzg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@relayfile/core/-/core-0.10.1.tgz",
+      "integrity": "sha512-VsNVlH4QPy9KGQSIiNosXadRJLqwmV+lSWgDB93TwMnIH12TI1ochntlTIK70bOFPe+XLmPB7BFy/5pAKAxJ1A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"


### PR DESCRIPTION
Fixes #308.

## Summary
- Regenerate release lockfiles in `create-release` after npm publish has completed, so npm can resolve real tarball `resolved`/`integrity` metadata for `@relayfile/mount-*` packages.
- Gate the regenerated locks with `npm ci --dry-run` at the repo root and in `packages/sdk/typescript` before the version bump/tag commit is staged.
- Fail fast for real single-package releases (`package != all` and `dry_run != true`) as the first step of `build`, before manifest rewriting, artifact upload, or any npm publish job can run. The workflow currently version-bumps every `@relayfile/*` manifest, so single-package real releases need a separate workflow that does not rewrite all manifests/lockfiles.
- Repair the current stale `packages/sdk/typescript/package-lock.json` drift from `@relayfile/core@0.9.6` to `0.10.1`.

## Scope notes
- This intentionally updates only the two real lockfiles that participate in current CI drift: `package-lock.json` and `packages/sdk/typescript/package-lock.json`.
- `packages/server/package-lock.json` is not added; it does not exist and the CI reference is guarded with `if [ -f ... ]`.
- Follow-up surface, out of scope here: the example integration lockfiles pin `@relayfile/mount-*` and could drift if future CI starts running `npm ci` in those examples. They should eventually use workspace/file/latest-style references or be included in a dedicated example-lockfile policy.

## Verification
- `actionlint .github/workflows/publish.yml`
- YAML parse of `.github/workflows/publish.yml`
- DAG check: `Validate release mode` is the first `build` step; `publish-packages` and `publish-single` both need `build`.
- `git diff --check`
- `npm ci --dry-run`
- `npm ci --prefix packages/sdk/typescript --dry-run`

## Residual risk
This is a release-workflow change, so the full end-to-end validation happens on the next real release. The local and static checks cover YAML validity, workflow shell lint, current lockfile syncability, and the dry-run gates the release job will run before committing regenerated lockfiles.
