### PR TITLE
feat(control-plane): proxy webhook subscription create/delete to relayfile-cloud

### DIFF
--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -19,9 +19,9 @@ import (
 	"time"
 )
 
-const relayfileControlPlaneAPIVersion uint32 = 1
+const relayfileControlPlaneAPIVersion uint32 = 2
 
-var relayfileControlPlaneSupportedVersions = []uint32{relayfileControlPlaneAPIVersion}
+var relayfileControlPlaneSupportedVersions = []uint32{1, relayfileControlPlaneAPIVersion}
 
 type controlPlaneErrorCode string
 
@@ -492,7 +492,7 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 		}
 		var response webhookSubscriptionResponse
 		if err := commandClient.client.postJSON(
-			context.Background(),
+			r.Context(),
 			fmt.Sprintf("/v1/workspaces/%s/webhooks", url.PathEscape(workspaceID)),
 			map[string]any{
 				"url":       strings.TrimSpace(req.URL),
@@ -527,7 +527,7 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		if err := commandClient.client.deleteJSON(
-			context.Background(),
+			r.Context(),
 			fmt.Sprintf("/v1/workspaces/%s/webhooks/%s", url.PathEscape(workspaceID), url.PathEscape(subscriptionID)),
 			"",
 			nil,

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -119,6 +120,23 @@ type writebackSecretData struct {
 	Secret string `json:"secret"`
 }
 
+type webhookSubscriptionRequest struct {
+	Workspace string   `json:"workspace,omitempty"`
+	URL       string   `json:"url"`
+	PathGlobs []string `json:"pathGlobs"`
+	Secret    string   `json:"secret"`
+}
+
+type webhookSubscriptionResponse struct {
+	SubscriptionID string `json:"subscriptionId"`
+	Secret         string `json:"secret,omitempty"`
+}
+
+type deleteWebhookSubscriptionRequest struct {
+	Workspace      string `json:"workspace,omitempty"`
+	SubscriptionID string `json:"subscriptionId"`
+}
+
 func runControlPlane(args []string, stdout io.Writer) error {
 	if len(args) == 0 {
 		return errors.New("control-plane subcommand is required: serve")
@@ -210,6 +228,7 @@ func newControlPlaneHandler() http.Handler {
 	mux.HandleFunc("/v1/integrations/bindings", withControlPlaneVersion(handleControlPlaneListBindings))
 	mux.HandleFunc("/v1/integrations/unbind", withControlPlaneVersion(handleControlPlaneUnbind))
 	mux.HandleFunc("/v1/integrations/writeback-secret", withControlPlaneVersion(handleControlPlaneWritebackSecret))
+	mux.HandleFunc("/v1/integrations/webhook-subscriptions", withControlPlaneVersion(handleControlPlaneWebhookSubscription))
 	return mux
 }
 
@@ -447,6 +466,79 @@ func handleControlPlaneWritebackSecret(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeControlPlaneJSON(w, http.StatusOK, data)
+}
+
+func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var req webhookSubscriptionRequest
+		if err := decodeControlPlaneJSON(r, &req); err != nil {
+			writeControlPlaneError(w, http.StatusBadRequest, controlPlaneErrInvalidArgument, err.Error())
+			return
+		}
+		if strings.TrimSpace(req.URL) == "" || len(req.PathGlobs) == 0 || strings.TrimSpace(req.Secret) == "" {
+			writeControlPlaneError(w, http.StatusBadRequest, controlPlaneErrInvalidArgument, "url, pathGlobs, and secret are required")
+			return
+		}
+		commandClient, err := prepareWorkspaceCommandClient(strings.TrimSpace(req.Workspace), "", "", defaultJoinScopes)
+		if err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		workspaceID := strings.TrimSpace(commandClient.workspaceID)
+		if workspaceID == "" {
+			writeControlPlaneMappedError(w, errors.New("could not resolve relayfile workspace id"))
+			return
+		}
+		var response webhookSubscriptionResponse
+		if err := commandClient.client.postJSON(
+			context.Background(),
+			fmt.Sprintf("/v1/workspaces/%s/webhooks", url.PathEscape(workspaceID)),
+			map[string]any{
+				"url":       strings.TrimSpace(req.URL),
+				"pathGlobs": req.PathGlobs,
+				"secret":    strings.TrimSpace(req.Secret),
+			},
+			&response,
+		); err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		writeControlPlaneJSON(w, http.StatusOK, response)
+	case http.MethodDelete:
+		var req deleteWebhookSubscriptionRequest
+		if err := decodeControlPlaneJSON(r, &req); err != nil {
+			writeControlPlaneError(w, http.StatusBadRequest, controlPlaneErrInvalidArgument, err.Error())
+			return
+		}
+		subscriptionID := strings.TrimSpace(req.SubscriptionID)
+		if subscriptionID == "" {
+			writeControlPlaneError(w, http.StatusBadRequest, controlPlaneErrInvalidArgument, "subscriptionId is required")
+			return
+		}
+		commandClient, err := prepareWorkspaceCommandClient(strings.TrimSpace(req.Workspace), "", "", defaultJoinScopes)
+		if err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		workspaceID := strings.TrimSpace(commandClient.workspaceID)
+		if workspaceID == "" {
+			writeControlPlaneMappedError(w, errors.New("could not resolve relayfile workspace id"))
+			return
+		}
+		if err := commandClient.client.deleteJSON(
+			context.Background(),
+			fmt.Sprintf("/v1/workspaces/%s/webhooks/%s", url.PathEscape(workspaceID), url.PathEscape(subscriptionID)),
+			"",
+			nil,
+		); err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		writeControlPlaneJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	default:
+		writeControlPlaneError(w, http.StatusMethodNotAllowed, controlPlaneErrInvalidArgument, "method not allowed")
+	}
 }
 
 func controlPlaneHello() helloResponse {

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -35,12 +35,15 @@ func TestControlPlaneHelloVersionAndCLIVersion(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("hello status = %d", status)
 	}
-	if hello.DaemonVersion != "0.10.17" || hello.APIVersion != 1 {
+	if hello.DaemonVersion != "0.10.17" || hello.APIVersion != 2 {
 		t.Fatalf("unexpected hello response: %#v", hello)
+	}
+	if len(hello.SupportedAPIVersions) != 2 || hello.SupportedAPIVersions[0] != 1 || hello.SupportedAPIVersions[1] != 2 {
+		t.Fatalf("unexpected supported API versions: %#v", hello.SupportedAPIVersions)
 	}
 
 	var errResp map[string]controlPlaneError
-	status = controlPlaneJSONWithoutVersion(t, client, http.MethodGet, baseURL+"/v1/hello?apiVersion=2", nil, &errResp)
+	status = controlPlaneJSONWithoutVersion(t, client, http.MethodGet, baseURL+"/v1/hello?apiVersion=3", nil, &errResp)
 	if status != http.StatusUpgradeRequired {
 		t.Fatalf("incompatible hello status = %d, want %d", status, http.StatusUpgradeRequired)
 	}

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -187,6 +187,30 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 				t.Fatalf("unexpected writeback-secret channel: %q", r.URL.Query().Get("channel"))
 			}
 			_, _ = w.Write([]byte(`{"ok":true,"data":{"url":"https://relay.test/writeback","secret":"sec_123"}}`))
+		case "/v1/workspaces/ws_123/webhooks":
+			if r.Method != http.MethodPost {
+				t.Fatalf("expected webhooks POST, got %s", r.Method)
+			}
+			var body struct {
+				URL       string   `json:"url"`
+				PathGlobs []string `json:"pathGlobs"`
+				Secret    string   `json:"secret"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode webhook subscription body failed: %v", err)
+			}
+			if body.URL != "https://cast.test/v1/integrations/relayfile/inbound/ws/ch" ||
+				len(body.PathGlobs) != 1 ||
+				body.PathGlobs[0] != "/github/repos/acme/widgets/issues/**" ||
+				body.Secret != "inbound-secret" {
+				t.Fatalf("unexpected webhook subscription body: %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"subscriptionId":"whsub_123"}`))
+		case "/v1/workspaces/ws_123/webhooks/whsub_123":
+			if r.Method != http.MethodDelete {
+				t.Fatalf("expected webhooks DELETE, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -239,6 +263,32 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	}
 	if secret.URL != "https://relay.test/writeback" || secret.Secret != "sec_123" {
 		t.Fatalf("unexpected writeback secret: %#v", secret)
+	}
+
+	var subscription webhookSubscriptionResponse
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/webhook-subscriptions", webhookSubscriptionRequest{
+		Workspace: "demo",
+		URL:       "https://cast.test/v1/integrations/relayfile/inbound/ws/ch",
+		PathGlobs: []string{"/github/repos/acme/widgets/issues/**"},
+		Secret:    "inbound-secret",
+	}, &subscription)
+	if status != http.StatusOK {
+		t.Fatalf("webhook subscription status = %d", status)
+	}
+	if subscription.SubscriptionID != "whsub_123" {
+		t.Fatalf("unexpected webhook subscription: %#v", subscription)
+	}
+
+	var deleted map[string]bool
+	status = controlPlaneJSON(t, client, http.MethodDelete, baseURL+"/v1/integrations/webhook-subscriptions", deleteWebhookSubscriptionRequest{
+		Workspace:      "demo",
+		SubscriptionID: "whsub_123",
+	}, &deleted)
+	if status != http.StatusOK {
+		t.Fatalf("delete webhook subscription status = %d", status)
+	}
+	if !deleted["ok"] {
+		t.Fatalf("unexpected delete response: %#v", deleted)
 	}
 }
 

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -6,7 +6,7 @@ info:
     Versioned local control-plane contract for the relayfile daemon/CLI.
     The service listens on a user-owned Unix domain socket
     (`RELAYFILE_SOCK`, or `$XDG_RUNTIME_DIR/relayfile.sock`) and uses
-    `X-Relayfile-API-Version: 1` for client compatibility checks.
+    `X-Relayfile-API-Version: 2` for client compatibility checks.
 servers:
   - url: http://relayfile.local
     description: Logical HTTP origin over the relayfile Unix domain socket.
@@ -264,11 +264,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [ok]
-                properties:
-                  ok:
-                    type: boolean
+                $ref: "#/components/schemas/DeleteWebhookSubscriptionResponse"
 components:
   parameters:
     ApiVersionHeader:
@@ -278,7 +274,7 @@ components:
       schema:
         type: integer
         format: uint32
-        const: 1
+        const: 2
     ApiVersionQuery:
       name: apiVersion
       in: query
@@ -558,6 +554,12 @@ components:
           type: string
         subscriptionId:
           type: string
+    DeleteWebhookSubscriptionResponse:
+      type: object
+      required: [ok]
+      properties:
+        ok:
+          type: boolean
     ErrorEnvelope:
       type: object
       required: [error]

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -228,6 +228,47 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/WritebackSecret"
+  /v1/integrations/webhook-subscriptions:
+    post:
+      operationId: createWebhookSubscription
+      summary: Create a server-side relayfile webhook subscription
+      parameters:
+        - $ref: "#/components/parameters/ApiVersionHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookSubscriptionRequest"
+      responses:
+        "200":
+          description: Created webhook subscription
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookSubscriptionResponse"
+    delete:
+      operationId: deleteWebhookSubscription
+      summary: Delete a server-side relayfile webhook subscription
+      parameters:
+        - $ref: "#/components/parameters/ApiVersionHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteWebhookSubscriptionRequest"
+      responses:
+        "200":
+          description: Subscription deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok]
+                properties:
+                  ok:
+                    type: boolean
 components:
   parameters:
     ApiVersionHeader:
@@ -484,6 +525,38 @@ components:
         url:
           type: string
         secret:
+          type: string
+    WebhookSubscriptionRequest:
+      type: object
+      required: [url, pathGlobs, secret]
+      properties:
+        workspace:
+          type: string
+        url:
+          type: string
+          format: uri
+        pathGlobs:
+          type: array
+          minItems: 1
+          items:
+            type: string
+        secret:
+          type: string
+    WebhookSubscriptionResponse:
+      type: object
+      required: [subscriptionId]
+      properties:
+        subscriptionId:
+          type: string
+        secret:
+          type: string
+    DeleteWebhookSubscriptionRequest:
+      type: object
+      required: [subscriptionId]
+      properties:
+        workspace:
+          type: string
+        subscriptionId:
           type: string
     ErrorEnvelope:
       type: object

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,10 +29,6 @@
     "typescript": "^5.7.3",
     "vitest": "^3.0.0"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentWorkforce/relayfile",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,6 +29,10 @@
     "typescript": "^5.7.3",
     "vitest": "^3.0.0"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/AgentWorkforce/relayfile",

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -106,6 +106,42 @@ describe('RelayfileControlPlaneClient lifecycle', () => {
   });
 });
 
