### PR TITLE
fix(control-plane): persist inbound webhook subscriptions

### DIFF
--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -594,13 +594,24 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 			"",
 			nil,
 		); err != nil {
-			// Idempotent delete: an upstream 404 means the subscription is
-			// already gone. Callers retry recorded cleanup ids, so a retried
-			// delete of a known-deleted id must observe success — surfacing an
-			// error here would make them retain the id forever.
+			// Idempotent delete, but ONLY for a workspace-pinned request: a
+			// pinned 404 proves the subscription is gone at its recorded
+			// workspace, so retried cleanups must observe success. An
+			// UNPINNED 404 may just mean the daemon's active workspace
+			// changed — surface it so callers retain their record instead of
+			// discarding an id that still exists elsewhere.
 			var upstreamErr *apiError
 			if errors.As(err, &upstreamErr) && upstreamErr.StatusCode == http.StatusNotFound {
-				writeControlPlaneJSON(w, http.StatusOK, map[string]bool{"ok": true})
+				if strings.TrimSpace(req.Workspace) != "" {
+					writeControlPlaneJSON(w, http.StatusOK, map[string]bool{"ok": true})
+					return
+				}
+				writeControlPlaneError(
+					w,
+					http.StatusNotFound,
+					controlPlaneErrBindingNotFound,
+					"webhook subscription not found in the active workspace; retry with its workspace pin",
+				)
 				return
 			}
 			writeControlPlaneMappedError(w, err)

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -19,9 +19,9 @@ import (
 	"time"
 )
 
-const relayfileControlPlaneAPIVersion uint32 = 2
+const relayfileControlPlaneAPIVersion uint32 = 3
 
-var relayfileControlPlaneSupportedVersions = []uint32{1, relayfileControlPlaneAPIVersion}
+var relayfileControlPlaneSupportedVersions = []uint32{1, 2, relayfileControlPlaneAPIVersion}
 
 type controlPlaneErrorCode string
 
@@ -87,12 +87,13 @@ type resolveResourcePathResponse struct {
 }
 
 type bindRequest struct {
-	Provider       string `json:"provider"`
-	Resource       string `json:"resource"`
-	Channel        string `json:"channel"`
-	WebhookID      string `json:"webhookId"`
-	WebhookToken   string `json:"webhookToken"`
-	SubscriptionID string `json:"subscriptionId,omitempty"`
+	Provider              string `json:"provider"`
+	Resource              string `json:"resource"`
+	Channel               string `json:"channel"`
+	WebhookID             string `json:"webhookId"`
+	WebhookToken          string `json:"webhookToken"`
+	SubscriptionID        string `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
 }
 
 type bindResponse struct {
@@ -396,12 +397,13 @@ func handleControlPlaneBind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:       req.Provider,
-		Resource:       req.Resource,
-		Channel:        req.Channel,
-		WebhookID:      req.WebhookID,
-		WebhookToken:   req.WebhookToken,
-		SubscriptionID: req.SubscriptionID,
+		Provider:              req.Provider,
+		Resource:              req.Resource,
+		Channel:               req.Channel,
+		WebhookID:             req.WebhookID,
+		WebhookToken:          req.WebhookToken,
+		SubscriptionID:        req.SubscriptionID,
+		WebhookSubscriptionID: req.WebhookSubscriptionID,
 	})
 	if err != nil {
 		writeControlPlaneMappedError(w, err)

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -87,13 +87,14 @@ type resolveResourcePathResponse struct {
 }
 
 type bindRequest struct {
-	Provider              string `json:"provider"`
-	Resource              string `json:"resource"`
-	Channel               string `json:"channel"`
-	WebhookID             string `json:"webhookId"`
-	WebhookToken          string `json:"webhookToken"`
-	SubscriptionID        string `json:"subscriptionId,omitempty"`
-	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
+	Provider                      string    `json:"provider"`
+	Resource                      string    `json:"resource"`
+	Channel                       string    `json:"channel"`
+	WebhookID                     string    `json:"webhookId"`
+	WebhookToken                  string    `json:"webhookToken"`
+	SubscriptionID                string    `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID         string    `json:"webhookSubscriptionId,omitempty"`
+	PendingWebhookSubscriptionIDs *[]string `json:"pendingWebhookSubscriptionIds,omitempty"`
 }
 
 type bindResponse struct {
@@ -397,13 +398,14 @@ func handleControlPlaneBind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:              req.Provider,
-		Resource:              req.Resource,
-		Channel:               req.Channel,
-		WebhookID:             req.WebhookID,
-		WebhookToken:          req.WebhookToken,
-		SubscriptionID:        req.SubscriptionID,
-		WebhookSubscriptionID: req.WebhookSubscriptionID,
+		Provider:                      req.Provider,
+		Resource:                      req.Resource,
+		Channel:                       req.Channel,
+		WebhookID:                     req.WebhookID,
+		WebhookToken:                  req.WebhookToken,
+		SubscriptionID:                req.SubscriptionID,
+		WebhookSubscriptionID:         req.WebhookSubscriptionID,
+		PendingWebhookSubscriptionIDs: req.PendingWebhookSubscriptionIDs,
 	})
 	if err != nil {
 		writeControlPlaneMappedError(w, err)

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -94,6 +94,10 @@ type bindRequest struct {
 	WebhookToken          string `json:"webhookToken"`
 	SubscriptionID        string `json:"subscriptionId,omitempty"`
 	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
+	// Workspace the webhook subscription was created in, persisted with the
+	// binding so later cleanup deletes are pinned to the right workspace even
+	// after the daemon's active workspace changes.
+	WebhookSubscriptionWorkspaceID string `json:"webhookSubscriptionWorkspaceId,omitempty"`
 }
 
 type bindResponse struct {
@@ -119,6 +123,9 @@ type writebackSecretRequest struct {
 type writebackSecretData struct {
 	URL    string `json:"url"`
 	Secret string `json:"secret"`
+	// WorkspaceID pins which workspace resolved this channel's writeback
+	// binding, so callers can journal it before creating cloud resources.
+	WorkspaceID string `json:"workspaceId,omitempty"`
 }
 
 type webhookSubscriptionRequest struct {
@@ -412,13 +419,14 @@ func handleControlPlaneBind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:              req.Provider,
-		Resource:              req.Resource,
-		Channel:               req.Channel,
-		WebhookID:             req.WebhookID,
-		WebhookToken:          req.WebhookToken,
-		SubscriptionID:        req.SubscriptionID,
-		WebhookSubscriptionID: req.WebhookSubscriptionID,
+		Provider:                       req.Provider,
+		Resource:                       req.Resource,
+		Channel:                        req.Channel,
+		WebhookID:                      req.WebhookID,
+		WebhookToken:                   req.WebhookToken,
+		SubscriptionID:                 req.SubscriptionID,
+		WebhookSubscriptionID:          req.WebhookSubscriptionID,
+		WebhookSubscriptionWorkspaceID: req.WebhookSubscriptionWorkspaceID,
 	})
 	if err != nil {
 		writeControlPlaneMappedError(w, err)

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -131,6 +131,10 @@ type webhookSubscriptionRequest struct {
 type webhookSubscriptionResponse struct {
 	SubscriptionID string `json:"subscriptionId"`
 	Secret         string `json:"secret,omitempty"`
+	// WorkspaceID pins which workspace the subscription was created in, so
+	// callers can journal it and later delete/list through the SAME workspace
+	// even if the daemon's active workspace changes.
+	WorkspaceID string `json:"workspaceId,omitempty"`
 }
 
 type deleteWebhookSubscriptionRequest struct {
@@ -140,6 +144,7 @@ type deleteWebhookSubscriptionRequest struct {
 
 type listWebhookSubscriptionsResponse struct {
 	Subscriptions []webhookSubscriptionSummary `json:"subscriptions"`
+	WorkspaceID   string                       `json:"workspaceId,omitempty"`
 }
 
 type webhookSubscriptionSummary struct {
@@ -514,7 +519,10 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 				PathGlobs:      item.PathGlobs,
 			})
 		}
-		writeControlPlaneJSON(w, http.StatusOK, listWebhookSubscriptionsResponse{Subscriptions: subscriptions})
+		writeControlPlaneJSON(w, http.StatusOK, listWebhookSubscriptionsResponse{
+			Subscriptions: subscriptions,
+			WorkspaceID:   workspaceID,
+		})
 	case http.MethodPost:
 		var req webhookSubscriptionRequest
 		if err := decodeControlPlaneJSON(r, &req); err != nil {
@@ -536,6 +544,7 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 			return
 		}
 		var response webhookSubscriptionResponse
+		response.WorkspaceID = workspaceID
 		if err := commandClient.client.postJSON(
 			r.Context(),
 			fmt.Sprintf("/v1/workspaces/%s/webhooks", url.PathEscape(workspaceID)),

--- a/cmd/relayfile-cli/control_plane.go
+++ b/cmd/relayfile-cli/control_plane.go
@@ -87,14 +87,13 @@ type resolveResourcePathResponse struct {
 }
 
 type bindRequest struct {
-	Provider                      string    `json:"provider"`
-	Resource                      string    `json:"resource"`
-	Channel                       string    `json:"channel"`
-	WebhookID                     string    `json:"webhookId"`
-	WebhookToken                  string    `json:"webhookToken"`
-	SubscriptionID                string    `json:"subscriptionId,omitempty"`
-	WebhookSubscriptionID         string    `json:"webhookSubscriptionId,omitempty"`
-	PendingWebhookSubscriptionIDs *[]string `json:"pendingWebhookSubscriptionIds,omitempty"`
+	Provider              string `json:"provider"`
+	Resource              string `json:"resource"`
+	Channel               string `json:"channel"`
+	WebhookID             string `json:"webhookId"`
+	WebhookToken          string `json:"webhookToken"`
+	SubscriptionID        string `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
 }
 
 type bindResponse struct {
@@ -137,6 +136,16 @@ type webhookSubscriptionResponse struct {
 type deleteWebhookSubscriptionRequest struct {
 	Workspace      string `json:"workspace,omitempty"`
 	SubscriptionID string `json:"subscriptionId"`
+}
+
+type listWebhookSubscriptionsResponse struct {
+	Subscriptions []webhookSubscriptionSummary `json:"subscriptions"`
+}
+
+type webhookSubscriptionSummary struct {
+	SubscriptionID string   `json:"subscriptionId"`
+	URL            string   `json:"url"`
+	PathGlobs      []string `json:"pathGlobs"`
 }
 
 func runControlPlane(args []string, stdout io.Writer) error {
@@ -398,14 +407,13 @@ func handleControlPlaneBind(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:                      req.Provider,
-		Resource:                      req.Resource,
-		Channel:                       req.Channel,
-		WebhookID:                     req.WebhookID,
-		WebhookToken:                  req.WebhookToken,
-		SubscriptionID:                req.SubscriptionID,
-		WebhookSubscriptionID:         req.WebhookSubscriptionID,
-		PendingWebhookSubscriptionIDs: req.PendingWebhookSubscriptionIDs,
+		Provider:              req.Provider,
+		Resource:              req.Resource,
+		Channel:               req.Channel,
+		WebhookID:             req.WebhookID,
+		WebhookToken:          req.WebhookToken,
+		SubscriptionID:        req.SubscriptionID,
+		WebhookSubscriptionID: req.WebhookSubscriptionID,
 	})
 	if err != nil {
 		writeControlPlaneMappedError(w, err)
@@ -474,6 +482,39 @@ func handleControlPlaneWritebackSecret(w http.ResponseWriter, r *http.Request) {
 
 func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
+	case http.MethodGet:
+		commandClient, err := prepareWorkspaceCommandClient(strings.TrimSpace(r.URL.Query().Get("workspace")), "", "", defaultJoinScopes)
+		if err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		workspaceID := strings.TrimSpace(commandClient.workspaceID)
+		if workspaceID == "" {
+			writeControlPlaneMappedError(w, errors.New("could not resolve relayfile workspace id"))
+			return
+		}
+		var upstream []struct {
+			ID        string   `json:"id"`
+			URL       string   `json:"url"`
+			PathGlobs []string `json:"pathGlobs"`
+		}
+		if err := commandClient.client.getJSON(
+			r.Context(),
+			fmt.Sprintf("/v1/workspaces/%s/webhooks", url.PathEscape(workspaceID)),
+			&upstream,
+		); err != nil {
+			writeControlPlaneMappedError(w, err)
+			return
+		}
+		subscriptions := make([]webhookSubscriptionSummary, 0, len(upstream))
+		for _, item := range upstream {
+			subscriptions = append(subscriptions, webhookSubscriptionSummary{
+				SubscriptionID: item.ID,
+				URL:            item.URL,
+				PathGlobs:      item.PathGlobs,
+			})
+		}
+		writeControlPlaneJSON(w, http.StatusOK, listWebhookSubscriptionsResponse{Subscriptions: subscriptions})
 	case http.MethodPost:
 		var req webhookSubscriptionRequest
 		if err := decodeControlPlaneJSON(r, &req); err != nil {
@@ -536,6 +577,15 @@ func handleControlPlaneWebhookSubscription(w http.ResponseWriter, r *http.Reques
 			"",
 			nil,
 		); err != nil {
+			// Idempotent delete: an upstream 404 means the subscription is
+			// already gone. Callers retry recorded cleanup ids, so a retried
+			// delete of a known-deleted id must observe success — surfacing an
+			// error here would make them retain the id forever.
+			var upstreamErr *apiError
+			if errors.As(err, &upstreamErr) && upstreamErr.StatusCode == http.StatusNotFound {
+				writeControlPlaneJSON(w, http.StatusOK, map[string]bool{"ok": true})
+				return
+			}
 			writeControlPlaneMappedError(w, err)
 			return
 		}

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -61,7 +61,6 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 		t.Fatalf("upsert workspace failed: %v", err)
 	}
 	writeTestMountFile(t, localDir, "slack/channels/by-name/watchdog-test.json", `{"id":"C123","canonicalPath":"/slack/channels/C123__watchdog-test/meta.json"}`)
-	pending := []string{"relayfile_whsub_old", " relayfile_whsub_old ", ""}
 
 	client, baseURL, cleanup := startControlPlaneTestServer(t)
 	defer cleanup()
@@ -80,19 +79,18 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 
 	var bound bindResponse
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:                      "slack",
-		Resource:                      "#watchdog-test",
-		Channel:                       "#events",
-		WebhookID:                     "wh_1",
-		WebhookToken:                  "tok_1",
-		SubscriptionID:                "relay_sub_1",
-		WebhookSubscriptionID:         "relayfile_whsub_1",
-		PendingWebhookSubscriptionIDs: &pending,
+		Provider:              "slack",
+		Resource:              "#watchdog-test",
+		Channel:               "#events",
+		WebhookID:             "wh_1",
+		WebhookToken:          "tok_1",
+		SubscriptionID:        "relay_sub_1",
+		WebhookSubscriptionID: "relayfile_whsub_1",
 	}, &bound)
 	if status != http.StatusOK {
 		t.Fatalf("bind status = %d", status)
 	}
-	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" || len(bound.Binding.PendingWebhookSubscriptionIDs) != 1 || bound.Binding.PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
+	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected bind response: %#v", bound)
 	}
 
@@ -101,7 +99,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("bindings status = %d", status)
 	}
-	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" || len(listed.Bindings[0].PendingWebhookSubscriptionIDs) != 1 || listed.Bindings[0].PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
+	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected bindings response: %#v", listed)
 	}
 
@@ -113,38 +111,8 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &cliBindings); err != nil {
 		t.Fatalf("parse bind --list --json output failed: %v\n%s", err, stdout.String())
 	}
-	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob || cliBindings[0].WebhookSubscriptionID != "relayfile_whsub_1" || len(cliBindings[0].PendingWebhookSubscriptionIDs) != 1 || cliBindings[0].PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
+	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob || cliBindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected CLI bindings: %#v", cliBindings)
-	}
-
-	// Omitted fields preserve pending cleanup work for older callers, while an
-	// explicit empty list clears it after the caller has confirmed retirement.
-	var updated bindResponse
-	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:              "slack",
-		Resource:              "#watchdog-test",
-		Channel:               "#events",
-		WebhookID:             "wh_2",
-		WebhookToken:          "tok_2",
-		SubscriptionID:        "relay_sub_2",
-		WebhookSubscriptionID: "relayfile_whsub_2",
-	}, &updated)
-	if status != http.StatusOK || len(updated.Binding.PendingWebhookSubscriptionIDs) != 1 || updated.Binding.PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
-		t.Fatalf("omitted pending cleanup IDs were not preserved: status=%d binding=%#v", status, updated.Binding)
-	}
-	emptyPending := []string{}
-	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:                      "slack",
-		Resource:                      "#watchdog-test",
-		Channel:                       "#events",
-		WebhookID:                     "wh_2",
-		WebhookToken:                  "tok_2",
-		SubscriptionID:                "relay_sub_2",
-		WebhookSubscriptionID:         "relayfile_whsub_2",
-		PendingWebhookSubscriptionIDs: &emptyPending,
-	}, &updated)
-	if status != http.StatusOK || len(updated.Binding.PendingWebhookSubscriptionIDs) != 0 {
-		t.Fatalf("explicit empty pending cleanup IDs did not clear: status=%d binding=%#v", status, updated.Binding)
 	}
 
 	var unbound relayIntegrationUnbindResult
@@ -225,6 +193,10 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 			}
 			_, _ = w.Write([]byte(`{"ok":true,"data":{"url":"https://relay.test/writeback","secret":"sec_123"}}`))
 		case "/v1/workspaces/ws_123/webhooks":
+			if r.Method == http.MethodGet {
+				_, _ = w.Write([]byte(`[{"id":"whsub_123","url":"https://cast.test/v1/integrations/relayfile/inbound/ws/ch","pathGlobs":["/github/repos/acme/widgets/issues/**"],"createdAt":"2026-07-10T00:00:00Z","updatedAt":"2026-07-10T00:00:00Z","health":{"lastDeliveryAt":null,"lastSuccessAt":null,"lastError":null,"consecutiveFailures":0}}]`))
+				return
+			}
 			if r.Method != http.MethodPost {
 				t.Fatalf("expected webhooks POST, got %s", r.Method)
 			}
@@ -248,6 +220,12 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 				t.Fatalf("expected webhooks DELETE, got %s", r.Method)
 			}
 			w.WriteHeader(http.StatusNoContent)
+		case "/v1/workspaces/ws_123/webhooks/whsub_gone":
+			if r.Method != http.MethodDelete {
+				t.Fatalf("expected webhooks DELETE, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"webhook subscription not found","code":"not_found"}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -316,6 +294,19 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 		t.Fatalf("unexpected webhook subscription: %#v", subscription)
 	}
 
+	var listedSubscriptions listWebhookSubscriptionsResponse
+	status = controlPlaneJSON(t, client, http.MethodGet, baseURL+"/v1/integrations/webhook-subscriptions?workspace=demo", nil, &listedSubscriptions)
+	if status != http.StatusOK {
+		t.Fatalf("list webhook subscriptions status = %d", status)
+	}
+	if len(listedSubscriptions.Subscriptions) != 1 ||
+		listedSubscriptions.Subscriptions[0].SubscriptionID != "whsub_123" ||
+		listedSubscriptions.Subscriptions[0].URL != "https://cast.test/v1/integrations/relayfile/inbound/ws/ch" ||
+		len(listedSubscriptions.Subscriptions[0].PathGlobs) != 1 ||
+		listedSubscriptions.Subscriptions[0].PathGlobs[0] != "/github/repos/acme/widgets/issues/**" {
+		t.Fatalf("unexpected webhook subscription list: %#v", listedSubscriptions)
+	}
+
 	var deleted map[string]bool
 	status = controlPlaneJSON(t, client, http.MethodDelete, baseURL+"/v1/integrations/webhook-subscriptions", deleteWebhookSubscriptionRequest{
 		Workspace:      "demo",
@@ -326,6 +317,21 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	}
 	if !deleted["ok"] {
 		t.Fatalf("unexpected delete response: %#v", deleted)
+	}
+
+	// Idempotent delete: the upstream 404 for an already-deleted subscription
+	// must surface as success so retried cleanups of a recorded id progress
+	// instead of retaining it forever.
+	var deletedGone map[string]bool
+	status = controlPlaneJSON(t, client, http.MethodDelete, baseURL+"/v1/integrations/webhook-subscriptions", deleteWebhookSubscriptionRequest{
+		Workspace:      "demo",
+		SubscriptionID: "whsub_gone",
+	}, &deletedGone)
+	if status != http.StatusOK {
+		t.Fatalf("delete of already-deleted webhook subscription status = %d", status)
+	}
+	if !deletedGone["ok"] {
+		t.Fatalf("unexpected idempotent delete response: %#v", deletedGone)
 	}
 }
 

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -290,7 +290,7 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("webhook subscription status = %d", status)
 	}
-	if subscription.SubscriptionID != "whsub_123" {
+	if subscription.SubscriptionID != "whsub_123" || subscription.WorkspaceID != "ws_123" {
 		t.Fatalf("unexpected webhook subscription: %#v", subscription)
 	}
 
@@ -298,6 +298,9 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	status = controlPlaneJSON(t, client, http.MethodGet, baseURL+"/v1/integrations/webhook-subscriptions?workspace=demo", nil, &listedSubscriptions)
 	if status != http.StatusOK {
 		t.Fatalf("list webhook subscriptions status = %d", status)
+	}
+	if listedSubscriptions.WorkspaceID != "ws_123" {
+		t.Fatalf("unexpected webhook subscription list workspace: %#v", listedSubscriptions)
 	}
 	if len(listedSubscriptions.Subscriptions) != 1 ||
 		listedSubscriptions.Subscriptions[0].SubscriptionID != "whsub_123" ||

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -79,18 +79,19 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 
 	var bound bindResponse
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:              "slack",
-		Resource:              "#watchdog-test",
-		Channel:               "#events",
-		WebhookID:             "wh_1",
-		WebhookToken:          "tok_1",
-		SubscriptionID:        "relay_sub_1",
-		WebhookSubscriptionID: "relayfile_whsub_1",
+		Provider:                       "slack",
+		Resource:                       "#watchdog-test",
+		Channel:                        "#events",
+		WebhookID:                      "wh_1",
+		WebhookToken:                   "tok_1",
+		SubscriptionID:                 "relay_sub_1",
+		WebhookSubscriptionID:          "relayfile_whsub_1",
+		WebhookSubscriptionWorkspaceID: "rw_pin_1",
 	}, &bound)
 	if status != http.StatusOK {
 		t.Fatalf("bind status = %d", status)
 	}
-	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" {
+	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" || bound.Binding.WebhookSubscriptionWorkspaceID != "rw_pin_1" {
 		t.Fatalf("unexpected bind response: %#v", bound)
 	}
 
@@ -99,7 +100,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("bindings status = %d", status)
 	}
-	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
+	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" || listed.Bindings[0].WebhookSubscriptionWorkspaceID != "rw_pin_1" {
 		t.Fatalf("unexpected bindings response: %#v", listed)
 	}
 
@@ -276,7 +277,7 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("writeback-secret status = %d", status)
 	}
-	if secret.URL != "https://relay.test/writeback" || secret.Secret != "sec_123" {
+	if secret.URL != "https://relay.test/writeback" || secret.Secret != "sec_123" || secret.WorkspaceID != "ws_123" {
 		t.Fatalf("unexpected writeback secret: %#v", secret)
 	}
 

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -116,6 +116,69 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 		t.Fatalf("unexpected CLI bindings: %#v", cliBindings)
 	}
 
+	// A replacement that omits the workspace pin (legacy/partial caller) must
+	// not strip it from the persisted binding.
+	var repinned bindResponse
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:     "slack",
+		Resource:     "#watchdog-test",
+		Channel:      "#events",
+		WebhookID:    "wh_2",
+		WebhookToken: "tok_2",
+	}, &repinned)
+	if status != http.StatusOK {
+		t.Fatalf("replacement bind status = %d", status)
+	}
+	if repinned.Binding.WebhookSubscriptionID != "relayfile_whsub_1" || repinned.Binding.WebhookSubscriptionWorkspaceID != "rw_pin_1" {
+		t.Fatalf("omitted ids/pin were not preserved on replacement: %#v", repinned.Binding)
+	}
+
+	// Mismatched-pair permutation 1: a replacement PROVIDING a new id but no
+	// workspace must persist (newSub, "") — never (newSub, oldWs).
+	var newIDNoWs bindResponse
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:              "slack",
+		Resource:              "#watchdog-test",
+		Channel:               "#events",
+		WebhookID:             "wh_3",
+		WebhookToken:          "tok_3",
+		WebhookSubscriptionID: "relayfile_whsub_2",
+	}, &newIDNoWs)
+	if status != http.StatusOK {
+		t.Fatalf("new-id replacement bind status = %d", status)
+	}
+	if newIDNoWs.Binding.WebhookSubscriptionID != "relayfile_whsub_2" || newIDNoWs.Binding.WebhookSubscriptionWorkspaceID != "" {
+		t.Fatalf("new id inherited a stale workspace pin: %#v", newIDNoWs.Binding)
+	}
+
+	// Mismatched-pair permutation 2: a workspace without its id is rejected.
+	var pairErr map[string]controlPlaneError
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:                       "slack",
+		Resource:                       "#watchdog-test",
+		Channel:                        "#events",
+		WebhookID:                      "wh_4",
+		WebhookToken:                   "tok_4",
+		WebhookSubscriptionWorkspaceID: "rw_orphan_ws",
+	}, &pairErr)
+	if status != http.StatusBadRequest {
+		t.Fatalf("workspace-without-id bind status = %d, want 400", status)
+	}
+
+	// Restore the pinned pair for the remaining assertions.
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:                       "slack",
+		Resource:                       "#watchdog-test",
+		Channel:                        "#events",
+		WebhookID:                      "wh_2",
+		WebhookToken:                   "tok_2",
+		WebhookSubscriptionID:          "relayfile_whsub_1",
+		WebhookSubscriptionWorkspaceID: "rw_pin_1",
+	}, &repinned)
+	if status != http.StatusOK {
+		t.Fatalf("restore bind status = %d", status)
+	}
+
 	var unbound relayIntegrationUnbindResult
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/unbind", unbindRequest{
 		Provider: "slack",

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -61,6 +61,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 		t.Fatalf("upsert workspace failed: %v", err)
 	}
 	writeTestMountFile(t, localDir, "slack/channels/by-name/watchdog-test.json", `{"id":"C123","canonicalPath":"/slack/channels/C123__watchdog-test/meta.json"}`)
+	pending := []string{"relayfile_whsub_old", " relayfile_whsub_old ", ""}
 
 	client, baseURL, cleanup := startControlPlaneTestServer(t)
 	defer cleanup()
@@ -79,18 +80,19 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 
 	var bound bindResponse
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:              "slack",
-		Resource:              "#watchdog-test",
-		Channel:               "#events",
-		WebhookID:             "wh_1",
-		WebhookToken:          "tok_1",
-		SubscriptionID:        "relay_sub_1",
-		WebhookSubscriptionID: "relayfile_whsub_1",
+		Provider:                      "slack",
+		Resource:                      "#watchdog-test",
+		Channel:                       "#events",
+		WebhookID:                     "wh_1",
+		WebhookToken:                  "tok_1",
+		SubscriptionID:                "relay_sub_1",
+		WebhookSubscriptionID:         "relayfile_whsub_1",
+		PendingWebhookSubscriptionIDs: &pending,
 	}, &bound)
 	if status != http.StatusOK {
 		t.Fatalf("bind status = %d", status)
 	}
-	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" {
+	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" || len(bound.Binding.PendingWebhookSubscriptionIDs) != 1 || bound.Binding.PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
 		t.Fatalf("unexpected bind response: %#v", bound)
 	}
 
@@ -99,7 +101,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("bindings status = %d", status)
 	}
-	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
+	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" || len(listed.Bindings[0].PendingWebhookSubscriptionIDs) != 1 || listed.Bindings[0].PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
 		t.Fatalf("unexpected bindings response: %#v", listed)
 	}
 
@@ -111,8 +113,38 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &cliBindings); err != nil {
 		t.Fatalf("parse bind --list --json output failed: %v\n%s", err, stdout.String())
 	}
-	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob || cliBindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
+	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob || cliBindings[0].WebhookSubscriptionID != "relayfile_whsub_1" || len(cliBindings[0].PendingWebhookSubscriptionIDs) != 1 || cliBindings[0].PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
 		t.Fatalf("unexpected CLI bindings: %#v", cliBindings)
+	}
+
+	// Omitted fields preserve pending cleanup work for older callers, while an
+	// explicit empty list clears it after the caller has confirmed retirement.
+	var updated bindResponse
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:              "slack",
+		Resource:              "#watchdog-test",
+		Channel:               "#events",
+		WebhookID:             "wh_2",
+		WebhookToken:          "tok_2",
+		SubscriptionID:        "relay_sub_2",
+		WebhookSubscriptionID: "relayfile_whsub_2",
+	}, &updated)
+	if status != http.StatusOK || len(updated.Binding.PendingWebhookSubscriptionIDs) != 1 || updated.Binding.PendingWebhookSubscriptionIDs[0] != "relayfile_whsub_old" {
+		t.Fatalf("omitted pending cleanup IDs were not preserved: status=%d binding=%#v", status, updated.Binding)
+	}
+	emptyPending := []string{}
+	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
+		Provider:                      "slack",
+		Resource:                      "#watchdog-test",
+		Channel:                       "#events",
+		WebhookID:                     "wh_2",
+		WebhookToken:                  "tok_2",
+		SubscriptionID:                "relay_sub_2",
+		WebhookSubscriptionID:         "relayfile_whsub_2",
+		PendingWebhookSubscriptionIDs: &emptyPending,
+	}, &updated)
+	if status != http.StatusOK || len(updated.Binding.PendingWebhookSubscriptionIDs) != 0 {
+		t.Fatalf("explicit empty pending cleanup IDs did not clear: status=%d binding=%#v", status, updated.Binding)
 	}
 
 	var unbound relayIntegrationUnbindResult

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -35,15 +35,15 @@ func TestControlPlaneHelloVersionAndCLIVersion(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("hello status = %d", status)
 	}
-	if hello.DaemonVersion != "0.10.17" || hello.APIVersion != 2 {
+	if hello.DaemonVersion != "0.10.17" || hello.APIVersion != 3 {
 		t.Fatalf("unexpected hello response: %#v", hello)
 	}
-	if len(hello.SupportedAPIVersions) != 2 || hello.SupportedAPIVersions[0] != 1 || hello.SupportedAPIVersions[1] != 2 {
+	if len(hello.SupportedAPIVersions) != 3 || hello.SupportedAPIVersions[0] != 1 || hello.SupportedAPIVersions[1] != 2 || hello.SupportedAPIVersions[2] != 3 {
 		t.Fatalf("unexpected supported API versions: %#v", hello.SupportedAPIVersions)
 	}
 
 	var errResp map[string]controlPlaneError
-	status = controlPlaneJSONWithoutVersion(t, client, http.MethodGet, baseURL+"/v1/hello?apiVersion=3", nil, &errResp)
+	status = controlPlaneJSONWithoutVersion(t, client, http.MethodGet, baseURL+"/v1/hello?apiVersion=4", nil, &errResp)
 	if status != http.StatusUpgradeRequired {
 		t.Fatalf("incompatible hello status = %d, want %d", status, http.StatusUpgradeRequired)
 	}
@@ -79,16 +79,18 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 
 	var bound bindResponse
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
-		Provider:     "slack",
-		Resource:     "#watchdog-test",
-		Channel:      "#events",
-		WebhookID:    "wh_1",
-		WebhookToken: "tok_1",
+		Provider:              "slack",
+		Resource:              "#watchdog-test",
+		Channel:               "#events",
+		WebhookID:             "wh_1",
+		WebhookToken:          "tok_1",
+		SubscriptionID:        "relay_sub_1",
+		WebhookSubscriptionID: "relayfile_whsub_1",
 	}, &bound)
 	if status != http.StatusOK {
 		t.Fatalf("bind status = %d", status)
 	}
-	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" {
+	if bound.Binding.PathGlob != resolved.PathGlob || bound.Binding.WebhookToken != "tok_1" || bound.Binding.WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected bind response: %#v", bound)
 	}
 
@@ -97,7 +99,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if status != http.StatusOK {
 		t.Fatalf("bindings status = %d", status)
 	}
-	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob {
+	if len(listed.Bindings) != 1 || listed.Bindings[0].PathGlob != resolved.PathGlob || listed.Bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected bindings response: %#v", listed)
 	}
 
@@ -109,7 +111,7 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &cliBindings); err != nil {
 		t.Fatalf("parse bind --list --json output failed: %v\n%s", err, stdout.String())
 	}
-	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob {
+	if len(cliBindings) != 1 || cliBindings[0].PathGlob != resolved.PathGlob || cliBindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected CLI bindings: %#v", cliBindings)
 	}
 

--- a/cmd/relayfile-cli/control_plane_test.go
+++ b/cmd/relayfile-cli/control_plane_test.go
@@ -133,9 +133,11 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 		t.Fatalf("omitted ids/pin were not preserved on replacement: %#v", repinned.Binding)
 	}
 
-	// Mismatched-pair permutation 1: a replacement PROVIDING a new id but no
-	// workspace must persist (newSub, "") — never (newSub, oldWs).
-	var newIDNoWs bindResponse
+	// Mismatched-pair permutation 1: a NEW id without its workspace is
+	// rejected — persisting it unpinned (or worse, inheriting the old pin)
+	// would leave the new cloud resource unretryable across a workspace
+	// switch.
+	var newIDNoWsErr map[string]controlPlaneError
 	status = controlPlaneJSON(t, client, http.MethodPost, baseURL+"/v1/integrations/bind", bindRequest{
 		Provider:              "slack",
 		Resource:              "#watchdog-test",
@@ -143,12 +145,9 @@ func TestControlPlaneBindingConformance(t *testing.T) {
 		WebhookID:             "wh_3",
 		WebhookToken:          "tok_3",
 		WebhookSubscriptionID: "relayfile_whsub_2",
-	}, &newIDNoWs)
-	if status != http.StatusOK {
-		t.Fatalf("new-id replacement bind status = %d", status)
-	}
-	if newIDNoWs.Binding.WebhookSubscriptionID != "relayfile_whsub_2" || newIDNoWs.Binding.WebhookSubscriptionWorkspaceID != "" {
-		t.Fatalf("new id inherited a stale workspace pin: %#v", newIDNoWs.Binding)
+	}, &newIDNoWsErr)
+	if status != http.StatusBadRequest {
+		t.Fatalf("new-id-without-workspace bind status = %d, want 400", status)
 	}
 
 	// Mismatched-pair permutation 2: a workspace without its id is rejected.
@@ -399,6 +398,17 @@ func TestControlPlaneCloudIntegrationConformance(t *testing.T) {
 	}
 	if !deletedGone["ok"] {
 		t.Fatalf("unexpected idempotent delete response: %#v", deletedGone)
+	}
+
+	// An UNPINNED delete of a missing subscription must NOT read as success:
+	// without the workspace pin, "not found" may just be the wrong active
+	// workspace, and a 200 would let callers discard a live resource's record.
+	var unpinnedGone map[string]controlPlaneError
+	status = controlPlaneJSON(t, client, http.MethodDelete, baseURL+"/v1/integrations/webhook-subscriptions", deleteWebhookSubscriptionRequest{
+		SubscriptionID: "whsub_gone",
+	}, &unpinnedGone)
+	if status != http.StatusNotFound {
+		t.Fatalf("unpinned delete of missing subscription status = %d, want 404", status)
 	}
 }
 

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -434,14 +434,15 @@ type integrationConnectionState struct {
 }
 
 type relayIntegrationBinding struct {
-	Provider       string `json:"provider"`
-	PathGlob       string `json:"pathGlob"`
-	Channel        string `json:"channel"`
-	WebhookID      string `json:"webhookId"`
-	WebhookToken   string `json:"webhookToken"`
-	SubscriptionID string `json:"subscriptionId,omitempty"`
-	CreatedAt      string `json:"createdAt,omitempty"`
-	UpdatedAt      string `json:"updatedAt,omitempty"`
+	Provider              string `json:"provider"`
+	PathGlob              string `json:"pathGlob"`
+	Channel               string `json:"channel"`
+	WebhookID             string `json:"webhookId"`
+	WebhookToken          string `json:"webhookToken"`
+	SubscriptionID        string `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
+	CreatedAt             string `json:"createdAt,omitempty"`
+	UpdatedAt             string `json:"updatedAt,omitempty"`
 }
 
 type relayIntegrationBindingStore struct {
@@ -2319,12 +2320,13 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 }
 
 type relayIntegrationBindInput struct {
-	Provider       string
-	Resource       string
-	Channel        string
-	WebhookID      string
-	WebhookToken   string
-	SubscriptionID string
+	Provider              string
+	Resource              string
+	Channel               string
+	WebhookID             string
+	WebhookToken          string
+	SubscriptionID        string
+	WebhookSubscriptionID string
 }
 
 func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBinding, bool, string, error) {
@@ -2337,12 +2339,13 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 		return relayIntegrationBinding{}, false, "", err
 	}
 	binding := relayIntegrationBinding{
-		Provider:       provider,
-		PathGlob:       resolved.PathGlob,
-		Channel:        strings.TrimSpace(input.Channel),
-		WebhookID:      strings.TrimSpace(input.WebhookID),
-		WebhookToken:   strings.TrimSpace(input.WebhookToken),
-		SubscriptionID: strings.TrimSpace(input.SubscriptionID),
+		Provider:              provider,
+		PathGlob:              resolved.PathGlob,
+		Channel:               strings.TrimSpace(input.Channel),
+		WebhookID:             strings.TrimSpace(input.WebhookID),
+		WebhookToken:          strings.TrimSpace(input.WebhookToken),
+		SubscriptionID:        strings.TrimSpace(input.SubscriptionID),
+		WebhookSubscriptionID: strings.TrimSpace(input.WebhookSubscriptionID),
 	}
 	if binding.Channel == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--channel is required")
@@ -2371,6 +2374,9 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 			if binding.SubscriptionID == "" {
 				binding.SubscriptionID = bindings[i].SubscriptionID
 			}
+			if binding.WebhookSubscriptionID == "" {
+				binding.WebhookSubscriptionID = bindings[i].WebhookSubscriptionID
+			}
 			bindings[i] = binding
 			replaced = true
 			break
@@ -2396,13 +2402,15 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 	webhookID := fs.String("webhook", "", "RelayCast inbound webhook id")
 	webhookToken := fs.String("webhook-token", "", "RelayCast inbound webhook token")
 	subscriptionID := fs.String("subscription", "", "relay integration subscription id")
+	webhookSubscriptionID := fs.String("webhook-subscription", "", "relayfile-cloud inbound webhook subscription id")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"list":          false,
-		"channel":       true,
-		"webhook":       true,
-		"webhook-token": true,
-		"subscription":  true,
-		"json":          false,
+		"list":                 false,
+		"channel":              true,
+		"webhook":              true,
+		"webhook-token":        true,
+		"subscription":         true,
+		"webhook-subscription": true,
+		"json":                 false,
 	})); err != nil {
 		return err
 	}
@@ -2420,12 +2428,13 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		return errors.New("usage: relayfile integration bind PROVIDER RESOURCE_OR_PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN")
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:       fs.Arg(0),
-		Resource:       fs.Arg(1),
-		Channel:        *channel,
-		WebhookID:      *webhookID,
-		WebhookToken:   *webhookToken,
-		SubscriptionID: *subscriptionID,
+		Provider:              fs.Arg(0),
+		Resource:              fs.Arg(1),
+		Channel:               *channel,
+		WebhookID:             *webhookID,
+		WebhookToken:          *webhookToken,
+		SubscriptionID:        *subscriptionID,
+		WebhookSubscriptionID: *webhookSubscriptionID,
 	})
 	if err != nil {
 		return err

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -2359,11 +2359,16 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 	if binding.WebhookToken == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--webhook-token is required")
 	}
