### PR TITLE
fix(mountsync): ignore nested runtime state paths

### DIFF
--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1051,19 +1051,19 @@ type mountState struct {
 	// are additive/omitempty: legacy state files load with zero values
 	// (BootstrapComplete=false), which self-heals by forcing a full
 	// reconcile on the next cycle.
-	BootstrapComplete        bool   `json:"bootstrapComplete,omitempty"`
-	BootstrapCursor          string `json:"bootstrapCursor,omitempty"`
-	BootstrapFilesSynced     int    `json:"bootstrapFilesSynced,omitempty"`
-	BootstrapFilesTotal      int    `json:"bootstrapFilesTotal,omitempty"`
-	BootstrapStartedAt       string `json:"bootstrapStartedAt,omitempty"`
+	BootstrapComplete    bool   `json:"bootstrapComplete,omitempty"`
+	BootstrapCursor      string `json:"bootstrapCursor,omitempty"`
+	BootstrapFilesSynced int    `json:"bootstrapFilesSynced,omitempty"`
+	BootstrapFilesTotal  int    `json:"bootstrapFilesTotal,omitempty"`
+	BootstrapStartedAt   string `json:"bootstrapStartedAt,omitempty"`
 	// QuarantinedPaths holds remote paths that cannot be materialized locally
 	// due to file/directory name collisions. Persisted across cycle restarts
 	// so the daemon does not re-fetch these paths from the cloud until the
 	// adapter emitting the collision is fixed. Cleared on bootstrap completion
 	// so a fixed adapter gets a clean slate on the next full cycle.
 	QuarantinedPaths         map[string]string `json:"quarantinedPaths,omitempty"`
-	SyncMode                 string `json:"syncMode,omitempty"`
-	GithubWorkingTreeHeadSHA string `json:"githubWorkingTreeHeadSha,omitempty"`
+	SyncMode                 string            `json:"syncMode,omitempty"`
+	GithubWorkingTreeHeadSHA string            `json:"githubWorkingTreeHeadSha,omitempty"`
 	// IncrementalReadNotReadySince records first-seen timestamps for
 	// incremental create/update events whose remote content was not readable
 	// yet. The daemon retries these without advancing EventsCursor until the
@@ -1724,6 +1724,9 @@ func (s *Syncer) PushLocalAndFlushOnce(ctx context.Context) error {
 func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op fsnotify.Op) error {
 	relativePath = filepath.ToSlash(strings.TrimSpace(filepath.Clean(relativePath)))
 	if relativePath == "" || relativePath == "." {
+		return nil
+	}
+	if isMountRuntimeRelativePath(relativePath) {
 		return nil
 	}
 	if first := strings.SplitN(relativePath, "/", 2)[0]; reservedTopLevel(first) {
@@ -3871,6 +3874,9 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			if !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 				continue
 			}
+			if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
+				continue
+			}
 			// Contract: lazy GitHub repos do not eagerly hydrate per-repo content at startup.
 			if s.lazyRepos && isUnderLazyGithubRepoSubtree(s.remoteRoot, remotePath) {
 				continue
@@ -4702,6 +4708,9 @@ func (s *Syncer) pullRemoteIncremental(ctx context.Context, conflicted map[strin
 			if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 				continue
 			}
+			if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
+				continue
+			}
 			if tracked, ok := s.state.Files[remotePath]; ok && tracked.Denied {
 				continue
 			}
@@ -5133,6 +5142,9 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 			s.clearIncrementalReadNotReady(remotePath)
 		}
 	}()
