### PR TITLE
fix(cli): decouple integration connect from sync readiness

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -201,6 +201,7 @@ type treeEntry struct {
 type syncProviderStatus struct {
 	Provider              string         `json:"provider"`
 	Status                string         `json:"status"`
+	Ready                 bool           `json:"ready,omitempty"`
 	Cursor                *string        `json:"cursor"`
 	WatermarkTs           *string        `json:"watermarkTs"`
 	LagSeconds            int            `json:"lagSeconds"`
@@ -667,7 +668,7 @@ func printWorkspaceUsage(w io.Writer, subcommand string) {
 func printIntegrationUsage(w io.Writer, subcommand string) {
 	switch subcommand {
 	case "connect":
-		fmt.Fprintln(w, "Usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m]")
+		fmt.Fprintln(w, "Usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m] [--wait-sync]")
 	case "available", "catalog", "providers":
 		fmt.Fprintln(w, "Usage: relayfile integration available [--search QUERY] [--backend BACKEND] [--json] [--refresh]")
 	case "search":
@@ -682,7 +683,7 @@ func printIntegrationUsage(w io.Writer, subcommand string) {
 		fmt.Fprintln(w, "Usage: relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]")
 	default:
 		fmt.Fprintln(w, `Usage:
-  relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME]
+  relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--wait-sync]
   relayfile integration available [--search QUERY] [--backend BACKEND] [--json] [--refresh]
   relayfile integration search QUERY [--backend BACKEND] [--json] [--refresh]
   relayfile integration list [--workspace NAME] [--json]
@@ -1934,7 +1935,7 @@ func connectCloudIntegration(cloudAPIURL, workspaceID, workspaceToken, provider,
 					UpdatedAt:    time.Now().UTC().Format(time.RFC3339),
 				})
 			}
-			fmt.Fprintf(stdout, "%s connected. Files will appear under %s/%s as Relayfile syncs in the background; keep this command running while the mount is active.\n", provider, localDir, providerRootDir(provider))
+			fmt.Fprintf(stdout, "%s connected. Files will appear under %s/%s as Relayfile syncs in the background.\n", provider, localDir, providerRootDir(provider))
 			pollErr = nil
 			return pollResult{done: true}
 		}
@@ -2245,17 +2246,19 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 	backend := fs.String("backend", "", "integration backend to request (nango or composio)")
 	noOpen := fs.Bool("no-open", false, "print the hosted URL instead of opening it")
 	timeout := fs.Duration("timeout", 5*time.Minute, "integration readiness timeout")
+	waitSync := fs.Bool("wait-sync", false, "wait for initial sync before returning")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"workspace":     true,
 		"cloud-api-url": true,
 		"backend":       true,
 		"no-open":       false,
 		"timeout":       true,
+		"wait-sync":     false,
 	})); err != nil {
 		return err
 	}
 	if fs.NArg() != 1 {
-		return errors.New("usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m]")
+		return errors.New("usage: relayfile integration connect PROVIDER [--backend BACKEND] [--workspace NAME] [--no-open] [--timeout 5m] [--wait-sync]")
 	}
 	provider := normalizeProviderID(fs.Arg(0))
 	requestedBackend, err := normalizeIntegrationBackend(*backend)
@@ -2301,7 +2304,15 @@ func runIntegrationConnect(args []string, stdin io.Reader, stdout io.Writer) err
 			return err
 		}
 	}
-	return waitForInitialSync(delegated.ServerURL(), delegated.BearerToken(), relayWorkspaceID, provider, record.LocalDir, *timeout, stdout)
+	if *waitSync {
+		return waitForInitialSync(delegated.ServerURL(), delegated.BearerToken(), relayWorkspaceID, provider, record.LocalDir, *timeout, stdout)
+	}
+	if record.LocalDir != "" {
+		fmt.Fprintf(stdout, "Run `relayfile mount %s %s` to mirror files locally, or rerun with --wait-sync to block until initial data is ready.\n", record.ID, record.LocalDir)
+	} else {
+		fmt.Fprintln(stdout, "Run `relayfile mount` to mirror files locally, or rerun with --wait-sync to block until initial data is ready.")
+	}
+	return nil
 }
 
 func isAtlassianProvider(provider string) bool {
@@ -2642,6 +2653,7 @@ func runIntegrationList(args []string, stdout io.Writer) error {
 	if err := client.getJSON(context.Background(), fmt.Sprintf("/api/v1/workspaces/%s/integrations", url.PathEscape(record.ID)), &entries); err != nil {
 		return err
 	}
+	entries = overlayIntegrationListRuntimeStatus(entries, record)
 	if *jsonOutput {
 		return writeJSON(stdout, entries)
 	}
@@ -2657,6 +2669,79 @@ func runIntegrationList(args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", entry.Provider, defaultIfBlank(entry.Status, "unknown"), formatLag(entry.LagSeconds), defaultIfBlank(entry.LastEventAt, "-"))
 	}
 	return nil
+}
+
+func overlayIntegrationListRuntimeStatus(entries []cloudIntegrationListEntry, record workspaceRecord) []cloudIntegrationListEntry {
+	if len(entries) == 0 {
+		return entries
+	}
+	runtimeStatus, ok := runtimeSyncStatusForIntegrationList(record)
+	if !ok {
+		return entries
+	}
+	overlaid := append([]cloudIntegrationListEntry(nil), entries...)
+	for i := range overlaid {
+		runtimeProvider, found := syncProviderByName(runtimeStatus, overlaid[i].Provider)
+		if !found || !syncProviderHasDataReadyEvidence(runtimeProvider) || !cloudIntegrationListStatusUpgradeable(overlaid[i].Status) {
+			continue
+		}
+		overlaid[i].Status = "ready"
+		if strings.TrimSpace(overlaid[i].LastEventAt) == "" && hasNonEmptyString(runtimeProvider.WatermarkTs) {
+			overlaid[i].LastEventAt = strings.TrimSpace(*runtimeProvider.WatermarkTs)
+		}
+	}
+	return overlaid
+}
+
+func runtimeSyncStatusForIntegrationList(record workspaceRecord) (syncStatusResponse, bool) {
+	workspaceID := strings.TrimSpace(record.ID)
+	if workspaceID == "" {
+		workspaceID = strings.TrimSpace(record.RelayWorkspaceID)
+	}
+	scopes := normalizedScopeSet(record.Scopes)
+	if len(scopes) == 0 {
+		scopes = append([]string(nil), defaultJoinScopes...)
+	}
+	bundle, _, err := loadDelegatedCredentialsForRequest("", workspaceID, scopes)
+	if err != nil {
+		return syncStatusResponse{}, false
+	}
+	client, err := newAPIClient(bundle.ServerURL(), bundle.BearerToken())
+	if err != nil {
+		return syncStatusResponse{}, false
+	}
+	runtimeWorkspaceID := strings.TrimSpace(bundle.Workspace())
+	if runtimeWorkspaceID == "" {
+		runtimeWorkspaceID = workspaceID
+	}
+	status, err := fetchWorkspaceSyncStatus(client, runtimeWorkspaceID)
+	if err != nil {
+		return syncStatusResponse{}, false
+	}
+	return status, true
+}
+
+func syncProviderHasDataReadyEvidence(status syncProviderStatus) bool {
+	if status.Ready {
+		return true
+	}
+	switch strings.TrimSpace(strings.ToLower(status.Status)) {
+	case "ready":
+		return true
+	case "healthy":
+		return hasNonEmptyString(status.Cursor) || hasNonEmptyString(status.WatermarkTs)
+	default:
+		return false
+	}
+}
+
+func cloudIntegrationListStatusUpgradeable(status string) bool {
+	switch strings.TrimSpace(strings.ToLower(status)) {
+	case "connected", "oauth_connected", "sync_queued", "syncing":
+		return true
+	default:
+		return false
+	}
 }
 
 func runIntegrationDisconnect(args []string, stdin io.Reader, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -1284,10 +1284,7 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 			_, _ = w.Write([]byte(`{"ready":true}`))
 		case "/v1/workspaces/ws_123/sync/status":
 			seen["sync"] = true
-			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
-				t.Fatalf("unexpected sync Authorization: %q", got)
-			}
-			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+			t.Fatalf("integration connect should not poll sync status unless --wait-sync is set")
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -1307,24 +1304,96 @@ func TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace(t *testin
 	if err != nil {
 		t.Fatalf("run integration connect failed: %v\noutput:\n%s", err, stdout.String())
 	}
-	for _, key := range []string{"delegated", "connect", "status", "sync"} {
+	for _, key := range []string{"delegated", "connect", "status"} {
 		if !seen[key] {
 			t.Fatalf("expected %s request", key)
 		}
+	}
+	if seen["sync"] {
+		t.Fatalf("did not expect sync status request without --wait-sync")
 	}
 	got := stdout.String()
 	if !strings.Contains(got, "notion connected") {
 		t.Fatalf("unexpected integration connect output: %q", got)
 	}
-	if !strings.Contains(got, "keep this command running while the mount is active") {
-		t.Fatalf("expected connected-but-still-working guidance, got %q", got)
+	if strings.Contains(got, "keep this command running while the mount is active") {
+		t.Fatalf("did not expect keep-running guidance by default, got %q", got)
 	}
-	if !strings.Contains(got, "Waiting for notion initial sync. Leave this command running") {
-		t.Fatalf("expected initial sync wait guidance, got %q", got)
+	if strings.Contains(got, "Waiting for notion initial sync") {
+		t.Fatalf("did not expect initial sync wait by default, got %q", got)
+	}
+	if !strings.Contains(got, "relayfile mount") {
+		t.Fatalf("expected mount guidance, got %q", got)
 	}
 	state := loadSavedConnection(localDir, "notion")
 	if state.ConnectionID != "conn_789" || state.Backend != "composio" {
 		t.Fatalf("unexpected saved integration connection: %#v", state)
+	}
+}
+
+func TestIntegrationConnectWaitSyncPreservesInitialSyncGate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	localDir := t.TempDir()
+	if _, err := upsertWorkspaceDetails(workspaceRecord{
+		Name:       "demo",
+		ID:         "ws_123",
+		LocalDir:   localDir,
+		AgentName:  "relayfile-cli",
+		Scopes:     append([]string(nil), defaultJoinScopes...),
+		CreatedAt:  time.Now().UTC().Format(time.RFC3339),
+		LastUsedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("upsertWorkspaceDetails failed: %v", err)
+	}
+	seen := map[string]bool{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/relayfile/delegated-token":
+			seen["delegated"] = true
+			writeDelegatedBundleResponse(t, w, server.URL, "ws_123", "rf_join", "refresh_join")
+		case "/api/v1/workspaces/ws_123/integrations/connect-session":
+			seen["connect"] = true
+			_, _ = w.Write([]byte(`{"connectLink":"https://connect.test/notion","connectionId":"conn_789","backend":"composio"}`))
+		case "/api/v1/workspaces/ws_123/integrations/notion/status":
+			seen["status"] = true
+			_, _ = w.Write([]byte(`{"ready":true}`))
+		case "/v1/workspaces/ws_123/sync/status":
+			seen["sync"] = true
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected sync Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"notion","status":"ready","lagSeconds":4,"watermarkTs":"2026-05-02T18:00:00Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	installFakeAgentRelaySession(t, server.URL, "cld_new", "demo", "ws_123", "ws_123")
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"integration", "connect", "notion",
+		"--workspace", "demo",
+		"--cloud-api-url", server.URL,
+		"--backend", "composio",
+		"--no-open",
+		"--timeout", "1s",
+		"--wait-sync",
+	}, strings.NewReader(""), &stdout, &stdout)
+	if err != nil {
+		t.Fatalf("run integration connect --wait-sync failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	for _, key := range []string{"delegated", "connect", "status", "sync"} {
+		if !seen[key] {
+			t.Fatalf("expected %s request", key)
+		}
+	}
+	if got := stdout.String(); !strings.Contains(got, "Waiting for notion initial sync. Leave this command running") {
+		t.Fatalf("expected initial sync wait guidance, got %q", got)
 	}
 }
 
@@ -1376,6 +1445,229 @@ func TestConnectCloudIntegrationAcceptsWorkspaceScopedGitHubStatus(t *testing.T)
 	state := loadSavedConnection(localDir, "github")
 	if state.ConnectionID != "conn_actual" || state.Backend != "nango" {
 		t.Fatalf("expected resolved github connection to be saved, got %#v", state)
+	}
+}
+
+func TestIntegrationListOverlaysRuntimeReadyStatus(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	var seenCloudIntegrations bool
+	var seenRuntimeStatus bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations":
+			seenCloudIntegrations = true
+			_, _ = w.Write([]byte(`[{"provider":"slack","status":"syncing","lagSeconds":0}]`))
+		case "/v1/workspaces/ws_123/sync/status":
+			seenRuntimeStatus = true
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected runtime Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"ready","lagSeconds":0,"watermarkTs":"2026-05-28T22:30:46Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_123",
+		AccessToken:          "rf_join",
+	})
+
+	var stdout bytes.Buffer
+	if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if !seenCloudIntegrations || !seenRuntimeStatus {
+		t.Fatalf("expected cloud integrations and runtime sync status requests, got cloud=%v runtime=%v", seenCloudIntegrations, seenRuntimeStatus)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "slack\tready\t0s\t2026-05-28T22:30:46Z") {
+		t.Fatalf("expected runtime-ready slack row, got %q", got)
+	}
+}
+
+func TestIntegrationListUsesSavedWorkspaceScopesForRuntimeStatus(t *testing.T) {
+	record, _ := setupAdoptWorkspace(t)
+	var seenRuntimeStatus bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations":
+			_, _ = w.Write([]byte(`[{"provider":"slack","status":"syncing","lagSeconds":0}]`))
+		case "/v1/workspaces/ws_123/sync/status":
+			seenRuntimeStatus = true
+			if got := r.Header.Get("Authorization"); got != "Bearer rf_join" {
+				t.Fatalf("unexpected runtime Authorization: %q", got)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"ready","lagSeconds":0,"watermarkTs":"2026-05-28T22:30:46Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+	if err := delegatedauth.SaveAtomic(delegatedCredentialsPathForRequest(record.ID, record.Scopes), delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_123",
+		AccessToken:          "rf_join",
+		RefreshToken:         "refresh_join",
+		Scopes:               append([]string(nil), record.Scopes...),
+	}); err != nil {
+		t.Fatalf("save join-scoped delegated credentials failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if !seenRuntimeStatus {
+		t.Fatal("expected runtime sync status request using saved workspace scopes")
+	}
+	if got := stdout.String(); !strings.Contains(got, "slack\tready\t0s\t2026-05-28T22:30:46Z") {
+		t.Fatalf("expected join-scoped runtime-ready overlay, got %q", got)
+	}
+}
+
+func TestIntegrationListDoesNotMaskCloudActionRequiredStatus(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations":
+			_, _ = w.Write([]byte(`[{"provider":"slack","status":"error","lagSeconds":0}]`))
+		case "/v1/workspaces/ws_123/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"ready","lagSeconds":0,"watermarkTs":"2026-05-28T22:30:46Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_123",
+		AccessToken:          "rf_join",
+	})
+
+	var stdout bytes.Buffer
+	if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "slack\terror\t0s\t-") {
+		t.Fatalf("expected cloud error status to remain visible, got %q", got)
+	}
+}
+
+func TestIntegrationListDoesNotUpgradeBareHealthyRuntimeStatus(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations":
+			_, _ = w.Write([]byte(`[{"provider":"slack","status":"syncing","lagSeconds":0}]`))
+		case "/v1/workspaces/ws_123/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"healthy","lagSeconds":0}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_123",
+		AccessToken:          "rf_join",
+	})
+
+	var stdout bytes.Buffer
+	if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "slack\tsyncing\t0s\t-") {
+		t.Fatalf("expected bare healthy runtime status not to upgrade cloud syncing, got %q", got)
+	}
+}
+
+func TestIntegrationListDoesNotUpgradeUnknownCloudStatus(t *testing.T) {
+	_, _ = setupAdoptWorkspace(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/workspaces/ws_123/integrations":
+			_, _ = w.Write([]byte(`[{"provider":"slack","status":"needs_operator","lagSeconds":0}]`))
+		case "/v1/workspaces/ws_123/sync/status":
+			_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"ready","lagSeconds":0,"watermarkTs":"2026-05-28T22:30:46Z"}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	pointAdoptCloudCredentials(t, server.URL)
+	writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+		RelayfileURL:         server.URL,
+		RelayfileWorkspaceID: "ws_123",
+		AccessToken:          "rf_join",
+	})
+
+	var stdout bytes.Buffer
+	if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if got := stdout.String(); !strings.Contains(got, "slack\tneeds_operator\t0s\t-") {
+		t.Fatalf("expected unknown cloud status not to be upgraded, got %q", got)
+	}
+}
+
+func TestIntegrationListDoesNotUpgradeBlankOrUnknownCloudStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		cloudJSON  string
+		wantStatus string
+	}{
+		{
+			name:       "blank",
+			cloudJSON:  `[{"provider":"slack","lagSeconds":0}]`,
+			wantStatus: "unknown",
+		},
+		{
+			name:       "unknown",
+			cloudJSON:  `[{"provider":"slack","status":"unknown","lagSeconds":0}]`,
+			wantStatus: "unknown",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _ = setupAdoptWorkspace(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/v1/workspaces/ws_123/integrations":
+					_, _ = w.Write([]byte(tc.cloudJSON))
+				case "/v1/workspaces/ws_123/sync/status":
+					_, _ = w.Write([]byte(`{"workspaceId":"ws_123","providers":[{"provider":"slack","status":"ready","lagSeconds":0,"watermarkTs":"2026-05-28T22:30:46Z"}]}`))
+				default:
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+			pointAdoptCloudCredentials(t, server.URL)
+			writeDelegatedCredentialsForTest(t, delegatedauth.Bundle{
+				RelayfileURL:         server.URL,
+				RelayfileWorkspaceID: "ws_123",
+				AccessToken:          "rf_join",
+			})
+
+			var stdout bytes.Buffer
+			if err := run([]string{"integration", "list", "--workspace", "demo", "--cloud-api-url", server.URL}, strings.NewReader(""), &stdout, &stdout); err != nil {
+				t.Fatalf("integration list failed: %v\noutput:\n%s", err, stdout.String())
+			}
+			want := "slack\t" + tc.wantStatus + "\t0s\t-"
+			if got := stdout.String(); !strings.Contains(got, want) {
+				t.Fatalf("expected %q, got %q", want, got)
+			}
+		})
 	}
 }
 
@@ -5839,6 +6131,7 @@ func TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForS
 		"--cloud-api-url", server.URL,
 		"--no-open",
 		"--timeout", "5s",
+		"--wait-sync",
 	}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("integration connect slack failed: %v\noutput:\n%s", err, stdout.String())
 	}


### PR DESCRIPTION
## Summary
- make `relayfile integration connect` return after the cloud connection is established and provider metadata setup completes
- add `--wait-sync` to preserve the old explicit initial-sync wait behavior
- overlay `integration list` benign control-plane statuses with Relayfile runtime readiness evidence from `/sync/status` without masking action-required cloud states

## Issues
- Fixes #217
- Fixes #218

## Verification
- `go test ./cmd/relayfile-cli -run 'TestIntegrationConnectRefreshesCloudAccessTokenAndReusesWorkspace|TestIntegrationConnectWaitSyncPreservesInitialSyncGate|TestIntegrationConnectKeepsSelectedWorkspaceAndUsesJoinedRelayWorkspaceForSync|TestIntegrationList' -count=1`\n- `go test ./cmd/relayfile-cli`\n- `git diff --check`\n\n## Notes\n- `integration list` uses the same evidence shape as the self-host data-ready work: `ready == true`, `status == ready`, or `status == healthy` with cursor/watermark evidence. It does not upgrade cloud error/disconnected/action-required statuses.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