-	// The subscription id and its workspace pin are an atomic pair: a
-	// workspace without its id is unusable and could only produce a
-	// mismatched (oldSub, newWs) record.
+	// The subscription id and its workspace pin are an atomic pair in BOTH
+	// directions: a workspace without its id could only produce a mismatched
+	// (oldSub, newWs) record, and a NEW id without its workspace would be
+	// unpinned — unretryable across an active-workspace switch. A legacy
+	// unpinned pair survives only when a replacement omits both fields.
 	if binding.WebhookSubscriptionWorkspaceID != "" && binding.WebhookSubscriptionID == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--webhook-subscription-workspace requires --webhook-subscription")
+	}
+	if binding.WebhookSubscriptionID != "" && binding.WebhookSubscriptionWorkspaceID == "" {
+		return relayIntegrationBinding{}, false, "", errors.New("--webhook-subscription requires --webhook-subscription-workspace")
 	}
 	relayIntegrationBindingsMu.Lock()
 	defer relayIntegrationBindingsMu.Unlock()

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -2359,6 +2359,12 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 	if binding.WebhookToken == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--webhook-token is required")
 	}
+	// The subscription id and its workspace pin are an atomic pair: a
+	// workspace without its id is unusable and could only produce a
+	// mismatched (oldSub, newWs) record.
+	if binding.WebhookSubscriptionWorkspaceID != "" && binding.WebhookSubscriptionID == "" {
+		return relayIntegrationBinding{}, false, "", errors.New("--webhook-subscription-workspace requires --webhook-subscription")
+	}
 	relayIntegrationBindingsMu.Lock()
 	defer relayIntegrationBindingsMu.Unlock()
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -2377,8 +2383,14 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 			if binding.SubscriptionID == "" {
 				binding.SubscriptionID = bindings[i].SubscriptionID
 			}
