### PR TITLE
fix(cli): classify delegated-token invalid_scope as permanent (stop retry storm)

### DIFF
--- a/cmd/relayfile-cli/delegated_token_error_test.go
+++ b/cmd/relayfile-cli/delegated_token_error_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestMapDelegatedTokenCloudError verifies that the delegated-token mint error
+// classifier routes permanent client errors (bad/insufficient scopes, needs
+// reauth) to needs-human sentinels while leaving genuinely transient backend
+// failures retryable. The invalid_scope case is the storm-retry fix: a 400
+// invalid_scope re-sends the same bad scopes on every retry and can never
+// succeed, so it must NOT be treated as transient.
+func TestMapDelegatedTokenCloudError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		wantSentinel   error // errors.Is target; nil means "no permanent sentinel"
+		wantCredExpiry bool  // isMountCredentialExpired => pause-for-human, stop retry storm
+	}{
+		{
+			name:           "nil error passes through",
+			err:            nil,
+			wantSentinel:   nil,
+			wantCredExpiry: false,
+		},
+		{
+			name:           "invalid_scope is permanent (storm-retry fix)",
+			err:            &apiError{StatusCode: 400, Code: "invalid_scope", Message: "scopes must be relayfile path scopes within the requested paths"},
+			wantSentinel:   ErrDelegatedScopeInvalid,
+			wantCredExpiry: true,
+		},
+		{
+			name:           "scope_insufficient is permanent",
+			err:            &apiError{StatusCode: 403, Code: "scope_insufficient", Message: "insufficient scope"},
+			wantSentinel:   ErrDelegatedScopeInsufficient,
+			wantCredExpiry: true,
+		},
+		{
+			name:           "needs_reauth is permanent",
+			err:            &apiError{StatusCode: 401, Code: "needs_reauth", Message: "session expired"},
+			wantSentinel:   ErrDelegatedRelayfileCredentialsExpired,
+			wantCredExpiry: true,
+		},
+		{
+			name:           "relayauth_unavailable stays transient (must remain retryable)",
+			err:            &apiError{StatusCode: 503, Code: "relayauth_unavailable", Message: "upstream unavailable"},
+			wantSentinel:   nil,
+			wantCredExpiry: false,
+		},
+		{
+			name:           "unknown code stays transient",
+			err:            &apiError{StatusCode: 500, Code: "boom", Message: "internal error"},
+			wantSentinel:   nil,
+			wantCredExpiry: false,
+		},
+		{
+			name:           "non-apiError stays transient",
+			err:            fmt.Errorf("dial tcp: connection refused"),
+			wantSentinel:   nil,
+			wantCredExpiry: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapDelegatedTokenCloudError(tc.err)
+
+			if tc.err == nil {
+				if got != nil {
+					t.Fatalf("expected nil for nil input, got %v", got)
+				}
+				return
+			}
+
+			if tc.wantSentinel != nil && !errors.Is(got, tc.wantSentinel) {
+				t.Fatalf("expected error to wrap %v, got %v", tc.wantSentinel, got)
+			}
+			if tc.wantSentinel == nil {
+				// Must not be misclassified as any permanent needs-human sentinel.
+				for _, sentinel := range []error{ErrDelegatedScopeInvalid, ErrDelegatedScopeInsufficient, ErrDelegatedRelayfileCredentialsExpired, ErrCloudRefreshExpired} {
+					if errors.Is(got, sentinel) {
+						t.Fatalf("transient error misclassified as permanent %v: %v", sentinel, got)
+					}
+				}
+			}
+
+			if gotCred := isMountCredentialExpired(got); gotCred != tc.wantCredExpiry {
+				t.Fatalf("isMountCredentialExpired = %v, want %v (err=%v)", gotCred, tc.wantCredExpiry, got)
+			}
+		})
+	}
+}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -1305,10 +1305,19 @@ var ErrDelegatedRelayfileCredentialsExpired = errors.New("delegated relayfile cr
 // (re-mint with corrected scopes) and cannot be recovered automatically.
 var ErrDelegatedScopeInsufficient = errors.New("delegated relayfile credentials have insufficient scope — re-mint with broader scopes")
 
+// ErrDelegatedScopeInvalid is returned when the cloud delegated-token mint
+// rejects the request because the requested scopes are malformed — e.g. not
+// valid relayfile path scopes. Unlike a transient backend failure, retrying
+// re-sends the identical bad scopes and can never succeed, so this is a
+// permanent client error that must surface to a human (correct the scope shape)
+// rather than drive an endless retry loop.
+var ErrDelegatedScopeInvalid = errors.New("delegated relayfile credentials requested invalid scopes — scopes must be valid relayfile path scopes; retrying will not succeed, re-mint with corrected scopes")
+
 func isMountCredentialExpired(err error) bool {
 	return errors.Is(err, ErrCloudRefreshExpired) ||
 		errors.Is(err, ErrDelegatedRelayfileCredentialsExpired) ||
-		errors.Is(err, ErrDelegatedScopeInsufficient)
+		errors.Is(err, ErrDelegatedScopeInsufficient) ||
+		errors.Is(err, ErrDelegatedScopeInvalid)
 }
 
 // mapDelegatedTokenCloudError translates structured cloud error codes returned
@@ -1328,6 +1337,12 @@ func mapDelegatedTokenCloudError(err error) error {
 		return fmt.Errorf("%w: %s", ErrDelegatedRelayfileCredentialsExpired, ae.Message)
 	case "scope_insufficient":
 		return fmt.Errorf("%w: %s", ErrDelegatedScopeInsufficient, ae.Message)
+	case "invalid_scope":
+		// The requested scopes are malformed (e.g. not relayfile path scopes).
+		// This is a permanent client error: retrying re-sends the same bad
+		// scopes and cannot succeed, so surface it as needs-human rather than
+		// letting the mount loop back off and retry forever.
+		return fmt.Errorf("%w: %s", ErrDelegatedScopeInvalid, ae.Message)
 	default:
 		// relayauth_unavailable and other codes are transient — wrap plainly
 		// so the caller can back off and retry.


### PR DESCRIPTION
## Problem

`mapDelegatedTokenCloudError` (cmd/relayfile-cli/main.go) only mapped `needs_reauth` and `scope_insufficient` to needs-human sentinels. A **`400 invalid_scope`** from the delegated-token mint fell through to the transient `default` branch.

The mount loop retries transient failures (back off + retry). But an `invalid_scope` re-sends the **identical malformed scopes** on every attempt and can **never** succeed — so it drove an **endless retry storm** instead of surfacing an actionable error.

This was observed live: the relayfile mount Go client → `/relayfile/delegated-token` → `400 invalid_scope "scopes must be relayfile path scopes within the requested paths"`, retried continuously.

## Fix

- Add `ErrDelegatedScopeInvalid` sentinel.
- Map the `invalid_scope` code to it in `mapDelegatedTokenCloudError`.
- Include it in `isMountCredentialExpired`, so the mount enters its **degraded / pause-for-human** state (capped backoff + recovery guidance) instead of hammering.
- Genuinely transient codes (`relayauth_unavailable`, unknown codes, non-`apiError`) **remain retryable** — verified by test.

## Why this is safe / scope-independent

This is a pure error-**classification** fix. It is correct regardless of how the underlying cause (the mount client sending legacy 2-segment scopes vs. relayauth's required 4-segment `relayfile:fs:read:*` path scopes — a separate staged decision) is ultimately resolved. It only changes retry behavior for a permanently-failing request.

## Tests

New `TestMapDelegatedTokenCloudError` (7 cases), all passing:
- `invalid_scope` → permanent (`ErrDelegatedScopeInvalid`, pause-for-human) ✅
- `scope_insufficient` / `needs_reauth` → permanent (regression guard) ✅
- **`relayauth_unavailable` → stays transient (must remain retryable)** ✅ ← guards against suppressing legitimately transient errors
- unknown code / non-apiError → stays transient ✅
- nil → nil ✅

`go build`, `go vet`, and the test all pass.

Note: takes effect on the next relayfile-CLI release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