+describe('RelayfileControlPlaneClient integration webhook subscriptions', () => {
+  it('posts and deletes webhook subscriptions through the control-plane socket', async () => {
+    const client = new RelayfileControlPlaneClient({ socketPath: '/nope.sock', autoStart: false });
+    vi.spyOn(client, 'ensureReady').mockResolvedValue(undefined);
+    const rawRequest = vi.spyOn(client as unknown as { rawRequest: (opts: unknown) => Promise<unknown> }, 'rawRequest');
+    rawRequest.mockResolvedValueOnce({ subscriptionId: 'whsub_123' }).mockResolvedValueOnce(undefined);
+
+    await expect(
+      client.createWebhookSubscription({
+        workspace: 'demo',
+        url: 'https://cast.test/v1/integrations/relayfile/inbound/ws/ch',
+        pathGlobs: ['/github/repos/acme/widgets/issues/**'],
+        secret: 'inbound-secret',
+      })
+    ).resolves.toEqual({ subscriptionId: 'whsub_123' });
+
+    await expect(client.deleteWebhookSubscription('whsub_123', 'demo')).resolves.toBeUndefined();
+
+    expect(rawRequest).toHaveBeenNthCalledWith(1, {
+      method: 'POST',
+      path: '/v1/integrations/webhook-subscriptions',
+      body: {
+        workspace: 'demo',
+        url: 'https://cast.test/v1/integrations/relayfile/inbound/ws/ch',
+        pathGlobs: ['/github/repos/acme/widgets/issues/**'],
+        secret: 'inbound-secret',
+      },
+    });
+    expect(rawRequest).toHaveBeenNthCalledWith(2, {
+      method: 'DELETE',
+      path: '/v1/integrations/webhook-subscriptions',
+      body: { subscriptionId: 'whsub_123', workspace: 'demo' },
+    });
+  });
+});
+
 // Real-daemon contract tests — opt-in via RELAYFILE_BIN (CI builds the binary:
 // `go build -o relayfile ./cmd/relayfile-cli`). Boots the daemon and drives the
 // client over the socket.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -64,8 +64,8 @@ describe('RelayfileControlPlaneClient lifecycle', () => {
     const client = new RelayfileControlPlaneClient({ socketPath: '/nope.sock', autoStart: false });
     vi.spyOn(client, 'hello').mockResolvedValue({
       daemonVersion: '0.10.17',
-      apiVersion: 2,
-      supportedApiVersions: [2],
+      apiVersion: 1,
+      supportedApiVersions: [1],
     });
     await expect(client.ensureReady()).rejects.toMatchObject({ code: 'VERSION_INCOMPATIBLE' });
   });
