### PR TITLE
fix(cli): suppress duplicate listen run events

### DIFF
--- a/cmd/relayfile-cli/listen_test.go
+++ b/cmd/relayfile-cli/listen_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestMatchListenPath(t *testing.T) {
 	cases := []struct {
@@ -50,5 +55,137 @@ func TestWsEncodeGlob(t *testing.T) {
 		if got != c.want {
 			t.Errorf("wsEncodeGlob(%q) = %q, want %q", c.input, got, c.want)
 		}
+	}
+}
+
+func TestListenRunDuplicateSuppressorSuppressesSameContentHashWithinWindow(t *testing.T) {
+	suppressor := newListenRunDuplicateSuppressor(2 * time.Second)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	evt := listenEvent{
+		Type:        "file.updated",
+		Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+		ContentHash: "sha256:a",
+	}
+
+	if suppressor.shouldSuppress(evt, now) {
+		t.Fatal("first event should not be suppressed")
+	}
+	if !suppressor.shouldSuppress(evt, now.Add(time.Second)) {
+		t.Fatal("duplicate event within window should be suppressed")
+	}
+	if suppressor.shouldSuppress(evt, now.Add(4*time.Second)) {
+		t.Fatal("duplicate event after window should not be suppressed")
+	}
+}
+
+func TestListenRunDuplicateSuppressorUsesFixedWindow(t *testing.T) {
+	suppressor := newListenRunDuplicateSuppressor(2 * time.Second)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	evt := listenEvent{
+		Type:        "file.updated",
+		Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+		ContentHash: "sha256:a",
+	}
+
+	if suppressor.shouldSuppress(evt, now) {
+		t.Fatal("first event should not be suppressed")
+	}
+	if !suppressor.shouldSuppress(evt, now.Add(time.Second)) {
+		t.Fatal("duplicate event within window should be suppressed")
+	}
+	if suppressor.shouldSuppress(evt, now.Add(2500*time.Millisecond)) {
+		t.Fatal("duplicate event after original fixed window should not be suppressed")
+	}
+}
+
+func TestListenRunDuplicateSuppressorSweepsPeriodically(t *testing.T) {
+	suppressor := newListenRunDuplicateSuppressor(2 * time.Second)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	for i := 0; i < listenRunDuplicateSweepInterval-1; i++ {
+		evt := listenEvent{
+			Type:        "file.updated",
+			Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+			ContentHash: "sha256:" + strconv.Itoa(i),
+		}
+		if suppressor.shouldSuppress(evt, now) {
+			t.Fatalf("first event %d should not be suppressed", i)
+		}
+	}
+	if len(suppressor.seen) != listenRunDuplicateSweepInterval-1 {
+		t.Fatalf("expected unswept keys to remain, got %d", len(suppressor.seen))
+	}
+
+	evt := listenEvent{
+		Type:        "file.updated",
+		Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+		ContentHash: "sha256:trigger",
+	}
+	if suppressor.shouldSuppress(evt, now.Add(3*time.Second)) {
+		t.Fatal("first trigger event should not be suppressed")
+	}
+	if len(suppressor.seen) != 1 {
+		t.Fatalf("expected periodic sweep to retain only current key, got %d", len(suppressor.seen))
+	}
+}
+
+func TestListenRunDuplicateSuppressorAllowsDifferentContentHashes(t *testing.T) {
+	suppressor := newListenRunDuplicateSuppressor(2 * time.Second)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	first := listenEvent{
+		Type:        "file.updated",
+		Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+		ContentHash: "sha256:a",
+	}
+	second := first
+	second.ContentHash = "sha256:b"
+
+	if suppressor.shouldSuppress(first, now) {
+		t.Fatal("first event should not be suppressed")
+	}
+	if suppressor.shouldSuppress(second, now.Add(time.Second)) {
+		t.Fatal("changed content hash should not be suppressed")
+	}
+}
+
+func TestListenRunDuplicateSuppressorFallsBackToCorrelationID(t *testing.T) {
+	suppressor := newListenRunDuplicateSuppressor(2 * time.Second)
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	evt := listenEvent{
+		Type:          "file.updated",
+		Path:          "/linear/issues/by-state/in-planning/AR-322.json",
+		CorrelationID: "corr_1",
+	}
+
+	if suppressor.shouldSuppress(evt, now) {
+		t.Fatal("first event should not be suppressed")
+	}
+	if !suppressor.shouldSuppress(evt, now.Add(time.Second)) {
+		t.Fatal("same correlation ID should be suppressed when content hash is absent")
+	}
+
+	next := evt
+	next.CorrelationID = "corr_2"
+	if suppressor.shouldSuppress(next, now.Add(time.Second)) {
+		t.Fatal("different correlation ID should not be suppressed")
+	}
+}
+
+func TestListenRunDuplicateKeyRequiresStableIdentity(t *testing.T) {
+	key := listenRunDuplicateKey(listenEvent{
+		Type: "file.updated",
+		Path: "/linear/issues/by-state/in-planning/AR-322.json",
+	})
+	if key != "" {
+		t.Fatalf("expected no key without content hash or correlation ID, got %q", key)
+	}
+
+	key = listenRunDuplicateKey(listenEvent{
+		Type:        "file.updated",
+		Path:        "/linear/issues/by-state/in-planning/AR-322.json",
+		ContentHash: "sha256:a",
+	})
+	if !strings.Contains(key, "hash:sha256:a") {
+		t.Fatalf("expected content hash in duplicate key, got %q", key)
 	}
 }

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -5750,6 +5750,66 @@ type listenEvent struct {
 	Timestamp     string `json:"timestamp,omitempty"`
 }
 
+const listenRunDuplicateWindow = 2 * time.Second
+const listenRunDuplicateSweepInterval = 100
+
+type listenRunDuplicateSuppressor struct {
+	window time.Duration
+	seen   map[string]time.Time
+	calls  int
+}
+
+func newListenRunDuplicateSuppressor(window time.Duration) *listenRunDuplicateSuppressor {
+	if window <= 0 {
+		window = listenRunDuplicateWindow
+	}
+	return &listenRunDuplicateSuppressor{
+		window: window,
+		seen:   map[string]time.Time{},
+	}
+}
+
+func (s *listenRunDuplicateSuppressor) shouldSuppress(evt listenEvent, now time.Time) bool {
+	if s == nil {
+		return false
+	}
+	key := listenRunDuplicateKey(evt)
+	if key == "" {
+		return false
+	}
+	s.calls++
+	if s.calls%listenRunDuplicateSweepInterval == 0 {
+		for existingKey, seenAt := range s.seen {
+			if now.Sub(seenAt) > s.window {
+				delete(s.seen, existingKey)
+			}
+		}
+	}
+	if seenAt, ok := s.seen[key]; ok {
+		if now.Sub(seenAt) <= s.window {
+			return true
+		}
+		delete(s.seen, key)
+	}
+	s.seen[key] = now
+	return false
+}
+
+func listenRunDuplicateKey(evt listenEvent) string {
+	eventType := strings.TrimSpace(evt.Type)
+	eventPath := strings.TrimSpace(evt.Path)
+	if eventType == "" || eventPath == "" {
+		return ""
+	}
+	if contentHash := strings.TrimSpace(evt.ContentHash); contentHash != "" {
+		return eventType + "\x00" + eventPath + "\x00hash:" + contentHash
+	}
+	if correlationID := strings.TrimSpace(evt.CorrelationID); correlationID != "" {
+		return eventType + "\x00" + eventPath + "\x00corr:" + correlationID
+	}
+	return ""
+}
+
 func printListenUsage(w io.Writer) {
 	fmt.Fprintln(w, `relayfile listen streams live file events from a workspace and optionally
 runs a command for each matching event.
@@ -6035,6 +6095,10 @@ func runListen(args []string, stdout io.Writer) error {
 	typeFilter := strings.TrimSpace(*eventFlag)
 	runCmd := strings.TrimSpace(*runFlag)
 	format := strings.TrimSpace(*formatFlag)
+	var runDuplicateSuppressor *listenRunDuplicateSuppressor
+	if runCmd != "" {
+		runDuplicateSuppressor = newListenRunDuplicateSuppressor(listenRunDuplicateWindow)
+	}
 
 	label := "all events"
 	if pathFilter != "" {
@@ -6076,6 +6140,9 @@ func runListen(args []string, stdout io.Writer) error {
 		}
 
 		if runCmd != "" {
+			if runDuplicateSuppressor.shouldSuppress(evt, time.Now()) {
+				continue
+			}
 			expanded := listenExpandTemplate(runCmd, evt, raw)
 			cmd := exec.CommandContext(rootCtx, "sh", "-c", expanded)
 			cmd.Stdout = stdout


### PR DESCRIPTION
## Summary
- suppress duplicate `relayfile listen --run` executions for the same event type/path/content hash within a short window
- fall back to correlation ID when content hash is unavailable
- keep raw listen event streaming unchanged

## Self-review
- Verified suppression only applies when `--run` is set, so `--format json` still shows every event.
- Verified changed content hashes are not suppressed.

## Tests
- `go test ./cmd/relayfile-cli`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