+	if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
+		return nil
+	}
 	if conflicted != nil {
 		if _, skip := conflicted[remotePath]; skip {
 			return nil
@@ -5217,6 +5229,25 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		ReadOnly:    !canWrite,
 	}
 	return nil
+}
+
+func (s *Syncer) skipMountRuntimeRemotePath(remotePath string, conflicted map[string]struct{}) bool {
+	remotePath = normalizeRemotePath(remotePath)
+	if !isMountRuntimeRemotePath(remotePath) {
+		return false
+	}
+	s.logf("skipping mount runtime path surfaced as workspace content: %s", remotePath)
+	if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
+		s.logf("failed to clean local mount runtime path %s: %v", remotePath, err)
+	}
+	if localPath, err := s.remoteToLocalPath(remotePath); err == nil {
+		if removeErr := os.Remove(localPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			s.logf("failed to remove local mount runtime file %s (%s): %v", remotePath, localPath, removeErr)
+		}
+	}
+	delete(s.state.Files, remotePath)
+	s.clearIncrementalReadNotReady(remotePath)
+	return true
 }
 
 func (s *Syncer) applyLocalPermissions(localPath string, canWrite bool) error {
@@ -5544,11 +5575,19 @@ func (s *Syncer) scanLocalFiles() (map[string]localSnapshot, error) {
 			if d.Name() == ".relay" {
 				return filepath.SkipDir
 			}
+			if rel, relErr := filepath.Rel(s.localRoot, path); relErr == nil &&
+				rel != "." &&
+				isMountRuntimeRelativePath(rel) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		// Data-loss guard: skip any top-level entry whose name collides
 		// with the mount directory's own basename (round-trip-onto-root).
 		if rel, relErr := filepath.Rel(s.localRoot, path); relErr == nil {
+			if isMountRuntimeRelativePath(rel) {
+				return nil
+			}
 			first := strings.SplitN(rel, string(os.PathSeparator), 2)[0]
 			if reservedTopLevel(first) || first == filepath.Base(s.localRoot) {
 				return nil
@@ -5622,6 +5661,28 @@ func normalizeScopes(scopes []string) []string {
 		normalized = append(normalized, scope)
 	}
 	return normalized
+}
+
+func isMountRuntimeRemotePath(path string) bool {
+	return isMountRuntimeRelativePath(strings.TrimPrefix(normalizeRemotePath(path), "/"))
+}
+
+func isMountRuntimeRelativePath(path string) bool {
+	normalized := filepath.ToSlash(strings.TrimSpace(path))
+	if normalized == "" || normalized == "." {
+		return false
+	}
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == "" || segment == "." {
+			continue
+		}
+		if segment == ".relay" ||
+			segment == ".relayfile-mount-state.json" ||
+			strings.HasPrefix(segment, ".relayfile-mount-state.json.tmp-") {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Syncer) loadState() error {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -782,6 +782,42 @@ func TestHandleLocalChangeDeletesWhenFileGone(t *testing.T) {
 	}
 }
 
+func TestHandleLocalChangeSkipsNestedMountRuntimeState(t *testing.T) {
+	client := &fakeClient{
+		files:           map[string]RemoteFile{},
+		revisionCounter: 1,
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   "ws_nested_relay_change",
+		RemoteRoot:    "/slack",
+		LocalRoot:     localDir,
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	runtimeRel := filepath.ToSlash(filepath.Join("channels", "C123", "messages", ".relay", "state.json"))
+	runtimeLocal := filepath.Join(localDir, filepath.FromSlash(runtimeRel))
+	if err := os.MkdirAll(filepath.Dir(runtimeLocal), 0o755); err != nil {
+		t.Fatalf("mkdir nested .relay: %v", err)
+	}
+	if err := os.WriteFile(runtimeLocal, []byte(`{"status":"writeback-pending"}`), 0o644); err != nil {
+		t.Fatalf("write nested .relay state: %v", err)
+	}
+
+	if err := syncer.HandleLocalChange(context.Background(), runtimeRel, fsnotify.Write); err != nil {
+		t.Fatalf("handle nested runtime change failed: %v", err)
+	}
+
+	if client.bulkWriteCalls != 0 || client.writeFileCalls != 0 {
+		t.Fatalf("nested mount runtime file must not be uploaded, bulk=%d write=%d", client.bulkWriteCalls, client.writeFileCalls)
+	}
+	if len(syncer.state.Files) != 0 {
+		t.Fatalf("nested mount runtime file must not be tracked, got %#v", syncer.state.Files)
+	}
+}
+
 func TestReconcileUsesExportSnapshotForInitialPull(t *testing.T) {
 	base := &fakeClient{
 		files: map[string]RemoteFile{
@@ -5663,6 +5699,46 @@ func TestScanLocalFilesSkipsSymlinkedDirectories(t *testing.T) {
 	}
 }
 
+func TestScanLocalFilesSkipsNestedMountRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	localDir := t.TempDir()
+	realPath := filepath.Join(localDir, "slack", "channels", "C123", "messages", "1780145510_376649.json")
+	if err := os.MkdirAll(filepath.Dir(realPath), 0o755); err != nil {
+		t.Fatalf("mkdir real message dir: %v", err)
+	}
+	if err := os.WriteFile(realPath, []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("write real message: %v", err)
+	}
+	runtimePath := filepath.Join(localDir, "slack", "channels", "C123", "messages", ".relay", "state.json")
+	if err := os.MkdirAll(filepath.Dir(runtimePath), 0o755); err != nil {
+		t.Fatalf("mkdir nested .relay: %v", err)
+	}
+	if err := os.WriteFile(runtimePath, []byte(`{"pendingWriteback":200}`), 0o644); err != nil {
+		t.Fatalf("write nested .relay state: %v", err)
+	}
+
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_scan_nested_relay",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	files, err := syncer.scanLocalFiles()
+	if err != nil {
+		t.Fatalf("scanLocalFiles failed: %v", err)
+	}
+
+	if _, ok := files["/slack/channels/C123/messages/1780145510_376649.json"]; !ok {
+		t.Fatalf("expected real provider file to be scanned, got keys %#v", files)
+	}
+	if _, ok := files["/slack/channels/C123/messages/.relay/state.json"]; ok {
+		t.Fatalf("nested .relay/state.json must not be scanned as provider content")
+	}
+}
+
 func TestLowMemoryPublicStateOmitsPerFileDetails(t *testing.T) {
 	t.Parallel()
 
@@ -8332,6 +8408,131 @@ func TestScanLocalFilesLogsOversizedFileOncePerSize(t *testing.T) {
 	}
 	if oversizedLogs != 1 {
 		t.Fatalf("expected one oversized-file log across repeated scans, got %d lines: %#v", oversizedLogs, logger.lines)
+	}
+}
+
+func TestPullRemoteFullTreeSkipsNestedMountRuntimeState(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/slack/channels/C123/messages/1780145510_376649.json": {
+				Path:        "/slack/channels/C123/messages/1780145510_376649.json",
+				Revision:    "rev_msg",
+				ContentType: "application/json",
+				Content:     `{"text":"hello"}`,
+			},
+			"/slack/channels/C123/messages/.relay/state.json": {
+				Path:        "/slack/channels/C123/messages/.relay/state.json",
+				Revision:    "rev_runtime",
+				ContentType: "application/json",
+				Content:     `{"pendingWriteback":200}`,
+			},
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_pull_nested_relay",
+		RemoteRoot:  "/slack",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	runtimeLocal := filepath.Join(localDir, "channels", "C123", "messages", ".relay", "state.json")
+	if err := os.MkdirAll(filepath.Dir(runtimeLocal), 0o755); err != nil {
+		t.Fatalf("mkdir stale nested .relay: %v", err)
+	}
+	if err := os.WriteFile(runtimeLocal, []byte(`{"stale":true}`), 0o644); err != nil {
+		t.Fatalf("write stale nested .relay: %v", err)
+	}
+	syncer.state.Files["/slack/channels/C123/messages/.relay/state.json"] = trackedFile{
+		Revision: "rev_old",
+		Hash:     hashString(`{"stale":true}`),
+	}
+
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("pullRemoteFullTree failed: %v", err)
+	}
+
+	realLocal := filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649.json")
+	if _, err := os.Stat(realLocal); err != nil {
+		t.Fatalf("expected real message mirrored locally: %v", err)
+	}
+	if _, err := os.Stat(runtimeLocal); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested mount runtime file should be absent after full pull, stat err=%v", err)
+	}
+	if _, ok := syncer.state.Files["/slack/channels/C123/messages/.relay/state.json"]; ok {
+		t.Fatalf("nested mount runtime path should not remain tracked")
+	}
+	if got := client.readFileCallsByPath["/slack/channels/C123/messages/.relay/state.json"]; got != 0 {
+		t.Fatalf("nested mount runtime path should not be read from remote, got %d reads", got)
+	}
+}
+
+func TestPullRemoteIncrementalSkipsNestedMountRuntimeState(t *testing.T) {
+	client := &fakeClient{
+		files: map[string]RemoteFile{
+			"/slack/channels/C123/messages/1780145510_376649.json": {
+				Path:        "/slack/channels/C123/messages/1780145510_376649.json",
+				Revision:    "rev_msg",
+				ContentType: "application/json",
+				Content:     `{"text":"hello"}`,
+			},
+			"/slack/channels/C123/messages/.relay/state.json": {
+				Path:        "/slack/channels/C123/messages/.relay/state.json",
+				Revision:    "rev_runtime",
+				ContentType: "application/json",
+				Content:     `{"pendingWriteback":200}`,
+			},
+		},
+		events: []FilesystemEvent{
+			{
+				EventID:  "evt_runtime",
+				Type:     "file.created",
+				Path:     "/slack/channels/C123/messages/.relay/state.json",
+				Revision: "rev_runtime",
+			},
+			{
+				EventID:  "evt_msg",
+				Type:     "file.created",
+				Path:     "/slack/channels/C123/messages/1780145510_376649.json",
+				Revision: "rev_msg",
+			},
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_incremental_nested_relay",
+		RemoteRoot:  "/slack",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	runtimeLocal := filepath.Join(localDir, "channels", "C123", "messages", ".relay", "state.json")
+	if err := os.MkdirAll(filepath.Dir(runtimeLocal), 0o755); err != nil {
+		t.Fatalf("mkdir stale nested .relay: %v", err)
+	}
+	if err := os.WriteFile(runtimeLocal, []byte(`{"stale":true}`), 0o644); err != nil {
+		t.Fatalf("write stale nested .relay: %v", err)
+	}
+	syncer.state.Files["/slack/channels/C123/messages/.relay/state.json"] = trackedFile{Revision: "rev_old"}
+
+	cursor, err := syncer.pullRemoteIncremental(context.Background(), nil, "")
+	if err != nil {
+		t.Fatalf("pullRemoteIncremental failed: %v", err)
+	}
+	if cursor != "evt_msg" {
+		t.Fatalf("cursor = %q, want evt_msg", cursor)
+	}
+	if got := client.readFileCallsByPath["/slack/channels/C123/messages/.relay/state.json"]; got != 0 {
+		t.Fatalf("nested mount runtime path should not be read from remote, got %d reads", got)
+	}
+	if _, err := os.Stat(runtimeLocal); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested mount runtime file should be absent after incremental pull, stat err=%v", err)
+	}
+	realLocal := filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649.json")
+	if _, err := os.Stat(realLocal); err != nil {
+		t.Fatalf("expected real message mirrored locally: %v", err)
 	}
 }
 

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -97,6 +97,9 @@ func (fw *FileWatcher) Start(ctx context.Context) error {
 }
 
 func (fw *FileWatcher) shouldSkip(rel string) bool {
+	if isMountRuntimeRelativePath(rel) {
+		return true
+	}
 	parts := strings.SplitN(rel, string(os.PathSeparator), 2)
 	first := parts[0]
 	// Match the state file itself and only its writeFileAtomic temp
@@ -187,6 +190,11 @@ func (fw *FileWatcher) addDirRecursive(base string) error {
 		}
 		if !info.IsDir() {
 			return nil
+		}
+		if rel, relErr := filepath.Rel(fw.localDir, path); relErr == nil &&
+			rel != "." &&
+			isMountRuntimeRelativePath(rel) {
+			return filepath.SkipDir
 		}
 		name := info.Name()
 		if fw.isTopLevelReservedDir(path, name) {

--- a/internal/mountsync/watcher_test.go
+++ b/internal/mountsync/watcher_test.go
@@ -801,3 +801,31 @@ func TestWatcherDoesNotSkipNestedReservedNameDirectories(t *testing.T) {
 		t.Fatalf("no watcher event for nested reserved-name directory path")
 	}
 }
+
+func TestWatcherSkipsNestedMountRuntimeDirectories(t *testing.T) {
+	localDir := t.TempDir()
+	events, _, _ := startFileWatcher(t, localDir)
+
+	nestedDir := filepath.Join(localDir, "slack", "channels", "C123", "messages", ".relay")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("create nested .relay directory: %v", err)
+	}
+	target := filepath.Join(nestedDir, "state.json")
+	if err := os.WriteFile(target, []byte(`{"pendingWriteback":200}`), 0o644); err != nil {
+		t.Fatalf("write nested .relay state: %v", err)
+	}
+
+	notExpected := filepath.ToSlash("slack/channels/C123/messages/.relay/state.json")
+	if _, ok := waitForWatcherEventPath(t, events, notExpected, 300*time.Millisecond); ok {
+		t.Fatalf("watcher emitted nested mount runtime state path %q", notExpected)
+	}
+
+	realPath := filepath.Join(localDir, "slack", "channels", "C123", "messages", "1780145510_376649.json")
+	if err := os.WriteFile(realPath, []byte(`{"text":"hello"}`), 0o644); err != nil {
+		t.Fatalf("write real provider file: %v", err)
+	}
+	expected := filepath.ToSlash("slack/channels/C123/messages/1780145510_376649.json")
+	if _, ok := waitForWatcherEventPath(t, events, expected, 2*time.Second); !ok {
+		t.Fatalf("no watcher event for real provider file")
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent nested mount runtime state paths like `/slack/.../.relay/state.json` from being uploaded as provider content
- Skip the same polluted runtime paths during full-tree and incremental remote pull so existing cloud rows do not re-enter the local mirror
- Keep legitimate nested provider paths such as `digests/` observable while suppressing nested `.relay/` watcher events

Fixes #237.

## Tests
- go test ./internal/mountsync -run 'TestHandleLocalChangeSkipsNestedMountRuntimeState|TestScanLocalFilesSkipsNestedMountRuntimeState|TestPullRemoteFullTreeSkipsNestedMountRuntimeState|TestPullRemoteIncrementalSkipsNestedMountRuntimeState|TestWatcherDoesNotSkipNestedReservedNameDirectories|TestWatcherSkipsNestedMountRuntimeDirectories' -count=1\n- go test ./internal/mountsync\n- go test ./cmd/relayfile-cli\n- git diff --check\n\n## Notes\n- The root cause was narrower than top-level `.relay` handling: existing guards skipped top-level runtime state, but nested `.relay/state.json` under provider/resource directories could still be scanned, watched, uploaded, and mirrored back from already polluted remote rows.\n- This change filters only mount runtime path segments (`.relay` and legacy `.relayfile-mount-state.json` names), not arbitrary nested reserved-looking provider directories.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