@@ -111,7 +111,7 @@ describe('RelayfileControlPlaneClient integration webhook subscriptions', () => 
     const client = new RelayfileControlPlaneClient({ socketPath: '/nope.sock', autoStart: false });
     vi.spyOn(client, 'ensureReady').mockResolvedValue(undefined);
     const rawRequest = vi.spyOn(client as unknown as { rawRequest: (opts: unknown) => Promise<unknown> }, 'rawRequest');
-    rawRequest.mockResolvedValueOnce({ subscriptionId: 'whsub_123' }).mockResolvedValueOnce(undefined);
+    rawRequest.mockResolvedValueOnce({ subscriptionId: 'whsub_123' }).mockResolvedValueOnce({ ok: true });
 
     await expect(
       client.createWebhookSubscription({
@@ -122,7 +122,7 @@ describe('RelayfileControlPlaneClient integration webhook subscriptions', () => 
       })
     ).resolves.toEqual({ subscriptionId: 'whsub_123' });
 
-    await expect(client.deleteWebhookSubscription('whsub_123', 'demo')).resolves.toBeUndefined();
+    await expect(client.deleteWebhookSubscription('whsub_123', 'demo')).resolves.toEqual({ ok: true });
 
     expect(rawRequest).toHaveBeenNthCalledWith(1, {
       method: 'POST',

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -106,6 +106,8 @@ export type ConnectRequestBody = Schemas['ConnectProviderRequest'];
 export type ConnectResult = Schemas['ConnectProviderResponse'];
 export type ProviderStatusResult = Schemas['ProviderStatus'];
 export type WritebackSecretResult = Schemas['WritebackSecret'];
+export type WebhookSubscriptionRequestBody = Schemas['WebhookSubscriptionRequest'];
+export type WebhookSubscriptionResult = Schemas['WebhookSubscriptionResponse'];
 
 export interface RelayfileClientOptions {
   /** Socket to connect to. Defaults to defaultRelayfileSocketPath(). */
@@ -124,7 +126,7 @@ export interface RelayfileClientOptions {
 }
 
 interface RequestOptions {
-  method: 'GET' | 'POST';
+  method: 'DELETE' | 'GET' | 'POST';
   path: string;
   query?: Record<string, string | undefined>;
   body?: unknown;
@@ -390,6 +392,22 @@ export class RelayfileControlPlaneClient {
       method: 'POST',
       path: '/v1/integrations/writeback-secret',
       body: { channel, ...(workspace ? { workspace } : {}) },
+    });
+  }
+
+  createWebhookSubscription(input: WebhookSubscriptionRequestBody): Promise<WebhookSubscriptionResult> {
+    return this.request<WebhookSubscriptionResult>({
+      method: 'POST',
+      path: '/v1/integrations/webhook-subscriptions',
+      body: input,
+    });
+  }
+
+  deleteWebhookSubscription(subscriptionId: string, workspace?: string): Promise<void> {
+    return this.request<void>({
+      method: 'DELETE',
+      path: '/v1/integrations/webhook-subscriptions',
+      body: { subscriptionId, ...(workspace ? { workspace } : {}) },
     });
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -17,14 +17,13 @@ import type { components } from './generated/control-plane.js';
  * rename in the contract is a compile error here.
  */
 
-/** Control-plane API version this client speaks. Bump on a breaking wire change. */
-export const RELAYFILE_API_VERSION = 1;
+/** Control-plane API version this client speaks. Bump when adding required endpoint support. */
+export const RELAYFILE_API_VERSION = 2;
 
 /**
  * Minimum `relayfile` daemon version this client requires. The control-plane
  * first shipped in 0.10.17, so anything that answers `/v1/hello` is already >=
- * this — the check is belt-and-suspenders and the bump point for future
- * contract changes.
+ * this — API compatibility is enforced by RELAYFILE_API_VERSION.
  */
 export const MIN_RELAYFILE_VERSION = '0.10.17';
 
@@ -108,6 +107,8 @@ export type ProviderStatusResult = Schemas['ProviderStatus'];
 export type WritebackSecretResult = Schemas['WritebackSecret'];
 export type WebhookSubscriptionRequestBody = Schemas['WebhookSubscriptionRequest'];
 export type WebhookSubscriptionResult = Schemas['WebhookSubscriptionResponse'];
+export type DeleteWebhookSubscriptionRequestBody = Schemas['DeleteWebhookSubscriptionRequest'];
+export type DeleteWebhookSubscriptionResult = Schemas['DeleteWebhookSubscriptionResponse'];
 
 export interface RelayfileClientOptions {
   /** Socket to connect to. Defaults to defaultRelayfileSocketPath(). */
@@ -403,11 +404,14 @@ export class RelayfileControlPlaneClient {
     });
   }
 
-  deleteWebhookSubscription(subscriptionId: string, workspace?: string): Promise<void> {
-    return this.request<void>({
+  deleteWebhookSubscription(
+    subscriptionId: DeleteWebhookSubscriptionRequestBody['subscriptionId'],
+    workspace?: DeleteWebhookSubscriptionRequestBody['workspace']
+  ): Promise<DeleteWebhookSubscriptionResult> {
+    return this.request<DeleteWebhookSubscriptionResult>({
       method: 'DELETE',
       path: '/v1/integrations/webhook-subscriptions',
-      body: { subscriptionId, ...(workspace ? { workspace } : {}) },
+      body: { subscriptionId, ...(workspace ? { workspace } : {}) } satisfies DeleteWebhookSubscriptionRequestBody,
     });
   }
 

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -301,6 +301,9 @@ export interface components {
             workspace?: string;
             subscriptionId: string;
         };
+        DeleteWebhookSubscriptionResponse: {
+            ok: boolean;
+        };
         ErrorEnvelope: {
             error: {
                 /** @enum {string} */
@@ -339,7 +342,7 @@ export interface components {
         };
     };
     parameters: {
-        ApiVersionHeader: 1;
+        ApiVersionHeader: 2;
         ApiVersionQuery: number;
     };
     requestBodies: never;
@@ -679,9 +682,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        ok: boolean;
-                    };
+                    "application/json": components["schemas"]["DeleteWebhookSubscriptionResponse"];
                 };
             };
         };

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -159,6 +159,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/integrations/webhook-subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a server-side relayfile webhook subscription */
+        post: operations["createWebhookSubscription"];
+        /** Delete a server-side relayfile webhook subscription */
+        delete: operations["deleteWebhookSubscription"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -267,6 +285,21 @@ export interface components {
         WritebackSecret: {
             url: string;
             secret: string;
+        };
+        WebhookSubscriptionRequest: {
+            workspace?: string;
+            /** Format: uri */
+            url: string;
+            pathGlobs: string[];
+            secret: string;
+        };
+        WebhookSubscriptionResponse: {
+            subscriptionId: string;
+            secret?: string;
+        };
+        DeleteWebhookSubscriptionRequest: {
+            workspace?: string;
+            subscriptionId: string;
         };
         ErrorEnvelope: {
             error: {
@@ -595,6 +628,60 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WritebackSecret"];
+                };
+            };
+        };
+    };
+    createWebhookSubscription: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Relayfile-API-Version"?: components["parameters"]["ApiVersionHeader"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WebhookSubscriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description Created webhook subscription */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebhookSubscriptionResponse"];
+                };
+            };
+        };
+    };
+    deleteWebhookSubscription: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Relayfile-API-Version"?: components["parameters"]["ApiVersionHeader"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["DeleteWebhookSubscriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description Subscription deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        ok: boolean;
+                    };
                 };
             };
         };

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,6 +20,10 @@ export type {
   ConnectResult,
   ProviderStatusResult,
   WritebackSecretResult,
+  WebhookSubscriptionRequestBody,
+  WebhookSubscriptionResult,
+  DeleteWebhookSubscriptionRequestBody,
+  DeleteWebhookSubscriptionResult,
 } from './client.js';
 
 export type { components, paths, operations } from './generated/control-plane.js';