+			// The (id, workspace) pin is preserved as an ATOMIC PAIR, and only
+			// when the replacement omits the id entirely (legacy/partial
+			// caller). A replacement that PROVIDES a new id takes its own
+			// workspace exactly as given — inheriting the old workspace would
+			// pin the new subscription to the wrong place.
 			if binding.WebhookSubscriptionID == "" {
 				binding.WebhookSubscriptionID = bindings[i].WebhookSubscriptionID
+				binding.WebhookSubscriptionWorkspaceID = bindings[i].WebhookSubscriptionWorkspaceID
 			}
 			bindings[i] = binding
 			replaced = true
@@ -2406,14 +2418,16 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 	webhookToken := fs.String("webhook-token", "", "RelayCast inbound webhook token")
 	subscriptionID := fs.String("subscription", "", "relay integration subscription id")
 	webhookSubscriptionID := fs.String("webhook-subscription", "", "relayfile-cloud inbound webhook subscription id")
+	webhookSubscriptionWorkspaceID := fs.String("webhook-subscription-workspace", "", "workspace the webhook subscription was created in (pairs with --webhook-subscription)")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"list":                 false,
-		"channel":              true,
-		"webhook":              true,
-		"webhook-token":        true,
-		"subscription":         true,
-		"webhook-subscription": true,
-		"json":                 false,
+		"list":                           false,
+		"channel":                        true,
+		"webhook":                        true,
+		"webhook-token":                  true,
+		"subscription":                   true,
+		"webhook-subscription":           true,
+		"webhook-subscription-workspace": true,
+		"json":                           false,
 	})); err != nil {
 		return err
 	}
