### PR TITLE
local-mount: git-list population, warm reattach, and teardown safety

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,6 +2481,19 @@
         "linux"
       ]
     },
+    "node_modules/@relayfile/mount-linux-x64": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@relayfile/mount-linux-x64/-/mount-linux-x64-0.10.22.tgz",
+      "integrity": "sha512-Js0tkXCu4NqLe5JyiDgXVJJN33dYKzSOUsCJdOl/Xfpu83+2D9kSquzFy2ccyf9+mzb7GNh+1R51Q+jMk7wU2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@relayfile/sdk": {
       "resolved": "packages/sdk/typescript",
       "link": true

--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -12,14 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `git ls-files --cached --others --exclude-standard` instead of walking the
   tree, so gitignored trees (nested caches, stale worktrees, build outputs at
   any depth) never enter the mount; the repo's root `.gitignore` +
-  `.git/info/exclude` rules also join the mount's ignore set so reconcile and
-  syncBack agree with the populated file set. Tracked-but-gitignored files
-  (`git add -f` survivors) are excepted and sync normally. Falls back to the
-  walk for non-git projects, submodules, and pattern negations.
+  `.git/info/exclude` rules — plus the user's global excludes file and any
+  tracked nested `.gitignore` files (directory-scoped, as git applies them) —
+  also join the mount's ignore set so reconcile and syncBack agree with the
+  populated file set. Tracked-but-gitignored files (`git add -f` survivors)
+  are excepted and sync normally. Falls back to the walk for non-git
+  projects, submodules, and pattern negations. Linked-worktree projects
+  (`.git` pointer file) get no sandboxed `.git` under git population: copying
+  the pointer would let mount-side git commands mutate the host checkout's
+  worktree metadata.
 - `attachMount()`: reattach to a kept mount directory without wiping or
   re-copying, for warm session reuse. Pass `initialState` from a prior
   `exportState()` so the first reconcile distinguishes deletions from
-  creations.
+  creations. Runs the same overlap/safety validation as `createMount`
+  (with both sides realpath-resolved) and throws for explicit
+  `population: 'git'` when git preconditions fail.
 - `AutoSyncHandle.exportState()`: serializable snapshot of the per-file sync
   state for persistence alongside a kept mount.
 - `MountHandle.population` reports which strategy ran (`git`, `walk`, or
@@ -40,7 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   writes always get byte-compared.
 - With `includeGit` under git population, `.git` is copied as one
   timestamp-preserving bulk clone (copy-on-write where the filesystem
-  supports it) instead of file-by-file.
+  supports it) instead of file-by-file, and the cloned files are seeded into
+  the autosync state so project-side `.git` deletions (pack-refs, gc)
+  propagate and pre-autosync mount-side `.git` setup writes survive the
+  first reconcile.
 - `syncBack` no longer descends into no-sync-back subtrees (`.git/**` under
   `includeGit`), which on large repos removed thousands of pointless stats
   per teardown.

--- a/packages/local-mount/CHANGELOG.md
+++ b/packages/local-mount/CHANGELOG.md
@@ -6,7 +6,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+
+- `population: 'walk' | 'git' | 'auto'` mount option. Git mode enumerates via
+  `git ls-files --cached --others --exclude-standard` instead of walking the
+  tree, so gitignored trees (nested caches, stale worktrees, build outputs at
+  any depth) never enter the mount; the repo's root `.gitignore` +
+  `.git/info/exclude` rules also join the mount's ignore set so reconcile and
+  syncBack agree with the populated file set. Tracked-but-gitignored files
+  (`git add -f` survivors) are excepted and sync normally. Falls back to the
+  walk for non-git projects, submodules, and pattern negations.
+- `attachMount()`: reattach to a kept mount directory without wiping or
+  re-copying, for warm session reuse. Pass `initialState` from a prior
+  `exportState()` so the first reconcile distinguishes deletions from
+  creations.
+- `AutoSyncHandle.exportState()`: serializable snapshot of the per-file sync
+  state for persistence alongside a kept mount.
+- `MountHandle.population` reports which strategy ran (`git`, `walk`, or
+  `reattach`).
+
+### Changed
+
+- Mount population records both sides' mtimes for every copied file and hands
+  that state to `startAutoSync`, which skips its full-tree content-comparison
+  priming pass — on large repos this pass alone took many seconds and re-read
+  every file pair. This also fixes a latent first-reconcile bug: project
+  edits made between `createMount` and `startAutoSync` now win over the stale
+  mount copy, and mount-side `.git` setup writes survive instead of being
+  clobbered by the project's copy.
+- Copies preserve source mtimes (population, reconcile, and syncBack), and
+  content comparison takes an rsync-style quick path: equal size plus mtimes
+  within 2ms imply equal content, guarded by a 5s recency window so fresh
+  writes always get byte-compared.
+- With `includeGit` under git population, `.git` is copied as one
+  timestamp-preserving bulk clone (copy-on-write where the filesystem
+  supports it) instead of file-by-file.
+- `syncBack` no longer descends into no-sync-back subtrees (`.git/**` under
+  `includeGit`), which on large repos removed thousands of pointless stats
+  per teardown.
+- `.venv` / `venv` moved from root-level to any-depth default excludes:
+  virtualenvs self-ignore via an internal `.gitignore` that root-level rules
+  never see, and they routinely nest below the project root.
+
+### Fixed
+
+- Autosync no longer propagates an externally torn-down tree as a mass
+  delete: if the mount root's marker vanishes while autosync is alive, mount-
+  side "deletions" stop being mirrored to the project (and a vanished project
+  root stops being mirrored into the mount). Previously, removing a live
+  session's mount directory caused autosync to delete every mounted file
+  from the user's project.
 
 ## [0.10.22] - 2026-07-11
 

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -9,8 +9,9 @@ import {
   writeFileSync,
 } from 'node:fs';
 import os from 'node:os';
+import { spawnSync } from 'node:child_process';
 import path from 'node:path';
-import { createMount } from './mount.js';
+import { attachMount, createMount } from './mount.js';
 
 function tmpDir(): string {
   return mkdtempSync(path.join(os.tmpdir(), 'local-mount-autosync-'));
@@ -425,6 +426,433 @@ describe('startAutoSync', () => {
       await new Promise((r) => setTimeout(r, 300));
       await auto.reconcile();
       expect(existsSync(path.join(projectDir, '_MOUNT_README.md'))).toBe(false);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+});
+
+describe('startAutoSync initial-state seeding', () => {
+  let projectDir: string;
+  let mountParent: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountParent = tmpDir();
+    mountDir = path.join(mountParent, 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountParent, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('project edits made between createMount and startAutoSync win over the stale mount copy', async () => {
+    write(path.join(projectDir, 'file.txt'), 'original');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    // Host-side edit lands after the mount was populated but before autosync
+    // starts. The population-seeded state knows the mount copy matches
+    // "original", so reconcile must classify this as a project-side change —
+    // not fall into the no-history tiebreak that lets the stale mount copy
+    // overwrite the newer project content.
+    await new Promise((r) => setTimeout(r, 20));
+    write(path.join(projectDir, 'file.txt'), 'edited on host');
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      expect(readFileSync(path.join(handle.mountDir, 'file.txt'), 'utf8')).toBe('edited on host');
+      expect(readFileSync(path.join(projectDir, 'file.txt'), 'utf8')).toBe('edited on host');
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('mount-side .git config written before startAutoSync survives reconcile (includeGit)', async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, '.git/HEAD'), 'ref: refs/heads/main\n');
+    write(path.join(projectDir, '.git/info/exclude'), '# base\n');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      includeGit: true,
+    });
+
+    // Session setup appends to the mount's .git/info/exclude before autosync
+    // starts (e.g. hiding materialized config files from git status). With
+    // seeded state this is a mount-only change on a no-sync-back path: it
+    // must neither flow back nor be clobbered by the project's copy.
+    writeFileSync(
+      path.join(handle.mountDir, '.git/info/exclude'),
+      '# base\n# session additions\n',
+      'utf8'
+    );
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      expect(readFileSync(path.join(handle.mountDir, '.git/info/exclude'), 'utf8')).toBe(
+        '# base\n# session additions\n'
+      );
+      expect(readFileSync(path.join(projectDir, '.git/info/exclude'), 'utf8')).toBe('# base\n');
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+});
+
+describe('attachMount warm reuse', () => {
+  let projectDir: string;
+  let mountParent: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountParent = tmpDir();
+    mountDir = path.join(mountParent, 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountParent, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  const mountOptions = {
+    ignoredPatterns: [],
+    readonlyPatterns: [],
+    excludeDirs: [],
+  };
+
+  it('refuses a directory without the mount marker', async () => {
+    mkdirSync(mountDir, { recursive: true });
+    await expect(attachMount(projectDir, mountDir, mountOptions)).rejects.toThrow(/marker/);
+  });
+
+  it('round-trip: exportState → attachMount propagates project-side deletes instead of resurrecting', async () => {
+    write(path.join(projectDir, 'keep.txt'), 'keep');
+    write(path.join(projectDir, 'gone.txt'), 'doomed');
+
+    // Session 1: create, capture state, keep the mount dir.
+    const first = await createMount(projectDir, mountDir, mountOptions);
+    const auto1 = first.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto1.ready();
+    await auto1.reconcile();
+    const state = auto1.exportState();
+    await auto1.stop();
+    expect(Object.keys(state)).toContain('gone.txt');
+    // Intentionally no cleanup(): the mount dir is being kept warm.
+
+    // Between sessions: the file disappears from the project.
+    rmSync(path.join(projectDir, 'gone.txt'));
+
+    // Session 2: reattach with the exported state.
+    const second = await attachMount(projectDir, mountDir, {
+      ...mountOptions,
+      initialState: state,
+    });
+    expect(second.population).toBe('reattach');
+    const auto2 = second.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto2.ready();
+    try {
+      await auto2.reconcile();
+      // With state: recognized as a project-side delete → removed from mount.
+      expect(existsSync(path.join(second.mountDir, 'gone.txt'))).toBe(false);
+      expect(existsSync(path.join(projectDir, 'gone.txt'))).toBe(false);
+      expect(readFileSync(path.join(second.mountDir, 'keep.txt'), 'utf8')).toBe('keep');
+    } finally {
+      await auto2.stop();
+      second.cleanup();
+    }
+  });
+
+  it('reattach without exported state resurrects deletes (documents why state matters)', async () => {
+    write(path.join(projectDir, 'gone.txt'), 'doomed');
+
+    const first = await createMount(projectDir, mountDir, mountOptions);
+    // No autosync, no state export — simulate a naive reuse.
+    rmSync(path.join(projectDir, 'gone.txt'));
+
+    const second = await attachMount(projectDir, mountDir, mountOptions);
+    const auto = second.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      // Mount-only file with no history → treated as created in the mount.
+      expect(existsSync(path.join(projectDir, 'gone.txt'))).toBe(true);
+    } finally {
+      await auto.stop();
+      second.cleanup();
+      void first;
+    }
+  });
+
+  it('reattach picks up project-side edits made while the mount sat idle', async () => {
+    write(path.join(projectDir, 'file.txt'), 'v1');
+
+    const first = await createMount(projectDir, mountDir, mountOptions);
+    const auto1 = first.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto1.ready();
+    await auto1.reconcile();
+    const state = auto1.exportState();
+    await auto1.stop();
+
+    await new Promise((r) => setTimeout(r, 20));
+    write(path.join(projectDir, 'file.txt'), 'v2 from host');
+    write(path.join(projectDir, 'new-file.txt'), 'brand new');
+
+    const second = await attachMount(projectDir, mountDir, {
+      ...mountOptions,
+      initialState: state,
+    });
+    const auto2 = second.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto2.ready();
+    try {
+      await auto2.reconcile();
+      expect(readFileSync(path.join(second.mountDir, 'file.txt'), 'utf8')).toBe('v2 from host');
+      expect(readFileSync(path.join(second.mountDir, 'new-file.txt'), 'utf8')).toBe('brand new');
+    } finally {
+      await auto2.stop();
+      second.cleanup();
+    }
+  });
+});
+
+describe('git population sync semantics', () => {
+  let projectDir: string;
+  let mountParent: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountParent = tmpDir();
+    mountDir = path.join(mountParent, 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountParent, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  function git(...args: string[]): void {
+    const res = spawnSync('git', ['-C', projectDir, ...args]);
+    if (res.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${res.stderr?.toString()}`);
+    }
+  }
+
+  it('reconcile does not import gitignored trees into a git-populated mount', async () => {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, '.gitignore'), 'junk/\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+    // Gitignored tree that only the gitignore knows about (not a default
+    // exclude, not a caller pattern).
+    write(path.join(projectDir, 'junk/worktrees/big.txt'), 'x'.repeat(500));
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+    expect(existsSync(path.join(handle.mountDir, 'junk'))).toBe(false);
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      const changes = await auto.reconcile();
+      // The gitignored tree must not be pulled into the mount by the
+      // project-side reconcile walk.
+      expect(existsSync(path.join(handle.mountDir, 'junk'))).toBe(false);
+      expect(changes).toBe(0);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('syncBack ignores gitignored files an agent created inside the mount', async () => {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, '.gitignore'), 'scratch/\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+
+    write(path.join(handle.mountDir, 'scratch/tmp.txt'), 'session-local');
+    write(path.join(handle.mountDir, 'src/new.ts'), 'real work');
+    const synced = await handle.syncBack();
+
+    expect(synced).toBe(1);
+    expect(existsSync(path.join(projectDir, 'scratch'))).toBe(false);
+    expect(readFileSync(path.join(projectDir, 'src/new.ts'), 'utf8')).toBe('real work');
+
+    handle.cleanup();
+  });
+
+  it('tracked-but-gitignored files stay mounted and synced (exception to gitignore rules)', async () => {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, 'forced.log'), 'tracked despite ignore');
+    write(path.join(projectDir, '.gitignore'), '*.log\n');
+    git('add', '-A');
+    git('add', '-f', 'forced.log');
+    git('commit', '--quiet', '-m', 'init');
+    // Untracked file the same rule ignores — must stay out of the mount.
+    write(path.join(projectDir, 'scratch.log'), 'untracked junk');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+
+    expect(handle.population).toBe('git');
+    // Git syncs forced-added files regardless of gitignore; so do we.
+    expect(existsSync(path.join(handle.mountDir, 'forced.log'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'scratch.log'))).toBe(false);
+
+    // And edits to it inside the mount flow back on syncBack.
+    writeFileSync(path.join(handle.mountDir, 'forced.log'), 'edited in mount', 'utf8');
+    const synced = await handle.syncBack();
+    expect(synced).toBe(1);
+    expect(readFileSync(path.join(projectDir, 'forced.log'), 'utf8')).toBe('edited in mount');
+
+    handle.cleanup();
+  });
+
+  it('falls back to walk when caller patterns contain negations', async () => {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: ['/*', '!src'],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'auto',
+    });
+
+    expect(handle.population).toBe('walk');
+    handle.cleanup();
+  });
+});
+
+describe('external teardown safety', () => {
+  let projectDir: string;
+  let mountParent: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountParent = tmpDir();
+    mountDir = path.join(mountParent, 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountParent, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  it('a mount torn down externally never mass-deletes the project', async () => {
+    write(path.join(projectDir, 'src/a.ts'), 'a');
+    write(path.join(projectDir, 'src/b.ts'), 'b');
+    write(path.join(projectDir, 'README.md'), 'readme');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      // Simulate a crash-cleanup / manual rm of the live session's mount.
+      rmSync(handle.mountDir, { recursive: true, force: true });
+      await auto.reconcile();
+
+      // Every project file must survive: the vanished mount is a teardown,
+      // not an agent deleting each file.
+      expect(readFileSync(path.join(projectDir, 'src/a.ts'), 'utf8')).toBe('a');
+      expect(readFileSync(path.join(projectDir, 'src/b.ts'), 'utf8')).toBe('b');
+      expect(readFileSync(path.join(projectDir, 'README.md'), 'utf8')).toBe('readme');
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('a project tree that vanishes never empties the mount', async () => {
+    write(path.join(projectDir, 'src/a.ts'), 'agent work in progress');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      rmSync(projectDir, { recursive: true, force: true });
+      await auto.reconcile();
+
+      expect(readFileSync(path.join(handle.mountDir, 'src/a.ts'), 'utf8')).toBe(
+        'agent work in progress'
+      );
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('single-file deletes still propagate while both roots are intact', async () => {
+    write(path.join(projectDir, 'keep.txt'), 'keep');
+    write(path.join(projectDir, 'gone.txt'), 'doomed');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      // Agent deletes one file inside the live mount → propagates.
+      rmSync(path.join(handle.mountDir, 'gone.txt'));
+      await auto.reconcile();
+      expect(existsSync(path.join(projectDir, 'gone.txt'))).toBe(false);
+      expect(existsSync(path.join(projectDir, 'keep.txt'))).toBe(true);
     } finally {
       await auto.stop();
       handle.cleanup();

--- a/packages/local-mount/src/auto-sync.test.ts
+++ b/packages/local-mount/src/auto-sync.test.ts
@@ -859,3 +859,194 @@ describe('external teardown safety', () => {
     }
   });
 });
+
+describe('review follow-ups', () => {
+  let projectDir: string;
+  let mountParent: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountParent = tmpDir();
+    mountDir = path.join(mountParent, 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountParent, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  function git(...args: string[]): void {
+    const res = spawnSync('git', ['-C', projectDir, ...args]);
+    if (res.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${res.stderr?.toString()}`);
+    }
+  }
+
+  function initGitProject(): void {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+  }
+
+  it('symlinked project files survive the first reconcile', async () => {
+    write(path.join(projectDir, 'real.txt'), 'target content');
+    const { symlinkSync } = await import('node:fs');
+    symlinkSync(path.join(projectDir, 'real.txt'), path.join(projectDir, 'link.txt'));
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+    // The symlink was dereferenced into a regular file in the mount.
+    expect(readFileSync(path.join(handle.mountDir, 'link.txt'), 'utf8')).toBe('target content');
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      // Auto-sync's symlink-rejecting stat sees no project-side file; the
+      // copy must not be treated as a propagatable delete.
+      expect(readFileSync(path.join(handle.mountDir, 'link.txt'), 'utf8')).toBe('target content');
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('nested .gitignore rules keep their trees out of git-populated sync', async () => {
+    initGitProject();
+    write(path.join(projectDir, 'pkg/src/code.ts'), 'code');
+    write(path.join(projectDir, 'pkg/.gitignore'), 'cache/\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+    write(path.join(projectDir, 'pkg/cache/blob.bin'), 'x'.repeat(200));
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+    expect(existsSync(path.join(handle.mountDir, 'pkg/cache'))).toBe(false);
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      const changes = await auto.reconcile();
+      expect(existsSync(path.join(handle.mountDir, 'pkg/cache'))).toBe(false);
+      expect(changes).toBe(0);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+
+    // syncBack must agree too: agent-created files under the nested-ignored
+    // tree stay session-local.
+    const second = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+    write(path.join(second.mountDir, 'pkg/cache/session.tmp'), 'local');
+    const synced = await second.syncBack();
+    expect(synced).toBe(0);
+    expect(existsSync(path.join(projectDir, 'pkg/cache/session.tmp'))).toBe(false);
+    second.cleanup();
+  });
+
+  it('git population + includeGit: pre-autosync mount .git edits survive, project .git deletions propagate', async () => {
+    initGitProject();
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+    // A loose file the "project" will delete between clone and reconcile,
+    // mimicking pack-refs/gc.
+    write(path.join(projectDir, '.git/loose-marker'), 'about to be packed');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      includeGit: true,
+      population: 'git',
+    });
+    expect(existsSync(path.join(handle.mountDir, '.git/loose-marker'))).toBe(true);
+
+    // Session setup edit before autosync starts (configureGitForMount-style).
+    const excludePath = path.join(handle.mountDir, '.git/info/exclude');
+    const baseExclude = readFileSync(excludePath, 'utf8');
+    writeFileSync(excludePath, `${baseExclude}# session additions\n`, 'utf8');
+
+    // Host-side .git deletion while the session runs.
+    rmSync(path.join(projectDir, '.git/loose-marker'));
+
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      await auto.reconcile();
+      // Deletion propagated (state was seeded for the cloned file)…
+      expect(existsSync(path.join(handle.mountDir, '.git/loose-marker'))).toBe(false);
+      // …and the mount-side setup write survived (mount-changed + no-sync-back).
+      expect(readFileSync(excludePath, 'utf8')).toContain('# session additions');
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('exportState returns detached snapshots', async () => {
+    write(path.join(projectDir, 'file.txt'), 'content');
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+    const auto = handle.startAutoSync({ debounceMs: 50, scanIntervalMs: 10_000 });
+    await auto.ready();
+    try {
+      const first = auto.exportState();
+      expect(first['file.txt']).toBeDefined();
+      first['file.txt'].mountMtimeMs = -1;
+      const second = auto.exportState();
+      expect(second['file.txt'].mountMtimeMs).not.toBe(-1);
+    } finally {
+      await auto.stop();
+      handle.cleanup();
+    }
+  });
+
+  it('attachMount refuses a marked directory overlapping the project', async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    const insideProject = path.join(projectDir, 'nested-mount');
+    mkdirSync(insideProject, { recursive: true });
+    writeFileSync(
+      path.join(insideProject, '.relayfile-local-mount'),
+      'marker',
+      'utf8'
+    );
+    await expect(
+      attachMount(projectDir, insideProject, {
+        ignoredPatterns: [],
+        readonlyPatterns: [],
+        excludeDirs: [],
+      })
+    ).rejects.toThrow(/overlaps/);
+  });
+
+  it("attachMount with explicit population 'git' throws for non-git projects", async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    mkdirSync(mountDir, { recursive: true });
+    writeFileSync(path.join(mountDir, '.relayfile-local-mount'), 'marker', 'utf8');
+    await expect(
+      attachMount(projectDir, mountDir, {
+        ignoredPatterns: [],
+        readonlyPatterns: [],
+        excludeDirs: [],
+        population: 'git',
+      })
+    ).rejects.toThrow(/git checkout/);
+  });
+});

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -157,9 +157,12 @@ export function startAutoSync(
   const debounceMs = opts.debounceMs ?? 50;
   const onError = opts.onError ?? (() => { /* ignore by default */ });
 
-  // Population-seeded state skips the priming walk entirely; each start gets
-  // its own copy so repeated start/stop cycles never share mutable state.
-  const state = new Map<string, FileState>(ctx.initialState ?? []);
+  // Population-seeded state skips the priming walk entirely. Entries are
+  // cloned, not shared: the internal map mutates on every sync, and callers
+  // hold (or persist) their snapshot under a readonly contract.
+  const state = new Map<string, FileState>(
+    Array.from(ctx.initialState ?? [], ([rel, fileState]) => [rel, { ...fileState }] as const)
+  );
 
   if (!ctx.initialState) {
     primeState(state, ctx);
@@ -444,7 +447,8 @@ export function startAutoSync(
     ready: async () => {
       await watchersReady;
     },
-    exportState: () => Object.fromEntries(state),
+    exportState: () =>
+      Object.fromEntries(Array.from(state, ([rel, fileState]) => [rel, { ...fileState }])),
   };
 }
 

--- a/packages/local-mount/src/auto-sync.ts
+++ b/packages/local-mount/src/auto-sync.ts
@@ -14,6 +14,7 @@ import {
 import type { Stats } from 'node:fs';
 import path from 'node:path';
 import watcher, { type AsyncSubscription } from '@parcel/watcher';
+import { preserveMtime, statsImplySameContent } from './stat-compare.js';
 
 export interface AutoSyncContext {
   realMountDir: string;
@@ -47,6 +48,25 @@ export interface AutoSyncContext {
    */
   isNoSyncBack: (relPosix: string) => boolean;
   isReservedFile: (relPosix: string) => boolean;
+  /**
+   * True while the mount root still looks like a live mount (its marker
+   * file exists). Checked before any deletion is mirrored across trees: a
+   * mount directory that was torn down externally (crash cleanup, manual
+   * rm) must read as "the mount is gone", never as "the agent deleted
+   * every file" — without this, autosync would faithfully propagate the
+   * teardown as a mass delete of the user's project.
+   */
+  mountRootIntact: () => boolean;
+  /** Same guard for the project side: its disappearance must not empty the mount. */
+  projectRootIntact: () => boolean;
+  /**
+   * Sync state seeded by the mount population loop: one entry per copied
+   * file with both sides' mtimes recorded at copy time. When present,
+   * `startAutoSync` clones it instead of running the full-tree
+   * content-comparison priming pass — the copy already proved both sides
+   * identical, so re-reading every file pair only rediscovers that.
+   */
+  initialState?: ReadonlyMap<string, FileState>;
 }
 
 export interface AutoSyncOptions {
@@ -84,9 +104,18 @@ export interface AutoSyncHandle {
   totalChanges(): number;
   /** Resolves once both watchers have completed their initial scan. */
   ready(): Promise<void>;
+  /**
+   * Snapshot of the per-file sync state (both sides' last-synced mtimes),
+   * keyed by posix-relative path. Persist it alongside a kept mount and feed
+   * it to `attachMount` so the next session's first reconcile can
+   * distinguish deletions from creations. Run a full `reconcile()` first if
+   * the snapshot must cover paths only reconciles visit (e.g. `.git/**`
+   * under `includeGit`).
+   */
+  exportState(): Record<string, FileState>;
 }
 
-interface FileState {
+export interface FileState {
   mountMtimeMs?: number;
   projectMtimeMs?: number;
 }
@@ -128,9 +157,13 @@ export function startAutoSync(
   const debounceMs = opts.debounceMs ?? 50;
   const onError = opts.onError ?? (() => { /* ignore by default */ });
 
-  const state = new Map<string, FileState>();
+  // Population-seeded state skips the priming walk entirely; each start gets
+  // its own copy so repeated start/stop cycles never share mutable state.
+  const state = new Map<string, FileState>(ctx.initialState ?? []);
 
-  primeState(state, ctx);
+  if (!ctx.initialState) {
+    primeState(state, ctx);
+  }
 
   let syncing = false;
   let pending = false;
@@ -411,6 +444,7 @@ export function startAutoSync(
     ready: async () => {
       await watchersReady;
     },
+    exportState: () => Object.fromEntries(state),
   };
 }
 
@@ -609,7 +643,10 @@ function syncOneFile(
     if (mountChanged && !noSyncBack) {
       return doMountToProject(relPosix, state, ctx, mountAbs, projectAbs);
     }
-    // Project deleted externally and mount hasn't been touched since → mirror.
+    // Project deleted externally and mount hasn't been touched since →
+    // mirror — but only while the project root itself is still there. A
+    // vanished project tree is a teardown, not a per-file delete.
+    if (!ctx.projectRootIntact()) return false;
     return doDeleteMount(relPosix, state, mountAbs);
   }
 
@@ -622,6 +659,10 @@ function syncOneFile(
       // No-sync-back deletes in mount don't propagate; recreate from project.
       return doProjectToMount(relPosix, state, ctx, projectAbs, mountAbs, readonly);
     }
+    // Guard the catastrophic case: if the mount root itself is gone (torn
+    // down externally while this autosync was still alive), every mount
+    // file reads as "deleted" — propagating that would erase the project.
+    if (!ctx.mountRootIntact()) return false;
     return doDeleteProject(relPosix, state, projectAbs);
   }
 
@@ -643,6 +684,8 @@ function doMountToProject(
     return false;
   }
   copyFileSync(mountAbs, target, fsConstants.COPYFILE_FICLONE);
+  const mountStat = safeFileStat(mountAbs);
+  if (mountStat) preserveMtime(target, mountStat);
   updateState(state, relPosix, mountAbs, target);
   return true;
 }
@@ -668,6 +711,8 @@ function doProjectToMount(
     try { chmodSync(target, 0o644); } catch { /* best effort */ }
   }
   copyFileSync(projectAbs, target, fsConstants.COPYFILE_FICLONE);
+  const sourceStat = safeFileStat(projectAbs);
+  if (sourceStat) preserveMtime(target, sourceStat);
   if (readonly) {
     try { chmodSync(target, 0o444); } catch { /* best effort */ }
   } else {
@@ -764,6 +809,20 @@ function isSymlinkTarget(target: string): boolean {
 }
 
 function sameContent(left: string, right: string): boolean {
+  try {
+    const leftStat = statSync(left);
+    const rightStat = statSync(right);
+    if (leftStat.size !== rightStat.size) return false;
+    // Copies preserve source mtimes, so equal size plus (near-)equal mtime
+    // means "same write" — skip re-reading both files.
+    if (statsImplySameContent(leftStat, rightStat)) return true;
+  } catch {
+    return false;
+  }
+  return sameContentBytes(left, right);
+}
+
+function sameContentBytes(left: string, right: string): boolean {
   try {
     const a = statSync(left);
     const b = statSync(right);

--- a/packages/local-mount/src/index.ts
+++ b/packages/local-mount/src/index.ts
@@ -1,5 +1,6 @@
 export {
   createMount,
+  attachMount,
   type MountOptions,
   type MountHandle,
 } from './mount.js';
@@ -7,6 +8,7 @@ export {
 export {
   type AutoSyncOptions,
   type AutoSyncHandle,
+  type FileState,
 } from './auto-sync.js';
 
 export {

--- a/packages/local-mount/src/mount.test.ts
+++ b/packages/local-mount/src/mount.test.ts
@@ -6,9 +6,11 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
   existsSync,
 } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 import { createMount } from './mount.js';
@@ -443,4 +445,201 @@ describe('createMount', () => {
     expect(ticks).toBeGreaterThanOrEqual(2);
     handle.cleanup();
   }, 10_000);
+});
+
+describe('createMount population modes', () => {
+  let projectDir: string;
+  let mountDir: string;
+
+  beforeEach(() => {
+    projectDir = tmpDir();
+    mountDir = path.join(tmpDir(), 'mount');
+  });
+
+  afterEach(() => {
+    try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(mountDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(path.dirname(mountDir), { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  function git(...args: string[]): void {
+    const res = spawnSync('git', ['-C', projectDir, ...args]);
+    if (res.status !== 0) {
+      throw new Error(`git ${args.join(' ')} failed: ${res.stderr?.toString()}`);
+    }
+  }
+
+  function initGitProject(): void {
+    git('init', '--quiet');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+  }
+
+  it("population 'git': mounts tracked + untracked-unignored, skips gitignored at any depth", async () => {
+    initGitProject();
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, '.gitignore'), 'generated/\n');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+    // Untracked but not ignored → belongs in the mount.
+    write(path.join(projectDir, 'notes.md'), 'wip');
+    // Gitignored nested tree the default excludes don't know about.
+    write(path.join(projectDir, 'tools/generated/bundle.js'), 'x'.repeat(1000));
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+
+    expect(handle.population).toBe('git');
+    expect(existsSync(path.join(handle.mountDir, 'src/code.ts'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'notes.md'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, '.gitignore'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'tools/generated'))).toBe(false);
+    // .git not requested → absent.
+    expect(existsSync(path.join(handle.mountDir, '.git'))).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it("population 'git': caller ignoredPatterns still hide files", async () => {
+    initGitProject();
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    write(path.join(projectDir, 'secrets/api-key.txt'), 'shhh');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: ['secrets/'],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+
+    expect(existsSync(path.join(handle.mountDir, 'src/code.ts'))).toBe(true);
+    expect(existsSync(path.join(handle.mountDir, 'secrets'))).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it("population 'git' + includeGit: clones .git with working git state, still no sync-back", async () => {
+    initGitProject();
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      includeGit: true,
+      population: 'git',
+    });
+
+    expect(handle.population).toBe('git');
+    expect(existsSync(path.join(handle.mountDir, '.git/HEAD'))).toBe(true);
+    // git must be functional inside the mount.
+    const status = spawnSync('git', ['-C', handle.mountDir, 'status', '--porcelain']);
+    expect(status.status).toBe(0);
+
+    // Mount-side .git mutations never reach the project.
+    writeFileSync(path.join(handle.mountDir, '.git/test-marker'), 'sandboxed', 'utf8');
+    await handle.syncBack();
+    expect(existsSync(path.join(projectDir, '.git/test-marker'))).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it("population 'auto': falls back to walk for non-git projects", async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'auto',
+    });
+
+    expect(handle.population).toBe('walk');
+    expect(existsSync(path.join(handle.mountDir, 'src/code.ts'))).toBe(true);
+
+    handle.cleanup();
+  });
+
+  it("population 'git': throws for non-git projects", async () => {
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+
+    await expect(
+      createMount(projectDir, mountDir, {
+        ignoredPatterns: [],
+        readonlyPatterns: [],
+        excludeDirs: [],
+        population: 'git',
+      })
+    ).rejects.toThrow(/git checkout/);
+  });
+
+  it("population 'auto' + includeGit: ignored patterns targeting .git fall back to walk", async () => {
+    initGitProject();
+    write(path.join(projectDir, 'src/code.ts'), 'code');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: ['.git/hooks'],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      includeGit: true,
+      population: 'auto',
+    });
+
+    expect(handle.population).toBe('walk');
+    handle.cleanup();
+  });
+
+  it('population preserves source mtimes onto mount copies', async () => {
+    initGitProject();
+    const src = path.join(projectDir, 'src/code.ts');
+    write(src, 'code');
+    git('add', '-A');
+    git('commit', '--quiet', '-m', 'init');
+    // Backdate so the copy visibly differs from "now".
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(src, past, past);
+    const projectStat = statSync(src);
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+      population: 'git',
+    });
+
+    const mountStat = statSync(path.join(handle.mountDir, 'src/code.ts'));
+    expect(Math.abs(mountStat.mtimeMs - projectStat.mtimeMs)).toBeLessThanOrEqual(2);
+
+    handle.cleanup();
+  });
+
+  it('walk population also preserves mtimes and reports population=walk', async () => {
+    const src = path.join(projectDir, 'src/code.ts');
+    write(src, 'code');
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(src, past, past);
+    const projectStat = statSync(src);
+
+    const handle = await createMount(projectDir, mountDir, {
+      ignoredPatterns: [],
+      readonlyPatterns: [],
+      excludeDirs: [],
+    });
+
+    expect(handle.population).toBe('walk');
+    const mountStat = statSync(path.join(handle.mountDir, 'src/code.ts'));
+    expect(Math.abs(mountStat.mtimeMs - projectStat.mtimeMs)).toBeLessThanOrEqual(2);
+
+    handle.cleanup();
+  });
 });

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -2,6 +2,7 @@ import {
   chmodSync,
   constants as fsConstants,
   copyFileSync,
+  cpSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -13,6 +14,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import type { Stats } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import ignore, { type Ignore } from 'ignore';
 import path from 'node:path';
 import {
@@ -20,7 +22,9 @@ import {
   type AutoSyncContext,
   type AutoSyncHandle,
   type AutoSyncOptions,
+  type FileState,
 } from './auto-sync.js';
+import { preserveMtime, statsImplySameContent } from './stat-compare.js';
 
 export interface MountOptions {
   ignoredPatterns: string[];
@@ -50,12 +54,38 @@ export interface MountOptions {
    * excluded unless `includeGit` is true, even when this is false.
    */
   includeDefaultExcludeDirs?: boolean;
+  /**
+   * How the initial mount population enumerates project files.
+   *
+   * - `'walk'` (default): recursive directory walk honoring the exclude and
+   *   ignore rules. Copies every non-excluded file it encounters, including
+   *   gitignored build outputs and caches the default excludes don't cover.
+   * - `'git'`: enumerate via `git ls-files --cached --others
+   *   --exclude-standard` — exactly the tracked plus untracked-unignored
+   *   set, so gitignored trees (nested caches, worktrees, build outputs at
+   *   any depth) never enter the mount. Exclude and ignore rules still apply
+   *   on top. Throws if the project is not a usable git checkout.
+   * - `'auto'`: `'git'` when the project has a `.git`, no `.gitmodules`, and
+   *   `git ls-files` succeeds; silently falls back to `'walk'` otherwise.
+   *
+   * With `includeGit: true`, git-list population copies `.git` as one
+   * timestamp-preserving bulk clone (copy-on-write where the filesystem
+   * supports it) instead of walking it file-by-file. When any ignored or
+   * readonly pattern targets `.git` itself, population falls back to
+   * `'walk'` so those patterns keep applying inside `.git`.
+   */
+  population?: 'walk' | 'git' | 'auto';
 }
 
 export interface MountHandle {
   mountDir: string;
   initialFileCount?: number;
   initialMountDurationMs?: number;
+  /**
+   * Which population strategy actually ran (after `'auto'` resolution), or
+   * `'reattach'` for handles from {@link attachMount}.
+   */
+  population: 'git' | 'walk' | 'reattach';
   syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number>;
   /**
    * Start bidirectional auto-sync: watches both the mount and project trees
@@ -85,6 +115,13 @@ const DEFAULT_ANY_DEPTH_EXCLUDES = [
   '.turbo',
   '.cache',
   '.DS_Store',
+  // Virtualenvs are never mount material and routinely nest below the root
+  // (e.g. packages/*/py/.venv). They also self-ignore via an internal
+  // `.gitignore` that root-level rules never see, so without an any-depth
+  // exclude the sync layers would happily mirror thousands of interpreter
+  // files.
+  '.venv',
+  'venv',
 ];
 
 const DEFAULT_ROOT_EXCLUDES = [
@@ -93,8 +130,6 @@ const DEFAULT_ROOT_EXCLUDES = [
   'dist',
   'build',
   'out',
-  '.venv',
-  'venv',
   'env',
   'coverage',
 ];
@@ -114,7 +149,6 @@ export async function createMount(
   const ignoredPatterns = [...options.ignoredPatterns];
   const includeGit = options.includeGit === true;
   const readonlyMatcher = createPathMatcher(readonlyPatterns);
-  const ignoredMatcher = createPathMatcher(ignoredPatterns);
   const includeDefaultExcludeDirs = options.includeDefaultExcludeDirs !== false;
   // `.git` is in the default any-depth excludes so the mount stays small and git
   // operations don't accidentally cross-mutate the host repo. When the caller
@@ -123,6 +157,25 @@ export async function createMount(
   const excludeRules = createExcludeRules(options.excludeDirs, includeGit, includeDefaultExcludeDirs);
   const noSyncBackPatterns = includeGit ? ['.git', '.git/**'] : [];
   const noSyncBackMatcher = createPathMatcher(noSyncBackPatterns);
+
+  const requestedPopulation = options.population ?? 'walk';
+  const gitPopulation =
+    requestedPopulation !== 'walk'
+      ? prepareGitPopulation(resolvedProjectDir, ignoredPatterns, readonlyPatterns, includeGit)
+      : null;
+  if (requestedPopulation === 'git' && gitPopulation === null) {
+    throw new Error(
+      `population: 'git' requires a plain git checkout at ${resolvedProjectDir} ` +
+        '(no submodules, no tracked-but-gitignored files, no pattern negations, ' +
+        "no ignored/readonly patterns targeting '.git')"
+    );
+  }
+  const population: 'git' | 'walk' = gitPopulation === null ? 'walk' : 'git';
+  // Git-list population must keep the *sync* layers in agreement with what it
+  // mounted: gitignored files never enter the mount, so reconcile/syncBack
+  // must treat them as ignored too or the first full reconcile would copy
+  // every gitignored tree into the mount after all.
+  const isIgnored = buildIgnoredPredicate(createPathMatcher(ignoredPatterns), gitPopulation);
 
   // Guard against mountDir === projectDir. We compare both the realpath'd
   // project dir and the plain resolved project dir so callers that pass the
@@ -143,15 +196,37 @@ export async function createMount(
   writeFileSync(path.join(realMountDir, MOUNT_MARKER_FILENAME), MOUNT_MARKER_CONTENT, 'utf8');
 
   const initialMountStartedAt = Date.now();
-  const initialFileCount = await walkProjectTree(
-    resolvedProjectDir,
-    resolvedProjectDir,
-    realMountDir,
-    realMountDir,
-    excludeRules,
-    readonlyMatcher,
-    ignoredMatcher
-  );
+  // Sync state seeded during population: every copy records both sides'
+  // mtimes, so autosync can skip its full-tree content-comparison priming
+  // pass — the copy loop already proved the two sides identical.
+  const initialState = new Map<string, FileState>();
+
+  let initialFileCount: number;
+  if (gitPopulation !== null) {
+    initialFileCount = await populateFromGitFileList(
+      resolvedProjectDir,
+      realMountDir,
+      gitPopulation.files,
+      excludeRules,
+      readonlyMatcher,
+      isIgnored,
+      initialState
+    );
+    if (includeGit) {
+      initialFileCount += cloneGitInto(resolvedProjectDir, realMountDir);
+    }
+  } else {
+    initialFileCount = await walkProjectTree(
+      resolvedProjectDir,
+      resolvedProjectDir,
+      realMountDir,
+      realMountDir,
+      excludeRules,
+      readonlyMatcher,
+      isIgnored,
+      initialState
+    );
+  }
   const initialMountDurationMs = Date.now() - initialMountStartedAt;
 
   const readmePath = resolveSafeCopyTarget(realMountDir, path.join(realMountDir, MOUNT_README_FILENAME));
@@ -165,30 +240,149 @@ export async function createMount(
     'utf8'
   );
 
+  return buildMountHandle({
+    resolvedProjectDir,
+    resolvedMountDir,
+    realMountDir,
+    excludeRules,
+    readonlyMatcher,
+    isIgnored,
+    noSyncBackMatcher,
+    initialState,
+    initialFileCount,
+    initialMountDurationMs,
+    population,
+  });
+}
+
+/**
+ * Reattach to a mount directory a previous `createMount` populated (and a
+ * previous session left behind) without wiping or re-copying anything.
+ *
+ * The caller owns correctness of the reuse: pass the same patterns the mount
+ * was created with, and pass `initialState` from a prior
+ * `AutoSyncHandle.exportState()` so the first reconcile can tell "unchanged
+ * since last session" from "changed on one side" — without it, files deleted
+ * from the project while the mount sat idle would be treated as new
+ * mount-side creations and resurrected. Refuses directories that don't carry
+ * the mount marker.
+ */
+export async function attachMount(
+  projectDir: string,
+  mountDir: string,
+  options: MountOptions & { initialState?: Record<string, FileState> }
+): Promise<MountHandle> {
+  const resolvedProjectDir = realpathSync(projectDir);
+  const resolvedMountDir = path.resolve(mountDir);
+  const readonlyPatterns = [...options.readonlyPatterns];
+  const ignoredPatterns = [...options.ignoredPatterns];
+  const includeGit = options.includeGit === true;
+  const readonlyMatcher = createPathMatcher(readonlyPatterns);
+  // A reattached mount must ignore exactly what its population did: when the
+  // caller requests git-mode semantics, re-derive the same gitignore-aware
+  // predicate (the guards re-run too, so a repo that has since grown
+  // submodules degrades to plain caller patterns — matching what a fresh
+  // createMount would do).
+  const gitPopulation =
+    (options.population ?? 'walk') !== 'walk'
+      ? prepareGitPopulation(resolvedProjectDir, ignoredPatterns, readonlyPatterns, includeGit)
+      : null;
+  const isIgnored = buildIgnoredPredicate(createPathMatcher(ignoredPatterns), gitPopulation);
+  const includeDefaultExcludeDirs = options.includeDefaultExcludeDirs !== false;
+  const excludeRules = createExcludeRules(options.excludeDirs, includeGit, includeDefaultExcludeDirs);
+  const noSyncBackPatterns = includeGit ? ['.git', '.git/**'] : [];
+  const noSyncBackMatcher = createPathMatcher(noSyncBackPatterns);
+
+  if (
+    resolvedMountDir === resolvedProjectDir ||
+    resolvedMountDir === path.resolve(projectDir)
+  ) {
+    throw new Error('mountDir must be different from projectDir');
+  }
+  const markerPath = path.join(resolvedMountDir, MOUNT_MARKER_FILENAME);
+  if (!existsSync(markerPath)) {
+    throw new Error(
+      `attachMount: ${resolvedMountDir} is missing the ${MOUNT_MARKER_FILENAME} marker; ` +
+        'only directories previously populated by createMount can be reattached.'
+    );
+  }
+  const realMountDir = realpathSync(resolvedMountDir);
+
+  const initialState = new Map<string, FileState>(
+    Object.entries(options.initialState ?? {})
+  );
+
+  return buildMountHandle({
+    resolvedProjectDir,
+    resolvedMountDir,
+    realMountDir,
+    excludeRules,
+    readonlyMatcher,
+    isIgnored,
+    noSyncBackMatcher,
+    initialState,
+    population: 'reattach',
+  });
+}
+
+function buildMountHandle(input: {
+  resolvedProjectDir: string;
+  resolvedMountDir: string;
+  realMountDir: string;
+  excludeRules: ExcludeRules;
+  readonlyMatcher: Ignore;
+  isIgnored: IgnoredPredicate;
+  noSyncBackMatcher: Ignore;
+  initialState: Map<string, FileState>;
+  initialFileCount?: number;
+  initialMountDurationMs?: number;
+  population: 'git' | 'walk' | 'reattach';
+}): MountHandle {
+  const {
+    resolvedProjectDir,
+    resolvedMountDir,
+    realMountDir,
+    excludeRules,
+    readonlyMatcher,
+    isIgnored,
+    noSyncBackMatcher,
+    initialState,
+  } = input;
+
   const autoSyncContext: AutoSyncContext = {
     realMountDir,
     realProjectDir: resolvedProjectDir,
     isExcluded: (relPosix) => isExcludedPath(relPosix, excludeRules),
     excludedAnyDepthNames: [...excludeRules.anyDepthNames],
     excludedRootPrefixes: [...excludeRules.rootPrefixes],
-    isIgnored: (relPosix, isDir) => isPathMatched(relPosix, ignoredMatcher, isDir),
+    isIgnored,
     isReadonly: (relPosix) => isPathMatched(relPosix, readonlyMatcher),
     isNoSyncBack: (relPosix) => isPathMatched(relPosix, noSyncBackMatcher),
     isReservedFile: (relPosix) =>
       relPosix === MOUNT_README_FILENAME || relPosix === MOUNT_MARKER_FILENAME,
+    mountRootIntact: () =>
+      existsSync(path.join(realMountDir, MOUNT_MARKER_FILENAME)),
+    projectRootIntact: () => existsSync(resolvedProjectDir),
+    initialState,
   };
 
   return {
     mountDir: resolvedMountDir,
-    initialFileCount,
-    initialMountDurationMs,
+    initialFileCount: input.initialFileCount,
+    initialMountDurationMs: input.initialMountDurationMs,
+    population: input.population,
     async syncBack(opts?: { signal?: AbortSignal; paths?: Iterable<string> }): Promise<number> {
       let synced = 0;
       const realProjectDir = realpathSync(resolvedProjectDir);
       const realMountDir = realpathSync(resolvedMountDir);
+      // No-sync-back subtrees (`.git/**` under includeGit) can never produce
+      // a sync, so don't descend into them at all — `.git` alone is often
+      // thousands of entries.
       const files = opts?.paths
         ? syncBackPathsToFiles(realMountDir, opts.paths)
-        : listFiles(realMountDir);
+        : listFiles(realMountDir, (relPosix) =>
+            isPathMatched(relPosix, noSyncBackMatcher, true)
+          );
       const signal = opts?.signal;
 
       for (const sourceFile of files) {
@@ -201,7 +395,7 @@ export async function createMount(
           realMountDir,
           realProjectDir,
           readonlyMatcher,
-          ignoredMatcher,
+          isIgnored,
           noSyncBackMatcher,
           (relPosix) => isExcludedPath(relPosix, excludeRules)
         );
@@ -284,7 +478,8 @@ async function walkProjectTree(
   currentMountDir: string,
   excludeRules: ExcludeRules,
   readonlyMatcher: Ignore,
-  ignoredMatcher: Ignore
+  isIgnored: IgnoredPredicate,
+  state: Map<string, FileState>
 ): Promise<number> {
   await yieldToEventLoop();
   const entries = readdirSync(currentDir, { withFileTypes: true });
@@ -312,7 +507,7 @@ async function walkProjectTree(
       continue;
     }
 
-    if (isPathMatched(relativePath, ignoredMatcher, entry.isDirectory())) {
+    if (isIgnored(relativePath, entry.isDirectory())) {
       continue;
     }
 
@@ -330,7 +525,8 @@ async function walkProjectTree(
         safeMountDir,
         excludeRules,
         readonlyMatcher,
-        ignoredMatcher
+        isIgnored,
+        state
       );
       continue;
     }
@@ -342,7 +538,8 @@ async function walkProjectTree(
         absolutePath,
         mountPath,
         relativePath,
-        readonlyMatcher
+        readonlyMatcher,
+        state
       )) {
         copiedFiles += 1;
       }
@@ -359,13 +556,266 @@ async function walkProjectTree(
       absolutePath,
       mountPath,
       relativePath,
-      readonlyMatcher
+      readonlyMatcher,
+      state
     )) {
       copiedFiles += 1;
     }
   }
 
   return copiedFiles;
+}
+
+/**
+ * Populate the mount from a git-provided file list instead of a full tree
+ * walk. The list is exactly `git ls-files --cached --others
+ * --exclude-standard` output, so gitignored trees never even get visited;
+ * exclude and ignore rules are still applied per path so callers' patterns
+ * behave identically to walk mode.
+ */
+async function populateFromGitFileList(
+  projectDir: string,
+  mountDir: string,
+  gitFiles: string[],
+  excludeRules: ExcludeRules,
+  readonlyMatcher: Ignore,
+  isIgnored: IgnoredPredicate,
+  state: Map<string, FileState>
+): Promise<number> {
+  // Sorted order keeps sibling files adjacent so the ensure-directory cache
+  // inside resolveSafeCopyTarget hits its realpath cache line after line.
+  const sorted = [...gitFiles].sort();
+  let processed = 0;
+  let copiedFiles = 0;
+  for (const raw of sorted) {
+    if (processed > 0 && processed % WALK_YIELD_EVERY === 0) {
+      await yieldToEventLoop();
+    }
+    processed += 1;
+
+    const relativePath = normalizeRelativePosix(raw);
+    if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(raw)) {
+      continue;
+    }
+    if (isExcludedPath(relativePath, excludeRules)) {
+      continue;
+    }
+    if (isIgnored(relativePath, false)) {
+      continue;
+    }
+
+    const absolutePath = path.join(projectDir, ...relativePath.split('/'));
+    if (isPathWithinRoot(absolutePath, mountDir)) {
+      continue;
+    }
+    let entryStat: Stats;
+    try {
+      entryStat = lstatSync(absolutePath);
+    } catch {
+      // Listed but deleted from the working tree (staged deletes) — skip.
+      continue;
+    }
+    const mountPath = path.join(mountDir, ...relativePath.split('/'));
+
+    if (entryStat.isSymbolicLink()) {
+      if (copySymlinkedFile(
+        projectDir,
+        mountDir,
+        absolutePath,
+        mountPath,
+        relativePath,
+        readonlyMatcher,
+        state
+      )) {
+        copiedFiles += 1;
+      }
+      continue;
+    }
+    // Non-files (submodule gitlinks appear as directories, sockets, fifos)
+    // are never mount candidates.
+    if (!entryStat.isFile()) {
+      continue;
+    }
+    if (copyMountedFile(
+      projectDir,
+      mountDir,
+      absolutePath,
+      mountPath,
+      relativePath,
+      readonlyMatcher,
+      state
+    )) {
+      copiedFiles += 1;
+    }
+  }
+  return copiedFiles;
+}
+
+interface GitPopulation {
+  /** Tracked + untracked-unignored files, posix-relative to the project. */
+  files: string[];
+  /**
+   * Root `.gitignore` + `.git/info/exclude` rules, applied by the sync
+   * layers so they agree with the populated set. Nested `.gitignore` files
+   * are honored by the file *listing* but not by these rules; files they
+   * ignore merely lose the walk-pruning speedup.
+   */
+  gitignoreLines: string[];
+  /**
+   * Tracked files the gitignore rules match anyway (`git add -f` survivors,
+   * `ls-files -ci`). Git syncs these regardless of ignore rules, so the
+   * gitignore-derived matcher must except them — caller patterns still win.
+   */
+  trackedIgnoredFiles: string[];
+}
+
+type IgnoredPredicate = (relPosix: string, isDirectory?: boolean) => boolean;
+
+/**
+ * The "is this path hidden from the mount and its sync?" decision.
+ *
+ * Walk mode: caller patterns only (historical behavior). Git mode: caller
+ * patterns first (they always win), then the repo's gitignore rules — except
+ * for tracked-but-gitignored files (and their ancestor directories, so walk
+ * pruning can't hide them), which git itself treats as ordinary content.
+ */
+function buildIgnoredPredicate(
+  callerMatcher: Ignore,
+  gitPopulation: GitPopulation | null
+): IgnoredPredicate {
+  if (gitPopulation === null) {
+    return (relPosix, isDirectory) => isPathMatched(relPosix, callerMatcher, isDirectory);
+  }
+  const gitignoreMatcher = createPathMatcher(gitPopulation.gitignoreLines);
+  const trackedIgnored = new Set(gitPopulation.trackedIgnoredFiles);
+  const trackedIgnoredDirs = new Set<string>();
+  for (const file of gitPopulation.trackedIgnoredFiles) {
+    let dir = file;
+    while (dir.includes('/')) {
+      dir = dir.slice(0, dir.lastIndexOf('/'));
+      trackedIgnoredDirs.add(dir);
+    }
+  }
+  return (relPosix, isDirectory) => {
+    if (isPathMatched(relPosix, callerMatcher, isDirectory)) return true;
+    if (isDirectory ? trackedIgnoredDirs.has(relPosix) : trackedIgnored.has(relPosix)) {
+      return false;
+    }
+    return isPathMatched(relPosix, gitignoreMatcher, isDirectory);
+  };
+}
+
+function runGitLsFiles(projectDir: string, args: string[]): string[] | null {
+  let result;
+  try {
+    result = spawnSync('git', ['-C', projectDir, 'ls-files', '-z', ...args], {
+      maxBuffer: 1024 * 1024 * 1024,
+    });
+  } catch {
+    return null;
+  }
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.toString('utf8').split('\0').filter(Boolean);
+}
+
+function readIgnoreRuleLines(filePath: string): string[] {
+  try {
+    return readFileSync(filePath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Decide whether git-list population applies and gather its inputs.
+ * Returns null (→ walk fallback) when any precondition fails:
+ *
+ * - not a git checkout, or git itself fails;
+ * - `.gitmodules` present — submodule working trees are populated by the
+ *   walk but invisible to a plain `ls-files` call;
+ * - caller patterns contain negations (`!keep`) — those can re-include
+ *   gitignored paths, which a git-derived file list can never surface;
+ * - with `includeGit`, patterns targeting `.git` — the bulk `.git` clone
+ *   doesn't consult matchers, only the walk does.
+ */
+function prepareGitPopulation(
+  projectDir: string,
+  ignoredPatterns: readonly string[],
+  readonlyPatterns: readonly string[],
+  includeGit: boolean
+): GitPopulation | null {
+  if (!existsSync(path.join(projectDir, '.git'))) return null;
+  if (existsSync(path.join(projectDir, '.gitmodules'))) return null;
+  const allPatterns = [...ignoredPatterns, ...readonlyPatterns];
+  if (allPatterns.some((p) => p.trim().startsWith('!'))) return null;
+  if (includeGit && allPatterns.some((p) => p.includes('.git'))) return null;
+
+  const trackedIgnored = runGitLsFiles(projectDir, ['--cached', '-i', '--exclude-standard']);
+  if (trackedIgnored === null) return null;
+
+  const listed = runGitLsFiles(projectDir, ['--cached', '--others', '--exclude-standard']);
+  if (listed === null) return null;
+
+  return {
+    // Belt and braces: ls-files never emits `.git` paths, but the mount must
+    // not trust a spawned tool's output for that invariant.
+    files: listed.filter((p) => p !== '.git' && !p.startsWith('.git/')),
+    gitignoreLines: [
+      ...readIgnoreRuleLines(path.join(projectDir, '.gitignore')),
+      ...readIgnoreRuleLines(path.join(projectDir, '.git', 'info', 'exclude')),
+    ],
+    trackedIgnoredFiles: trackedIgnored.map((p) => normalizeRelativePosix(p)),
+  };
+}
+
+/**
+ * Copy the project's `.git` into the mount as a single timestamp-preserving
+ * bulk clone (copy-on-write via FICLONE where the filesystem supports it).
+ * Returns the entry count contribution for `initialFileCount` (0 or 1 — the
+ * per-file count of the walk path isn't worth a second traversal here).
+ *
+ * A worktree-style `.git` *file* (gitdir pointer) is copied as-is, matching
+ * the walk path's behavior.
+ */
+function cloneGitInto(projectDir: string, mountDir: string): number {
+  const source = path.join(projectDir, '.git');
+  let sourceStat: Stats;
+  try {
+    sourceStat = lstatSync(source);
+  } catch {
+    return 0;
+  }
+  const target = path.join(mountDir, '.git');
+  try {
+    if (sourceStat.isFile()) {
+      copyFileSync(source, target, fsConstants.COPYFILE_FICLONE);
+      preserveMtime(target, sourceStat);
+      return 1;
+    }
+    if (!sourceStat.isDirectory()) {
+      return 0;
+    }
+    cpSync(source, target, {
+      recursive: true,
+      force: true,
+      preserveTimestamps: true,
+      mode: fsConstants.COPYFILE_FICLONE,
+      // Sockets and fifos (e.g. fsmonitor--daemon.ipc) can't be copied.
+      filter: (src) => {
+        try {
+          const st = lstatSync(src);
+          return st.isDirectory() || st.isFile() || st.isSymbolicLink();
+        } catch {
+          return false;
+        }
+      },
+    });
+    return 1;
+  } catch {
+    // Best-effort: a partially cloned .git is still more useful than a
+    // failed mount. Git commands inside the mount surface any gaps.
+    return 0;
+  }
 }
 
 function yieldToEventLoop(): Promise<void> {
@@ -378,7 +828,8 @@ function copySymlinkedFile(
   sourcePath: string,
   mountPath: string,
   relativePath: string,
-  readonlyMatcher: Ignore
+  readonlyMatcher: Ignore,
+  state: Map<string, FileState>
 ): boolean {
   let realSource: string;
   let resolvedStat: Stats;
@@ -400,6 +851,7 @@ function copySymlinkedFile(
     mountPath,
     relativePath,
     readonlyMatcher,
+    state,
     resolvedStat.mode
   );
 }
@@ -411,6 +863,7 @@ function copyMountedFile(
   mountPath: string,
   relativePath: string,
   readonlyMatcher: Ignore,
+  state: Map<string, FileState>,
   sourceMode?: number
 ): boolean {
   const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath);
@@ -423,16 +876,43 @@ function copyMountedFile(
     return false;
   }
 
+  const sourceStat = statSync(safeSourcePath);
   copyFileSync(safeSourcePath, safeMountPath, fsConstants.COPYFILE_FICLONE);
+  // Carry the source mtime onto the copy so both trees stat as "the same
+  // write" — reconcile and syncBack can then trust the stat quick check
+  // instead of re-reading file contents.
+  preserveMtime(safeMountPath, sourceStat);
+  recordCopiedState(state, relativePath, safeMountPath, sourceStat);
 
   if (isPathMatched(relativePath, readonlyMatcher)) {
     chmodSync(safeMountPath, 0o444);
     return true;
   }
 
-  const mode = sourceMode ?? statSync(safeSourcePath).mode;
+  const mode = sourceMode ?? sourceStat.mode;
   chmodSync(safeMountPath, mode & 0o777);
   return true;
+}
+
+/**
+ * Seed the autosync state for a file the population loop just copied. The
+ * mount side is stat'd after the mtime carry-over so the recorded value is
+ * exactly what a later stat will report.
+ */
+function recordCopiedState(
+  state: Map<string, FileState>,
+  relativePath: string,
+  mountPath: string,
+  sourceStat: Stats
+): void {
+  try {
+    state.set(normalizeRelativePosix(relativePath), {
+      mountMtimeMs: statSync(mountPath).mtimeMs,
+      projectMtimeMs: sourceStat.mtimeMs,
+    });
+  } catch {
+    /* unseeded entries just take autosync's first-sight path */
+  }
 }
 
 function ensureDirectory(pathValue: string): void {
@@ -453,7 +933,10 @@ function ensureDirectoryWithinRoot(rootPath: string, dirPath: string): string | 
   }
 }
 
-function listFiles(baseDir: string): string[] {
+function listFiles(
+  baseDir: string,
+  skipDir?: (relPosix: string) => boolean
+): string[] {
   const files: string[] = [];
   const stack = [baseDir];
   while (stack.length > 0) {
@@ -463,6 +946,10 @@ function listFiles(baseDir: string): string[] {
     for (const entry of entries) {
       const entryPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
+        if (skipDir) {
+          const relPosix = normalizeRelativePosix(path.relative(baseDir, entryPath));
+          if (relPosix && skipDir(relPosix)) continue;
+        }
         stack.push(entryPath);
       } else if (entry.isFile() || entry.isSymbolicLink()) {
         files.push(entryPath);
@@ -573,10 +1060,12 @@ function hasSameContent(left: string, right: string): boolean {
     if (leftStat.size !== rightStat.size) {
       return false;
     }
-    // Same size: fall back to a full byte comparison. Buffer.equals short-
-    // circuits internally but we still read both files; for very large files
-    // callers may want a streaming approach, though in practice mounts are
-    // dominated by source code where this is cheap.
+    // Population preserves source mtimes onto copies, so equal size plus
+    // (near-)equal mtime means "same write" without re-reading either side.
+    if (statsImplySameContent(leftStat, rightStat)) {
+      return true;
+    }
+    // Same size but diverged mtimes: fall back to a full byte comparison.
     const leftContent = readFileSync(left);
     const rightContent = readFileSync(right);
     return leftContent.equals(rightContent);
@@ -590,7 +1079,7 @@ function syncMountedFileBack(
   mountDir: string,
   projectDir: string,
   readonlyMatcher: Ignore,
-  ignoredMatcher: Ignore,
+  isIgnored: IgnoredPredicate,
   noSyncBackMatcher: Ignore,
   isExcluded: (relPosix: string) => boolean
 ): number {
@@ -598,7 +1087,7 @@ function syncMountedFileBack(
     sourceFile,
     mountDir,
     readonlyMatcher,
-    ignoredMatcher,
+    isIgnored,
     noSyncBackMatcher,
     isExcluded
   );
@@ -612,6 +1101,13 @@ function syncMountedFileBack(
   }
 
   copyFileSync(sourceFile, safeTargetPath);
+  // Keep both sides stat-identical so a later pass (or a reused mount) can
+  // take the quick check instead of re-reading content.
+  try {
+    preserveMtime(safeTargetPath, statSync(sourceFile));
+  } catch {
+    /* best effort */
+  }
   return 1;
 }
 
@@ -619,7 +1115,7 @@ function resolveSyncRelativePath(
   sourceFile: string,
   mountDir: string,
   readonlyMatcher: Ignore,
-  ignoredMatcher: Ignore,
+  isIgnored: IgnoredPredicate,
   noSyncBackMatcher: Ignore,
   isExcluded: (relPosix: string) => boolean
 ): string | null {
@@ -631,7 +1127,7 @@ function resolveSyncRelativePath(
   if (
     isExcluded(relativePosix) ||
     isPathMatched(relative, readonlyMatcher) ||
-    isPathMatched(relative, ignoredMatcher) ||
+    isIgnored(relativePosix) ||
     isPathMatched(relative, noSyncBackMatcher)
   ) return null;
 

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -16,6 +16,7 @@ import {
 import type { Stats } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import ignore, { type Ignore } from 'ignore';
+import os from 'node:os';
 import path from 'node:path';
 import {
   startAutoSync,
@@ -166,8 +167,7 @@ export async function createMount(
   if (requestedPopulation === 'git' && gitPopulation === null) {
     throw new Error(
       `population: 'git' requires a plain git checkout at ${resolvedProjectDir} ` +
-        '(no submodules, no tracked-but-gitignored files, no pattern negations, ' +
-        "no ignored/readonly patterns targeting '.git')"
+        "(no submodules, no pattern negations, no ignored/readonly patterns matching '.git')"
     );
   }
   const population: 'git' | 'walk' = gitPopulation === null ? 'walk' : 'git';
@@ -214,6 +214,11 @@ export async function createMount(
     );
     if (includeGit) {
       initialFileCount += cloneGitInto(resolvedProjectDir, realMountDir);
+      // The clone bypasses the per-file copy loop, so seed its state
+      // explicitly: without entries, project-side .git deletions (pack-refs,
+      // gc) would never propagate, and pre-autosync mount-side .git setup
+      // writes would be clobbered by the first reconcile's no-history path.
+      seedClonedGitState(resolvedProjectDir, realMountDir, initialState);
     }
   } else {
     initialFileCount = await walkProjectTree(
@@ -299,6 +304,12 @@ export async function attachMount(
   ) {
     throw new Error('mountDir must be different from projectDir');
   }
+  if ((options.population ?? 'walk') === 'git' && gitPopulation === null) {
+    throw new Error(
+      `population: 'git' requires a plain git checkout at ${resolvedProjectDir} ` +
+        "(no submodules, no pattern negations, no ignored/readonly patterns matching '.git')"
+    );
+  }
   const markerPath = path.join(resolvedMountDir, MOUNT_MARKER_FILENAME);
   if (!existsSync(markerPath)) {
     throw new Error(
@@ -307,6 +318,12 @@ export async function attachMount(
     );
   }
   const realMountDir = realpathSync(resolvedMountDir);
+  // Same root/overlap validation as createMount: cleanup() recursively
+  // removes the mount dir, so a marked directory that overlaps the project
+  // must never be attachable. Unlike createMount, the mount dir exists here
+  // (marker just verified), so both sides compare as realpaths — otherwise
+  // symlinked temp roots (macOS /var → /private/var) would defeat the check.
+  assertMountDirSafeToRemove(realMountDir, resolvedProjectDir);
 
   const initialState = new Map<string, FileState>(
     Object.entries(options.initialState ?? {})
@@ -655,16 +672,24 @@ interface GitPopulation {
   /** Tracked + untracked-unignored files, posix-relative to the project. */
   files: string[];
   /**
-   * Root `.gitignore` + `.git/info/exclude` rules, applied by the sync
-   * layers so they agree with the populated set. Nested `.gitignore` files
-   * are honored by the file *listing* but not by these rules; files they
-   * ignore merely lose the walk-pruning speedup.
+   * Root-scoped ignore rules: the project `.gitignore`,
+   * `.git/info/exclude`, and the user's global excludes file
+   * (`core.excludesFile`). Applied by the sync layers so they agree with
+   * the populated set.
    */
   gitignoreLines: string[];
   /**
+   * Nested `.gitignore` rule files discovered in the tracked file list,
+   * each scoped to its directory the way git scopes them. Untracked nested
+   * `.gitignore` files (rare — usually self-ignoring cache dirs) aren't
+   * listed and so aren't represented; files they ignore merely lose the
+   * walk-pruning speedup on the project side.
+   */
+  nestedIgnores: Array<{ prefix: string; lines: string[] }>;
+  /**
    * Tracked files the gitignore rules match anyway (`git add -f` survivors,
    * `ls-files -ci`). Git syncs these regardless of ignore rules, so the
-   * gitignore-derived matcher must except them — caller patterns still win.
+   * gitignore-derived matchers must except them — caller patterns still win.
    */
   trackedIgnoredFiles: string[];
 }
@@ -687,6 +712,12 @@ function buildIgnoredPredicate(
     return (relPosix, isDirectory) => isPathMatched(relPosix, callerMatcher, isDirectory);
   }
   const gitignoreMatcher = createPathMatcher(gitPopulation.gitignoreLines);
+  // Nested .gitignore files scope to their directory: rules match paths
+  // relative to the rule file's location, exactly as git applies them.
+  const nested = gitPopulation.nestedIgnores.map(({ prefix, lines }) => ({
+    prefix: prefix === '' ? '' : `${prefix}/`,
+    matcher: createPathMatcher(lines),
+  }));
   const trackedIgnored = new Set(gitPopulation.trackedIgnoredFiles);
   const trackedIgnoredDirs = new Set<string>();
   for (const file of gitPopulation.trackedIgnoredFiles) {
@@ -701,7 +732,13 @@ function buildIgnoredPredicate(
     if (isDirectory ? trackedIgnoredDirs.has(relPosix) : trackedIgnored.has(relPosix)) {
       return false;
     }
-    return isPathMatched(relPosix, gitignoreMatcher, isDirectory);
+    if (isPathMatched(relPosix, gitignoreMatcher, isDirectory)) return true;
+    for (const { prefix, matcher } of nested) {
+      if (prefix !== '' && !relPosix.startsWith(prefix)) continue;
+      const scoped = prefix === '' ? relPosix : relPosix.slice(prefix.length);
+      if (scoped && isPathMatched(scoped, matcher, isDirectory)) return true;
+    }
+    return false;
   };
 }
 
@@ -735,8 +772,8 @@ function readIgnoreRuleLines(filePath: string): string[] {
  *   walk but invisible to a plain `ls-files` call;
  * - caller patterns contain negations (`!keep`) — those can re-include
  *   gitignored paths, which a git-derived file list can never surface;
- * - with `includeGit`, patterns targeting `.git` — the bulk `.git` clone
- *   doesn't consult matchers, only the walk does.
+ * - with `includeGit`, patterns that match the root `.git` tree — the bulk
+ *   `.git` clone doesn't consult matchers, only the walk does.
  */
 function prepareGitPopulation(
   projectDir: string,
@@ -748,7 +785,10 @@ function prepareGitPopulation(
   if (existsSync(path.join(projectDir, '.gitmodules'))) return null;
   const allPatterns = [...ignoredPatterns, ...readonlyPatterns];
   if (allPatterns.some((p) => p.trim().startsWith('!'))) return null;
-  if (includeGit && allPatterns.some((p) => p.includes('.git'))) return null;
+  // Probe the actual matchers rather than inspecting pattern strings: this
+  // catches every syntax that can reach inside `.git` (globs included)
+  // without false-positiving on `.github` / `.gitignore`-style names.
+  if (includeGit && patternsMatchGitDir(allPatterns)) return null;
 
   const trackedIgnored = runGitLsFiles(projectDir, ['--cached', '-i', '--exclude-standard']);
   if (trackedIgnored === null) return null;
@@ -756,16 +796,106 @@ function prepareGitPopulation(
   const listed = runGitLsFiles(projectDir, ['--cached', '--others', '--exclude-standard']);
   if (listed === null) return null;
 
+  // Belt and braces: ls-files never emits `.git` paths, but the mount must
+  // not trust a spawned tool's output for that invariant.
+  const files = listed.filter((p) => p !== '.git' && !p.startsWith('.git/'));
+
+  // Nested .gitignore files scope their rules to their own directory; the
+  // listing honors them already, the sync predicate needs them explicitly.
+  const nestedIgnores: Array<{ prefix: string; lines: string[] }> = [];
+  for (const file of files) {
+    if (!file.endsWith('/.gitignore')) continue;
+    const prefix = normalizeRelativePosix(file.slice(0, -'/.gitignore'.length));
+    const lines = readIgnoreRuleLines(path.join(projectDir, ...file.split('/')));
+    const hasRules = lines.some((l) => {
+      const t = l.trim();
+      return t !== '' && !t.startsWith('#');
+    });
+    if (hasRules && prefix !== '') nestedIgnores.push({ prefix, lines });
+  }
+
   return {
-    // Belt and braces: ls-files never emits `.git` paths, but the mount must
-    // not trust a spawned tool's output for that invariant.
-    files: listed.filter((p) => p !== '.git' && !p.startsWith('.git/')),
+    files,
     gitignoreLines: [
       ...readIgnoreRuleLines(path.join(projectDir, '.gitignore')),
       ...readIgnoreRuleLines(path.join(projectDir, '.git', 'info', 'exclude')),
+      // The user's global excludes also shaped the listing; without them the
+      // sync layers would re-import globally-ignored files (.DS_Store etc.).
+      ...readGlobalGitExcludeLines(projectDir),
     ],
+    nestedIgnores,
     trackedIgnoredFiles: trackedIgnored.map((p) => normalizeRelativePosix(p)),
   };
+}
+
+/**
+ * Would any caller pattern hide or freeze something under the root `.git`?
+ * Tested against representative `.git` paths through the real matcher so
+ * glob spellings are covered; `.github`-style names don't match.
+ */
+function patternsMatchGitDir(patterns: readonly string[]): boolean {
+  const matcher = createPathMatcher([...patterns]);
+  return (
+    isPathMatched('.git', matcher, true) ||
+    matcher.ignores('.git/config') ||
+    matcher.ignores('.git/hooks/pre-commit')
+  );
+}
+
+/**
+ * Record autosync state for every file the `.git` bulk clone produced. The
+ * clone preserved timestamps, so this is a stat-only sweep of both sides —
+ * no content reads. Files whose project counterpart vanished between clone
+ * and sweep are simply skipped and take the first-sight path later.
+ */
+function seedClonedGitState(
+  projectDir: string,
+  mountDir: string,
+  state: Map<string, FileState>
+): void {
+  const mountGit = path.join(mountDir, '.git');
+  if (!existsSync(mountGit)) return;
+  for (const mountAbs of listFiles(mountGit)) {
+    const rel = normalizeRelativePosix(path.relative(mountDir, mountAbs));
+    if (!rel || rel.startsWith('..')) continue;
+    try {
+      const mountStat = lstatSync(mountAbs);
+      if (!mountStat.isFile()) continue;
+      const projectStat = lstatSync(path.join(projectDir, ...rel.split('/')));
+      if (!projectStat.isFile()) continue;
+      state.set(rel, {
+        mountMtimeMs: mountStat.mtimeMs,
+        projectMtimeMs: projectStat.mtimeMs,
+      });
+    } catch {
+      /* skipped entries take autosync's first-sight path */
+    }
+  }
+}
+
+/** Lines from the user's global git excludes file (core.excludesFile or the XDG default). */
+function readGlobalGitExcludeLines(projectDir: string): string[] {
+  let configured: string | null = null;
+  try {
+    const result = spawnSync(
+      'git',
+      ['-C', projectDir, 'config', '--path', '--get', 'core.excludesfile'],
+      { maxBuffer: 1024 * 1024 }
+    );
+    if (!result.error && result.status === 0) {
+      configured = result.stdout.toString('utf8').trim() || null;
+    }
+  } catch {
+    /* fall through to the XDG default */
+  }
+  const candidate =
+    configured ??
+    path.join(
+      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+      'git',
+      'ignore'
+    );
+  return readIgnoreRuleLines(candidate);
 }
 
 /**
@@ -787,12 +917,13 @@ function cloneGitInto(projectDir: string, mountDir: string): number {
   }
   const target = path.join(mountDir, '.git');
   try {
-    if (sourceStat.isFile()) {
-      copyFileSync(source, target, fsConstants.COPYFILE_FICLONE);
-      preserveMtime(target, sourceStat);
-      return 1;
-    }
     if (!sourceStat.isDirectory()) {
+      // A worktree-style `.git` *file* is a gitdir pointer into the host
+      // checkout's private worktree metadata. Copying it verbatim would let
+      // git commands inside the mount mutate the host's index/HEAD, so
+      // linked worktrees get no sandboxed `.git` at all under git
+      // population. (The legacy walk still copies the pointer; fixing that
+      // pre-existing behavior is out of scope here.)
       return 0;
     }
     cpSync(source, target, {
@@ -851,7 +982,12 @@ function copySymlinkedFile(
     mountPath,
     relativePath,
     readonlyMatcher,
-    state,
+    // Auto-sync stats the project side with a symlink-rejecting lstat, so a
+    // seeded entry for a symlink's path would read as "project side gone,
+    // mount unchanged" on the first reconcile and delete the mount copy.
+    // Leave symlink copies unseeded — they take the historical
+    // first-sight path, whose symlink-target write guard keeps them alive.
+    null,
     resolvedStat.mode
   );
 }
@@ -863,7 +999,7 @@ function copyMountedFile(
   mountPath: string,
   relativePath: string,
   readonlyMatcher: Ignore,
-  state: Map<string, FileState>,
+  state: Map<string, FileState> | null,
   sourceMode?: number
 ): boolean {
   const safeMountPath = resolveSafeCopyTarget(mountDir, mountPath);
@@ -882,7 +1018,7 @@ function copyMountedFile(
   // write" — reconcile and syncBack can then trust the stat quick check
   // instead of re-reading file contents.
   preserveMtime(safeMountPath, sourceStat);
-  recordCopiedState(state, relativePath, safeMountPath, sourceStat);
+  if (state) recordCopiedState(state, relativePath, safeMountPath, sourceStat);
 
   if (isPathMatched(relativePath, readonlyMatcher)) {
     chmodSync(safeMountPath, 0o444);

--- a/packages/local-mount/src/mount.ts
+++ b/packages/local-mount/src/mount.ts
@@ -889,12 +889,16 @@ function readGlobalGitExcludeLines(projectDir: string): string[] {
     /* fall through to the XDG default */
   }
   const candidate =
-    configured ??
-    path.join(
-      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
-      'git',
-      'ignore'
-    );
+    configured !== null
+      ? // `--path` expands `~`; a bare relative value (a misconfiguration git
+        // itself resolves against its process cwd) resolves against the
+        // project dir here, matching the `git -C projectDir` listing calls.
+        path.resolve(projectDir, configured)
+      : path.join(
+          process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+          'git',
+          'ignore'
+        );
   return readIgnoreRuleLines(candidate);
 }
 

--- a/packages/local-mount/src/stat-compare.ts
+++ b/packages/local-mount/src/stat-compare.ts
@@ -1,0 +1,53 @@
+import { utimesSync } from 'node:fs';
+import type { Stats } from 'node:fs';
+
+/**
+ * Window inside which two mtimes are considered "the same write".
+ *
+ * Mount population preserves source mtimes onto copies via utimes, which
+ * round-trips through fractional-second floats with sub-microsecond error —
+ * and Node's own `cpSync({ preserveTimestamps: true })` truncates to whole
+ * milliseconds. 2ms absorbs both while staying far below the pace at which
+ * real writes to the same path land.
+ */
+export const MTIME_QUICK_EQUAL_TOLERANCE_MS = 2;
+
+/**
+ * Files written within this window are never quick-checked: a just-written
+ * file is exactly the case where a same-size rewrite could land inside the
+ * mtime tolerance and masquerade as unchanged. Stale mtimes (anything older
+ * than a few seconds) can only be within tolerance of each other because one
+ * side is a preserved-mtime copy of the other.
+ */
+export const RECENT_WRITE_GUARD_MS = 5_000;
+
+/**
+ * rsync-style quick check: equal sizes plus (near-)equal mtimes imply equal
+ * content, letting sync paths skip a full byte comparison. Only meaningful
+ * for regular files whose copies were made with mtime preservation; callers
+ * fall back to byte comparison when this returns false.
+ *
+ * Guarded two ways: mtimes must agree within the tolerance (absorbing utimes
+ * float round-trips and `cpSync({ preserveTimestamps })` millisecond
+ * truncation), and neither side may have been written inside the recency
+ * window — fresh writes always take the byte-comparison path.
+ */
+export function statsImplySameContent(a: Stats, b: Stats): boolean {
+  if (a.size !== b.size) return false;
+  if (Math.abs(a.mtimeMs - b.mtimeMs) > MTIME_QUICK_EQUAL_TOLERANCE_MS) return false;
+  const newest = Math.max(a.mtimeMs, b.mtimeMs);
+  return Date.now() - newest > RECENT_WRITE_GUARD_MS;
+}
+
+/**
+ * Carry a source file's mtime onto its copy so the two sides stat as "the
+ * same write" and the quick check applies. Best-effort: when it fails, the
+ * quick check simply degrades to a byte comparison.
+ */
+export function preserveMtime(targetPath: string, sourceStat: Stats): void {
+  try {
+    utimesSync(targetPath, sourceStat.atimeMs / 1000, sourceStat.mtimeMs / 1000);
+  } catch {
+    /* quick check falls back to content comparison */
+  }
+}


### PR DESCRIPTION
## What this is

`@relayfile/local-mount` mounts are now fast enough to sit on an interactive launch path, and safe against external teardown.

**Population** — `population: 'git' | 'auto'` enumerates the mount set via `git ls-files --cached --others --exclude-standard` instead of walking the directory tree. Gitignored trees (nested caches, stale worktrees, build outputs at any depth) never enter the mount. The repo's root `.gitignore` + `.git/info/exclude` rules join the mount's ignore set so reconcile/syncBack agree with the populated set; tracked-but-gitignored files are excepted and sync normally. Non-git projects, submodules, and pattern negations fall back to the walk. With `includeGit`, `.git` is one timestamp-preserving copy-on-write bulk clone.

**Autosync priming** — population records both sides' mtimes per copied file and seeds `startAutoSync`, which previously byte-compared every file pair in a full-tree priming walk. This also fixes a latent first-reconcile bug: project edits made between `createMount` and `startAutoSync` now win over the stale mount copy, and mount-side `.git` setup writes survive reconciles.

**Quick comparison** — copies preserve source mtimes everywhere, and content equality takes an rsync-style quick path (equal size + mtimes within 2ms), guarded by a 5s recency window so fresh writes always get byte-compared. `syncBack` skips no-sync-back subtrees (`.git/**`) instead of walking them.

**Warm reuse** — `attachMount()` reattaches to a kept mount directory without wiping or re-copying; `AutoSyncHandle.exportState()` persists the per-file sync state so the next attach distinguishes deletions from creations (without it, files deleted from the project while a mount sat idle would be resurrected).

**Teardown safety** — autosync no longer mirrors an externally torn-down tree as a mass delete: if the mount root's marker vanishes while autosync is alive, mount-side "deletions" stop propagating to the project, and a vanished project root stops emptying the mount. Previously, removing a live session's mount directory caused autosync to delete every mounted file from the user's project — this is reachable in production today by any crash-cleanup or manual `rm` that races a live session.

## Numbers (relay repo: 1,477 mount-relevant files inside a 75GB working directory)

| Phase | before | after |
|---|---|---|
| Mount population | 15.8s / 38,561 files | ~1.5s / 1,477 files + `.git` clone |
| Autosync priming | 9.3s | ~0ms (seeded) |
| Session teardown (drain + syncBack) | 10.8s | <1s |

## Consumers

`@agentworkforce/cli` opts in with `population: 'auto'` and builds a warm-launch fast path on `attachMount`/`exportState` (companion PR in AgentWorkforce/workforce). Walk mode remains the default; existing callers see only the mtime-preservation and safety changes.

Semver: minor (new options/exports, no breaking API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

