### PR TITLE
Stop writeback path tokens from requesting global write scope

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -3192,8 +3192,10 @@ func runWritebackFileMutation(mode writebackCommandMode, args []string, stdout i
 	if mode != writebackCommandPush && !isCanonicalWritebackTargetPath(resolved.RemotePath) {
 		return fmt.Errorf("writeback %s requires a canonical provider record path, got %s", mode, resolved.RemotePath)
 	}
-	joinScopes := writebackPushJoinScopes(resolved.RemotePath)
-	requiredRelayfileScopes := writebackPushRequiredRelayfileScopes(resolved.RemotePath)
+	joinScopes, requiredRelayfileScopes, err := writebackPushCredentialScopes(resolved.RemotePath)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(*tokenOverride) == "" {
 		if err := ensureWritebackDelegatedCredentials(resolved.WorkspaceID, joinScopes, requiredRelayfileScopes); err != nil {
 			return err
@@ -3637,26 +3639,40 @@ func hashBytes(raw []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func writebackPushJoinScopes(remotePath string) []string {
+func writebackPushCredentialScopes(remotePath string) ([]string, []string, error) {
+	provider, err := writebackPushProviderSegment(remotePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return writebackPushJoinScopes(provider), writebackPushRequiredRelayfileScopes(provider), nil
+}
+
+func writebackPushProviderSegment(remotePath string) (string, error) {
+	normalized := normalizeWritebackFailurePath(remotePath)
+	trimmed := strings.Trim(normalized, "/")
+	if trimmed == "" {
+		if normalized == "" {
+			normalized = "<empty>"
+		}
+		return "", fmt.Errorf("writeback push requires a provider-scoped path under /<provider>/..., got %s", normalized)
+	}
+	provider := strings.TrimSpace(strings.Split(trimmed, "/")[0])
+	if provider == "" || provider == "." || provider == ".." || strings.ContainsAny(provider, "*?") {
+		return "", fmt.Errorf("writeback push requires a provider-scoped path under /<provider>/..., got %s", normalized)
+	}
+	return provider, nil
+}
+
+func writebackPushJoinScopes(provider string) []string {
 	// ops:read is requested alongside fs:write because a successful /fs/bulk
 	// returns an opID that this command then polls at
 	// GET /v1/workspaces/{id}/ops/{opId} (server.go requires ops:read). Without
 	// it the write succeeds but the status poll is unauthorized; the push then
 	// leaves the op pending+needsAttention rather than failing it.
-	parts := strings.Split(strings.Trim(normalizeWritebackFailurePath(remotePath), "/"), "/")
-	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
-		return []string{"fs:write:/**", "ops:read"}
-	}
-	provider := strings.TrimSpace(parts[0])
 	return []string{fmt.Sprintf("fs:write:/%s/**", provider), "ops:read"}
 }
 
-func writebackPushRequiredRelayfileScopes(remotePath string) []string {
-	parts := strings.Split(strings.Trim(normalizeWritebackFailurePath(remotePath), "/"), "/")
-	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
-		return []string{"relayfile:fs:write:/**"}
-	}
-	provider := strings.TrimSpace(parts[0])
+func writebackPushRequiredRelayfileScopes(provider string) []string {
 	return []string{fmt.Sprintf("relayfile:fs:write:/%s/**", provider)}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2734,6 +2734,33 @@ func TestDelegatedBundleHasScopesAllowsBroadWildcardGrant(t *testing.T) {
 	}
 }
 
+func TestWritebackPushCredentialScopesAreProviderScoped(t *testing.T) {
+	joinScopes, relayfileScopes, err := writebackPushCredentialScopes("/linear/issues/123.json")
+	if err != nil {
+		t.Fatalf("writebackPushCredentialScopes failed: %v", err)
+	}
+	if got, want := strings.Join(joinScopes, ","), "fs:write:/linear/**,ops:read"; got != want {
+		t.Fatalf("join scopes = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(relayfileScopes, ","), "relayfile:fs:write:/linear/**"; got != want {
+		t.Fatalf("relayfile scopes = %q, want %q", got, want)
+	}
+}
+
+func TestWritebackPushCredentialScopesRejectGlobalFallbacks(t *testing.T) {
+	for _, remotePath := range []string{"", "/", "//", "////", "/./", "/**", "/*"} {
+		t.Run(remotePath, func(t *testing.T) {
+			joinScopes, relayfileScopes, err := writebackPushCredentialScopes(remotePath)
+			if err == nil {
+				t.Fatalf("expected provider-scoped path error, got join=%v relayfile=%v", joinScopes, relayfileScopes)
+			}
+			if strings.Join(joinScopes, ",") == "fs:write:/**,ops:read" || strings.Join(relayfileScopes, ",") == "relayfile:fs:write:/**" {
+				t.Fatalf("providerless path produced global writeback scopes: join=%v relayfile=%v", joinScopes, relayfileScopes)
+			}
+		})
+	}
+}
+
 func TestReadLocalMountCursorHealthAggregatesStateFiles(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, ".relayfile-mount-state.json"), []byte(`{"incrementalReadNotReadySince":{"a":"now"},"incrementalBacklogDraining":false}`), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- derive writeback delegated-token scopes from the provider segment only
- fail writeback push before credential bootstrap when the resolved remote path has no provider segment
- add regressions proving root/providerless and wildcard paths never produce `fs:write:/**` or `relayfile:fs:write:/**`

## Tests
- `go test ./cmd/relayfile-cli -run 'TestWritebackPushCredentialScopes|TestDelegatedBundleHasScopesAllowsBroadWildcardGrant|Test.*Writeback.*Scope|Test.*writeback|Test.*Delegated' -count=1`\n\n## Scope contract\nThis is caller-side part (b) for relayauth#55/#57: path-token callers request `relayfile:fs:write:/<provider>/**`, never the global `/**` fallback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

