### PR TITLE
Keep relayfile-mount alive under watcher pressure

### DIFF
--- a/cmd/relayfile-mount/main.go
+++ b/cmd/relayfile-mount/main.go
@@ -463,12 +463,15 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 		}
 	})
 	if err != nil {
-		return fmt.Errorf("create file watcher: %w", err)
+		log.Printf("file watcher unavailable; continuing with polling sync: %v", err)
+	} else if err := watcher.Start(rootCtx); err != nil {
+		_ = watcher.Close()
+		log.Printf("file watcher disabled; continuing with polling sync: %v", err)
+		watcher = nil
 	}
-	if err := watcher.Start(rootCtx); err != nil {
-		return fmt.Errorf("start file watcher: %w", err)
+	if watcher != nil {
+		defer watcher.Close()
 	}
-	defer watcher.Close()
 
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	timer := time.NewTimer(jitteredIntervalWithSample(cfg.interval, cfg.intervalJitter, rng.Float64()))
@@ -491,7 +494,10 @@ func runSinglePollingMount(rootCtx context.Context, cfg mountConfig) error {
 			}
 		case <-timer.C:
 			cycle++
-			reconcile := shouldReconcileMountCycle(mountWebSocketEnabled(cfg), cycle)
+			reconcile := shouldReconcileMountCycle(
+				mountReconcileUsesWebSocketCadence(cfg, watcher != nil),
+				cycle,
+			)
 			if reconcile {
 				run(true)
 			}
@@ -825,6 +831,10 @@ func shouldReconcileMountCycle(websocketEnabled bool, cycle int) bool {
 
 func mountWebSocketEnabled(cfg mountConfig) bool {
 	return cfg.websocketEnabled && cfg.syncMode != syncModeWriteOnly
+}
+
+func mountReconcileUsesWebSocketCadence(cfg mountConfig, watcherActive bool) bool {
+	return watcherActive && mountWebSocketEnabled(cfg)
 }
 
 func clampJitterRatio(value float64) float64 {

--- a/cmd/relayfile-mount/main_test.go
+++ b/cmd/relayfile-mount/main_test.go
@@ -128,6 +128,16 @@ func TestWriteOnlyMountDisablesWebSocketCadence(t *testing.T) {
 	}
 }
 
+func TestWatcherUnavailableDisablesWebSocketReconcileCadence(t *testing.T) {
+	cfg := mountConfig{websocketEnabled: true, syncMode: syncModeMirror}
+	if !mountReconcileUsesWebSocketCadence(cfg, true) {
+		t.Fatal("active watcher should allow websocket reconcile cadence")
+	}
+	if mountReconcileUsesWebSocketCadence(cfg, false) {
+		t.Fatal("missing watcher must keep regular reconcile cadence for local scans")
+	}
+}
+
 func TestResolveMountMode(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/mountsync/watcher.go
+++ b/internal/mountsync/watcher.go
@@ -2,8 +2,10 @@ package mountsync
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -11,16 +13,22 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+const defaultMaxWatchedDirs = 8192
+
+var ErrWatcherLimitExceeded = errors.New("mount file watcher directory limit exceeded")
+
 // FileWatcher watches a local directory for changes using OS-level
 // notifications (inotify on Linux, FSEvents on macOS).
 type FileWatcher struct {
-	watcher  *fsnotify.Watcher
-	localDir string
-	onChange func(relativePath string, op fsnotify.Op)
-	mu       sync.Mutex
-	debounce map[string]*time.Timer // debounce rapid events per file
-	closed   bool
-	wg       sync.WaitGroup
+	watcher     *fsnotify.Watcher
+	localDir    string
+	onChange    func(relativePath string, op fsnotify.Op)
+	maxDirs     int
+	watchedDirs int
+	mu          sync.Mutex
+	debounce    map[string]*time.Timer // debounce rapid events per file
+	closed      bool
+	wg          sync.WaitGroup
 }
 
 func NewFileWatcher(localDir string, onChange func(string, fsnotify.Op)) (*FileWatcher, error) {
@@ -32,6 +40,7 @@ func NewFileWatcher(localDir string, onChange func(string, fsnotify.Op)) (*FileW
 		watcher:  w,
 		localDir: localDir,
 		onChange: onChange,
+		maxDirs:  watcherMaxDirsFromEnv(),
 		debounce: make(map[string]*time.Timer),
 	}, nil
 }
@@ -200,12 +209,44 @@ func (fw *FileWatcher) addDirRecursive(base string) error {
 		if fw.isTopLevelReservedDir(path, name) {
 			return filepath.SkipDir
 		}
-		// Best-effort add. fsnotify returns an error for already-watched dirs
-		// on macOS/FSEvents in some cases; we ignore it because re-adding is
-		// a no-op semantically.
-		_ = fw.watcher.Add(path)
+		if fw.maxDirs > 0 && fw.watchedDirs >= fw.maxDirs {
+			return fmtWatcherLimitExceeded(fw.maxDirs)
+		}
+		if err := fw.watcher.Add(path); err != nil {
+			if isBenignWatcherAddError(err) {
+				return nil
+			}
+			return err
+		}
+		fw.watchedDirs++
 		return nil
 	})
+}
+
+func watcherMaxDirsFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("RELAYFILE_MOUNT_MAX_WATCH_DIRS"))
+	if raw == "" {
+		return defaultMaxWatchedDirs
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return defaultMaxWatchedDirs
+	}
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func fmtWatcherLimitExceeded(limit int) error {
+	return errors.Join(ErrWatcherLimitExceeded, errors.New("watched directory limit reached: "+strconv.Itoa(limit)))
+}
+
+func isBenignWatcherAddError(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "already watched") ||
+		strings.Contains(message, "already exists") ||
+		strings.Contains(message, "file exists")
 }
 
 func (fw *FileWatcher) isTopLevelReservedDir(path, name string) bool {

--- a/internal/mountsync/watcher_test.go
+++ b/internal/mountsync/watcher_test.go
@@ -2,6 +2,7 @@ package mountsync
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,6 +100,36 @@ func TestWatcherCloseCancelsPendingDebounce(t *testing.T) {
 		t.Fatalf("close watcher: %v", err)
 	}
 	assertNoWatcherEvents(t, events, 150*time.Millisecond)
+}
+
+func TestWatcherStartReturnsLimitExceededWhenDirectoryBudgetExceeded(t *testing.T) {
+	t.Setenv("RELAYFILE_MOUNT_MAX_WATCH_DIRS", "1")
+	localDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(localDir, "github", "repos", "owner", "repo"), 0o755); err != nil {
+		t.Fatalf("seed nested tree: %v", err)
+	}
+	watcher, err := NewFileWatcher(localDir, func(string, fsnotify.Op) {})
+	if err != nil {
+		t.Fatalf("create watcher: %v", err)
+	}
+	defer watcher.Close()
+
+	err = watcher.Start(context.Background())
+	if !errors.Is(err, ErrWatcherLimitExceeded) {
+		t.Fatalf("expected watcher limit error, got %v", err)
+	}
+}
+
+func TestWatcherAddErrorClassificationDoesNotHideMissingPaths(t *testing.T) {
+	if !isBenignWatcherAddError(errors.New("file already exists")) {
+		t.Fatal("expected duplicate watcher add errors to be benign")
+	}
+	if isBenignWatcherAddError(errors.New("no such file or directory")) {
+		t.Fatal("missing paths must not be treated as benign watcher add errors")
+	}
+	if isBenignWatcherAddError(errors.New("does not exist")) {
+		t.Fatal("does-not-exist errors must not be treated as benign watcher add errors")
+	}
 }
 
 func TestWatcherDetectsFileWrite(t *testing.T) {


### PR DESCRIPTION
## Summary
- bound recursive relayfile-mount watcher subscriptions with RELAYFILE_MOUNT_MAX_WATCH_DIRS
- surface watcher setup exhaustion instead of silently running a partial watcher
- degrade watcher startup failures to polling-only sync instead of exiting
- keep regular reconciliation cadence while watcher setup is unavailable, even when websocket mode is enabled

Companion to AgentWorkforce/cloud#2297 for the mount resilience side of AgentWorkforce/cloud#2296.

## Verification
- go test ./cmd/relayfile-mount -count=1
- go test ./internal/mountsync -count=1 -timeout 180s

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

