### PR TITLE
Add `relayfile listen` — stream events, run a command per match

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,46 @@
 <p align="center">
-  <img src="assets/banner.png" alt="Relayfile — the integration filesystem for agents" width="900">
+  <img src="assets/banner.png" alt="Relayfile — reactive agents without the plumbing" width="900">
 </p>
 
-**The integration filesystem for agents.**
+**Reactive agents without the plumbing.**
 
-Mount Linear, Notion, GitHub, Slack, HubSpot, Salesforce, and the rest of your SaaS stack as a virtual filesystem. Every agent in your system reads them with `cat`, writes them by saving files, and coordinates through a real, ACL'd, real-time-synced filesystem. The mount can live anywhere — the SDK, CLI, and FUSE layer all let you choose where to expose it.
+A Linear issue lands in Triage. `relayfile listen` fires. Your agent reads `/linear/issues/ENG-123.md` — already synced, no API call — scans open triage items, finds an available assignee, and patches the issue by writing the file back. Event arrives, context is there, agent acts.
 
-LLMs are far better at reading files than calling typed tools — the file system is the most-trained-on API in existence. Relayfile leans on that instead of fighting it.
+That's the loop relayfile closes. Provider webhooks are normalized and delivered as file events. Your SaaS stack is a live filesystem the agent reads with `cat` and writes with file saves. No ingestion code. No per-provider API clients in the agent. No context window full of tool schemas.
+
+## The reactive loop
+
+```bash
+# Issue lands in Triage → agent reads context, assigns it, patches back
+relayfile listen --path "/linear/issues/by-state/triage/**" --event file.created \
+  --run "claude --print 'New issue at {{path}}. Read the file, check open triage items and available assignees, assign it.'"
+```
+
+When the event fires, `/linear/issues/ENG-123.md` is already there. So is `/linear/issues/by-state/triage/` (all open triage items), `/linear/users/` (who's available), `/linear/cycles/` (current sprint). The agent reads what it needs with `cat` and writes the result back — a file save, not an API call.
+
+Filter as deeply as the provider tree allows:
+
+```bash
+# PRs labeled needs-review on a specific repo
+relayfile listen --path "/github/repos/acme/api/pulls/by-label/needs-review/**" --event file.created \
+  --run "claude --print 'New PR at {{path}}. Read the diff context and write a review summary.'"
+
+# Deal moved to a new HubSpot stage
+relayfile listen --path "/hubspot/deals/**" --event file.updated \
+  --run "claude --print 'Deal updated at {{path}}. Draft a follow-up for the new stage.'"
+
+# New Shortcut story under a specific epic
+relayfile listen --path "/shortcut/stories/by-epic/payments/**" --event file.created \
+  --run "claude --print 'New payments story at {{path}}. Suggest an implementation plan.'"
+
+# Meeting notes → extract action items
+relayfile listen --provider granola --event file.created \
+  --run "claude --print 'New notes at {{path}}. Extract action items and owners.'"
+```
+
+Run in the foreground, detach with `--background`, or use `relayfile dev` for a zero-friction entry point that checks your auth and integration status first.
+
+## Read, write, coordinate
 
 ```bash
 $ ls mount/
@@ -15,395 +49,58 @@ github  linear  notion  slack
 $ cat mount/linear/issues/AGE-12.json
 { "identifier": "AGE-12", "title": "Fix login bug", "state": "Todo", ... }
 
-$ echo '{"description":"Updated by reviewer agent"}' \
-    > mount/linear/issues/AGE-12.json   # PATCH back to Linear
+$ echo '{"state":"In Review","description":"PR #42"}' > mount/linear/issues/AGE-12.json
+# ↑ PATCHes back to Linear
 
 $ grep -l '"state":"Todo"' mount/linear/issues/*.json
 ```
 
-That's the entire interface. No new SDK to learn, no MCP schemas eating your context window — just the bash and file-IO an agent already knows.
+Write-back is a file save on the same path the agent read from. No separate write API, no schema to learn.
 
-## Quick paths
+Multiple agents share the same mount. When agent A writes, agent B sees it within a second — no push, no merge. Reviewer agents watch implementer agents in real time. **The filesystem is the coordination protocol.**
 
-- **Hosted integrations:** `npx relayfile setup --provider notion --workspace research-room --local-dir ./relayfile-mount`
-- **Local OSS:** run the Docker stack below, then mount `ws_demo` as a normal directory.
-- **Sandbox SDK:** use `RelayfileSetup.ensureMountedWorkspace()` when your runtime already has a cloud access token.
-- **Programmatic agents:** wrap `RelayFileClient.readFile()` / `writeFile()` as one tool inside Vercel AI SDK, Claude Agent SDK, OpenAI Agents SDK, or any custom harness.
+Every provider tree has alias views for granular reads: `by-state/`, `by-label/`, `by-epic/`, `by-name/`, `by-id/`. Run `relayfile tree / --depth 3` to explore what's available for your connected providers.
 
-```ts
-import { RelayFileClient } from "@relayfile/sdk"
+## vs. MCP and webhook forwarders
 
-const files = new RelayFileClient({ token: process.env.RELAYFILE_TOKEN! })
+**vs. MCP.** MCP gives the agent a typed tool surface: `linear.search_issues(query)` returns what the API ranks, and each connected server loads schemas into the context window. Relayfile gives `ls /linear/issues/by-state/triage/` — exhaustive enumeration, zero schema overhead. The two compose: relayfile for reads and ambient context, MCP for typed writes that need server-side validation.
 
-// Use this as the body of a Vercel AI SDK tool, Claude SDK MCP tool,
-// OpenAI Agents SDK tool, or your own agent runtime callback.
-export async function readRelayfile(path: string) {
-  return files.readFile("rw_123", path)
-}
-```
+**vs. webhook forwarders** (Hookdeck, Svix). A forwarder delivers the event. It doesn't deliver the context. The agent still has to make API calls to understand what to do. Relayfile delivers both: the event fires, and the files were already there before it arrived.
 
-Common workflows:
+## Quick start
 
-- Read `/digests/yesterday.md`, then drill into `/github`, `/linear`, and `/notion` only when needed.
-- Create or patch provider records by writing JSON to canonical paths such as `/linear/issues/...`.
-- Give each worker only the paths it needs, e.g. read Notion and write Linear follow-ups.
-
-## Mount layout
-
-Every mount is self-describing. The agent never needs to learn paths from documentation — `cat mount/LAYOUT.md` lists everything, and per-integration `<integration>/.layout.md` files document tree shapes. Each directory holds an `_index.json` with the rows it contains, and entity files follow a `<sanitized-name>__<id>` naming convention so identifiers are recoverable from any filename.
-
-```
-mount/
-├── LAYOUT.md                              # virtual, read-only — top-level guide
-├── _index.json                            # root listing
-├── linear/
-│   ├── .layout.md                         # linear-specific tree shape
-│   ├── issues/
-│   │   ├── _index.json
-│   │   ├── AGE-12__fix-login-bug.json     # canonical: <slug>__<id>
-│   │   ├── by-title/AGE-12-fix-login-bug.json
-│   │   ├── by-id/AGE-12.json
-│   │   └── by-state/in-progress/AGE-12__fix-login-bug.json
-│   └── users/by-name/dana.json
-└── github/
-    └── repos/
-        ├── _index.json
-        ├── acme/api/
-        │   └── pulls/42__bump-deps/meta.json
-        └── by-name/acme__api.json
-```
-
-Four alias views ship out of the box: `by-title/` (slug lookups), `by-id/` (identifier lookups), `by-name/` (human-readable name lookups), and `by-state/` (grouped by issue/PR state). GitHub repo subtrees can be materialized lazily (opt-in via `--lazy-repos`) for huge-org workspaces.
-
-## Why files
-
-Three reasons:
-
-1. **Context efficiency.** A typical MCP setup loads 100+ tool schemas into every agent session before any work happens. Files load nothing — context cost is what the agent actually opens.
-2. **Completeness.** APIs return what their search ranks. `ls` returns what's there. For "what changed yesterday across these three integrations" type questions, exhaustive enumeration beats query-by-query retrieval.
-3. **Coordination.** Multiple agents working through the same filesystem can see each other's writes immediately, scoped by ACL. Multi-agent collaboration becomes a property of the substrate, not something each app re-implements.
-
-## Real-time multi-agent sync
-
-Most "filesystem for agents" projects assume one agent at a time. Relayfile assumes many.
-
-When agent A writes a file, agent B sees the new contents on the next read — within a second, no commit, no push, no merge. That's not polish; it's the difference between agents that *use* a filesystem and agents that *coordinate through* one.
-
-```
-# terminal 1: reviewer agent watching the ticket
-$ tail -F mount/linear/issues/AGE-12.json
-{ "title": "Fix login bug", "state": "Todo", ... }
-
-# terminal 2: implementer agent (writes after pushing the fix)
-$ echo '{"state":"In Review","description":"PR #42"}' \
-    > mount/linear/issues/AGE-12.json
-
-# terminal 1, ~half a second later — same file, new contents
-$ tail -F mount/linear/issues/AGE-12.json
-{ "title": "Fix login bug", "state": "In Review", ..., "description": "PR #42" }
-```
-
-Without write-through invalidation, this falls apart. Two agents on the same data either hit stale-read bugs (B reads a cached version after A wrote) or step on each other (last-write-wins, no notification). Some virtual-filesystem-for-agents projects have this as an open issue today; relayfile shipped it.
-
-This is what turns multi-agent collaboration into a property of the substrate instead of something every app has to reinvent. Reviewer agents watch implementer agents in real time. A persona-orchestrator agent watches workers' progress through their writes. None of that requires a coordination protocol on top of relayfile — **the filesystem is the protocol.**
-
-## React to events locally
-
-`relayfile listen` streams live file events from your workspace and runs a command for each one. Provider webhooks arrive normalized — you write the reaction, not the plumbing.
-
-Because every provider is a filesystem, `--path` can filter far below the provider level — by Linear status, GitHub label, Notion database, Slack channel, Asana project, and more:
+Fastest path — hosted, zero infrastructure:
 
 ```bash
-# New Linear issue → triage it
-relayfile listen --provider linear --event file.created \
-  --run "claude --print 'New issue at {{path}}. Suggest priority and owner.'"
-
-# Only issues that land in Triage state specifically
-relayfile listen --path "/linear/issues/by-state/triage/**" --event file.created \
-  --run "claude --print 'Untriaged issue at {{path}}. Assign priority, owner, and cycle.'"
-
-# New PR labeled needs-review on a specific repo
-relayfile listen --path "/github/repos/acme/api/pulls/by-label/needs-review/**" --event file.created \
-  --run "claude --print 'PR needs review at {{path}}. Summarise the diff and flag risks.'"
-
-# New message in a specific Slack incident channel
-relayfile listen --path "/slack/channels/incidents/**" --event file.created \
-  --run "claude --print 'New incident message at {{path}}. Draft a status-page update.'"
-
-# New Shortcut story under a specific epic
-relayfile listen --path "/shortcut/stories/by-epic/payments/**" --event file.created \
-  --run "claude --print 'New payments story at {{path}}. Suggest an implementation approach.'"
-
-# Fathom call recording → follow-up email
-relayfile listen --provider fathom --event file.created \
-  --run "claude --print 'New call at {{path}}. Write a follow-up with key decisions.'"
+npx relayfile setup --provider linear --workspace my-agent --local-dir ./mount
 ```
 
-`--run` supports `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, and `{{event}}` (full JSON). The alias views available in each provider tree (`by-state/`, `by-label/`, `by-epic/`, `by-name/`, …) are discoverable with `relayfile tree / --depth 3`. Run `relayfile help listen` for the full example set across all providers.
-
-No local daemon or FUSE mount is required — `relayfile listen` connects directly to Agent Relay Cloud via WebSocket.
-
-Run in the foreground, or detach:
+Local OSS:
 
 ```bash
-# Foreground (Ctrl+C to stop)
-relayfile listen --provider linear --event file.created --run "..."
-
-# Background — logs to ~/.relayfile/listen.log
-relayfile listen --provider linear --event file.created --run "..." --background
-
-# Zero-friction entry point: checks auth, prints status, then listens
-relayfile dev --provider linear --event file.created --run "..."
-```
-
-> **Cloud outbound delivery (coming soon):** push normalized events to any HTTPS endpoint with no local process required. Track [AgentWorkforce/relayfile-providers#cloud-webhooks](https://github.com/AgentWorkforce/relayfile-providers).
-
-> **Want this running headlessly for your whole team** — turning issues into reviewed PRs automatically?
-> See [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory).
-
-## What's in the box
-
-- **File-native reads.** `ls`, `cat`, `grep`, `find` — the agent's native vocabulary. No tool schemas in context.
-- **File-native writes.** PATCH a record by writing to its canonical path. CREATE by saving a draft filename. DELETE by removing the file. Per-resource schemas are discoverable in-tree (`<resource>/.schema.json`). See [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters).
-- **Per-agent ACLs.** Scope each agent's read/write surface via `.relayfile.acl`. Agents see only the paths they should — readonly on the rest of the tree.
-- **Real-time multi-agent sync.** Writes from one agent are visible to others on the next read. No commit/push/pull cycle, no merge.
-- **Real OS mount.** Native bash, native `find`/`grep`/`jq`/`rg`, no emulation gaps. Any process — agents, scripts, IDEs — can read or write the mount.
-- **Pluggable architecture.** A core file server plus [adapters](https://github.com/AgentWorkforce/relayfile-adapters) (per-integration logic) and [providers](https://github.com/AgentWorkforce/relayfile-providers) (auth/proxy via Nango, Composio, Pipedream). One provider integration unlocks tens of apps.
-- **`relayfile listen` / `relayfile dev`.** Stream live events and run a command per match. Foreground or `--background`. The local on-ramp to reactive agents.
-
-## Works with
-
-Anything that can read and write files works with relayfile out of the box — that's the point. Confirmed integration recipes ship for:
-
-| Framework | Recipe |
-|---|---|
-| Claude Code | [setting-up-relayfile skill](https://github.com/AgentWorkforce/skills/blob/main/skills/setting-up-relayfile/SKILL.md) |
-| Anything that runs `bash` | works out of the box (it's a real OS mount) |
-
-More framework recipes (Vercel AI SDK, OpenAI Agents SDK, LangGraph, Pydantic AI) are landing as part of [#106](https://github.com/AgentWorkforce/relayfile/issues/106).
-
-## How relayfile compares
-
-The "give agents a filesystem" idea is a healthy direction — relayfile isn't the only project pointing at it.
-
-**vs. MCP servers (Linear, Notion, Slack, GitHub, …).** MCP gives the agent a typed tool surface per integration. Strong for single, well-defined writes (`linear.create_issue(title, priority, …)` enforces the shape at call time). The cost is that each connected server loads tool schemas into the context window, and an LLM is more reliable reading a directory than juggling N typed APIs. Relayfile exposes the same integrations as paths you can `Read` / `Bash` / `Glob` — no schema overhead — with exhaustive enumeration where MCP returns API search results. The two compose well: relayfile for reads and synthesis, MCP for typed writes that need server-side validation.
-
-**vs. [Mirage](https://github.com/strukto-ai/mirage) and other virtual-filesystem-for-agents projects.** Mirage is doing thoughtful work in this space and it's worth a look. Their focus is **infrastructure and storage primitives** — S3, Postgres, Redis, GDrive, GCS, Mongo, SSH — mounted side-by-side as one tree. Relayfile's focus is **integrations** — the SaaS APIs where day-to-day agent work lives — with file-native writeback (PATCH / CREATE / DELETE through file ops), per-agent ACLs, real-time multi-agent sync, and a real OS mount you can put wherever fits your stack. Different scopes, both useful; pick the one your work lives in (or run both).
-
-**vs. rolling your own.** A single agent against a single backend can do fine with FUSE, Mountpoint, or direct SDK calls. Relayfile becomes worth it when you need multi-agent coordination, scoped capabilities, and a consistent read/write contract across many SaaS surfaces.
-
-## Run Locally
-
-Fastest path:
-
-```bash
-cd docker
-docker compose up --build
-```
-
-This starts:
-
-| Service | URL | Purpose |
-|---|---|---|
-| relayfile | `http://localhost:9090` | VFS API |
-| relayauth | `http://localhost:9091` | local dev token issuer |
-| seed | exits after setup | creates `ws_demo` sample files |
-
-Try the local API:
-
-```bash
+cd docker && docker compose up --build
 TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
-
-curl -H "Authorization: Bearer $TOKEN" \
-  -H "X-Correlation-Id: quickstart-tree" \
-  "http://localhost:9090/v1/workspaces/ws_demo/fs/tree?path=/"
-
-curl -H "Authorization: Bearer $TOKEN" \
-  -H "X-Correlation-Id: quickstart-read" \
-  "http://localhost:9090/v1/workspaces/ws_demo/fs/file?path=/docs/welcome.md"
-```
-
-Mount the workspace as ordinary local files:
-
-```bash
-cd ..
 RELAYFILE_TOKEN="$TOKEN" go run ./cmd/relayfile-mount \
-  --base-url http://localhost:9090 \
-  --workspace ws_demo \
-  --local-dir ./relayfile-mount
+  --base-url http://localhost:9090 --workspace ws_demo --local-dir ./mount
 ```
 
-Limit the daemon to one or more remote subtrees by repeating
-`--remote-path`. Each subtree is mirrored under the matching path inside
-`--local-dir`, which avoids full-workspace export pulls on large workspaces:
-
-```bash
-RELAYFILE_TOKEN="$TOKEN" go run ./cmd/relayfile-mount \
-  --base-url http://localhost:9090 \
-  --workspace ws_demo \
-  --local-dir ./relayfile-mount \
-  --remote-path /github \
-  --remote-path /slack/channels/proj-cloud
-```
-
-For long path lists, pass `--paths-file ./paths.json`; the file may be a JSON
-array of remote roots or a newline-separated list.
-
-Now any local tool or agent can use `./relayfile-mount` like a normal directory.
-
-## Running Evals
-
-Relayfile evals live under `evals/suites/*/cases.md` and compile to gitignored
-`cases.jsonl` files using the shared Agent Assistant human-eval harness.
-
-```bash
-npm run evals:list
-npm run evals -- --suite vfs-contracts
-npm run evals -- --suite provider-readiness
-npm run evals:offline
-```
-
-The default executor uses an isolated fixture-backed mount, so deterministic
-VFS, ACL, concurrency, and writeback cases run offline. Provider-backed or
-real-mount cases can opt into a configured mount with `RELAYFILE_MOUNT`,
-`RELAYFILE_WORKSPACE`, and `RELAYFILE_TOKEN`.
-
-To add a case, create a `## suite.case-id` block in a suite `cases.md` with
-`Message`, optional JSON `Mock`, JSON `Operations`, deterministic checks, and
-`Must` / `Must Not` reviewer notes. Run `npm run evals:compile` before running
-the suite.
-
-## Local Development Without Docker
-
-Start the local token issuer:
-
-```bash
-node docker/relayauth/server.js
-```
-
-In another terminal, start relayfile:
-
-```bash
-RELAYFILE_BACKEND_PROFILE=durable-local \
-RELAYFILE_DATA_DIR=.data \
-RELAYAUTH_JWKS_URL=http://127.0.0.1:9091/.well-known/jwks.json \
-go run ./cmd/relayfile
-```
-
-In a third terminal:
-
-```bash
-export RELAYFILE_WORKSPACE=ws_demo
-export RELAYFILE_TOKEN="$(./scripts/generate-dev-token.sh "$RELAYFILE_WORKSPACE")"
-
-go run ./cmd/relayfile-cli login \
-  --server http://127.0.0.1:8080 \
-  --token "$RELAYFILE_TOKEN"
-
-go run ./cmd/relayfile-cli seed "$RELAYFILE_WORKSPACE" ./examples
-go run ./cmd/relayfile-cli tree "$RELAYFILE_WORKSPACE" /
-go run ./cmd/relayfile-cli mount "$RELAYFILE_WORKSPACE" ./relayfile-mount --once
-```
+See [getting-started.md](docs/guides/getting-started.md) for the full local dev path and CLI reference.
 
 ## Ecosystem
 
-This repo is the file server and local mount layer. The wider Agent Relay file ecosystem also includes:
+This repo is the file server and mount layer.
 
-- [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters): maps provider webhooks and objects into relayfile paths, normalizes events, and defines writeback behavior.
-- [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers): handles provider auth, token lookup, API proxying, webhook subscriptions, and connection health.
+- [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters): webhook normalization, path mapping, writeback behavior per provider
+- [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers): provider auth, API proxy, webhook subscriptions, connection health
 
-Hosted Agent Relay runs these pieces for you. Fully self-hosted provider-backed files need relayfile plus the adapter and provider repos for the systems you expose.
+Hosted Agent Relay runs all of this for you. For end-to-end self-hosting, run relayfile plus the adapter and provider repos for the integrations you need.
 
-## Hosted Agent Relay
-
-If you want Notion, Slack, Linear, GitHub, or other provider-backed files without running any infrastructure, use hosted Agent Relay. Agent Relay Cloud runs the workspace, relayfile API, scoped auth, Nango OAuth, provider sync workers, and writeback workers for you.
-
-Use the [`setting-up-relayfile` skill](https://github.com/AgentWorkforce/skills/blob/main/skills/setting-up-relayfile/SKILL.md) when an agent should set up hosted files:
-
-```bash
-relayfile setup \
-  --provider notion \
-  --workspace my-agent \
-  --local-dir ./relayfile-mount \
-  --no-open
-```
-
-That command connects to `agentrelay.com`, creates or joins a cloud workspace, completes provider auth, waits for sync, and mounts the resulting files for the agent. The local directory is just the agent's file interface; the integration stack is hosted.
-
-Use the OSS repo when you want to run the file server yourself. Use hosted Agent Relay when you want the whole integration path managed:
-
-| Need | Local OSS | Hosted Agent Relay |
-|---|---:|---:|
-| Run relayfile locally | yes | no |
-| Mount files for an agent | yes | yes |
-| Provider OAuth | self-host provider auth | managed |
-| Provider sync/writeback | self-host workers | managed |
-| Nango | self-host for end-to-end OAuth | managed |
-
-For end-to-end self-hosting of provider-backed files, run relayfile, relayauth, the relevant [adapters](https://github.com/AgentWorkforce/relayfile-adapters), [providers](https://github.com/AgentWorkforce/relayfile-providers), and Nango. Relayfile itself does not store third-party OAuth credentials.
-
-### Mount a workspace from a sandbox (TypeScript SDK)
-
-Once a user has signed in and connected their providers in Agent Relay Cloud, a sandbox (Daytona, E2B, an ephemeral container, your own runtime) can attach the workspace as local files in a single SDK call:
-
-```ts
-import { RelayfileSetup } from "@relayfile/sdk"
-
-const setup = new RelayfileSetup({ accessToken })
-
-const handle = await setup.mountWorkspace({
-  workspaceId: "rw_…",
-  localDir: "/workspace",
-})
-
-// /workspace is now a live mount of the workspace
-console.log(handle.expiresAt)
-await handle.stop()
-```
-
-Use `ensureMountedWorkspace` when you also want provider-readiness gating in the same call:
-
-```ts
-const handle = await setup.ensureMountedWorkspace({
-  workspaceId: "rw_…",
-  provider: "notion",
-  verifyProvider: true,
-  localDir: "/workspace",
-})
-```
-
-`ensureMountedWorkspace` throws `ProviderNotConnectedError` when the provider isn't connected, and `ProviderNotReadyError({ provider, state, initialSyncState })` when the connection exists but isn't ready by `providerReadyTimeoutMs`. Pass `verifyProvider: false` to skip the probe.
-
-The handle exposes `ready`, `expiresAt`, `suggestedRefreshAt`, `env()`, `status()`, and `stop()`. The SDK supervises the local `relayfile-mount` process for you and only resolves once the mount is reachable.
-
-This is the programmatic sibling of the `relayfile setup` CLI above — same outcome (a workspace mounted at a local directory), different entry point. Use the CLI for human-driven setup; use the SDK from inside an already-authorized sandbox or agent runtime. Full details in [docs/guides/post-auth-mount-session.md](docs/guides/post-auth-mount-session.md).
-
-## Bring Existing Connections
-
-Relayfile tracks provider identity as `connectionId` metadata. The core OSS server can ingest events and queue writebacks with a `connectionId`, but the OAuth provider must be able to use that ID.
-
-Nango:
-
-- In your own self-hosted stack, point the Nango provider at your Nango host/secret and link the workspace to the existing `connectionId` and `providerConfigKey` before triggering sync.
-- Hosted `agentrelay.com` currently exposes the connect-session flow through the CLI, not a public import command for arbitrary existing Nango connections. If the connection is not in Agent Relay's Nango project, re-connect through the hosted flow or run your own Nango-backed stack.
-
-Composio:
-
-- Use your Composio API key and the existing connected account ID as the Relayfile `connectionId`.
-- The Composio provider can list/get connected accounts and proxy/write through that account.
-
-Pipedream:
-
-- Use your Pipedream Connect project credentials and the existing account ID as the Relayfile `connectionId`.
-- For proxy calls, also provide the external user ID through headers, query, or a resolver callback.
+> **Want this running headlessly for your whole team** — turning issues into reviewed PRs automatically?
+> See [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory).
 
 ## Docs
 
 - [Getting started](docs/guides/getting-started.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
-- [Post-auth mount session (SDK)](docs/guides/post-auth-mount-session.md)
-- [Adapters](https://github.com/AgentWorkforce/relayfile-adapters)
-- [Providers](https://github.com/AgentWorkforce/relayfile-providers)
 - [API reference](docs/api-reference.md)
-- [Docker quickstart](docker/README.md)
 - [OpenAPI spec](openapi/relayfile-v1.openapi.yaml)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Hosted Agent Relay runs all of this for you. For end-to-end self-hosting, run re
 ## Docs
 
 - [Getting started](docs/guides/getting-started.md)
+- [Self-hosted stack with n8n](docs/guides/self-hosted-n8n.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
 - [Pricing](docs/guides/pricing.md)
 - [API reference](docs/api-reference.md)

--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ relayfile listen --provider fathom --event file.created \
 
 `--run` supports `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, and `{{event}}` (full JSON). The alias views available in each provider tree (`by-state/`, `by-label/`, `by-epic/`, `by-name/`, …) are discoverable with `relayfile tree / --depth 3`. Run `relayfile help listen` for the full example set across all providers.
 
+No local daemon or FUSE mount is required — `relayfile listen` connects directly to Agent Relay Cloud via WebSocket.
+
+Run in the foreground, or detach:
+
+```bash
+# Foreground (Ctrl+C to stop)
+relayfile listen --provider linear --event file.created --run "..."
+
+# Background — logs to ~/.relayfile/listen.log
+relayfile listen --provider linear --event file.created --run "..." --background
+
+# Zero-friction entry point: checks auth, prints status, then listens
+relayfile dev --provider linear --event file.created --run "..."
+```
+
+> **Cloud outbound delivery (coming soon):** push normalized events to any HTTPS endpoint with no local process required. Track [AgentWorkforce/relayfile-providers#cloud-webhooks](https://github.com/AgentWorkforce/relayfile-providers).
+
 > **Want this running headlessly for your whole team** — turning issues into reviewed PRs automatically?
 > See [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory).
 
@@ -152,7 +169,7 @@ relayfile listen --provider fathom --event file.created \
 - **Real-time multi-agent sync.** Writes from one agent are visible to others on the next read. No commit/push/pull cycle, no merge.
 - **Real OS mount.** Native bash, native `find`/`grep`/`jq`/`rg`, no emulation gaps. Any process — agents, scripts, IDEs — can read or write the mount.
 - **Pluggable architecture.** A core file server plus [adapters](https://github.com/AgentWorkforce/relayfile-adapters) (per-integration logic) and [providers](https://github.com/AgentWorkforce/relayfile-providers) (auth/proxy via Nango, Composio, Pipedream). One provider integration unlocks tens of apps.
-- **`relayfile listen`.** Stream live events and run a command per match. The local on-ramp to reactive agents.
+- **`relayfile listen` / `relayfile dev`.** Stream live events and run a command per match. Foreground or `--background`. The local on-ramp to reactive agents.
 
 ## Works with
 

--- a/README.md
+++ b/README.md
@@ -125,5 +125,6 @@ Hosted Agent Relay runs all of this for you. For end-to-end self-hosting, run re
 
 - [Getting started](docs/guides/getting-started.md)
 - [Cloud integration](docs/guides/cloud-integration.md)
+- [Pricing](docs/guides/pricing.md)
 - [API reference](docs/api-reference.md)
 - [OpenAPI spec](openapi/relayfile-v1.openapi.yaml)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Every provider tree has alias views for granular reads: `by-state/`, `by-label/`
 
 **vs. MCP.** MCP gives the agent a typed tool surface: `linear.search_issues(query)` returns what the API ranks, and each connected server loads schemas into the context window. Relayfile gives `ls /linear/issues/by-state/triage/` — exhaustive enumeration, zero schema overhead. The two compose: relayfile for reads and ambient context, MCP for typed writes that need server-side validation.
 
-**vs. webhook forwarders** (Hookdeck, Svix). A forwarder delivers the event. It doesn't deliver the context. The agent still has to make API calls to understand what to do. Relayfile delivers both: the event fires, and the files were already there before it arrived.
+**vs. webhook forwarders** (Hookdeck, Svix). A raw webhook is a diff without context — it tells you something changed, not what the full state is. A forwarder delivers the notification; your agent still has to make API calls to understand what to do. Relayfile materializes the event: the webhook arrives, the file updates, and by the time your `--run` command fires the full record is already on disk. So are the sprint, the assignees, and every related record — materialized by previous webhooks. The agent wakes up into a complete world, not a notification.
 
 ## Cloud agents (SDK)
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,33 @@ Without write-through invalidation, this falls apart. Two agents on the same dat
 
 This is what turns multi-agent collaboration into a property of the substrate instead of something every app has to reinvent. Reviewer agents watch implementer agents in real time. A persona-orchestrator agent watches workers' progress through their writes. None of that requires a coordination protocol on top of relayfile — **the filesystem is the protocol.**
 
+## React to events locally
+
+`relayfile listen` streams live file events from your workspace and runs a command for each one. Provider webhooks arrive normalized — you write the reaction, not the plumbing.
+
+```bash
+# Wake Claude when a new Linear issue is filed
+relayfile listen --provider linear --event file.created \
+  --run "claude --print 'New issue at {{path}}. Read it and suggest a priority and owner.'"
+
+# Extract action items when Granola adds new meeting notes
+relayfile listen --provider granola --event file.created \
+  --run "claude --print 'New meeting notes at {{path}}. Extract action items and owners.'"
+
+# Draft follow-up emails from Fathom call recordings
+relayfile listen --provider fathom --event file.created \
+  --run "claude --print 'New call at {{path}}. Write a follow-up with key decisions.'"
+
+# New HubSpot contact → personalised first-touch email
+relayfile listen --provider hubspot --event file.created \
+  --run "claude --print 'New contact at {{path}}. Draft a personalised intro email.'"
+```
+
+`--run` supports `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, and `{{event}}` (full JSON). Works with Notion, Asana, Shortcut, HubSpot, Granola, Fathom, and every other connected provider. Run `relayfile help listen` for the full example set.
+
+> **Want this running headlessly for your whole team** — turning issues into reviewed PRs automatically?
+> See [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory).
+
 ## What's in the box
 
 - **File-native reads.** `ls`, `cat`, `grep`, `find` — the agent's native vocabulary. No tool schemas in context.
@@ -115,6 +142,7 @@ This is what turns multi-agent collaboration into a property of the substrate in
 - **Real-time multi-agent sync.** Writes from one agent are visible to others on the next read. No commit/push/pull cycle, no merge.
 - **Real OS mount.** Native bash, native `find`/`grep`/`jq`/`rg`, no emulation gaps. Any process — agents, scripts, IDEs — can read or write the mount.
 - **Pluggable architecture.** A core file server plus [adapters](https://github.com/AgentWorkforce/relayfile-adapters) (per-integration logic) and [providers](https://github.com/AgentWorkforce/relayfile-providers) (auth/proxy via Nango, Composio, Pipedream). One provider integration unlocks tens of apps.
+- **`relayfile listen`.** Stream live events and run a command per match. The local on-ramp to reactive agents.
 
 ## Works with
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ Every provider tree has alias views for granular reads: `by-state/`, `by-label/`
 
 **vs. webhook forwarders** (Hookdeck, Svix). A forwarder delivers the event. It doesn't deliver the context. The agent still has to make API calls to understand what to do. Relayfile delivers both: the event fires, and the files were already there before it arrived.
 
+## Cloud agents (SDK)
+
+For agents running in a sandbox — E2B, Daytona, an ephemeral container, your own runtime — the TypeScript SDK mounts the workspace as local files in one call. The agent gets `ls`, `cat`, `grep` against live provider data; no manual setup, no separate auth flow.
+
+```ts
+import { RelayfileSetup } from "@relayfile/sdk"
+
+const setup = new RelayfileSetup({ accessToken })
+
+// Mount and wait for the provider to be ready before the agent starts.
+const handle = await setup.ensureMountedWorkspace({
+  workspaceId: "rw_…",
+  provider: "notion",
+  localDir: "/workspace",
+})
+
+// /workspace is now a live, writable mount of the workspace.
+// The agent reads with cat/ls/grep and writes back by saving files.
+await handle.stop()
+```
+
+`ensureMountedWorkspace` throws `ProviderNotConnectedError` if the provider isn't connected and `ProviderNotReadyError` if the initial sync hasn't finished. Pass `verifyProvider: false` to skip the probe. Full details in [docs/guides/post-auth-mount-session.md](docs/guides/post-auth-mount-session.md).
+
 ## Quick start
 
 Fastest path — hosted, zero infrastructure:

--- a/README.md
+++ b/README.md
@@ -111,25 +111,35 @@ This is what turns multi-agent collaboration into a property of the substrate in
 
 `relayfile listen` streams live file events from your workspace and runs a command for each one. Provider webhooks arrive normalized — you write the reaction, not the plumbing.
 
+Because every provider is a filesystem, `--path` can filter far below the provider level — by Linear status, GitHub label, Notion database, Slack channel, Asana project, and more:
+
 ```bash
-# Wake Claude when a new Linear issue is filed
+# New Linear issue → triage it
 relayfile listen --provider linear --event file.created \
-  --run "claude --print 'New issue at {{path}}. Read it and suggest a priority and owner.'"
+  --run "claude --print 'New issue at {{path}}. Suggest priority and owner.'"
 
-# Extract action items when Granola adds new meeting notes
-relayfile listen --provider granola --event file.created \
-  --run "claude --print 'New meeting notes at {{path}}. Extract action items and owners.'"
+# Only issues that land in Triage state specifically
+relayfile listen --path "/linear/issues/by-state/triage/**" --event file.created \
+  --run "claude --print 'Untriaged issue at {{path}}. Assign priority, owner, and cycle.'"
 
-# Draft follow-up emails from Fathom call recordings
+# New PR labeled needs-review on a specific repo
+relayfile listen --path "/github/repos/acme/api/pulls/by-label/needs-review/**" --event file.created \
+  --run "claude --print 'PR needs review at {{path}}. Summarise the diff and flag risks.'"
+
+# New message in a specific Slack incident channel
+relayfile listen --path "/slack/channels/incidents/**" --event file.created \
+  --run "claude --print 'New incident message at {{path}}. Draft a status-page update.'"
+
+# New Shortcut story under a specific epic
+relayfile listen --path "/shortcut/stories/by-epic/payments/**" --event file.created \
+  --run "claude --print 'New payments story at {{path}}. Suggest an implementation approach.'"
+
+# Fathom call recording → follow-up email
 relayfile listen --provider fathom --event file.created \
   --run "claude --print 'New call at {{path}}. Write a follow-up with key decisions.'"
-
-# New HubSpot contact → personalised first-touch email
-relayfile listen --provider hubspot --event file.created \
-  --run "claude --print 'New contact at {{path}}. Draft a personalised intro email.'"
 ```
 
-`--run` supports `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, and `{{event}}` (full JSON). Works with Notion, Asana, Shortcut, HubSpot, Granola, Fathom, and every other connected provider. Run `relayfile help listen` for the full example set.
+`--run` supports `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, and `{{event}}` (full JSON). The alias views available in each provider tree (`by-state/`, `by-label/`, `by-epic/`, `by-name/`, …) are discoverable with `relayfile tree / --depth 3`. Run `relayfile help listen` for the full example set across all providers.
 
 > **Want this running headlessly for your whole team** — turning issues into reviewed PRs automatically?
 > See [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory).

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -549,6 +549,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runListen(args[1:], stdout)
 	case "dev":
 		return runDev(args[1:], nil, stdout)
+	case "supervisor":
+		return runSupervisor(args[1:], stdout)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -623,6 +625,8 @@ func printHelpForArgs(args []string, stdout io.Writer) {
 		printListenUsage(stdout)
 	case "dev":
 		printListenUsage(stdout)
+	case "supervisor":
+		printSupervisorUsage(stdout)
 	case "help":
 		printUsage(stdout)
 	default:
@@ -786,6 +790,9 @@ Usage:
   relayfile observer [WORKSPACE] [--no-open]
   relayfile listen [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD] [--background]
   relayfile dev [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD]
+  relayfile supervisor install [LISTEN_FLAGS...]
+  relayfile supervisor uninstall
+  relayfile supervisor status
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
@@ -818,7 +825,8 @@ Subcommands:
   logs        Print the background mount log
   observer    Open the hosted file observer for a workspace
   listen      Stream live file events from a workspace; run a command per event with --run
-  dev         Zero-friction entry point: checks auth and status, then streams events (alias for listen with friendly onboarding)`)
+  dev         Zero-friction entry point: checks auth and status, then streams events (alias for listen with friendly onboarding)
+  supervisor  Install, uninstall, or check status of the listen daemon as a system service (systemd on Linux, launchd on macOS)`)
 }
 
 func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
@@ -5938,6 +5946,292 @@ func listenExpandTemplate(tmpl string, evt listenEvent, raw json.RawMessage) str
 		"{{revision}}", evt.Revision,
 		"{{event}}", string(raw),
 	).Replace(tmpl)
+}
+
+func printSupervisorUsage(w io.Writer) {
+	fmt.Fprintln(w, `relayfile supervisor manages the listen daemon as a system service.
+
+On Linux  it writes a systemd user unit (~/.config/systemd/user/relayfile-listen.service).
+On macOS  it writes a launchd agent  (~/Library/LaunchAgents/com.relayfile.listen.plist).
+
+Usage:
+  relayfile supervisor install [LISTEN_FLAGS...]   install and start the service
+  relayfile supervisor uninstall                   stop, disable, and remove the service
+  relayfile supervisor status                      show service status
+
+Examples:
+
+  # Install: react to every new Linear triage issue
+  relayfile supervisor install \
+    --path "/linear/issues/by-state/triage/**" --event file.created \
+    --run "claude --print 'New triage issue at {{path}}. Assign it.'"
+
+  # Install: all Linear events, background agent
+  relayfile supervisor install --provider linear --run "my-agent --event '{{event}}'"
+
+  relayfile supervisor status
+  relayfile supervisor uninstall
+
+All flags accepted by 'relayfile listen' are accepted here and are embedded
+verbatim into the unit file. The service restarts automatically on failure.`)
+}
+
+const (
+	supervisorServiceName  = "relayfile-listen"
+	supervisorLaunchdLabel = "com.relayfile.listen"
+)
+
+func supervisorSystemdUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user", supervisorServiceName+".service"), nil
+}
+
+func supervisorLaunchdPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", supervisorLaunchdLabel+".plist"), nil
+}
+
+func runSupervisor(args []string, stdout io.Writer) error {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSupervisorUsage(stdout)
+		return nil
+	}
+	sub := args[0]
+	rest := args[1:]
+	switch sub {
+	case "install":
+		return supervisorInstall(rest, stdout)
+	case "uninstall", "remove":
+		return supervisorUninstall(stdout)
+	case "status":
+		return supervisorStatus(stdout)
+	default:
+		printSupervisorUsage(stdout)
+		return fmt.Errorf("unknown supervisor subcommand %q", sub)
+	}
+}
+
+func supervisorInstall(listenArgs []string, stdout io.Writer) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate relayfile binary: %w", err)
+	}
+	logFile := listenLogFile()
+
+	switch runtime.GOOS {
+	case "linux":
+		return supervisorInstallSystemd(executable, listenArgs, logFile, stdout)
+	case "darwin":
+		return supervisorInstallLaunchd(executable, listenArgs, logFile, stdout)
+	default:
+		return fmt.Errorf("supervisor install is not supported on %s; run 'relayfile listen --background' instead", runtime.GOOS)
+	}
+}
+
+func supervisorInstallSystemd(executable string, listenArgs []string, logFile string, stdout io.Writer) error {
+	unitPath, err := supervisorSystemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		return fmt.Errorf("create systemd user unit dir: %w", err)
+	}
+
+	// Build ExecStart line: quote args that contain spaces or special chars.
+	execArgs := []string{executable, "listen"}
+	execArgs = append(execArgs, listenArgs...)
+	execStart := shelljoin(execArgs)
+
+	unit := fmt.Sprintf(`[Unit]
+Description=Relayfile listen — reactive agent event stream
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%s
+Restart=on-failure
+RestartSec=5s
+StandardOutput=append:%s
+StandardError=append:%s
+
+[Install]
+WantedBy=default.target
+`, execStart, logFile, logFile)
+
+	if err := os.WriteFile(unitPath, []byte(unit), 0o644); err != nil {
+		return fmt.Errorf("write unit file: %w", err)
+	}
+	fmt.Fprintf(stdout, "Wrote %s\n", unitPath)
+
+	for _, args := range [][]string{
+		{"--user", "daemon-reload"},
+		{"--user", "enable", "--now", supervisorServiceName},
+	} {
+		cmd := exec.Command("systemctl", args...)
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("systemctl %s: %w", strings.Join(args, " "), err)
+		}
+	}
+	fmt.Fprintf(stdout, "\nService started. Logs: %s\n", logFile)
+	fmt.Fprintf(stdout, "Status: systemctl --user status %s\n", supervisorServiceName)
+	return nil
+}
+
+func supervisorInstallLaunchd(executable string, listenArgs []string, logFile string, stdout io.Writer) error {
+	plistPath, err := supervisorLaunchdPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		return fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+
+	// Build <array> of <string> elements for ProgramArguments.
+	programArgs := append([]string{executable, "listen"}, listenArgs...)
+	var argElems strings.Builder
+	for _, a := range programArgs {
+		argElems.WriteString("\t\t<string>")
+		argElems.WriteString(plistEscapeXML(a))
+		argElems.WriteString("</string>\n")
+	}
+
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>%s</string>
+	<key>ProgramArguments</key>
+	<array>
+%s	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>%s</string>
+	<key>StandardErrorPath</key>
+	<string>%s</string>
+</dict>
+</plist>
+`, supervisorLaunchdLabel, argElems.String(), plistEscapeXML(logFile), plistEscapeXML(logFile))
+
+	if err := os.WriteFile(plistPath, []byte(plist), 0o644); err != nil {
+		return fmt.Errorf("write plist: %w", err)
+	}
+	fmt.Fprintf(stdout, "Wrote %s\n", plistPath)
+
+	// Unload first in case an old version is loaded.
+	unload := exec.Command("launchctl", "unload", "-w", plistPath)
+	_ = unload.Run()
+
+	load := exec.Command("launchctl", "load", "-w", plistPath)
+	load.Stdout = stdout
+	load.Stderr = os.Stderr
+	if err := load.Run(); err != nil {
+		return fmt.Errorf("launchctl load: %w", err)
+	}
+	fmt.Fprintf(stdout, "\nService started. Logs: %s\n", logFile)
+	fmt.Fprintf(stdout, "Status: launchctl list %s\n", supervisorLaunchdLabel)
+	return nil
+}
+
+func supervisorUninstall(stdout io.Writer) error {
+	switch runtime.GOOS {
+	case "linux":
+		return supervisorUninstallSystemd(stdout)
+	case "darwin":
+		return supervisorUninstallLaunchd(stdout)
+	default:
+		return fmt.Errorf("supervisor uninstall is not supported on %s", runtime.GOOS)
+	}
+}
+
+func supervisorUninstallSystemd(stdout io.Writer) error {
+	for _, args := range [][]string{
+		{"--user", "disable", "--now", supervisorServiceName},
+	} {
+		cmd := exec.Command("systemctl", args...)
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+		_ = cmd.Run() // best-effort; unit may not be loaded
+	}
+	unitPath, err := supervisorSystemdUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove unit file: %w", err)
+	}
+	exec.Command("systemctl", "--user", "daemon-reload").Run() //nolint
+	fmt.Fprintln(stdout, "Service stopped and removed.")
+	return nil
+}
+
+func supervisorUninstallLaunchd(stdout io.Writer) error {
+	plistPath, err := supervisorLaunchdPlistPath()
+	if err != nil {
+		return err
+	}
+	unload := exec.Command("launchctl", "unload", "-w", plistPath)
+	unload.Stdout = stdout
+	unload.Stderr = os.Stderr
+	_ = unload.Run() // best-effort
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plist: %w", err)
+	}
+	fmt.Fprintln(stdout, "Service stopped and removed.")
+	return nil
+}
+
+func supervisorStatus(stdout io.Writer) error {
+	switch runtime.GOOS {
+	case "linux":
+		cmd := exec.Command("systemctl", "--user", "status", supervisorServiceName)
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+		_ = cmd.Run()
+	case "darwin":
+		cmd := exec.Command("launchctl", "list", supervisorLaunchdLabel)
+		cmd.Stdout = stdout
+		cmd.Stderr = os.Stderr
+		_ = cmd.Run()
+	default:
+		fmt.Fprintf(stdout, "supervisor status is not supported on %s\n", runtime.GOOS)
+	}
+	return nil
+}
+
+// shelljoin builds a shell-safe ExecStart string by quoting arguments that
+// contain spaces or shell metacharacters.
+func shelljoin(args []string) string {
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		if strings.ContainsAny(a, " \t\"'\\$`{}[]|&;<>()#~!") {
+			a = "\"" + strings.ReplaceAll(a, "\"", "\\\"") + "\""
+		}
+		quoted[i] = a
+	}
+	return strings.Join(quoted, " ")
+}
+
+// plistEscapeXML escapes the five XML entities that can appear in plist string values.
+func plistEscapeXML(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&apos;")
+	return s
 }
 
 func runTree(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -5576,7 +5576,9 @@ Usage:
 Flags:
   --provider PROVIDER  filter to a specific integration (linear, notion, hubspot, …)
                        shorthand for --path /PROVIDER/**
-  --path GLOB          glob path filter, e.g. /linear/issues/** or /notion/pages/*
+  --path GLOB          glob path filter. The workspace tree has alias views that let
+                       you filter far below the provider level — by status, label,
+                       project, channel, and more. See examples below.
   --event TYPE         filter by event type: file.created, file.updated, file.deleted
                        (default: all types)
   --run CMD            shell command to execute per matching event.
@@ -5589,40 +5591,85 @@ Examples:
   # Stream all events from the default workspace
   relayfile listen
 
-  # Watch Linear for new issues and let Claude triage them
+  # --- Linear ---
+
+  # New issue filed anywhere in Linear
   relayfile listen --provider linear --event file.created \
-    --run "claude --print 'A new Linear issue was filed. Read {{path}} and suggest a priority and owner.'"
+    --run "claude --print 'New Linear issue at {{path}}. Suggest a priority and owner.'"
 
-  # Watch Notion for any page edits
+  # New issue filed, but only when it lands in the Triage state
+  relayfile listen --path "/linear/issues/by-state/triage/**" --event file.created \
+    --run "claude --print 'Untriaged issue at {{path}}. Assign priority, owner, and cycle.'"
+
+  # Any In Progress issue updated (catch status changes, description edits, etc.)
+  relayfile listen --path "/linear/issues/by-state/in-progress/**" --event file.updated \
+    --run "claude --print 'In-progress issue changed at {{path}}. Check for blockers.'"
+
+  # --- GitHub ---
+
+  # New PR opened on any repo in the org
+  relayfile listen --path "/github/repos/**/pulls/**" --event file.created \
+    --run "claude --print 'New PR at {{path}}. Write a one-paragraph review summary.'"
+
+  # New PR labeled needs-review on a specific repo
+  relayfile listen --path "/github/repos/acme/api/pulls/by-label/needs-review/**" --event file.created \
+    --run "claude --print 'PR needs review at {{path}}. Summarise the diff and flag risks.'"
+
+  # --- Notion ---
+
+  # Any page edited across the whole workspace
   relayfile listen --provider notion --event file.updated \
-    --run "claude --print 'A Notion page changed at {{path}}. Summarise what likely changed.'"
+    --run "claude --print 'Notion page changed at {{path}}. Summarise the update.'"
 
-  # Watch HubSpot for new contacts and draft outreach
-  relayfile listen --provider hubspot --event file.created \
-    --run "claude --print 'New HubSpot contact at {{path}}. Draft a personalised first-touch email.'"
+  # Edits only inside a specific Notion database
+  relayfile listen --path "/notion/databases/roadmap/**" --event file.updated \
+    --run "claude --print 'Roadmap item changed at {{path}}. Send a Slack digest.'"
 
-  # Watch Asana for new tasks
-  relayfile listen --provider asana --event file.created \
-    --run "claude --print 'New Asana task at {{path}}. Break it into subtasks and estimate effort.'"
+  # --- Slack ---
 
-  # Watch Shortcut for new stories
-  relayfile listen --provider shortcut --event file.created \
-    --run "claude --print 'New Shortcut story at {{path}}. Suggest an implementation approach.'"
+  # New message in a specific channel
+  relayfile listen --path "/slack/channels/incidents/**" --event file.created \
+    --run "claude --print 'New incident message at {{path}}. Draft a status-page update.'"
 
-  # Watch Granola for new meeting notes and extract action items
+  # --- HubSpot ---
+
+  # New contact created
+  relayfile listen --path "/hubspot/contacts/**" --event file.created \
+    --run "claude --print 'New HubSpot contact at {{path}}. Draft a personalised intro email.'"
+
+  # Deal moved to a new stage
+  relayfile listen --path "/hubspot/deals/**" --event file.updated \
+    --run "claude --print 'Deal updated at {{path}}. Draft a follow-up for the new stage.'"
+
+  # --- Asana ---
+
+  # New task in a specific project
+  relayfile listen --path "/asana/projects/q3-launch/**" --event file.created \
+    --run "claude --print 'New task in Q3 launch at {{path}}. Break it into subtasks.'"
+
+  # --- Shortcut ---
+
+  # New story under a specific epic
+  relayfile listen --path "/shortcut/stories/by-epic/payments/**" --event file.created \
+    --run "claude --print 'New payments story at {{path}}. Suggest an implementation approach.'"
+
+  # --- Granola / Fathom ---
+
+  # New meeting notes → extract action items
   relayfile listen --provider granola --event file.created \
     --run "claude --print 'New meeting notes at {{path}}. Extract action items and owners.'"
 
-  # Watch Fathom for new call recordings and send a follow-up summary
+  # New Fathom call recording → follow-up email
   relayfile listen --provider fathom --event file.created \
-    --run "claude --print 'New Fathom call at {{path}}. Write a follow-up email with key decisions.'"
+    --run "claude --print 'New call at {{path}}. Write a follow-up email with key decisions.'"
 
-  # Print raw JSON for scripting
+  # --- Scripting ---
+
+  # Print raw JSON events for piping
   relayfile listen --provider linear --format json | jq '.path'
 
-  # Explicit path glob instead of --provider
-  relayfile listen --path "/linear/issues/**" --event file.created \
-    --run "claude --print 'New issue at {{path}}.'"
+The workspace tree has alias views (by-state/, by-label/, by-epic/, by-name/, by-id/, …)
+for every provider. Run 'relayfile tree / --depth 3' to explore what's available.
 
 Want this running headlessly for your whole team — turning issues into reviewed PRs automatically?
 See https://github.com/AgentWorkforce/factory`)

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -547,6 +547,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runObserver(args[1:], stdout)
 	case "listen", "watch":
 		return runListen(args[1:], stdout)
+	case "dev":
+		return runDev(args[1:], nil, stdout)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -618,6 +620,8 @@ func printHelpForArgs(args []string, stdout io.Writer) {
 	case "observer":
 		fmt.Fprintln(stdout, "Usage: relayfile observer [WORKSPACE] [--no-open]")
 	case "listen", "watch":
+		printListenUsage(stdout)
+	case "dev":
 		printListenUsage(stdout)
 	case "help":
 		printUsage(stdout)
@@ -780,7 +784,8 @@ Usage:
   relayfile status [WORKSPACE]
   relayfile logs [WORKSPACE]
   relayfile observer [WORKSPACE] [--no-open]
-  relayfile listen [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD]
+  relayfile listen [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD] [--background]
+  relayfile dev [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD]
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
@@ -812,7 +817,8 @@ Subcommands:
   status      Show sync status and local mirror state for a workspace
   logs        Print the background mount log
   observer    Open the hosted file observer for a workspace
-  listen      Stream live file events from a workspace; run a command per event with --run`)
+  listen      Stream live file events from a workspace; run a command per event with --run
+  dev         Zero-friction entry point: checks auth and status, then streams events (alias for listen with friendly onboarding)`)
 }
 
 func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
@@ -5675,6 +5681,44 @@ Want this running headlessly for your whole team — turning issues into reviewe
 See https://github.com/AgentWorkforce/factory`)
 }
 
+// runDev is the zero-friction entry point for reactive local agents.
+// It checks credentials and integration status, prints a status header,
+// then hands off to the listen loop.
+func runDev(args []string, stdin io.Reader, stdout io.Writer) error {
+	// Peek at flags without consuming them — runListen re-parses the same slice.
+	peek := flag.NewFlagSet("dev-peek", flag.ContinueOnError)
+	peek.SetOutput(io.Discard)
+	serverPeek := peek.String("server", "", "")
+	tokenPeek := peek.String("token", "", "")
+	providerPeek := peek.String("provider", "", "")
+	_ = peek.Parse(normalizeFlagArgs(args, map[string]bool{
+		"server": true, "token": true, "provider": true,
+		"path": true, "event": true, "run": true, "format": true,
+		"background": false, "daemonized": false,
+	}))
+
+	commandClient, err := prepareWorkspaceCommandClient("", *serverPeek, *tokenPeek, defaultInspectScopes)
+	if err != nil {
+		provider := strings.TrimSpace(*providerPeek)
+		if provider == "" {
+			provider = "linear"
+		}
+		fmt.Fprintln(stdout, "Not connected to Agent Relay. Get started with:")
+		fmt.Fprintf(stdout, "\n  relayfile setup --provider %s\n\n", provider)
+		fmt.Fprintln(stdout, "Then re-run: relayfile dev "+strings.Join(args, " "))
+		return err
+	}
+
+	fmt.Fprintf(stdout, "Workspace: %s\n", commandClient.workspaceID)
+	if p := strings.TrimSpace(*providerPeek); p != "" {
+		fmt.Fprintf(stdout, "Provider filter: %s\n", p)
+		fmt.Fprintf(stdout, "Tip: run 'relayfile integration list' to see connected providers.\n")
+	}
+	fmt.Fprintln(stdout)
+
+	return runListen(args, stdout)
+}
+
 func runListen(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("listen", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -5685,14 +5729,18 @@ func runListen(args []string, stdout io.Writer) error {
 	eventFlag := fs.String("event", "", "event type filter: file.created, file.updated, file.deleted")
 	runFlag := fs.String("run", "", "shell command per event; supports {{path}}, {{type}}, {{provider}}, {{revision}}, {{event}}")
 	formatFlag := fs.String("format", "text", "output format when --run is not set: text or json")
+	background := fs.Bool("background", false, "run in background; logs to ~/.relayfile/listen.log")
+	daemonized := fs.Bool("daemonized", false, "internal flag used by relayfile listen --background")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"server":   true,
-		"token":    true,
-		"provider": true,
-		"path":     true,
-		"event":    true,
-		"run":      true,
-		"format":   true,
+		"server":     true,
+		"token":      true,
+		"provider":   true,
+		"path":       true,
+		"event":      true,
+		"run":        true,
+		"format":     true,
+		"background": false,
+		"daemonized": false,
 	})); err != nil {
 		return err
 	}
@@ -5701,12 +5749,25 @@ func runListen(args []string, stdout io.Writer) error {
 		workspaceValue = strings.TrimSpace(fs.Arg(0))
 	}
 
+	if *background && !*daemonized {
+		logFile := listenLogFile()
+		pidFile := listenPIDFile()
+		return spawnBackgroundListenProcess(args, pidFile, logFile)
+	}
+	if *daemonized {
+		if err := rotateLogFile(listenLogFile()); err != nil {
+			return err
+		}
+	}
+
 	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
 	if err != nil {
 		return err
 	}
 
 	// Build WebSocket URL from the HTTP base URL.
+	// relayfile listen connects directly to Agent Relay Cloud — no local
+	// daemon or FUSE mount is required.
 	base, err := url.Parse(strings.TrimRight(commandClient.client.baseURL, "/"))
 	if err != nil {
 		return fmt.Errorf("invalid server URL: %w", err)
@@ -5756,12 +5817,15 @@ func runListen(args []string, stdout io.Writer) error {
 	if typeFilter != "" {
 		label += " (" + typeFilter + ")"
 	}
-	fmt.Fprintf(stdout, "Listening on %s — Ctrl+C to stop\n", label)
-	if runCmd == "" && format == "text" {
-		fmt.Fprintln(stdout, "Tip: pass --run to execute a command per event.")
-		fmt.Fprintln(stdout, "     See 'relayfile help listen' for examples with Linear, Notion, HubSpot, and more.")
+	if !*daemonized {
+		fmt.Fprintf(stdout, "Listening on %s — Ctrl+C to stop\n", label)
+		if runCmd == "" && format == "text" {
+			fmt.Fprintln(stdout, "Tip: pass --run to execute a command per event.")
+			fmt.Fprintln(stdout, "     See 'relayfile help listen' for examples with Linear, Notion, HubSpot, and more.")
+			fmt.Fprintln(stdout, "     Add --background to detach; 'relayfile supervisor install --listen' to survive reboots.")
+		}
+		fmt.Fprintln(stdout)
 	}
-	fmt.Fprintln(stdout)
 
 	for {
 		var raw json.RawMessage
@@ -5817,6 +5881,53 @@ func runListen(args []string, stdout io.Writer) error {
 			fmt.Fprintf(stdout, "%-20s  %-30s  %s\n", evt.Type, evt.Path, ts)
 		}
 	}
+}
+
+func listenPIDFile() string {
+	return filepath.Join(configDir(), "listen.pid")
+}
+
+func listenLogFile() string {
+	return filepath.Join(configDir(), "listen.log")
+}
+
+func spawnBackgroundListenProcess(originalArgs []string, pidFile, logFile string) error {
+	if err := rotateLogFile(logFile); err != nil {
+		return err
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	filtered := make([]string, 0, len(originalArgs))
+	for _, arg := range originalArgs {
+		if arg == "--background" || arg == "-background" ||
+			strings.HasPrefix(arg, "--background=") || strings.HasPrefix(arg, "-background=") {
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+	childArgs := append([]string{"listen"}, filtered...)
+	childArgs = append(childArgs, "--daemonized", "--pid-file", pidFile)
+	logHandle, err := os.OpenFile(logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer logHandle.Close()
+	cmd := exec.Command(executable, childArgs...)
+	cmd.Stdout = logHandle
+	cmd.Stderr = logHandle
+	if err := configureDetachedProcess(cmd); err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "Listen started in background. Logs: %s\n", logFile)
+	return nil
 }
 
 func listenExpandTemplate(tmpl string, evt listenEvent, raw json.RawMessage) string {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -37,6 +37,8 @@ import (
 	"github.com/agentworkforce/relayfile/internal/relayfile"
 	"github.com/agentworkforce/relayfile/internal/writeback"
 	"github.com/fsnotify/fsnotify"
+	"nhooyr.io/websocket"
+	"nhooyr.io/websocket/wsjson"
 )
 
 const (
@@ -543,6 +545,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
 		return runLogs(args[1:], stdout)
 	case "observer":
 		return runObserver(args[1:], stdout)
+	case "listen", "watch":
+		return runListen(args[1:], stdout)
 	case "help", "-h", "--help":
 		printUsage(stdout)
 		return nil
@@ -613,6 +617,8 @@ func printHelpForArgs(args []string, stdout io.Writer) {
 		fmt.Fprintln(stdout, "Usage: relayfile logs [WORKSPACE] [--lines N]")
 	case "observer":
 		fmt.Fprintln(stdout, "Usage: relayfile observer [WORKSPACE] [--no-open]")
+	case "listen", "watch":
+		printListenUsage(stdout)
 	case "help":
 		printUsage(stdout)
 	default:
@@ -774,6 +780,7 @@ Usage:
   relayfile status [WORKSPACE]
   relayfile logs [WORKSPACE]
   relayfile observer [WORKSPACE] [--no-open]
+  relayfile listen [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD]
 
 Subcommands:
   setup       Sign in, connect an integration, and mount the workspace
@@ -804,7 +811,8 @@ Subcommands:
   export      Export a workspace as json, tar, or patch
   status      Show sync status and local mirror state for a workspace
   logs        Print the background mount log
-  observer    Open the hosted file observer for a workspace`)
+  observer    Open the hosted file observer for a workspace
+  listen      Stream live file events from a workspace; run a command per event with --run`)
 }
 
 func runSetup(args []string, stdin io.Reader, stdout io.Writer) error {
@@ -5543,6 +5551,235 @@ func isAPIAuthError(err error) bool {
 	}
 	var httpErr *apiError
 	return errors.As(err, &httpErr) && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden)
+}
+
+// listenEvent is the wire format for events delivered over /fs/ws.
+type listenEvent struct {
+	EventID       string `json:"eventId"`
+	Type          string `json:"type"`
+	Path          string `json:"path"`
+	Revision      string `json:"revision"`
+	ContentHash   string `json:"contentHash,omitempty"`
+	Origin        string `json:"origin,omitempty"`
+	Provider      string `json:"provider,omitempty"`
+	CorrelationID string `json:"correlationId,omitempty"`
+	Timestamp     string `json:"timestamp,omitempty"`
+}
+
+func printListenUsage(w io.Writer) {
+	fmt.Fprintln(w, `relayfile listen streams live file events from a workspace and optionally
+runs a command for each matching event.
+
+Usage:
+  relayfile listen [WORKSPACE] [--provider PROVIDER] [--path GLOB] [--event TYPE] [--run CMD] [--format text|json]
+
+Flags:
+  --provider PROVIDER  filter to a specific integration (linear, notion, hubspot, …)
+                       shorthand for --path /PROVIDER/**
+  --path GLOB          glob path filter, e.g. /linear/issues/** or /notion/pages/*
+  --event TYPE         filter by event type: file.created, file.updated, file.deleted
+                       (default: all types)
+  --run CMD            shell command to execute per matching event.
+                       Use {{path}}, {{type}}, {{provider}}, {{revision}}, and
+                       {{event}} (full JSON) as placeholders.
+  --format text|json   output format when --run is not set (default: text)
+
+Examples:
+
+  # Stream all events from the default workspace
+  relayfile listen
+
+  # Watch Linear for new issues and let Claude triage them
+  relayfile listen --provider linear --event file.created \
+    --run "claude --print 'A new Linear issue was filed. Read {{path}} and suggest a priority and owner.'"
+
+  # Watch Notion for any page edits
+  relayfile listen --provider notion --event file.updated \
+    --run "claude --print 'A Notion page changed at {{path}}. Summarise what likely changed.'"
+
+  # Watch HubSpot for new contacts and draft outreach
+  relayfile listen --provider hubspot --event file.created \
+    --run "claude --print 'New HubSpot contact at {{path}}. Draft a personalised first-touch email.'"
+
+  # Watch Asana for new tasks
+  relayfile listen --provider asana --event file.created \
+    --run "claude --print 'New Asana task at {{path}}. Break it into subtasks and estimate effort.'"
+
+  # Watch Shortcut for new stories
+  relayfile listen --provider shortcut --event file.created \
+    --run "claude --print 'New Shortcut story at {{path}}. Suggest an implementation approach.'"
+
+  # Watch Granola for new meeting notes and extract action items
+  relayfile listen --provider granola --event file.created \
+    --run "claude --print 'New meeting notes at {{path}}. Extract action items and owners.'"
+
+  # Watch Fathom for new call recordings and send a follow-up summary
+  relayfile listen --provider fathom --event file.created \
+    --run "claude --print 'New Fathom call at {{path}}. Write a follow-up email with key decisions.'"
+
+  # Print raw JSON for scripting
+  relayfile listen --provider linear --format json | jq '.path'
+
+  # Explicit path glob instead of --provider
+  relayfile listen --path "/linear/issues/**" --event file.created \
+    --run "claude --print 'New issue at {{path}}.'"
+
+Want this running headlessly for your whole team — turning issues into reviewed PRs automatically?
+See https://github.com/AgentWorkforce/factory`)
+}
+
+func runListen(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("listen", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	server := fs.String("server", "", "relayfile server URL override")
+	token := fs.String("token", "", "relayfile token override")
+	providerFlag := fs.String("provider", "", "filter to a specific provider (e.g. linear, notion)")
+	pathFlag := fs.String("path", "", "glob path filter (e.g. /linear/issues/**)")
+	eventFlag := fs.String("event", "", "event type filter: file.created, file.updated, file.deleted")
+	runFlag := fs.String("run", "", "shell command per event; supports {{path}}, {{type}}, {{provider}}, {{revision}}, {{event}}")
+	formatFlag := fs.String("format", "text", "output format when --run is not set: text or json")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"server":   true,
+		"token":    true,
+		"provider": true,
+		"path":     true,
+		"event":    true,
+		"run":      true,
+		"format":   true,
+	})); err != nil {
+		return err
+	}
+	var workspaceValue string
+	if fs.NArg() > 0 {
+		workspaceValue = strings.TrimSpace(fs.Arg(0))
+	}
+
+	commandClient, err := prepareWorkspaceCommandClient(workspaceValue, *server, *token, defaultInspectScopes)
+	if err != nil {
+		return err
+	}
+
+	// Build WebSocket URL from the HTTP base URL.
+	base, err := url.Parse(strings.TrimRight(commandClient.client.baseURL, "/"))
+	if err != nil {
+		return fmt.Errorf("invalid server URL: %w", err)
+	}
+	switch base.Scheme {
+	case "http":
+		base.Scheme = "ws"
+	case "https":
+		base.Scheme = "wss"
+	}
+	base.Path = fmt.Sprintf("/v1/workspaces/%s/fs/ws", url.PathEscape(commandClient.workspaceID))
+
+	pathFilter := strings.TrimSpace(*pathFlag)
+	if pathFilter == "" && strings.TrimSpace(*providerFlag) != "" {
+		pathFilter = fmt.Sprintf("/%s/**", strings.TrimSpace(*providerFlag))
+	}
+	q := url.Values{}
+	q.Set("from", "now")
+	if pathFilter != "" {
+		q.Set("path", pathFilter)
+	}
+	// Token in query param for WS upgrade (server does not yet support Authorization on upgrade).
+	q.Set("token", commandClient.client.token)
+	base.RawQuery = q.Encode()
+
+	rootCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	conn, _, err := websocket.Dial(rootCtx, base.String(), &websocket.DialOptions{
+		HTTPHeader: http.Header{
+			"Authorization": []string{"Bearer " + commandClient.client.token},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("connect to event stream: %w", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	typeFilter := strings.TrimSpace(*eventFlag)
+	runCmd := strings.TrimSpace(*runFlag)
+	format := strings.TrimSpace(*formatFlag)
+
+	label := "all events"
+	if pathFilter != "" {
+		label = pathFilter
+	}
+	if typeFilter != "" {
+		label += " (" + typeFilter + ")"
+	}
+	fmt.Fprintf(stdout, "Listening on %s — Ctrl+C to stop\n", label)
+	if runCmd == "" && format == "text" {
+		fmt.Fprintln(stdout, "Tip: pass --run to execute a command per event.")
+		fmt.Fprintln(stdout, "     See 'relayfile help listen' for examples with Linear, Notion, HubSpot, and more.")
+	}
+	fmt.Fprintln(stdout)
+
+	for {
+		var raw json.RawMessage
+		if err := wsjson.Read(rootCtx, conn, &raw); err != nil {
+			if websocket.CloseStatus(err) == websocket.StatusNormalClosure ||
+				websocket.CloseStatus(err) == websocket.StatusGoingAway ||
+				errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return fmt.Errorf("event stream error: %w", err)
+		}
+
+		var evt listenEvent
+		if err := json.Unmarshal(raw, &evt); err != nil || evt.Type == "" || evt.Type == "pong" {
+			continue
+		}
+		if typeFilter != "" && evt.Type != typeFilter {
+			continue
+		}
+
+		if runCmd != "" {
+			expanded := listenExpandTemplate(runCmd, evt, raw)
+			cmd := exec.CommandContext(rootCtx, "sh", "-c", expanded)
+			cmd.Stdout = stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil && !errors.Is(err, context.Canceled) {
+				fmt.Fprintf(os.Stderr, "run error for %s: %v\n", evt.Path, err)
+			}
+			continue
+		}
+
+		if format == "json" {
+			fmt.Fprintf(stdout, "%s\n", string(raw))
+			continue
+		}
+
+		// Default text output.
+		ts := strings.TrimSpace(evt.Timestamp)
+		if ts == "" {
+			ts = time.Now().UTC().Format(time.RFC3339)
+		}
+		provider := strings.TrimSpace(evt.Provider)
+		if provider == "" {
+			// Infer provider from the leading path segment.
+			seg := strings.TrimPrefix(evt.Path, "/")
+			if i := strings.IndexByte(seg, '/'); i > 0 {
+				provider = seg[:i]
+			}
+		}
+		if provider != "" {
+			fmt.Fprintf(stdout, "%-20s  %-30s  %s  [%s]\n", evt.Type, evt.Path, ts, provider)
+		} else {
+			fmt.Fprintf(stdout, "%-20s  %-30s  %s\n", evt.Type, evt.Path, ts)
+		}
+	}
+}
+
+func listenExpandTemplate(tmpl string, evt listenEvent, raw json.RawMessage) string {
+	return strings.NewReplacer(
+		"{{path}}", evt.Path,
+		"{{type}}", evt.Type,
+		"{{provider}}", evt.Provider,
+		"{{revision}}", evt.Revision,
+		"{{event}}", string(raw),
+	).Replace(tmpl)
 }
 
 func runTree(args []string, stdout io.Writer) error {

--- a/docs/guides/pricing.md
+++ b/docs/guides/pricing.md
@@ -1,0 +1,41 @@
+# Pricing
+
+Relayfile is priced on events — the normalized webhook and sync events flowing through your workspace each month. This maps naturally to how teams actually use it: more integrations and more active providers generate more events.
+
+## Plans
+
+| | Free | Starter | Team | Enterprise |
+|---|---|---|---|---|
+| **Price** | $0 | $49/mo | $199/mo | Custom |
+| **Events/mo** | 10,000 | 100,000 | 500,000 | Unlimited |
+| **Workspaces** | 1 | 1 | 5 | Unlimited |
+| **Providers** | 2 | 5 | Unlimited | Unlimited |
+| **Writeback** | — | ✓ | ✓ | ✓ |
+| **Background supervisor** | — | ✓ | ✓ | ✓ |
+| **Per-agent ACLs** | — | — | ✓ | ✓ |
+| **Bring your own connections** | — | — | — | ✓ |
+| **SLA + dedicated support** | — | — | — | ✓ |
+
+## What counts as an event
+
+An event is any normalized file event delivered to your workspace: a webhook arriving from a connected provider, a record created or updated during an incremental sync, or a digest write. Reads — agents reading files from a mounted workspace — do not count.
+
+## Free tier
+
+The free tier is enough to build and test a reactive agent locally. 10,000 events per month covers moderate usage across one or two providers. Any team running agents in production will want Starter or above.
+
+## Bring your own connections (Enterprise)
+
+If you already have provider connections managed through Nango, Composio, or Pipedream, Enterprise lets you bring those connections directly. Relayfile acts as the VFS and event layer on top of your existing OAuth infrastructure — no duplicate auth setup, no migration required.
+
+## Overage
+
+On Starter and Team, usage beyond the monthly event limit is billed at **$0.50 per 1,000 events**. You will receive an email before your workspace is throttled. Enterprise plans have no overage — contact us to discuss volume pricing.
+
+## Hosted vs. self-hosted
+
+The plans above apply to hosted Agent Relay. If you self-host the relayfile server, there is no per-event charge — you run the infrastructure and pay only for the compute and storage you provision. Self-hosting requires running [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) and [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) alongside the core server.
+
+## Questions
+
+[contact@agentrelay.com](mailto:contact@agentrelay.com)

--- a/docs/guides/pricing.md
+++ b/docs/guides/pricing.md
@@ -1,6 +1,8 @@
 # Pricing
 
-Relayfile is priced on events — the normalized webhook and sync events flowing through your workspace each month. This maps naturally to how teams actually use it: more integrations and more active providers generate more events.
+Relayfile is priced on two dimensions: **events** and **storage**.
+
+Events are the normalized webhooks and sync updates flowing into your workspace. Storage is the live integration data — every issue, page, PR, message, deal, and contact kept current and queryable as files. Both scale with how deeply your agents rely on your connected providers.
 
 ## Plans
 
@@ -8,6 +10,7 @@ Relayfile is priced on events — the normalized webhook and sync events flowing
 |---|---|---|---|---|
 | **Price** | $0 | $49/mo | $199/mo | Custom |
 | **Events/mo** | 10,000 | 100,000 | 500,000 | Unlimited |
+| **Storage** | 1 GB | 10 GB | 50 GB | Custom |
 | **Workspaces** | 1 | 1 | 5 | Unlimited |
 | **Providers** | 2 | 5 | Unlimited | Unlimited |
 | **Writeback** | — | ✓ | ✓ | ✓ |
@@ -18,23 +21,32 @@ Relayfile is priced on events — the normalized webhook and sync events flowing
 
 ## What counts as an event
 
-An event is any normalized file event delivered to your workspace: a webhook arriving from a connected provider, a record created or updated during an incremental sync, or a digest write. Reads — agents reading files from a mounted workspace — do not count.
+An event is any normalized file event delivered to your workspace: a webhook arriving from a connected provider, or a record created or updated during an incremental sync. Reads — agents reading or mounting files — do not count.
+
+## What counts as storage
+
+Storage is the total size of your workspace file tree: all provider records kept live and queryable across your connected integrations. A typical team workspace with Linear, Notion, GitHub, and Slack connected uses 2–8 GB depending on history depth and record volume.
 
 ## Free tier
 
-The free tier is enough to build and test a reactive agent locally. 10,000 events per month covers moderate usage across one or two providers. Any team running agents in production will want Starter or above.
-
-## Bring your own connections (Enterprise)
-
-If you already have provider connections managed through Nango, Composio, or Pipedream, Enterprise lets you bring those connections directly. Relayfile acts as the VFS and event layer on top of your existing OAuth infrastructure — no duplicate auth setup, no migration required.
+Enough to build and test a reactive agent with one or two providers. Any team running agents in production will want Starter or above.
 
 ## Overage
 
-On Starter and Team, usage beyond the monthly event limit is billed at **$0.50 per 1,000 events**. You will receive an email before your workspace is throttled. Enterprise plans have no overage — contact us to discuss volume pricing.
+On Starter and Team, usage beyond plan limits is billed at:
+
+- **Events:** $0.50 per 1,000 events
+- **Storage:** $0.25 per GB per month
+
+You will receive an email before your workspace is throttled. Enterprise plans have no overage — contact us to discuss volume.
+
+## Bring your own connections (Enterprise)
+
+If your team already has provider connections managed through Nango, Composio, or Pipedream, Enterprise lets you bring those directly. Relayfile acts as the VFS and event layer on top of your existing OAuth infrastructure — no duplicate auth setup, no migration required.
 
 ## Hosted vs. self-hosted
 
-The plans above apply to hosted Agent Relay. If you self-host the relayfile server, there is no per-event charge — you run the infrastructure and pay only for the compute and storage you provision. Self-hosting requires running [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) and [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) alongside the core server.
+The plans above apply to hosted Agent Relay. If you self-host the relayfile server, there is no per-event or storage charge — you run the infrastructure and pay only for the compute and storage you provision. Self-hosting requires running [relayfile-adapters](https://github.com/AgentWorkforce/relayfile-adapters) and [relayfile-providers](https://github.com/AgentWorkforce/relayfile-providers) alongside the core server.
 
 ## Questions
 

--- a/docs/guides/self-hosted-n8n.md
+++ b/docs/guides/self-hosted-n8n.md
@@ -1,0 +1,130 @@
+# Self-Hosted Stack: n8n + Relayfile
+
+Run your entire agent integration stack on your own infrastructure. n8n handles webhook ingestion and normalization; relayfile handles the agent data layer. No data leaves your environment.
+
+## Architecture
+
+```
+Provider webhook
+  → n8n (self-hosted) receives and normalizes
+  → Relayfile Write node pushes event to workspace
+  → relayfile (self-hosted) materializes file
+  → relayfile listen fires
+  → agent reacts with full context
+```
+
+Agent write-back flows in reverse:
+
+```
+Agent writes file
+  → relayfile event fires
+  → Relayfile Trigger node
+  → n8n continues downstream automation
+```
+
+## Prerequisites
+
+- n8n self-hosted ([n8n installation docs](https://docs.n8n.io/hosting/))
+- Docker or a Go environment for relayfile
+- A JWT issuer for relayfile auth (relayauth ships in the Docker stack)
+
+## Start relayfile
+
+```bash
+git clone https://github.com/AgentWorkforce/relayfile
+cd relayfile/docker
+docker compose up --build
+```
+
+This starts relayfile on `http://localhost:9090` and relayauth on `http://localhost:9091`. A sample workspace `ws_demo` is created automatically.
+
+Get a token:
+
+```bash
+TOKEN="$(docker compose logs seed | awk '/token/ {print $NF}' | tail -1)"
+```
+
+For production, set `RELAYFILE_DATA_DIR` to a persistent volume and configure your own JWT issuer via `RELAYAUTH_JWKS_URL`.
+
+## Install the relayfile n8n node
+
+In your n8n instance, install the community node:
+
+```bash
+# In your n8n data directory
+npm install @agentworkforce/n8n-nodes-relayfile
+```
+
+Or via the n8n UI: **Settings → Community Nodes → Install** → search `@agentworkforce/n8n-nodes-relayfile`.
+
+Restart n8n after installation.
+
+## Configure the relayfile credential in n8n
+
+1. In n8n, go to **Credentials → New**
+2. Search for **Relayfile**
+3. Set:
+   - **Base URL:** `http://localhost:9090` (or your relayfile host)
+   - **Token:** your workspace token
+   - **Workspace ID:** `ws_demo` (or your workspace name)
+
+## Add a Relayfile Write node to a workflow
+
+Any n8n workflow can write events into relayfile. Add the **Relayfile Write** node as the final step:
+
+```
+[Trigger: Linear webhook]
+  → [normalize / filter nodes]
+  → [Relayfile Write]
+      Provider: linear
+      Path: /linear/issues/{{$json.identifier}}.md
+      Content: {{$json}}
+```
+
+When the workflow runs, the file materializes in your relayfile workspace and a file event fires.
+
+## React with relayfile listen
+
+On any machine with access to your relayfile instance:
+
+```bash
+RELAYFILE_TOKEN="$TOKEN" relayfile listen \
+  --path "/linear/issues/by-state/triage/**" \
+  --event file.created \
+  --run "claude --print 'New triage issue at {{path}}. Assign it.'"
+```
+
+To survive reboots:
+
+```bash
+relayfile supervisor install \
+  --path "/linear/issues/by-state/triage/**" \
+  --event file.created \
+  --run "claude --print 'New triage issue at {{path}}. Assign it.'"
+```
+
+## Use the Relayfile Trigger node (reverse direction)
+
+To kick off an n8n workflow when an agent writes a file back:
+
+1. Add a **Relayfile Trigger** node as the workflow start
+2. Set the path glob to watch: `/linear/issues/**`
+3. Connect downstream nodes (send a Slack message, update a sheet, etc.)
+
+The trigger fires whenever relayfile emits a file event matching the glob — including agent write-backs.
+
+## Data residency
+
+In this configuration, no provider data transits any external service. The flow is:
+
+```
+Provider → your n8n → your relayfile → your agent
+```
+
+All state is stored in `RELAYFILE_DATA_DIR` on your own infrastructure. Token storage and OAuth management are handled by your own relayauth instance or a compatible JWT issuer.
+
+## Next steps
+
+- [Environment variables](../environment-variables.md)
+- [Getting started](getting-started.md)
+- [API reference](../api-reference.md)


### PR DESCRIPTION
## What

Adds `relayfile listen` (alias: `watch`) to the CLI. Connects to the workspace WebSocket event stream and optionally executes a shell command for each matching event.

```bash
# Wake Claude when a new Linear issue is filed
relayfile listen --provider linear --event file.created \
  --run "claude --print 'New issue at {{path}}. Read it and suggest a priority and owner.'"

# Extract action items from Granola meeting notes
relayfile listen --provider granola --event file.created \
  --run "claude --print 'New meeting notes at {{path}}. Extract action items and owners.'"

# Draft follow-ups from Fathom call recordings
relayfile listen --provider fathom --event file.created \
  --run "claude --print 'New call at {{path}}. Write a follow-up with key decisions.'"
```

## Flags

| Flag | Description |
|---|---|
| `--provider PROVIDER` | Shorthand path filter — `--provider linear` maps to `/linear/**` |
| `--path GLOB` | Explicit glob filter, e.g. `/linear/issues/**` |
| `--event TYPE` | Filter by type: `file.created`, `file.updated`, `file.deleted` |
| `--run CMD` | Shell command per event. Placeholders: `{{path}}`, `{{type}}`, `{{provider}}`, `{{revision}}`, `{{event}}` (full JSON) |
| `--format text\|json` | Output format when `--run` is not set (default: `text`) |

## How it works

- Opens a WebSocket to `/v1/workspaces/{id}/fs/ws` with `from=now` (skips backlog, live events only)
- Applies server-side path filtering via query param when `--provider` or `--path` is set
- Applies client-side event-type filtering for `--event`
- For `--run`: shells out to `sh -c <expanded-cmd>` per event; stdout goes to the caller's stdout, stderr to stderr
- SIGINT/SIGTERM cancel the context and close the connection cleanly

## Scope

- Provider webhooks are already normalized by Agent Relay Cloud before they reach the workspace, so `--run` receives clean, consistent data regardless of which SaaS tool fired the event
- `relayfile help listen` shows runnable examples for Linear, Notion, HubSpot, Asana, Shortcut, Granola, and Fathom, plus a pointer to [AgentWorkforce/factory](https://github.com/AgentWorkforce/factory) for teams who want the same loop running headlessly at scale

## Test plan

- [ ] `relayfile listen --help` prints usage with examples
- [ ] `relayfile listen` connects and prints events in text format
- [ ] `relayfile listen --format json` prints raw JSON per event
- [ ] `relayfile listen --provider linear` filters to `/linear/**` events only
- [ ] `relayfile listen --event file.created` filters by type
- [ ] `relayfile listen --run "echo {{path}}"` executes once per matching event
- [ ] Ctrl+C exits cleanly with status 0
- [ ] `go build ./cmd/relayfile-cli/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PF9GK3mPDyWEKXpaJ8ReB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PF9GK3mPDyWEKXpaJ8ReB9)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