@@ -2428,16 +2442,17 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		return writeJSON(stdout, bindings)
 	}
 	if fs.NArg() != 2 {
-		return errors.New("usage: relayfile integration bind PROVIDER RESOURCE_OR_PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN [--subscription ID] [--webhook-subscription ID]")
+		return errors.New("usage: relayfile integration bind PROVIDER RESOURCE_OR_PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN [--subscription ID] [--webhook-subscription ID --webhook-subscription-workspace WS]")
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
-		Provider:              fs.Arg(0),
-		Resource:              fs.Arg(1),
-		Channel:               *channel,
-		WebhookID:             *webhookID,
-		WebhookToken:          *webhookToken,
-		SubscriptionID:        *subscriptionID,
-		WebhookSubscriptionID: *webhookSubscriptionID,
+		Provider:                       fs.Arg(0),
+		Resource:                       fs.Arg(1),
+		Channel:                        *channel,
+		WebhookID:                      *webhookID,
+		WebhookToken:                   *webhookToken,
+		SubscriptionID:                 *subscriptionID,
+		WebhookSubscriptionID:          *webhookSubscriptionID,
+		WebhookSubscriptionWorkspaceID: *webhookSubscriptionWorkspaceID,
 	})
 	if err != nil {
 		return err

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -434,16 +434,15 @@ type integrationConnectionState struct {
 }
 
 type relayIntegrationBinding struct {
-	Provider                      string   `json:"provider"`
-	PathGlob                      string   `json:"pathGlob"`
-	Channel                       string   `json:"channel"`
-	WebhookID                     string   `json:"webhookId"`
-	WebhookToken                  string   `json:"webhookToken"`
-	SubscriptionID                string   `json:"subscriptionId,omitempty"`
-	WebhookSubscriptionID         string   `json:"webhookSubscriptionId,omitempty"`
-	PendingWebhookSubscriptionIDs []string `json:"pendingWebhookSubscriptionIds,omitempty"`
-	CreatedAt                     string   `json:"createdAt,omitempty"`
-	UpdatedAt                     string   `json:"updatedAt,omitempty"`
+	Provider              string `json:"provider"`
+	PathGlob              string `json:"pathGlob"`
+	Channel               string `json:"channel"`
+	WebhookID             string `json:"webhookId"`
+	WebhookToken          string `json:"webhookToken"`
+	SubscriptionID        string `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
+	CreatedAt             string `json:"createdAt,omitempty"`
+	UpdatedAt             string `json:"updatedAt,omitempty"`
 }
 
 type relayIntegrationBindingStore struct {
@@ -2321,14 +2320,13 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 }
 
 type relayIntegrationBindInput struct {
-	Provider                      string
-	Resource                      string
-	Channel                       string
-	WebhookID                     string
-	WebhookToken                  string
-	SubscriptionID                string
-	WebhookSubscriptionID         string
-	PendingWebhookSubscriptionIDs *[]string
+	Provider              string
+	Resource              string
+	Channel               string
+	WebhookID             string
+	WebhookToken          string
+	SubscriptionID        string
+	WebhookSubscriptionID string
 }
 
 func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBinding, bool, string, error) {
@@ -2348,9 +2346,6 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 		WebhookToken:          strings.TrimSpace(input.WebhookToken),
 		SubscriptionID:        strings.TrimSpace(input.SubscriptionID),
 		WebhookSubscriptionID: strings.TrimSpace(input.WebhookSubscriptionID),
-	}
-	if input.PendingWebhookSubscriptionIDs != nil {
-		binding.PendingWebhookSubscriptionIDs = normalizeWebhookSubscriptionIDs(*input.PendingWebhookSubscriptionIDs)
 	}
 	if binding.Channel == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--channel is required")
@@ -2381,9 +2376,6 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 			}
 			if binding.WebhookSubscriptionID == "" {
 				binding.WebhookSubscriptionID = bindings[i].WebhookSubscriptionID
-			}
-			if input.PendingWebhookSubscriptionIDs == nil {
-				binding.PendingWebhookSubscriptionIDs = append([]string(nil), bindings[i].PendingWebhookSubscriptionIDs...)
 			}
 			bindings[i] = binding
 			replaced = true
@@ -2456,23 +2448,6 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "%s binding created: %s -> %s\n", binding.Provider, binding.PathGlob, binding.Channel)
 	}
 	return nil
-}
-
-func normalizeWebhookSubscriptionIDs(ids []string) []string {
-	seen := make(map[string]struct{}, len(ids))
-	normalized := make([]string, 0, len(ids))
-	for _, id := range ids {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		normalized = append(normalized, id)
-	}
-	return normalized
 }
 
 func runIntegrationResolvePath(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -434,15 +434,16 @@ type integrationConnectionState struct {
 }
 
 type relayIntegrationBinding struct {
-	Provider              string `json:"provider"`
-	PathGlob              string `json:"pathGlob"`
-	Channel               string `json:"channel"`
-	WebhookID             string `json:"webhookId"`
-	WebhookToken          string `json:"webhookToken"`
-	SubscriptionID        string `json:"subscriptionId,omitempty"`
-	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
-	CreatedAt             string `json:"createdAt,omitempty"`
-	UpdatedAt             string `json:"updatedAt,omitempty"`
+	Provider                      string   `json:"provider"`
+	PathGlob                      string   `json:"pathGlob"`
+	Channel                       string   `json:"channel"`
+	WebhookID                     string   `json:"webhookId"`
+	WebhookToken                  string   `json:"webhookToken"`
+	SubscriptionID                string   `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID         string   `json:"webhookSubscriptionId,omitempty"`
+	PendingWebhookSubscriptionIDs []string `json:"pendingWebhookSubscriptionIds,omitempty"`
+	CreatedAt                     string   `json:"createdAt,omitempty"`
+	UpdatedAt                     string   `json:"updatedAt,omitempty"`
 }
 
 type relayIntegrationBindingStore struct {
@@ -2320,13 +2321,14 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 }
 
 type relayIntegrationBindInput struct {
-	Provider              string
-	Resource              string
-	Channel               string
-	WebhookID             string
-	WebhookToken          string
-	SubscriptionID        string
-	WebhookSubscriptionID string
+	Provider                      string
+	Resource                      string
+	Channel                       string
+	WebhookID                     string
+	WebhookToken                  string
+	SubscriptionID                string
+	WebhookSubscriptionID         string
+	PendingWebhookSubscriptionIDs *[]string
 }
 
 func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBinding, bool, string, error) {
@@ -2346,6 +2348,9 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 		WebhookToken:          strings.TrimSpace(input.WebhookToken),
 		SubscriptionID:        strings.TrimSpace(input.SubscriptionID),
 		WebhookSubscriptionID: strings.TrimSpace(input.WebhookSubscriptionID),
+	}
+	if input.PendingWebhookSubscriptionIDs != nil {
+		binding.PendingWebhookSubscriptionIDs = normalizeWebhookSubscriptionIDs(*input.PendingWebhookSubscriptionIDs)
 	}
 	if binding.Channel == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--channel is required")
