### PR TITLE
feat(cli): integration writeback-secret command

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -721,7 +721,8 @@ func printIntegrationUsage(w io.Writer, subcommand string) {
   relayfile integration adopt PROVIDER --connection-id ID [--workspace NAME] [--provider-config-key KEY] [--yes]
   relayfile integration set-metadata PROVIDER KEY=VALUE [KEY=VALUE...] [--workspace NAME] [--yes]
   relayfile integration bind PROVIDER PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN
-  relayfile integration unbind PROVIDER [PATH_GLOB|--resource PATH_GLOB]`)
+  relayfile integration unbind PROVIDER [PATH_GLOB|--resource PATH_GLOB]
+  relayfile integration writeback-secret --channel CHANNEL [--workspace WS] [--json]`)
 	}
 }
 
@@ -2286,6 +2287,8 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 		return runIntegrationBind(args[1:], stdout)
 	case "unbind":
 		return runIntegrationUnbind(args[1:], stdout)
+	case "writeback-secret":
+		return runIntegrationWritebackSecret(args[1:], stdout)
 	default:
 		return fmt.Errorf("unknown integration subcommand %q", args[0])
 	}
@@ -2433,6 +2436,71 @@ func runIntegrationUnbind(args []string, stdout io.Writer) error {
 	} else {
 		fmt.Fprintf(stdout, "%s binding removed: %s\n", provider, pathGlob)
 	}
+	return nil
+}
+
+// writebackSecretResponse is the relayfile-cloud GET writeback-secret payload.
+type writebackSecretResponse struct {
+	OK   bool `json:"ok"`
+	Data struct {
+		URL    string `json:"url"`
+		Secret string `json:"secret"`
+	} `json:"data"`
+}
+
+// runIntegrationWritebackSecret fetches the per-channel writeback signing secret
+// (and ingress URL) for a relay channel from relayfile-cloud, over the
+// authenticated relayfile session. The relay CLI calls this at `subscribe` time
+// and signs the relay subscription with the returned secret, so there is no
+// static shared secret to provision. The secret is derived server-side from the
+// internal master key, so this endpoint just returns it to the workspace owner.
+func runIntegrationWritebackSecret(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("integration writeback-secret", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	workspaceName := fs.String("workspace", "", "workspace name or id")
+	channel := fs.String("channel", "", "relay channel the binding delivers to")
+	jsonOutput := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
+		"workspace": true,
+		"channel":   true,
+		"json":      false,
+	})); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: relayfile integration writeback-secret --channel CHANNEL [--workspace WS] [--json]")
+	}
+	channelValue := strings.TrimSpace(*channel)
+	if channelValue == "" {
+		return errors.New("--channel is required")
+	}
+
+	commandClient, err := prepareWorkspaceCommandClient(strings.TrimSpace(*workspaceName), "", "", defaultJoinScopes)
+	if err != nil {
+		return err
+	}
+	workspaceID := strings.TrimSpace(commandClient.workspaceID)
+	if workspaceID == "" {
+		return errors.New("could not resolve relayfile workspace id")
+	}
+
+	path := fmt.Sprintf(
+		"/v1/workspaces/%s/integrations/relay/writeback-secret?channel=%s",
+		url.PathEscape(workspaceID),
+		url.QueryEscape(channelValue),
+	)
+	var resp writebackSecretResponse
+	if err := commandClient.client.getJSON(context.Background(), path, &resp); err != nil {
+		return fmt.Errorf("fetch writeback secret: %w", err)
+	}
+	if strings.TrimSpace(resp.Data.Secret) == "" {
+		return errors.New("relayfile-cloud returned an empty writeback secret")
+	}
+
+	if *jsonOutput {
+		return writeJSON(stdout, resp.Data)
+	}
+	fmt.Fprintf(stdout, "url: %s\nsecret: %s\n", resp.Data.URL, resp.Data.Secret)
 	return nil
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -2493,6 +2493,9 @@ func runIntegrationWritebackSecret(args []string, stdout io.Writer) error {
 	if err := commandClient.client.getJSON(context.Background(), path, &resp); err != nil {
 		return fmt.Errorf("fetch writeback secret: %w", err)
 	}
+	if !resp.OK {
+		return errors.New("relayfile-cloud returned an unsuccessful writeback-secret response")
+	}
 	if strings.TrimSpace(resp.Data.Secret) == "" {
 		return errors.New("relayfile-cloud returned an empty writeback secret")
 	}


### PR DESCRIPTION
## Summary

Adds `relayfile integration writeback-secret --channel CHANNEL [--workspace WS] [--json]`.

It fetches the per-channel integration-bridge writeback **signing secret** + **ingress URL** from relayfile-cloud over the authenticated relayfile session:

```
GET /v1/workspaces/:workspaceId/integrations/relay/writeback-secret?channel=...
```

## Why

Part of the integration-bridge writeback path (companion to relayfile-cloud#96 and relay#1208). The relay CLI calls this at `agent-relay integration subscribe` time and signs the relay subscription with the returned secret, so the writeback ingress can HMAC-verify deliveries **without any statically-provisioned shared secret**.

The secret is derived server-side (`HMAC(INTERNAL_HMAC_SECRET, "relay-writeback:v1:{ws}:{channel}")`); this command just returns it to the authenticated workspace owner. Dynamic, tied to the logged-in account, nothing to provision.

## Output

```
$ relayfile integration writeback-secret --channel '#general' --json
{"url":"https://file.agentrelay.com/v1/workspaces/rw_xxx/integrations/relay/writeback","secret":"<hex>"}
```

## Implementation

- New `writeback-secret` case in the `integration` subcommand switch.
- Resolves the authenticated client + runtime workspace id via `prepareWorkspaceCommandClient` (same path as `writeback`/`sync` commands), then `getJSON` the endpoint.

## Verification

- `go build ./cmd/relayfile-cli/` ✅, `go vet` ✅
- Arg validation smoke test (`--channel is required`) ✅

## Ordering

Needs relayfile-cloud#96 (the GET endpoint) deployed to return real secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