### PR DESCRIPTION
Part of the **inbound integration bridge** (provider → relay agent, server-side, no client process). Companion PRs: relaycast (ingress), relaycast-cloud (secret+expose), relay (CLI subscribe), relayfile (control-plane proxy), relayfile-cloud (snapshot enrichment). **Cross-repo — review/merge together.**

Local control-plane proxies webhook_subscription create/delete to relayfile-cloud; TS client + generated OpenAPI types updated.

Tests: `@relayfile/client` (10 passing) + typecheck + `go test ./cmd/relayfile-cli -run TestControlPlaneCloudIntegrationConformance`.

### Review status
3-way fresh-eyes review completed. Fixed: fail-closed HMAC secret normalization, 5xx-on-transient (no silent loss), require-dedupe-key (no double-inject). Verified correct: exactly-once node delivery, snapshot bounds, signing order.

### ⚠️ Draft — before merge
- [ ] Fix C: `unsubscribe` must delete the relayfile-cloud webhook_subscription (persist its id on the binding) — currently unsubscribe does not stop inbound delivery (cross-repo: relay CLI + relayfile daemon)
- [ ] Add tests: golden-fixture HMAC round-trip, enrichment bounds/lazy hydration, CLI rollback/unsubscribe assertions
- [ ] Add `cast.agentrelay.com` to `RELAYFILE_WEBHOOK_HOST_ALLOWLIST` for the preview/prod host
- [ ] E2E on a preview stage: real Slack/GitHub/Linear message → relay channel, no client process
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