@@ -2376,6 +2381,9 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 			}
 			if binding.WebhookSubscriptionID == "" {
 				binding.WebhookSubscriptionID = bindings[i].WebhookSubscriptionID
+			}
+			if input.PendingWebhookSubscriptionIDs == nil {
+				binding.PendingWebhookSubscriptionIDs = append([]string(nil), bindings[i].PendingWebhookSubscriptionIDs...)
 			}
 			bindings[i] = binding
 			replaced = true
@@ -2425,7 +2433,7 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		return writeJSON(stdout, bindings)
 	}
 	if fs.NArg() != 2 {
-		return errors.New("usage: relayfile integration bind PROVIDER RESOURCE_OR_PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN")
+		return errors.New("usage: relayfile integration bind PROVIDER RESOURCE_OR_PATH_GLOB --channel CHANNEL --webhook ID --webhook-token TOKEN [--subscription ID] [--webhook-subscription ID]")
 	}
 	binding, replaced, warning, err := bindRelayIntegration(relayIntegrationBindInput{
 		Provider:              fs.Arg(0),
@@ -2448,6 +2456,23 @@ func runIntegrationBind(args []string, stdout io.Writer) error {
 		fmt.Fprintf(stdout, "%s binding created: %s -> %s\n", binding.Provider, binding.PathGlob, binding.Channel)
 	}
 	return nil
+}
+
+func normalizeWebhookSubscriptionIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	normalized := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		normalized = append(normalized, id)
+	}
+	return normalized
 }
 
 func runIntegrationResolvePath(args []string, stdout io.Writer) error {

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -434,15 +434,16 @@ type integrationConnectionState struct {
 }
 
 type relayIntegrationBinding struct {
-	Provider              string `json:"provider"`
-	PathGlob              string `json:"pathGlob"`
-	Channel               string `json:"channel"`
-	WebhookID             string `json:"webhookId"`
-	WebhookToken          string `json:"webhookToken"`
-	SubscriptionID        string `json:"subscriptionId,omitempty"`
-	WebhookSubscriptionID string `json:"webhookSubscriptionId,omitempty"`
-	CreatedAt             string `json:"createdAt,omitempty"`
-	UpdatedAt             string `json:"updatedAt,omitempty"`
+	Provider                       string `json:"provider"`
+	PathGlob                       string `json:"pathGlob"`
+	Channel                        string `json:"channel"`
+	WebhookID                      string `json:"webhookId"`
+	WebhookToken                   string `json:"webhookToken"`
+	SubscriptionID                 string `json:"subscriptionId,omitempty"`
+	WebhookSubscriptionID          string `json:"webhookSubscriptionId,omitempty"`
+	WebhookSubscriptionWorkspaceID string `json:"webhookSubscriptionWorkspaceId,omitempty"`
+	CreatedAt                      string `json:"createdAt,omitempty"`
+	UpdatedAt                      string `json:"updatedAt,omitempty"`
 }
 
 type relayIntegrationBindingStore struct {
@@ -2320,13 +2321,14 @@ func runIntegration(args []string, stdin io.Reader, stdout io.Writer) error {
 }
 
 type relayIntegrationBindInput struct {
-	Provider              string
-	Resource              string
-	Channel               string
-	WebhookID             string
-	WebhookToken          string
-	SubscriptionID        string
-	WebhookSubscriptionID string
+	Provider                       string
+	Resource                       string
+	Channel                        string
+	WebhookID                      string
+	WebhookToken                   string
+	SubscriptionID                 string
+	WebhookSubscriptionID          string
+	WebhookSubscriptionWorkspaceID string
 }
 
 func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBinding, bool, string, error) {
@@ -2339,13 +2341,14 @@ func bindRelayIntegration(input relayIntegrationBindInput) (relayIntegrationBind
 		return relayIntegrationBinding{}, false, "", err
 	}
 	binding := relayIntegrationBinding{
-		Provider:              provider,
-		PathGlob:              resolved.PathGlob,
-		Channel:               strings.TrimSpace(input.Channel),
-		WebhookID:             strings.TrimSpace(input.WebhookID),
-		WebhookToken:          strings.TrimSpace(input.WebhookToken),
-		SubscriptionID:        strings.TrimSpace(input.SubscriptionID),
-		WebhookSubscriptionID: strings.TrimSpace(input.WebhookSubscriptionID),
+		Provider:                       provider,
+		PathGlob:                       resolved.PathGlob,
+		Channel:                        strings.TrimSpace(input.Channel),
+		WebhookID:                      strings.TrimSpace(input.WebhookID),
+		WebhookToken:                   strings.TrimSpace(input.WebhookToken),
+		SubscriptionID:                 strings.TrimSpace(input.SubscriptionID),
+		WebhookSubscriptionID:          strings.TrimSpace(input.WebhookSubscriptionID),
+		WebhookSubscriptionWorkspaceID: strings.TrimSpace(input.WebhookSubscriptionWorkspaceID),
 	}
 	if binding.Channel == "" {
 		return relayIntegrationBinding{}, false, "", errors.New("--channel is required")
@@ -2646,7 +2649,14 @@ func runIntegrationWritebackSecret(args []string, stdout io.Writer) error {
 	}
 
 	if *jsonOutput {
-		return writeJSON(stdout, resp.Data)
+		// Include the resolved workspace id so callers can pin later
+		// webhook-subscription operations to the same workspace even if the
+		// daemon's active workspace changes between runs.
+		return writeJSON(stdout, struct {
+			URL         string `json:"url"`
+			Secret      string `json:"secret"`
+			WorkspaceID string `json:"workspaceId"`
+		}{URL: resp.Data.URL, Secret: resp.Data.Secret, WorkspaceID: workspaceID})
 	}
 	fmt.Fprintf(stdout, "url: %s\nsecret: %s\n", resp.Data.URL, resp.Data.Secret)
 	return nil

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -250,7 +250,7 @@ func TestIntegrationBindListAndUnbind(t *testing.T) {
 		"--channel", "#issues",
 		"--webhook", "wh_1",
 		"--webhook-token", "tok_1",
-		"--webhook-subscription", "relayfile_whsub_1",
+		"--webhook-subscription", "relayfile_whsub_1", "--webhook-subscription-workspace", "rw_test_pin",
 	}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("bind failed: %v\n%s", err, stdout.String())
 	}

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -315,6 +315,20 @@ func TestIntegrationBindListAndUnbind(t *testing.T) {
 	}
 }
 
+func TestIntegrationBindUsageListsOptionalSubscriptionFlags(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	var stdout bytes.Buffer
+	err := run([]string{"integration", "bind", "slack"}, strings.NewReader(""), &stdout, &stdout)
+	if err == nil {
+		t.Fatal("integration bind with missing resource unexpectedly succeeded")
+	}
+	if got, want := err.Error(), "[--subscription ID] [--webhook-subscription ID]"; !strings.Contains(got, want) {
+		t.Fatalf("usage = %q, want to contain %q", got, want)
+	}
+}
+
 func TestIntegrationUnbindNativeResourceRemovesStoredFallbackGlob(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -324,7 +324,7 @@ func TestIntegrationBindUsageListsOptionalSubscriptionFlags(t *testing.T) {
 	if err == nil {
 		t.Fatal("integration bind with missing resource unexpectedly succeeded")
 	}
-	if got, want := err.Error(), "[--subscription ID] [--webhook-subscription ID]"; !strings.Contains(got, want) {
+	if got, want := err.Error(), "[--subscription ID] [--webhook-subscription ID --webhook-subscription-workspace WS]"; !strings.Contains(got, want) {
 		t.Fatalf("usage = %q, want to contain %q", got, want)
 	}
 }

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -250,6 +250,7 @@ func TestIntegrationBindListAndUnbind(t *testing.T) {
 		"--channel", "#issues",
 		"--webhook", "wh_1",
 		"--webhook-token", "tok_1",
+		"--webhook-subscription", "relayfile_whsub_1",
 	}, strings.NewReader(""), &stdout, &stdout); err != nil {
 		t.Fatalf("bind failed: %v\n%s", err, stdout.String())
 	}
@@ -268,8 +269,30 @@ func TestIntegrationBindListAndUnbind(t *testing.T) {
 	if len(bindings) != 1 {
 		t.Fatalf("expected 1 binding, got %d", len(bindings))
 	}
-	if bindings[0].Provider != "linear" || bindings[0].PathGlob != "/linear/issues/**" || bindings[0].Channel != "#issues" {
+	if bindings[0].Provider != "linear" || bindings[0].PathGlob != "/linear/issues/**" || bindings[0].Channel != "#issues" || bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
 		t.Fatalf("unexpected binding: %#v", bindings[0])
+	}
+
+	// A legacy caller that does not know the webhook-subscription flag must not
+	// erase the ID needed by a later agent-relay unsubscribe cleanup.
+	stdout.Reset()
+	if err := run([]string{
+		"integration", "bind", "linear", "/linear/issues/**",
+		"--channel", "#issues",
+		"--webhook", "wh_2",
+		"--webhook-token", "tok_2",
+	}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("replacement bind failed: %v\n%s", err, stdout.String())
+	}
+	stdout.Reset()
+	if err := run([]string{"integration", "bind", "--list"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("bind --list after replacement failed: %v", err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &bindings); err != nil {
+		t.Fatalf("parse replacement bindings failed: %v\n%s", err, stdout.String())
+	}
+	if len(bindings) != 1 || bindings[0].WebhookID != "wh_2" || bindings[0].WebhookSubscriptionID != "relayfile_whsub_1" {
+		t.Fatalf("replacement lost webhook subscription id: %#v", bindings)
 	}
 
 	stdout.Reset()

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -571,6 +571,11 @@ components:
       type: object
       required: [subscriptionId]
       properties:
+        workspaceId:
+          type: string
+          description: >-
+            Workspace the subscription was created in, so callers can pin later
+            delete/list calls to the same workspace.
         subscriptionId:
           type: string
         secret:
@@ -593,6 +598,8 @@ components:
       type: object
       required: [subscriptions]
       properties:
+        workspaceId:
+          type: string
         subscriptions:
           type: array
           items:

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -229,6 +229,27 @@ paths:
               schema:
                 $ref: "#/components/schemas/WritebackSecret"
   /v1/integrations/webhook-subscriptions:
+    get:
+      operationId: listWebhookSubscriptions
+      summary: List server-side relayfile webhook subscriptions
+      description: >-
+        Lists the workspace's inbound webhook subscriptions so callers can
+        reconcile subscriptions created by runs that crashed before persisting
+        the server-assigned id.
+      parameters:
+        - $ref: "#/components/parameters/ApiVersionHeader"
+        - name: workspace
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Webhook subscriptions for the workspace
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListWebhookSubscriptionsResponse"
     post:
       operationId: createWebhookSubscription
       summary: Create a server-side relayfile webhook subscription
@@ -250,6 +271,10 @@ paths:
     delete:
       operationId: deleteWebhookSubscription
       summary: Delete a server-side relayfile webhook subscription
+      description: >-
+        Idempotent: deleting a subscription that no longer exists succeeds, so
+        retried cleanups of a known-deleted id observe progress instead of an
+        error.
       parameters:
         - $ref: "#/components/parameters/ApiVersionHeader"
       requestBody:
@@ -260,7 +285,7 @@ paths:
               $ref: "#/components/schemas/DeleteWebhookSubscriptionRequest"
       responses:
         "200":
-          description: Subscription deleted
+          description: Subscription deleted (or already absent)
           content:
             application/json:
               schema:
@@ -449,10 +474,6 @@ components:
           type: string
         webhookSubscriptionId:
           type: string
-        pendingWebhookSubscriptionIds:
-          type: array
-          items:
-            type: string
     BindResponse:
       type: object
       required: [binding, replaced]
@@ -482,10 +503,6 @@ components:
           type: string
         webhookSubscriptionId:
           type: string
-        pendingWebhookSubscriptionIds:
-          type: array
-          items:
-            type: string
         createdAt:
           type: string
         updatedAt:
@@ -572,6 +589,27 @@ components:
       properties:
         ok:
           type: boolean
+    ListWebhookSubscriptionsResponse:
+      type: object
+      required: [subscriptions]
+      properties:
+        subscriptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/WebhookSubscriptionSummary"
+    WebhookSubscriptionSummary:
+      type: object
+      required: [subscriptionId, url, pathGlobs]
+      properties:
+        subscriptionId:
+          type: string
+        url:
+          type: string
+          format: uri
+        pathGlobs:
+          type: array
+          items:
+            type: string
     ErrorEnvelope:
       type: object
       required: [error]

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -274,7 +274,7 @@ components:
       schema:
         type: integer
         format: uint32
-        const: 2
+        const: 3
     ApiVersionQuery:
       name: apiVersion
       in: query
@@ -447,6 +447,8 @@ components:
           type: string
         subscriptionId:
           type: string
+        webhookSubscriptionId:
+          type: string
     BindResponse:
       type: object
       required: [binding, replaced]
@@ -473,6 +475,8 @@ components:
         webhookToken:
           type: string
         subscriptionId:
+          type: string
+        webhookSubscriptionId:
           type: string
         createdAt:
           type: string

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -449,6 +449,10 @@ components:
           type: string
         webhookSubscriptionId:
           type: string
+        pendingWebhookSubscriptionIds:
+          type: array
+          items:
+            type: string
     BindResponse:
       type: object
       required: [binding, replaced]
@@ -478,6 +482,10 @@ components:
           type: string
         webhookSubscriptionId:
           type: string
+        pendingWebhookSubscriptionIds:
+          type: array
+          items:
+            type: string
         createdAt:
           type: string
         updatedAt:

--- a/openapi/relayfile-control-plane-v1.openapi.yaml
+++ b/openapi/relayfile-control-plane-v1.openapi.yaml
@@ -474,6 +474,8 @@ components:
           type: string
         webhookSubscriptionId:
           type: string
+        webhookSubscriptionWorkspaceId:
+          type: string
     BindResponse:
       type: object
       required: [binding, replaced]
@@ -502,6 +504,8 @@ components:
         subscriptionId:
           type: string
         webhookSubscriptionId:
+          type: string
+        webhookSubscriptionWorkspaceId:
           type: string
         createdAt:
           type: string
@@ -547,6 +551,8 @@ components:
       type: object
       required: [url, secret]
       properties:
+        workspaceId:
+          type: string
         url:
           type: string
         secret:

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this package will be documented in this file.
 
 ## [Unreleased]
 
-_No unreleased changes._
+- Control-plane API v3 persists the relayfile-cloud inbound webhook subscription ID on relay bindings so clients can remove it during replacement and unsubscribe.
 
 ## [0.10.20] - 2026-07-08
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -203,12 +203,14 @@ describeContract('control-plane client (real daemon)', () => {
       webhookToken: 'tok',
       subscriptionId: 'sub',
       webhookSubscriptionId: 'whsub',
+      pendingWebhookSubscriptionIds: ['whsub_retired'],
     });
     const after = await client.listBindings();
     const binding = after.find((b) => b.pathGlob === pathGlob);
     expect(binding).toBeDefined();
     expect(binding!.channel).toBe('general');
     expect(binding!.webhookSubscriptionId).toBe('whsub');
+    expect(binding!.pendingWebhookSubscriptionIds).toEqual(['whsub_retired']);
     await client.unbind('github', pathGlob);
     expect((await client.listBindings()).find((b) => b.pathGlob === pathGlob)).toBeUndefined();
   });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -140,6 +140,37 @@ describe('RelayfileControlPlaneClient integration webhook subscriptions', () => 
       body: { subscriptionId: 'whsub_123', workspace: 'demo' },
     });
   });
