### PR TITLE
fix(cli): require provider-scoped writeback tokens

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3649,34 +3649,13 @@ func writebackPushScopes(remotePath string) ([]string, []string, error) {
 		nil
 }
 
-func writebackPushJoinScopes(remotePath string) []string {
-	// ops:read is requested alongside fs:write because a successful /fs/bulk
-	// returns an opID that this command then polls at
-	// GET /v1/workspaces/{id}/ops/{opId} (server.go requires ops:read). Without
-	// it the write succeeds but the status poll is unauthorized; the push then
-	// leaves the op pending+needsAttention rather than failing it.
-	provider, ok := writebackPushProvider(remotePath)
-	if !ok {
-		return nil
-	}
-	return []string{fmt.Sprintf("fs:write:/%s/**", provider), "ops:read"}
-}
-
-func writebackPushRequiredRelayfileScopes(remotePath string) []string {
-	provider, ok := writebackPushProvider(remotePath)
-	if !ok {
-		return nil
-	}
-	return []string{fmt.Sprintf("relayfile:fs:write:/%s/**", provider)}
-}
-
 func writebackPushProvider(remotePath string) (string, bool) {
 	parts := strings.Split(strings.Trim(normalizeWritebackFailurePath(remotePath), "/"), "/")
-	if len(parts) == 0 {
+	if len(parts) < 2 {
 		return "", false
 	}
-	provider := strings.TrimSpace(parts[0])
-	if provider == "" {
+	provider := strings.ToLower(strings.TrimSpace(parts[0]))
+	if err := validateLocalProviderID(provider); err != nil {
 		return "", false
 	}
 	return provider, true

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3192,8 +3192,10 @@ func runWritebackFileMutation(mode writebackCommandMode, args []string, stdout i
 	if mode != writebackCommandPush && !isCanonicalWritebackTargetPath(resolved.RemotePath) {
 		return fmt.Errorf("writeback %s requires a canonical provider record path, got %s", mode, resolved.RemotePath)
 	}
-	joinScopes := writebackPushJoinScopes(resolved.RemotePath)
-	requiredRelayfileScopes := writebackPushRequiredRelayfileScopes(resolved.RemotePath)
+	joinScopes, requiredRelayfileScopes, err := writebackPushScopes(resolved.RemotePath)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(*tokenOverride) == "" {
 		if err := ensureWritebackDelegatedCredentials(resolved.WorkspaceID, joinScopes, requiredRelayfileScopes); err != nil {
 			return err
@@ -3637,27 +3639,47 @@ func hashBytes(raw []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+func writebackPushScopes(remotePath string) ([]string, []string, error) {
+	provider, ok := writebackPushProvider(remotePath)
+	if !ok {
+		return nil, nil, fmt.Errorf("writeback requires a provider-scoped remote path, got %s", normalizeWritebackFailurePath(remotePath))
+	}
+	return []string{fmt.Sprintf("fs:write:/%s/**", provider), "ops:read"},
+		[]string{fmt.Sprintf("relayfile:fs:write:/%s/**", provider)},
+		nil
+}
+
 func writebackPushJoinScopes(remotePath string) []string {
 	// ops:read is requested alongside fs:write because a successful /fs/bulk
 	// returns an opID that this command then polls at
 	// GET /v1/workspaces/{id}/ops/{opId} (server.go requires ops:read). Without
 	// it the write succeeds but the status poll is unauthorized; the push then
 	// leaves the op pending+needsAttention rather than failing it.
-	parts := strings.Split(strings.Trim(normalizeWritebackFailurePath(remotePath), "/"), "/")
-	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
-		return []string{"fs:write:/**", "ops:read"}
+	provider, ok := writebackPushProvider(remotePath)
+	if !ok {
+		return nil
 	}
-	provider := strings.TrimSpace(parts[0])
 	return []string{fmt.Sprintf("fs:write:/%s/**", provider), "ops:read"}
 }
 
 func writebackPushRequiredRelayfileScopes(remotePath string) []string {
+	provider, ok := writebackPushProvider(remotePath)
+	if !ok {
+		return nil
+	}
+	return []string{fmt.Sprintf("relayfile:fs:write:/%s/**", provider)}
+}
+
+func writebackPushProvider(remotePath string) (string, bool) {
 	parts := strings.Split(strings.Trim(normalizeWritebackFailurePath(remotePath), "/"), "/")
-	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
-		return []string{"relayfile:fs:write:/**"}
+	if len(parts) == 0 {
+		return "", false
 	}
 	provider := strings.TrimSpace(parts[0])
-	return []string{fmt.Sprintf("relayfile:fs:write:/%s/**", provider)}
+	if provider == "" {
+		return "", false
+	}
+	return provider, true
 }
 
 func writebackPushContentIdentity(workspaceID, remotePath, contentHash string) *contentIdentity {

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2735,18 +2735,37 @@ func TestDelegatedBundleHasScopesAllowsBroadWildcardGrant(t *testing.T) {
 }
 
 func TestWritebackPushScopesRequireProviderSubtree(t *testing.T) {
-	joinScopes, requiredRelayfileScopes, err := writebackPushScopes("/linear/issues/issue-55.json")
-	if err != nil {
-		t.Fatalf("writebackPushScopes returned error: %v", err)
-	}
-	if got, want := strings.Join(joinScopes, ","), "fs:write:/linear/**,ops:read"; got != want {
-		t.Fatalf("join scopes = %q, want %q", got, want)
-	}
-	if got, want := strings.Join(requiredRelayfileScopes, ","), "relayfile:fs:write:/linear/**"; got != want {
-		t.Fatalf("required relayfile scopes = %q, want %q", got, want)
+	for _, tc := range []struct {
+		remotePath          string
+		wantJoinScopes      string
+		wantRelayfileScopes string
+	}{
+		{
+			remotePath:          "/linear/issues/issue-55.json",
+			wantJoinScopes:      "fs:write:/linear/**,ops:read",
+			wantRelayfileScopes: "relayfile:fs:write:/linear/**",
+		},
+		{
+			remotePath:          "/GitHub/issues/issue-55.json",
+			wantJoinScopes:      "fs:write:/github/**,ops:read",
+			wantRelayfileScopes: "relayfile:fs:write:/github/**",
+		},
+	} {
+		t.Run(tc.remotePath, func(t *testing.T) {
+			joinScopes, requiredRelayfileScopes, err := writebackPushScopes(tc.remotePath)
+			if err != nil {
+				t.Fatalf("writebackPushScopes returned error: %v", err)
+			}
+			if got := strings.Join(joinScopes, ","); got != tc.wantJoinScopes {
+				t.Fatalf("join scopes = %q, want %q", got, tc.wantJoinScopes)
+			}
+			if got := strings.Join(requiredRelayfileScopes, ","); got != tc.wantRelayfileScopes {
+				t.Fatalf("required relayfile scopes = %q, want %q", got, tc.wantRelayfileScopes)
+			}
+		})
 	}
 
-	for _, remotePath := range []string{"", "/", "///"} {
+	for _, remotePath := range []string{"", "/", "///", "/foo.json", "/linear", "/**", "/*", "/./record.json", "/../record.json", "/bad provider/record.json"} {
 		joinScopes, requiredRelayfileScopes, err := writebackPushScopes(remotePath)
 		if err == nil {
 			t.Fatalf("writebackPushScopes(%q) succeeded with join=%v relayfile=%v", remotePath, joinScopes, requiredRelayfileScopes)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2734,6 +2734,32 @@ func TestDelegatedBundleHasScopesAllowsBroadWildcardGrant(t *testing.T) {
 	}
 }
 
+func TestWritebackPushScopesRequireProviderSubtree(t *testing.T) {
+	joinScopes, requiredRelayfileScopes, err := writebackPushScopes("/linear/issues/issue-55.json")
+	if err != nil {
+		t.Fatalf("writebackPushScopes returned error: %v", err)
+	}
+	if got, want := strings.Join(joinScopes, ","), "fs:write:/linear/**,ops:read"; got != want {
+		t.Fatalf("join scopes = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(requiredRelayfileScopes, ","), "relayfile:fs:write:/linear/**"; got != want {
+		t.Fatalf("required relayfile scopes = %q, want %q", got, want)
+	}
+
+	for _, remotePath := range []string{"", "/", "///"} {
+		joinScopes, requiredRelayfileScopes, err := writebackPushScopes(remotePath)
+		if err == nil {
+			t.Fatalf("writebackPushScopes(%q) succeeded with join=%v relayfile=%v", remotePath, joinScopes, requiredRelayfileScopes)
+		}
+		if strings.Contains(strings.Join(joinScopes, ","), "/**") || strings.Contains(strings.Join(requiredRelayfileScopes, ","), "/**") {
+			t.Fatalf("writebackPushScopes(%q) returned whole-tree scopes join=%v relayfile=%v", remotePath, joinScopes, requiredRelayfileScopes)
+		}
+		if got := err.Error(); !strings.Contains(got, "provider-scoped remote path") {
+			t.Fatalf("writebackPushScopes(%q) error = %q, want provider-scoped remote path", remotePath, got)
+		}
+	}
+}
+
 func TestReadLocalMountCursorHealthAggregatesStateFiles(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), []byte(`{"incrementalReadNotReadySince":{"a":"now"},"incrementalBacklogDraining":false}`), 0o644); err != nil {

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -1601,6 +1601,14 @@ func (s *Server) handleBulkWrite(w http.ResponseWriter, r *http.Request, workspa
 	errorsOut := make([]relayfile.BulkWriteError, 0)
 	for _, file := range body.Files {
 		path := normalizeRoutePath(file.Path)
+		if !scopeMatchesPath(claims.Scopes, "fs:write", path) {
+			errorsOut = append(errorsOut, relayfile.BulkWriteError{
+				Path:    path,
+				Code:    "forbidden",
+				Message: "file access denied by path scope",
+			})
+			continue
+		}
 		_, readErr := s.readFile(workspaceID, forkID, path)
 		if readErr == nil {
 			existingPermissions := s.resolveFilePermissions(workspaceID, forkID, path, true)

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -1261,6 +1261,63 @@ func TestBulkWriteEndpoint(t *testing.T) {
 	}
 }
 
+func TestBulkWriteEndpointEnforcesPathScopedTokenPerFile(t *testing.T) {
+	store := relayfile.NewStoreWithOptions(relayfile.StoreOptions{DisableWorkers: true})
+	t.Cleanup(store.Close)
+	server := NewServer(store)
+	token := mustTestJWT(t, "dev-secret", "ws_bulk_scope", "Worker1", []string{"relayfile:fs:write:/linear/**"}, time.Now().Add(time.Hour))
+
+	resp := doRequest(t, server, request{
+		method: http.MethodPost,
+		path:   "/v1/workspaces/ws_bulk_scope/fs/bulk",
+		headers: map[string]string{
+			"Authorization":    "Bearer " + token,
+			"X-Correlation-Id": "corr_bulk_scope",
+		},
+		body: map[string]any{
+			"files": []map[string]any{
+				{
+					"path":        "/linear/issues/ISS-1.json",
+					"contentType": "application/json",
+					"content":     `{"id":"ISS-1"}`,
+				},
+				{
+					"path":        "/github/issues/1.json",
+					"contentType": "application/json",
+					"content":     `{"id":1}`,
+				},
+			},
+		},
+	})
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 on partially scoped bulk write, got %d (%s)", resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Written    int                        `json:"written"`
+		ErrorCount int                        `json:"errorCount"`
+		Errors     []relayfile.BulkWriteError `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode bulk response: %v", err)
+	}
+	if payload.Written != 1 {
+		t.Fatalf("written = %d, want 1", payload.Written)
+	}
+	if payload.ErrorCount != 1 || len(payload.Errors) != 1 {
+		t.Fatalf("expected one path-scope error, got errorCount=%d errors=%+v", payload.ErrorCount, payload.Errors)
+	}
+	if got := payload.Errors[0]; got.Path != "/github/issues/1.json" || got.Code != "forbidden" || got.Message != "file access denied by path scope" {
+		t.Fatalf("unexpected path-scope error: %+v", got)
+	}
+	if _, err := store.ReadFile("ws_bulk_scope", "/linear/issues/ISS-1.json"); err != nil {
+		t.Fatalf("in-scope file was not written: %v", err)
+	}
+	if _, err := store.ReadFile("ws_bulk_scope", "/github/issues/1.json"); err == nil {
+		t.Fatal("out-of-scope file was written")
+	}
+}
+
 // TestBulkWriteReadImmediatelyAfter202 documents the OSS contract for issue #306:
 // a 202 from POST /fs/bulk means every file in the results array is immediately
 // readable — the handler is synchronous so "accepted" and "written" are the same.


### PR DESCRIPTION
## Summary
- remove the relayfile CLI writeback delegated-token whole-tree fallback (`fs:write:/**` / `relayfile:fs:write:/**`)
- require writeback paths to derive a provider subtree before bootstrapping delegated credentials
- keep normal provider writeback requests unchanged (`fs:write:/linear/**`, `relayfile:fs:write:/linear/**`)

## Context
Completes the caller-side half of the relayauth#55 / relayauth#57 mount-scope fix. Relayauth v0.2.16 now accepts bounded provider-subtree path tokens while still rejecting whole-tree scopes, so callers must not send the global `/**` fallback to path-token mint.

## Verification
- `go test ./cmd/relayfile-cli -run 'TestWritebackPushScopesRequireProviderSubtree|TestWritebackPushPostsBulkAndWritesAckedReceipt'`
- `go test ./cmd/relayfile-cli`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

