### PR TITLE
fix(cli): point defaultServerURL at file.agentrelay.com

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	defaultServerURL        = "https://api.relayfile.dev"
+	defaultServerURL        = "https://file.agentrelay.com"
 	defaultCloudAPIURL      = "https://agentrelay.com/cloud"
 	defaultObserverURL      = "https://agentrelay.com/observer/file"
 	minAgentRelayCLIVersion = "8.7.0"

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -55,7 +55,7 @@ func TestWorkspaceCreateStoresCatalogEntry(t *testing.T) {
 func TestResolveServerDefaultsToHostedRelayfile(t *testing.T) {
 	clearRelayfileEnv(t)
 
-	if got := resolveServer("", credentials{}); got != "https://api.relayfile.dev" {
+	if got := resolveServer("", credentials{}); got != "https://file.agentrelay.com" {
 		t.Fatalf("expected hosted Relayfile default server, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Changes `defaultServerURL` from `https://api.relayfile.dev` to `https://file.agentrelay.com`, the production relayfile-cloud API
- Updates the corresponding test assertion
- Fixes `relayfile observer` showing incorrect/stale data — the observer passes `baseUrl` as a URL fragment parameter, so it was fetching from the wrong server

## Test plan

- [ ] `go test ./cmd/relayfile-cli/... -run TestResolveServer` passes
- [ ] `relayfile observer` opens with the correct `baseUrl=https://file.agentrelay.com` in the URL fragment
- [ ] Observer dashboard shows accurate workspace state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

