### PR TITLE
fix(cli): add --subscription flag to relayfile integration bind

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -429,13 +429,14 @@ type integrationConnectionState struct {
 }
 
 type relayIntegrationBinding struct {
-	Provider     string `json:"provider"`
-	PathGlob     string `json:"pathGlob"`
-	Channel      string `json:"channel"`
-	WebhookID    string `json:"webhookId"`
-	WebhookToken string `json:"webhookToken"`
-	CreatedAt    string `json:"createdAt,omitempty"`
-	UpdatedAt    string `json:"updatedAt,omitempty"`
+	Provider       string `json:"provider"`
+	PathGlob       string `json:"pathGlob"`
+	Channel        string `json:"channel"`
+	WebhookID      string `json:"webhookId"`
+	WebhookToken   string `json:"webhookToken"`
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	CreatedAt      string `json:"createdAt,omitempty"`
+	UpdatedAt      string `json:"updatedAt,omitempty"`
 }
 
 type relayIntegrationBindingStore struct {
@@ -2297,11 +2298,13 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 	channel := fs.String("channel", "", "relay channel to receive provider records")
 	webhookID := fs.String("webhook", "", "RelayCast inbound webhook id")
 	webhookToken := fs.String("webhook-token", "", "RelayCast inbound webhook token")
+	subscriptionID := fs.String("subscription", "", "relay integration subscription id")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
 		"list":          false,
 		"channel":       true,
 		"webhook":       true,
 		"webhook-token": true,
+		"subscription":  true,
 	})); err != nil {
 		return err
 	}
@@ -2327,11 +2330,12 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		return errors.New("PATH_GLOB must start with /")
 	}
 	binding := relayIntegrationBinding{
-		Provider:     provider,
-		PathGlob:     pathGlob,
-		Channel:      strings.TrimSpace(*channel),
-		WebhookID:    strings.TrimSpace(*webhookID),
-		WebhookToken: strings.TrimSpace(*webhookToken),
+		Provider:       provider,
+		PathGlob:       pathGlob,
+		Channel:        strings.TrimSpace(*channel),
+		WebhookID:      strings.TrimSpace(*webhookID),
+		WebhookToken:   strings.TrimSpace(*webhookToken),
+		SubscriptionID: strings.TrimSpace(*subscriptionID),
 	}
 	if binding.Channel == "" {
 		return errors.New("--channel is required")

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -2359,6 +2359,9 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 			if binding.CreatedAt == "" {
 				binding.CreatedAt = now
 			}
+			if binding.SubscriptionID == "" {
+				binding.SubscriptionID = bindings[i].SubscriptionID
+			}
 			bindings[i] = binding
 			replaced = true
 			break


### PR DESCRIPTION
## Summary

- `relayfile integration bind` was missing the `--subscription` flag, causing `agent-relay integration subscribe` to fail with `flag provided but not defined: -subscription`
- Added `--subscription <id>` flag that stores the relay integration subscription ID alongside the binding so it can be used during `unbind` cleanup
- Added `subscriptionId` field to `relayIntegrationBinding` struct (omitempty for backwards compatibility)

## Test plan
- [ ] `relayfile integration bind slack /slack/** --channel #general --webhook <id> --webhook-token <tok> --subscription <sub-id>` runs without error
- [ ] `relayfile integration bind --list --json` output includes `subscriptionId` field
- [ ] `agent-relay integration subscribe slack --resource "#channel" --to "#general"` completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