+
+  it('lists webhook subscriptions through the control-plane socket', async () => {
+    const client = new RelayfileControlPlaneClient({ socketPath: '/nope.sock', autoStart: false });
+    vi.spyOn(client, 'ensureReady').mockResolvedValue(undefined);
+    const rawRequest = vi.spyOn(client as unknown as { rawRequest: (opts: unknown) => Promise<unknown> }, 'rawRequest');
+    rawRequest.mockResolvedValueOnce({
+      subscriptions: [
+        {
+          subscriptionId: 'whsub_123',
+          url: 'https://cast.test/v1/integrations/relayfile/inbound/ws/ch',
+          pathGlobs: ['/github/repos/acme/widgets/issues/**'],
+        },
+      ],
+    });
+
+    await expect(client.listWebhookSubscriptions('demo')).resolves.toEqual({
+      subscriptions: [
+        {
+          subscriptionId: 'whsub_123',
+          url: 'https://cast.test/v1/integrations/relayfile/inbound/ws/ch',
+          pathGlobs: ['/github/repos/acme/widgets/issues/**'],
+        },
+      ],
+    });
+
+    expect(rawRequest).toHaveBeenCalledWith({
+      method: 'GET',
+      path: '/v1/integrations/webhook-subscriptions',
+      query: { workspace: 'demo' },
+    });
+  });
 });
 
 // Real-daemon contract tests — opt-in via RELAYFILE_BIN (CI builds the binary:
