### PR TITLE
fix(cli): stabilize delegated credential shard lookup

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -6992,23 +6992,88 @@ func delegatedCredentialsPath() string {
 }
 
 func delegatedCredentialsPathForRequest(workspaceValue string, scopes []string) string {
-	workspaceKey := delegatedCredentialsWorkspaceKey(workspaceValue)
+	workspaceKey := workspaceShardKey(workspaceValue)
 	scopeKey := delegatedCredentialsScopeKey(scopes)
 	return filepath.Join(configDir(), "delegated", workspaceKey, scopeKey+".json")
 }
 
-func delegatedCredentialsWorkspaceKey(workspaceValue string) string {
+func delegatedCredentialsRawPathForRequest(workspaceValue string, scopes []string) string {
+	workspaceKey := rawWorkspaceShardKey(workspaceValue)
+	scopeKey := delegatedCredentialsScopeKey(scopes)
+	return filepath.Join(configDir(), "delegated", workspaceKey, scopeKey+".json")
+}
+
+func workspaceShardKey(workspaceValue string) string {
+	workspaceValue = canonicalWorkspaceShardValue(workspaceValue)
+	sum := sha256.Sum256([]byte(workspaceValue))
+	return hex.EncodeToString(sum[:])[:24]
+}
+
+func rawWorkspaceShardKey(workspaceValue string) string {
 	workspaceValue = strings.TrimSpace(workspaceValue)
 	if workspaceValue == "" {
 		workspaceValue = "active"
 	}
-	if record, ok := workspaceRecordByName(workspaceValue); ok && strings.TrimSpace(record.ID) != "" {
-		workspaceValue = record.ID
-	} else if record, ok := workspaceRecordByID(workspaceValue); ok && strings.TrimSpace(record.ID) != "" {
-		workspaceValue = record.ID
-	}
 	sum := sha256.Sum256([]byte(workspaceValue))
 	return hex.EncodeToString(sum[:])[:24]
+}
+
+func canonicalWorkspaceShardValue(workspaceValue string) string {
+	value, _ := canonicalWorkspaceShardValueStatus(workspaceValue)
+	return value
+}
+
+func canonicalWorkspaceShardValueStatus(workspaceValue string) (string, bool) {
+	workspaceValue = strings.TrimSpace(workspaceValue)
+	if workspaceValue == "" || strings.EqualFold(workspaceValue, "active") {
+		if name, _ := activeWorkspaceName(""); strings.TrimSpace(name) != "" {
+			workspaceValue = strings.TrimSpace(name)
+		} else if workspaceValue == "" {
+			workspaceValue = "active"
+		}
+	}
+	if record, ok := workspaceRecordForShardValue(workspaceValue); ok {
+		return strings.TrimSpace(record.ID), true
+	}
+	return workspaceValue, false
+}
+
+func workspaceRecordForShardValue(workspaceValue string) (workspaceRecord, bool) {
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return workspaceRecord{}, false
+	}
+	workspaceValue = strings.TrimSpace(workspaceValue)
+	var match workspaceRecord
+	canonicalID := ""
+	for _, record := range catalog.Workspaces {
+		if record.Name != workspaceValue && record.ID != workspaceValue && record.RelayWorkspaceID != workspaceValue {
+			continue
+		}
+		recordID := strings.TrimSpace(record.ID)
+		if recordID == "" {
+			return workspaceRecord{}, false
+		}
+		if canonicalID == "" {
+			canonicalID = recordID
+			match = record
+			continue
+		}
+		if canonicalID != recordID {
+			return workspaceRecord{}, false
+		}
+		if strings.TrimSpace(match.Name) == "" {
+			match.Name = strings.TrimSpace(record.Name)
+		}
+		if strings.TrimSpace(match.RelayWorkspaceID) == "" {
+			match.RelayWorkspaceID = strings.TrimSpace(record.RelayWorkspaceID)
+		}
+	}
+	if canonicalID == "" {
+		return workspaceRecord{}, false
+	}
+	match.ID = canonicalID
+	return match, true
 }
 
 func delegatedCredentialsScopeKey(scopes []string) string {
@@ -7062,22 +7127,10 @@ func resolveDelegatedCredentialsPathForRequest(flagValue, workspaceValue string,
 	if value, ok := explicitDelegatedCredentialsPath(flagValue); ok {
 		return value, true
 	}
-	workspaceValue = resolveDelegatedCredentialsWorkspaceValue(workspaceValue)
 	if strings.TrimSpace(workspaceValue) != "" || len(scopes) > 0 {
 		return delegatedCredentialsPathForRequest(workspaceValue, scopes), false
 	}
 	return delegatedCredentialsPath(), false
-}
-
-func resolveDelegatedCredentialsWorkspaceValue(workspaceValue string) string {
-	workspaceValue = strings.TrimSpace(workspaceValue)
-	if workspaceValue != "" && !strings.EqualFold(workspaceValue, "active") {
-		return workspaceValue
-	}
-	if name, _ := activeWorkspaceName(""); strings.TrimSpace(name) != "" {
-		return strings.TrimSpace(name)
-	}
-	return workspaceValue
 }
 
 func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error) {
@@ -7096,16 +7149,87 @@ func loadDelegatedCredentials(path string) (delegatedauth.Bundle, string, error)
 }
 
 func loadDelegatedCredentialsForRequest(path, workspaceValue string, scopes []string) (delegatedauth.Bundle, string, error) {
+	canonicalWorkspaceValue, canonicalWorkspaceOK := canonicalWorkspaceShardValueStatus(workspaceValue)
+	if !canonicalWorkspaceOK && strings.TrimSpace(workspaceValue) != "" {
+		fmt.Fprintf(os.Stderr, "warning: delegated credential workspace %q was not uniquely resolved in %s; using raw workspace shard and probing alias shards\n", canonicalWorkspaceValue, workspacesPath())
+	}
 	resolvedPath, explicit := resolveDelegatedCredentialsPathForRequest(path, workspaceValue, scopes)
 	bundle, loadedPath, err := loadDelegatedCredentials(resolvedPath)
 	if err == nil || explicit || resolvedPath == delegatedCredentialsPath() || !errors.Is(err, delegatedauth.ErrMissingCredentials) {
 		return bundle, loadedPath, err
+	}
+	for _, legacyPath := range legacyDelegatedCredentialsPathsForRequest(workspaceValue, scopes) {
+		legacyBundle, loadedLegacyPath, legacyErr := loadDelegatedCredentials(legacyPath)
+		if legacyErr == nil && delegatedBundleSatisfiesRequestedScopes(legacyBundle, scopes) {
+			if created, migrateErr := delegatedauth.SaveAtomicIfMissing(resolvedPath, legacyBundle); migrateErr == nil && created {
+				return legacyBundle, resolvedPath, nil
+			} else if migrateErr == nil && !created {
+				canonicalBundle, canonicalLoadedPath, canonicalErr := loadDelegatedCredentials(resolvedPath)
+				if canonicalErr == nil && delegatedBundleSatisfiesRequestedScopes(canonicalBundle, scopes) {
+					return canonicalBundle, canonicalLoadedPath, nil
+				}
+			}
+			return legacyBundle, loadedLegacyPath, nil
+		}
 	}
 	legacyBundle, legacyPath, legacyErr := loadDelegatedCredentials(delegatedCredentialsPath())
 	if legacyErr == nil && delegatedBundleSatisfiesRequestedScopes(legacyBundle, scopes) {
 		return legacyBundle, legacyPath, nil
 	}
 	return bundle, loadedPath, err
+}
+
+func legacyDelegatedCredentialsPathsForRequest(workspaceValue string, scopes []string) []string {
+	aliases := legacyDelegatedCredentialsWorkspaceAliases(workspaceValue)
+	paths := make([]string, 0, len(aliases))
+	seen := map[string]struct{}{delegatedCredentialsPathForRequest(workspaceValue, scopes): {}}
+	for _, alias := range aliases {
+		path := delegatedCredentialsRawPathForRequest(alias, scopes)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func legacyDelegatedCredentialsWorkspaceAliases(workspaceValue string) []string {
+	value := strings.TrimSpace(workspaceValue)
+	if value == "" || strings.EqualFold(value, "active") {
+		if name, _ := activeWorkspaceName(""); strings.TrimSpace(name) != "" {
+			value = strings.TrimSpace(name)
+		}
+	}
+	aliases := make([]string, 0, 3)
+	addAlias := func(alias string) {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			return
+		}
+		for _, existing := range aliases {
+			if existing == alias {
+				return
+			}
+		}
+		aliases = append(aliases, alias)
+	}
+	addAlias(value)
+	catalog, err := loadWorkspaceCatalog()
+	if err != nil {
+		return aliases
+	}
+	for _, record := range catalog.Workspaces {
+		if strings.TrimSpace(record.Name) != value &&
+			strings.TrimSpace(record.ID) != value &&
+			strings.TrimSpace(record.RelayWorkspaceID) != value {
+			continue
+		}
+		addAlias(record.ID)
+		addAlias(record.RelayWorkspaceID)
+		addAlias(record.Name)
+	}
+	return aliases
 }
 
 func delegatedBundleSatisfiesRequestedScopes(bundle delegatedauth.Bundle, requested []string) bool {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2809,6 +2809,131 @@ func TestLoadDelegatedCredentialsForActiveWorkspaceUsesCatalogDefault(t *testing
 	}
 }
 
+func TestDelegatedCredentialsPathCanonicalizesWorkspaceAliases(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Default: "default",
+		Workspaces: []workspaceRecord{
+			{Name: "50587328-441d-4acb-b8f3-dbe1b3c5de99", ID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", RelayWorkspaceID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+			{Name: "default", ID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", RelayWorkspaceID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+			{Name: "default", ID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", RelayWorkspaceID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+			{Name: "other", ID: "60698439-552e-4bdc-c9f4-ecf2c4d6efa0", RelayWorkspaceID: "rw_other", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+		},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	want := delegatedCredentialsPathForRequest("50587328-441d-4acb-b8f3-dbe1b3c5de99", defaultJoinScopes)
+	for _, input := range []string{"rw_7ccfea89", "default", "active", ""} {
+		if got := delegatedCredentialsPathForRequest(input, defaultJoinScopes); got != want {
+			t.Fatalf("path for %q = %q, want %q", input, got, want)
+		}
+	}
+	other := delegatedCredentialsPathForRequest("rw_other", defaultJoinScopes)
+	if other == want {
+		t.Fatalf("rw_ aliases were not one-to-one: other path %q matched default path", other)
+	}
+	if got := delegatedCredentialsPathForRequest("other", defaultJoinScopes); got != other {
+		t.Fatalf("path for other name = %q, want %q", got, other)
+	}
+}
+
+func TestDelegatedCredentialsPathLeavesAmbiguousRelayWorkspaceAliasRaw(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if err := saveWorkspaceCatalog(workspaceCatalog{
+		Workspaces: []workspaceRecord{
+			{Name: "one", ID: "11111111-1111-1111-1111-111111111111", RelayWorkspaceID: "rw_shared", CreatedAt: now},
+			{Name: "two", ID: "22222222-2222-2222-2222-222222222222", RelayWorkspaceID: "rw_shared", CreatedAt: now},
+		},
+	}); err != nil {
+		t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+	}
+
+	if value, ok := canonicalWorkspaceShardValueStatus("rw_shared"); ok || value != "rw_shared" {
+		t.Fatalf("ambiguous relay alias canonicalized to value=%q ok=%v, want raw rw_shared false", value, ok)
+	}
+	if got, want := workspaceShardKey("rw_shared"), rawWorkspaceShardKey("rw_shared"); got != want {
+		t.Fatalf("ambiguous relay alias shard key = %q, want raw %q", got, want)
+	}
+}
+
+func TestLoadDelegatedCredentialsMigratesLegacyRelayWorkspaceShard(t *testing.T) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	records := []workspaceRecord{
+		{Name: "default", ID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", RelayWorkspaceID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+		{Name: "default", ID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", RelayWorkspaceID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+		{Name: "rw_7ccfea89", ID: "rw_7ccfea89", RelayWorkspaceID: "50587328-441d-4acb-b8f3-dbe1b3c5de99", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+		{Name: "rw_7ccfea89", ID: "rw_7ccfea89", CreatedAt: now, Scopes: append([]string(nil), defaultJoinScopes...)},
+	}
+	run := func(t *testing.T, records []workspaceRecord) {
+		t.Helper()
+		t.Setenv("HOME", t.TempDir())
+		clearRelayfileEnv(t)
+		if err := saveWorkspaceCatalog(workspaceCatalog{
+			Default:    "default",
+			Workspaces: records,
+		}); err != nil {
+			t.Fatalf("saveWorkspaceCatalog failed: %v", err)
+		}
+		mintedPath := delegatedCredentialsPathForRequest("50587328-441d-4acb-b8f3-dbe1b3c5de99", defaultJoinScopes)
+		resolvedPath := delegatedCredentialsPathForRequest("rw_7ccfea89", defaultJoinScopes)
+		if mintedPath == resolvedPath {
+			t.Fatalf("test setup expected polluted catalog to produce distinct mint/resolve paths, got %q", mintedPath)
+		}
+		if err := delegatedauth.SaveAtomic(mintedPath, delegatedauth.Bundle{
+			RelayfileURL:         "https://relayfile.test",
+			RelayfileWorkspaceID: "rw_7ccfea89",
+			AccessToken:          testJWTWithWorkspaceAndScopes("rw_7ccfea89", "relayfile-cli", defaultJoinScopes),
+			RefreshToken:         "refresh_join",
+			Scopes:               append([]string(nil), defaultJoinScopes...),
+		}); err != nil {
+			t.Fatalf("save minted delegated credentials failed: %v", err)
+		}
+		if _, err := os.Stat(resolvedPath); !os.IsNotExist(err) {
+			t.Fatalf("resolved path unexpectedly exists before heal: %v", err)
+		}
+
+		bundle, loadedPath, err := loadDelegatedCredentialsForRequest("", "rw_7ccfea89", defaultJoinScopes)
+		if err != nil {
+			t.Fatalf("loadDelegatedCredentialsForRequest failed: %v", err)
+		}
+		if loadedPath != resolvedPath {
+			t.Fatalf("loadedPath = %q, want healed resolve path %q", loadedPath, resolvedPath)
+		}
+		if bundle.BearerToken() == "" {
+			t.Fatal("expected delegated bundle from minted shard")
+		}
+		if _, err := delegatedauth.Load(resolvedPath); err != nil {
+			t.Fatalf("expected healed delegated credentials at resolved path: %v", err)
+		}
+
+		if err := os.Remove(mintedPath); err != nil {
+			t.Fatalf("remove minted path failed: %v", err)
+		}
+		_, loadedPath, err = loadDelegatedCredentialsForRequest("", "rw_7ccfea89", defaultJoinScopes)
+		if err != nil {
+			t.Fatalf("second loadDelegatedCredentialsForRequest failed: %v", err)
+		}
+		if loadedPath != resolvedPath {
+			t.Fatalf("second loadedPath = %q, want healed resolve path %q", loadedPath, resolvedPath)
+		}
+	}
+	t.Run("polluted catalog order", func(t *testing.T) {
+		run(t, records)
+	})
+	t.Run("reversed polluted catalog order", func(t *testing.T) {
+		reversed := append([]workspaceRecord(nil), records...)
+		for i, j := 0, len(reversed)-1; i < j; i, j = i+1, j-1 {
+			reversed[i], reversed[j] = reversed[j], reversed[i]
+		}
+		run(t, reversed)
+	})
+}
+
 func TestWritebackSkipStuckUsesDelegatedCredentialsWithoutLegacyCredentials(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/internal/delegatedauth/delegatedauth.go
+++ b/internal/delegatedauth/delegatedauth.go
@@ -145,23 +145,37 @@ func Load(path string) (Bundle, error) {
 }
 
 func SaveAtomic(path string, bundle Bundle) error {
+	_, err := saveAtomic(path, bundle, false)
+	return err
+}
+
+func SaveAtomicIfMissing(path string, bundle Bundle) (bool, error) {
+	if _, err := os.Stat(strings.TrimSpace(path)); err == nil {
+		return false, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, err
+	}
+	return saveAtomic(path, bundle, true)
+}
+
+func saveAtomic(path string, bundle Bundle, createOnly bool) (bool, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return errors.New("credential path is required")
+		return false, errors.New("credential path is required")
 	}
 	bundle.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	payload, err := json.MarshalIndent(bundle, "", "  ")
 	if err != nil {
-		return err
+		return false, err
 	}
 	payload = append(payload, '\n')
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
+		return false, err
 	}
 	tmp, err := os.CreateTemp(dir, ".relayfile-credentials-*.tmp")
 	if err != nil {
-		return err
+		return false, err
 	}
 	tmpName := tmp.Name()
 	cleanup := true
@@ -172,24 +186,36 @@ func SaveAtomic(path string, bundle Bundle) error {
 	}()
 	if err := tmp.Chmod(0o600); err != nil {
 		_ = tmp.Close()
-		return err
+		return false, err
 	}
 	if _, err := tmp.Write(payload); err != nil {
 		_ = tmp.Close()
-		return err
+		return false, err
 	}
 	if err := tmp.Sync(); err != nil {
 		_ = tmp.Close()
-		return err
+		return false, err
 	}
 	if err := tmp.Close(); err != nil {
-		return err
+		return false, err
 	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return err
+	if createOnly {
+		if err := os.Link(tmpName, path); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return false, nil
+			}
+			return false, err
+		}
+	} else if err := os.Rename(tmpName, path); err != nil {
+		return false, err
 	}
-	cleanup = false
-	return os.Chmod(path, 0o600)
+	if !createOnly {
+		cleanup = false
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func RenewFile(ctx context.Context, client *http.Client, path string, timeout time.Duration) (Bundle, bool, error) {

--- a/internal/delegatedauth/delegatedauth_test.go
+++ b/internal/delegatedauth/delegatedauth_test.go
@@ -13,6 +13,68 @@ import (
 	"time"
 )
 
+func TestSaveAtomicIfMissingCreatesCredentialFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds", "delegated.json")
+	created, err := SaveAtomicIfMissing(path, Bundle{
+		RelayfileURL:         "https://relayfile.test",
+		RelayfileWorkspaceID: "rw_test",
+		AccessToken:          "access_new",
+		RefreshToken:         "refresh_new",
+	})
+	if err != nil {
+		t.Fatalf("SaveAtomicIfMissing failed: %v", err)
+	}
+	if !created {
+		t.Fatal("created = false, want true")
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.BearerToken() != "access_new" || loaded.RotationToken() != "refresh_new" {
+		t.Fatalf("unexpected saved bundle: %#v", loaded)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat saved file failed: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential mode = %o, want 0600", got)
+	}
+}
+
+func TestSaveAtomicIfMissingDoesNotOverwriteExistingCredentialFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "delegated.json")
+	if err := SaveAtomic(path, Bundle{
+		RelayfileURL:         "https://relayfile.test",
+		RelayfileWorkspaceID: "rw_test",
+		AccessToken:          "access_existing",
+		RefreshToken:         "refresh_existing",
+	}); err != nil {
+		t.Fatalf("SaveAtomic failed: %v", err)
+	}
+
+	created, err := SaveAtomicIfMissing(path, Bundle{
+		RelayfileURL:         "https://relayfile.test",
+		RelayfileWorkspaceID: "rw_test",
+		AccessToken:          "access_late",
+		RefreshToken:         "refresh_late",
+	})
+	if err != nil {
+		t.Fatalf("SaveAtomicIfMissing failed: %v", err)
+	}
+	if created {
+		t.Fatal("created = true, want false")
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.BearerToken() != "access_existing" || loaded.RotationToken() != "refresh_existing" {
+		t.Fatalf("existing bundle was overwritten: %#v", loaded)
+	}
+}
+
 func TestRenewFileRotatesAndPersistsDelegatedTokenPair(t *testing.T) {
 	var sawRefresh string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Canonicalize delegated credential shard keys through a shared workspace shard helper.
- Probe all catalog aliases (`id`, `relayWorkspaceId`, `name`) across every matching record when the canonical shard is missing, then heal with a create-if-missing write.
- Add polluted-catalog regression coverage for the inverted id/rw row, missing cross-link twin, benign duplicates, scope guard, and no-clobber heal helper.

## Verification
- `go test ./internal/delegatedauth`
- focused `go test ./cmd/relayfile-cli -run ...` regression set
- `go test ./cmd/relayfile-cli`
- `go test ./...`

## Non-blocking follow-ups
- Deduplicate the catalog-pollution warning in `loadDelegatedCredentialsForRequest` once per process to reduce log noise on permanently polluted catalogs.
- Track the upstream source that wrote the inverted `id=rw_/rw=uuid` workspace catalog row so new poisoned records stop accumulating.

Merge hold: review-ready for #321, not auto-merge.