@@ -203,14 +234,12 @@ describeContract('control-plane client (real daemon)', () => {
       webhookToken: 'tok',
       subscriptionId: 'sub',
       webhookSubscriptionId: 'whsub',
-      pendingWebhookSubscriptionIds: ['whsub_retired'],
     });
     const after = await client.listBindings();
     const binding = after.find((b) => b.pathGlob === pathGlob);
     expect(binding).toBeDefined();
     expect(binding!.channel).toBe('general');
     expect(binding!.webhookSubscriptionId).toBe('whsub');
-    expect(binding!.pendingWebhookSubscriptionIds).toEqual(['whsub_retired']);
     await client.unbind('github', pathGlob);
     expect((await client.listBindings()).find((b) => b.pathGlob === pathGlob)).toBeUndefined();
   });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -146,6 +146,7 @@ describe('RelayfileControlPlaneClient integration webhook subscriptions', () => 
     vi.spyOn(client, 'ensureReady').mockResolvedValue(undefined);
     const rawRequest = vi.spyOn(client as unknown as { rawRequest: (opts: unknown) => Promise<unknown> }, 'rawRequest');
     rawRequest.mockResolvedValueOnce({
+      workspaceId: 'ws_123',
       subscriptions: [
         {
           subscriptionId: 'whsub_123',
@@ -156,6 +157,7 @@ describe('RelayfileControlPlaneClient integration webhook subscriptions', () => 
     });
 
     await expect(client.listWebhookSubscriptions('demo')).resolves.toEqual({
+      workspaceId: 'ws_123',
       subscriptions: [
         {
           subscriptionId: 'whsub_123',

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -202,11 +202,13 @@ describeContract('control-plane client (real daemon)', () => {
       webhookId: 'wh',
       webhookToken: 'tok',
       subscriptionId: 'sub',
+      webhookSubscriptionId: 'whsub',
     });
     const after = await client.listBindings();
     const binding = after.find((b) => b.pathGlob === pathGlob);
     expect(binding).toBeDefined();
     expect(binding!.channel).toBe('general');
+    expect(binding!.webhookSubscriptionId).toBe('whsub');
     await client.unbind('github', pathGlob);
     expect((await client.listBindings()).find((b) => b.pathGlob === pathGlob)).toBeUndefined();
   });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -109,6 +109,8 @@ export type WebhookSubscriptionRequestBody = Schemas['WebhookSubscriptionRequest
 export type WebhookSubscriptionResult = Schemas['WebhookSubscriptionResponse'];
 export type DeleteWebhookSubscriptionRequestBody = Schemas['DeleteWebhookSubscriptionRequest'];
 export type DeleteWebhookSubscriptionResult = Schemas['DeleteWebhookSubscriptionResponse'];
+export type ListWebhookSubscriptionsResult = Schemas['ListWebhookSubscriptionsResponse'];
+export type WebhookSubscriptionSummary = Schemas['WebhookSubscriptionSummary'];
 
 export interface RelayfileClientOptions {
   /** Socket to connect to. Defaults to defaultRelayfileSocketPath(). */
@@ -393,6 +395,19 @@ export class RelayfileControlPlaneClient {
       method: 'POST',
       path: '/v1/integrations/writeback-secret',
       body: { channel, ...(workspace ? { workspace } : {}) },
+    });
+  }
+
+  /**
+   * Lists the workspace's inbound webhook subscriptions so callers can
+   * reconcile subscriptions created by runs that crashed before persisting
+   * the server-assigned id.
+   */
+  listWebhookSubscriptions(workspace?: string): Promise<ListWebhookSubscriptionsResult> {
+    return this.request<ListWebhookSubscriptionsResult>({
+      method: 'GET',
+      path: '/v1/integrations/webhook-subscriptions',
+      ...(workspace ? { query: { workspace } } : {}),
     });
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -18,7 +18,7 @@ import type { components } from './generated/control-plane.js';
  */
 
 /** Control-plane API version this client speaks. Bump when adding required endpoint support. */
-export const RELAYFILE_API_VERSION = 2;
+export const RELAYFILE_API_VERSION = 3;
 
 /**
  * Minimum `relayfile` daemon version this client requires. The control-plane

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -303,6 +303,8 @@ export interface components {
             secret: string;
         };
         WebhookSubscriptionResponse: {
+            /** @description Workspace the subscription was created in, so callers can pin later delete/list calls to the same workspace. */
+            workspaceId?: string;
             subscriptionId: string;
             secret?: string;
         };
@@ -314,6 +316,7 @@ export interface components {
             ok: boolean;
         };
         ListWebhookSubscriptionsResponse: {
+            workspaceId?: string;
             subscriptions: components["schemas"]["WebhookSubscriptionSummary"][];
         };
         WebhookSubscriptionSummary: {

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -249,6 +249,7 @@ export interface components {
             webhookId: string;
             webhookToken: string;
             subscriptionId?: string;
+            webhookSubscriptionId?: string;
         };
         BindResponse: {
             binding: components["schemas"]["Binding"];
@@ -262,6 +263,7 @@ export interface components {
             webhookId: string;
             webhookToken: string;
             subscriptionId?: string;
+            webhookSubscriptionId?: string;
             createdAt?: string;
             updatedAt?: string;
         };
@@ -342,7 +344,7 @@ export interface components {
         };
     };
     parameters: {
-        ApiVersionHeader: 2;
+        ApiVersionHeader: 3;
         ApiVersionQuery: number;
     };
     requestBodies: never;

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -166,11 +166,18 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List server-side relayfile webhook subscriptions
+         * @description Lists the workspace's inbound webhook subscriptions so callers can reconcile subscriptions created by runs that crashed before persisting the server-assigned id.
+         */
+        get: operations["listWebhookSubscriptions"];
         put?: never;
         /** Create a server-side relayfile webhook subscription */
         post: operations["createWebhookSubscription"];
-        /** Delete a server-side relayfile webhook subscription */
+        /**
+         * Delete a server-side relayfile webhook subscription
+         * @description Idempotent: deleting a subscription that no longer exists succeeds, so retried cleanups of a known-deleted id observe progress instead of an error.
+         */
         delete: operations["deleteWebhookSubscription"];
         options?: never;
         head?: never;
@@ -250,7 +257,6 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
-            pendingWebhookSubscriptionIds?: string[];
         };
         BindResponse: {
             binding: components["schemas"]["Binding"];
@@ -265,7 +271,6 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
-            pendingWebhookSubscriptionIds?: string[];
             createdAt?: string;
             updatedAt?: string;
         };
@@ -307,6 +312,15 @@ export interface components {
         };
         DeleteWebhookSubscriptionResponse: {
             ok: boolean;
+        };
+        ListWebhookSubscriptionsResponse: {
+            subscriptions: components["schemas"]["WebhookSubscriptionSummary"][];
+        };
+        WebhookSubscriptionSummary: {
+            subscriptionId: string;
+            /** Format: uri */
+            url: string;
+            pathGlobs: string[];
         };
         ErrorEnvelope: {
             error: {
@@ -639,6 +653,30 @@ export interface operations {
             };
         };
     };
+    listWebhookSubscriptions: {
+        parameters: {
+            query?: {
+                workspace?: string;
+            };
+            header?: {
+                "X-Relayfile-API-Version"?: components["parameters"]["ApiVersionHeader"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Webhook subscriptions for the workspace */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListWebhookSubscriptionsResponse"];
+                };
+            };
+        };
+    };
     createWebhookSubscription: {
         parameters: {
             query?: never;
@@ -680,7 +718,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Subscription deleted */
+            /** @description Subscription deleted (or already absent) */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -250,6 +250,7 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
+            pendingWebhookSubscriptionIds?: string[];
         };
         BindResponse: {
             binding: components["schemas"]["Binding"];
@@ -264,6 +265,7 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
+            pendingWebhookSubscriptionIds?: string[];
             createdAt?: string;
             updatedAt?: string;
         };

--- a/packages/client/src/generated/control-plane.ts
+++ b/packages/client/src/generated/control-plane.ts
@@ -257,6 +257,7 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
+            webhookSubscriptionWorkspaceId?: string;
         };
         BindResponse: {
             binding: components["schemas"]["Binding"];
@@ -271,6 +272,7 @@ export interface components {
             webhookToken: string;
             subscriptionId?: string;
             webhookSubscriptionId?: string;
+            webhookSubscriptionWorkspaceId?: string;
             createdAt?: string;
             updatedAt?: string;
         };
@@ -292,6 +294,7 @@ export interface components {
             channel: string;
         };
         WritebackSecret: {
+            workspaceId?: string;
             url: string;
             secret: string;
         };


### PR DESCRIPTION
## Summary
- persist each relayfile-cloud inbound webhook subscription ID with its relay binding
- expose it through the CLI, control-plane API, OpenAPI contract, and typed client
- preserve the ID when a legacy caller updates a binding without the new field
- require control-plane API v3 while retaining server support for v1/v2

## Verification
- go test ./...
- npm run test --workspace=@relayfile/client
- npm run typecheck --workspace=@relayfile/client
- scripts/check-contract-surface.sh

Full npm run typecheck is blocked by pre-existing unrelated errors in packages/agents/src/tools/vercel.ts.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

