### PR TITLE
fix(cli): handle messaging-only workspaces

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -44,18 +44,19 @@ import (
 )
 
 const (
-	relayfileDefaultVersion = "0.10.17"
-	defaultServerURL        = "https://file.agentrelay.com"
-	defaultCloudAPIURL      = "https://agentrelay.com/cloud"
-	defaultRelaycastAPIURL  = "https://gateway.relaycast.dev"
-	defaultObserverURL      = "https://agentrelay.com/observer/file"
-	minAgentRelayCLIVersion = "8.7.0"
-	configDirName           = ".relayfile"
-	websocketReconcileEvery = 10
-	defaultMountMode        = "poll"
-	defaultMountInterval    = 30 * time.Second
-	minMountPollInterval    = 5 * time.Second
-	defaultMountTimeout     = 15 * time.Second
+	relayfileDefaultVersion                   = "0.10.17"
+	defaultServerURL                          = "https://file.agentrelay.com"
+	defaultCloudAPIURL                        = "https://agentrelay.com/cloud"
+	defaultRelaycastAPIURL                    = "https://gateway.relaycast.dev"
+	defaultObserverURL                        = "https://agentrelay.com/observer/file"
+	minAgentRelayCLIVersion                   = "8.7.0"
+	messagingOnlyRelayfileWorkspaceNameSuffix = " (Relayfile)"
+	configDirName                             = ".relayfile"
+	websocketReconcileEvery                   = 10
+	defaultMountMode                          = "poll"
+	defaultMountInterval                      = 30 * time.Second
+	minMountPollInterval                      = 5 * time.Second
+	defaultMountTimeout                       = 15 * time.Second
 )
 
 var relayfileVersion = relayfileDefaultVersion
@@ -1295,9 +1296,8 @@ func classifyAgentRelayActiveWorkspaceError(err error) error {
 	}
 	detail := err.Error()
 	normalized := strings.ToLower(detail)
-	if !strings.Contains(normalized, "workspace resolve failed") ||
-		!strings.Contains(normalized, "404") ||
-		!strings.Contains(normalized, "workspace not found") {
+	if !strings.Contains(normalized, "resolve failed") ||
+		!strings.Contains(normalized, "404") {
 		return err
 	}
 	match := agentRelayWorkspaceKeyInResolverError.FindStringSubmatch(detail)
@@ -1314,7 +1314,7 @@ func classifyAgentRelayActiveWorkspaceError(err error) error {
 	name, statusCode, validationErr := validateRelaycastWorkspaceKey(ctx, workspaceKey)
 	if validationErr != nil {
 		return fmt.Errorf(
-			"the active Agent Relay workspace could not be resolved through Cloud, and Relayfile could not verify it with Relaycast: %v. Check network connectivity and try again",
+			"the active Agent Relay workspace could not be resolved through Cloud, and Relayfile could not verify it with Relaycast: %w. Check network connectivity and try again",
 			validationErr,
 		)
 	}
@@ -1339,6 +1339,7 @@ func validateRelaycastWorkspaceKey(ctx context.Context, workspaceKey string) (st
 		return "", 0, err
 	}
 	req.Header.Set("Authorization", "Bearer "+workspaceKey)
+	req.Header.Set("User-Agent", "relayfile-cli/"+relayfileVersion)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", 0, err
@@ -1983,7 +1984,11 @@ func provisionRelayfileWorkspaceForMessagingOnly(cloud cloudCredentials, name st
 	if name == "" {
 		return workspaceRecord{}, "", errors.New("the messaging-only workspace did not include a name; run `relayfile setup --workspace <name>` to create a separate Relayfile-backed workspace")
 	}
-	record, _, err := ensureWorkspaceForSetup(cloud, name, "")
+	// Keep the Relayfile-backed workspace visually distinct from the original
+	// Relaycast-only workspace. ensureWorkspaceForSetup deduplicates this name
+	// against the local workspace catalog before calling Cloud.
+	provisionedName := name + messagingOnlyRelayfileWorkspaceNameSuffix
+	record, _, err := ensureWorkspaceForSetup(cloud, provisionedName, "")
 	if err != nil {
 		return workspaceRecord{}, "", err
 	}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -46,6 +47,7 @@ const (
 	relayfileDefaultVersion = "0.10.17"
 	defaultServerURL        = "https://file.agentrelay.com"
 	defaultCloudAPIURL      = "https://agentrelay.com/cloud"
+	defaultRelaycastAPIURL  = "https://gateway.relaycast.dev"
 	defaultObserverURL      = "https://agentrelay.com/observer/file"
 	minAgentRelayCLIVersion = "8.7.0"
 	configDirName           = ".relayfile"
@@ -59,6 +61,8 @@ const (
 var relayfileVersion = relayfileDefaultVersion
 
 var relayIntegrationBindingsMu sync.Mutex
+
+var agentRelayWorkspaceKeyInResolverError = regexp.MustCompile(`(?:[?&]key=|/api/v1/workspaces/)(rk_live_[A-Za-z0-9_-]+)`)
 
 // defaultJoinScopes are the scopes minted for every delegated-credential
 // workspace join. ops:read is required for writeback op-status polling
@@ -103,6 +107,31 @@ type agentRelayActiveWorkspace struct {
 	URLs                     map[string]string `json:"urls"`
 	RelayfileURL             string            `json:"relayfileUrl"`
 	RelayfileURLAlternateKey string            `json:"relayfileURL"`
+}
+
+type agentRelayMessagingOnlyWorkspaceError struct {
+	Name string
+}
+
+func (e *agentRelayMessagingOnlyWorkspaceError) Error() string {
+	name := strings.TrimSpace(e.Name)
+	setupCommand := "relayfile setup --workspace <name>"
+	workspaceLabel := "active Agent Relay workspace"
+	if name != "" {
+		setupCommand = "relayfile setup --workspace " + strconv.Quote(name)
+		workspaceLabel = "Agent Relay workspace " + strconv.Quote(name)
+	}
+	return fmt.Sprintf(
+		"%s is messaging-only (Relaycast-only) and is not Relayfile-backed. Run `%s` to create a separate Relayfile-backed workspace, or rerun `relayfile login --provision-messaging-only` to provision one automatically. The messaging workspace and its key will remain unchanged.",
+		workspaceLabel,
+		setupCommand,
+	)
+}
+
+type agentRelayInvalidWorkspaceKeyError struct{}
+
+func (*agentRelayInvalidWorkspaceKeyError) Error() string {
+	return "the active Agent Relay workspace key is invalid or unknown: Cloud could not resolve it and Relaycast rejected it. Run `agent-relay workspace list`, switch to a valid workspace with `agent-relay workspace switch <name>`, or create a Relayfile-backed workspace with `relayfile setup --workspace <name>`."
 }
 
 type workspaceCatalog struct {
@@ -632,7 +661,7 @@ func printHelpForArgs(args []string, stdout io.Writer) {
 	case "setup":
 		fmt.Fprintln(stdout, "Usage: relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]")
 	case "login":
-		fmt.Fprintln(stdout, "Usage: relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]")
+		fmt.Fprintln(stdout, "Usage: relayfile login [--no-open] [--provision-messaging-only] [--api-key] [--server URL] [--token TOKEN]")
 	case "logout":
 		fmt.Fprintln(stdout, "Usage: relayfile logout")
 	case "workspace":
@@ -808,7 +837,7 @@ func printUsage(w io.Writer) {
 Usage:
   relayfile
   relayfile setup [--provider PROVIDER] [--backend BACKEND] [--workspace NAME] [--local-dir DIR]
-  relayfile login [--no-open] [--api-key] [--server URL] [--token TOKEN]
+  relayfile login [--no-open] [--provision-messaging-only] [--api-key] [--server URL] [--token TOKEN]
   relayfile logout
   relayfile workspace create NAME
   relayfile workspace join WORKSPACE_ID [--name NAME] [--write]
@@ -1246,7 +1275,7 @@ func cloudCredentialsFromAgentRelay() (cloudCredentials, error) {
 func activeWorkspaceFromAgentRelay() (agentRelayActiveWorkspace, error) {
 	var workspace agentRelayActiveWorkspace
 	if err := runAgentRelayJSON([]string{"workspace", "active", "--json"}, &workspace); err != nil {
-		return agentRelayActiveWorkspace{}, err
+		return agentRelayActiveWorkspace{}, classifyAgentRelayActiveWorkspaceError(err)
 	}
 	if strings.TrimSpace(workspace.RelayfileWorkspaceID) == "" {
 		return agentRelayActiveWorkspace{}, errors.New("agent-relay workspace active --json did not include relayfileWorkspaceId")
@@ -1258,6 +1287,79 @@ func activeWorkspaceFromAgentRelay() (agentRelayActiveWorkspace, error) {
 		workspace.Name = firstNonEmpty(workspace.Slug, workspace.RelayfileWorkspaceID, workspace.CloudWorkspaceID, workspace.ID)
 	}
 	return workspace, nil
+}
+
+func classifyAgentRelayActiveWorkspaceError(err error) error {
+	if err == nil {
+		return nil
+	}
+	detail := err.Error()
+	normalized := strings.ToLower(detail)
+	if !strings.Contains(normalized, "workspace resolve failed") ||
+		!strings.Contains(normalized, "404") ||
+		!strings.Contains(normalized, "workspace not found") {
+		return err
+	}
+	match := agentRelayWorkspaceKeyInResolverError.FindStringSubmatch(detail)
+	if len(match) != 2 {
+		return err
+	}
+	workspaceKey, unescapeErr := url.QueryUnescape(match[1])
+	if unescapeErr != nil || !strings.HasPrefix(workspaceKey, "rk_live_") {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	name, statusCode, validationErr := validateRelaycastWorkspaceKey(ctx, workspaceKey)
+	if validationErr != nil {
+		return fmt.Errorf(
+			"the active Agent Relay workspace could not be resolved through Cloud, and Relayfile could not verify it with Relaycast: %v. Check network connectivity and try again",
+			validationErr,
+		)
+	}
+	switch statusCode {
+	case http.StatusOK:
+		return &agentRelayMessagingOnlyWorkspaceError{Name: name}
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return &agentRelayInvalidWorkspaceKeyError{}
+	default:
+		return fmt.Errorf(
+			"the active Agent Relay workspace could not be resolved through Cloud, and Relaycast verification returned HTTP %d. Try again or run `relayfile setup --workspace <name>` to create a Relayfile-backed workspace",
+			statusCode,
+		)
+	}
+}
+
+func validateRelaycastWorkspaceKey(ctx context.Context, workspaceKey string) (string, int, error) {
+	baseURL := firstNonEmpty(os.Getenv("RELAYCAST_BASE_URL"), os.Getenv("RELAY_BASE_URL"), defaultRelaycastAPIURL)
+	endpoint := strings.TrimRight(baseURL, "/") + "/v1/workspace"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+workspaceKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+		return "", resp.StatusCode, nil
+	}
+	var payload struct {
+		Data struct {
+			Name string `json:"name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		// A successful authenticated response is sufficient to prove that the
+		// key is valid in Relaycast. The name only improves the remediation.
+		return "", resp.StatusCode, nil
+	}
+	return strings.TrimSpace(payload.Data.Name), resp.StatusCode, nil
 }
 
 func firstNonEmpty(values ...string) string {
@@ -1812,21 +1914,39 @@ func delegatedRelayfileTokenViaCloud(cloud cloudCredentials, workspaceID, agentN
 	return bundle, nil
 }
 
+type delegatedBootstrapOptions struct {
+	ProvisionMessagingOnly bool
+}
+
 func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes []string) (workspaceRecord, string, error) {
+	record, path, _, err := bootstrapDelegatedCredentialsFromAgentRelayWithOptions(workspaceValue, scopes, delegatedBootstrapOptions{})
+	return record, path, err
+}
+
+func bootstrapDelegatedCredentialsFromAgentRelayWithOptions(workspaceValue string, scopes []string, options delegatedBootstrapOptions) (workspaceRecord, string, bool, error) {
 	cloudCreds, err := cloudCredentialsFromAgentRelay()
 	if err != nil {
-		return workspaceRecord{}, "", err
+		return workspaceRecord{}, "", false, err
 	}
 	workspace, err := activeWorkspaceFromAgentRelay()
 	if err != nil {
-		return workspaceRecord{}, "", err
+		var messagingOnly *agentRelayMessagingOnlyWorkspaceError
+		if !options.ProvisionMessagingOnly || !errors.As(err, &messagingOnly) {
+			return workspaceRecord{}, "", false, err
+		}
+		requested := strings.TrimSpace(workspaceValue)
+		if requested != "" && !strings.EqualFold(requested, "active") && requested != strings.TrimSpace(messagingOnly.Name) {
+			return workspaceRecord{}, "", false, fmt.Errorf("active messaging-only Agent Relay workspace %q does not match requested workspace %q", messagingOnly.Name, workspaceValue)
+		}
+		record, path, provisionErr := provisionRelayfileWorkspaceForMessagingOnly(cloudCreds, messagingOnly.Name, scopes)
+		return record, path, true, provisionErr
 	}
 	if !agentRelayWorkspaceMatches(workspaceValue, workspace) {
-		return workspaceRecord{}, "", fmt.Errorf("active agent-relay workspace %s does not match requested workspace %q", workspace.Name, workspaceValue)
+		return workspaceRecord{}, "", false, fmt.Errorf("active agent-relay workspace %s does not match requested workspace %q", workspace.Name, workspaceValue)
 	}
 	cloudWorkspaceID := firstNonEmpty(workspace.CloudWorkspaceID, workspace.ID, workspace.RelayfileWorkspaceID)
 	if cloudWorkspaceID == "" {
-		return workspaceRecord{}, "", errors.New("agent-relay workspace active --json did not include a cloud workspace id")
+		return workspaceRecord{}, "", false, errors.New("agent-relay workspace active --json did not include a cloud workspace id")
 	}
 	mintScopes := append([]string(nil), scopes...)
 	if len(mintScopes) == 0 {
@@ -1845,13 +1965,41 @@ func bootstrapDelegatedCredentialsFromAgentRelay(workspaceValue string, scopes [
 	}
 	delegated, err := delegatedRelayfileTokenViaCloud(cloudCreds, cloudWorkspaceID, record.AgentName, mintScopes)
 	if err != nil {
+		return workspaceRecord{}, "", false, err
+	}
+	credsPath := delegatedCredentialsPathForRequest(record.ID, mintScopes)
+	if err := delegatedauth.SaveAtomic(credsPath, delegated); err != nil {
+		return workspaceRecord{}, "", false, fmt.Errorf("persist delegated relayfile credentials: %w", err)
+	}
+	persisted, err := persistDelegatedWorkspace(record, delegated, "", true)
+	if err != nil {
+		return workspaceRecord{}, "", false, err
+	}
+	return persisted, credsPath, false, nil
+}
+
+func provisionRelayfileWorkspaceForMessagingOnly(cloud cloudCredentials, name string, scopes []string) (workspaceRecord, string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return workspaceRecord{}, "", errors.New("the messaging-only workspace did not include a name; run `relayfile setup --workspace <name>` to create a separate Relayfile-backed workspace")
+	}
+	record, _, err := ensureWorkspaceForSetup(cloud, name, "")
+	if err != nil {
+		return workspaceRecord{}, "", err
+	}
+	mintScopes := append([]string(nil), scopes...)
+	if len(mintScopes) == 0 {
+		mintScopes = append([]string(nil), defaultJoinScopes...)
+	}
+	delegated, err := delegatedRelayfileTokenViaCloud(cloud, record.ID, record.AgentName, mintScopes)
+	if err != nil {
 		return workspaceRecord{}, "", err
 	}
 	credsPath := delegatedCredentialsPathForRequest(record.ID, mintScopes)
 	if err := delegatedauth.SaveAtomic(credsPath, delegated); err != nil {
 		return workspaceRecord{}, "", fmt.Errorf("persist delegated relayfile credentials: %w", err)
 	}
-	persisted, err := persistDelegatedWorkspace(record, delegated, "", true)
+	persisted, err := persistDelegatedWorkspace(record, delegated, record.LocalDir, true)
 	if err != nil {
 		return workspaceRecord{}, "", err
 	}
@@ -2148,16 +2296,18 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 	loginTimeout := fs.Duration("login-timeout", 5*time.Minute, "cloud login timeout")
 	workspaceFlag := fs.String("workspace", "", "workspace name or id to refresh; defaults to the active workspace")
 	skipWorkspace := fs.Bool("skip-workspace-refresh", false, "sign into the cloud only; do not refresh the workspace token")
+	provisionMessagingOnly := fs.Bool("provision-messaging-only", false, "create a separate Relayfile-backed workspace when the active Agent Relay workspace is messaging-only")
 	if err := fs.Parse(normalizeFlagArgs(args, map[string]bool{
-		"server":                 true,
-		"token":                  true,
-		"cloud-api-url":          true,
-		"cloud-token":            true,
-		"api-key":                false,
-		"no-open":                false,
-		"login-timeout":          true,
-		"workspace":              true,
-		"skip-workspace-refresh": false,
+		"server":                   true,
+		"token":                    true,
+		"cloud-api-url":            true,
+		"cloud-token":              true,
+		"api-key":                  false,
+		"no-open":                  false,
+		"login-timeout":            true,
+		"workspace":                true,
+		"skip-workspace-refresh":   false,
+		"provision-messaging-only": false,
 	})); err != nil {
 		return err
 	}
@@ -2165,8 +2315,14 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 	if *skipWorkspace && strings.TrimSpace(*workspaceFlag) != "" {
 		return errors.New("--workspace cannot be used with --skip-workspace-refresh: pick one")
 	}
+	if *skipWorkspace && *provisionMessagingOnly {
+		return errors.New("--provision-messaging-only cannot be used with --skip-workspace-refresh")
+	}
 
 	tokenValue := strings.TrimSpace(*token)
+	if *provisionMessagingOnly && (tokenValue != "" || *apiKey) {
+		return errors.New("--provision-messaging-only is only available with the Agent Relay cloud login flow")
+	}
 
 	// Token explicitly provided → legacy server-credential flow.
 	if tokenValue != "" {
@@ -2200,14 +2356,22 @@ func runLogin(args []string, stdin io.Reader, stdout io.Writer) error {
 		fmt.Fprintln(stdout, "Relayfile now uses the active agent-relay cloud session.")
 		return nil
 	}
-	record, _, err := bootstrapDelegatedCredentialsFromAgentRelay(strings.TrimSpace(*workspaceFlag), defaultJoinScopes)
+	record, _, usedSeparateWorkspace, err := bootstrapDelegatedCredentialsFromAgentRelayWithOptions(
+		strings.TrimSpace(*workspaceFlag),
+		defaultJoinScopes,
+		delegatedBootstrapOptions{ProvisionMessagingOnly: *provisionMessagingOnly},
+	)
 	if err != nil {
 		return fmt.Errorf("bootstrap delegated relayfile credentials: %w", err)
 	}
 	if err := removeCredentialFile(credentialsPath()); err != nil {
 		fmt.Fprintf(stdout, "warning: could not clear stale relayfile credentials: %v\n", err)
 	}
-	fmt.Fprintf(stdout, "Relayfile now uses the active agent-relay cloud session and workspace %s.\n", record.Name)
+	if usedSeparateWorkspace {
+		fmt.Fprintf(stdout, "Relayfile now uses separate Relayfile-backed workspace %s (id: %s). The active messaging-only Agent Relay workspace and its key were left unchanged.\n", record.Name, record.ID)
+	} else {
+		fmt.Fprintf(stdout, "Relayfile now uses the active agent-relay cloud session and workspace %s.\n", record.Name)
+	}
 	return nil
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2899,6 +2899,19 @@ exit 2
 	installFakeAgentRelay(t, body)
 }
 
+func relayfileCLITestFixture(t *testing.T, name string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read CLI test fixture %s: %v", name, err)
+	}
+	return strings.TrimSpace(string(content))
+}
+
+func agentRelayResolver404Error(workspaceKey, body string) error {
+	return errors.New("Workspace resolve failed at /api/v1/workspaces/active?key=" + workspaceKey + ": 404 " + body)
+}
+
 func TestActiveWorkspaceFromAgentRelayReportsMessagingOnlyWorkspace(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	clearRelayfileEnv(t)
@@ -2913,19 +2926,23 @@ func TestActiveWorkspaceFromAgentRelayReportsMessagingOnlyWorkspace(t *testing.T
 		if got := r.Header.Get("Authorization"); got != "Bearer "+workspaceKey {
 			t.Fatalf("unexpected Relaycast Authorization: %q", got)
 		}
+		if got := r.Header.Get("User-Agent"); got != "relayfile-cli/"+relayfileVersion {
+			t.Fatalf("unexpected Relaycast User-Agent: %q", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"rc_123","name":"chat-only"}}`))
 	}))
 	defer relaycast.Close()
 	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
-	installFakeAgentRelay(t, `
+	resolverFailure := agentRelayResolver404Error(workspaceKey, relayfileCLITestFixture(t, "cloud-workspace-not-found.json"))
+	installFakeAgentRelay(t, fmt.Sprintf(`
 if [ "$*" = "workspace active --json" ]; then
-  echo 'Workspace resolve failed at /api/v1/workspaces/active?key=`+workspaceKey+`: 404 Workspace not found' >&2
+  printf '%%s\n' %s >&2
   exit 1
 fi
 echo "unexpected args: $*" >&2
 exit 2
-`)
+`, strconv.Quote(resolverFailure.Error())))
 
 	_, err := activeWorkspaceFromAgentRelay()
 	if err == nil {
@@ -2957,6 +2974,75 @@ exit 2
 	}
 	if validationCalls != 1 {
 		t.Fatalf("Relaycast validation calls = %d, want 1", validationCalls)
+	}
+}
+
+func TestClassifyAgentRelayActiveWorkspaceErrorReportsRelaycastNetworkError(t *testing.T) {
+	clearRelayfileEnv(t)
+
+	const workspaceKey = "rk_live_network_error_test"
+	relaycast := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := relaycast.URL
+	relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", baseURL)
+
+	err := classifyAgentRelayActiveWorkspaceError(agentRelayResolver404Error(workspaceKey, "upstream response body omitted"))
+	if err == nil {
+		t.Fatal("expected Relaycast network verification error")
+	}
+	var messagingOnly *agentRelayMessagingOnlyWorkspaceError
+	var invalidKey *agentRelayInvalidWorkspaceKeyError
+	if errors.As(err, &messagingOnly) || errors.As(err, &invalidKey) {
+		t.Fatalf("network failure was misclassified: %T: %v", err, err)
+	}
+	for _, want := range []string{"could not verify it with Relaycast", "Check network connectivity and try again"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("network verification error missing %q: %q", want, err)
+		}
+	}
+}
+
+func TestClassifyAgentRelayActiveWorkspaceErrorReportsUnexpectedRelaycastStatus(t *testing.T) {
+	clearRelayfileEnv(t)
+
+	const workspaceKey = "rk_live_unexpected_status_test"
+	relaycast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspace" {
+			t.Fatalf("unexpected Relaycast request: %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
+
+	err := classifyAgentRelayActiveWorkspaceError(agentRelayResolver404Error(workspaceKey, "opaque Cloud miss"))
+	if err == nil || !strings.Contains(err.Error(), "Relaycast verification returned HTTP 503") {
+		t.Fatalf("unexpected-status error = %v", err)
+	}
+	var messagingOnly *agentRelayMessagingOnlyWorkspaceError
+	var invalidKey *agentRelayInvalidWorkspaceKeyError
+	if errors.As(err, &messagingOnly) || errors.As(err, &invalidKey) {
+		t.Fatalf("unexpected status was misclassified: %T: %v", err, err)
+	}
+}
+
+func TestClassifyAgentRelayActiveWorkspaceErrorPreservesRegexMiss(t *testing.T) {
+	clearRelayfileEnv(t)
+
+	var validationCalls int
+	relaycast := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		validationCalls++
+	}))
+	defer relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
+
+	original := errors.New("Workspace resolve failed without an embedded key: 404 " + relayfileCLITestFixture(t, "cloud-workspace-not-found.json"))
+	classified := classifyAgentRelayActiveWorkspaceError(original)
+	if classified != original {
+		t.Fatalf("regex-miss fallback changed the original error: got %v, want %v", classified, original)
+	}
+	if validationCalls != 0 {
+		t.Fatalf("Relaycast validation calls = %d, want 0", validationCalls)
 	}
 }
 
@@ -3009,7 +3095,7 @@ func TestLoginCanProvisionSeparateWorkspaceForMessagingOnlyRelaycastWorkspace(t 
 
 	const workspaceKey = "rk_live_messaging_only_provision_test"
 	relaycast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/workspace" || r.Header.Get("Authorization") != "Bearer "+workspaceKey {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspace" || r.Header.Get("Authorization") != "Bearer "+workspaceKey {
 			t.Fatalf("unexpected Relaycast validation request: %s auth=%q", r.URL.Path, r.Header.Get("Authorization"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -3029,7 +3115,7 @@ func TestLoginCanProvisionSeparateWorkspaceForMessagingOnlyRelaycastWorkspace(t 
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode Cloud create body: %v", err)
 			}
-			if len(body) != 1 || body["name"] != "chat-only" {
+			if len(body) != 1 || body["name"] != "chat-only (Relayfile)" {
 				t.Fatalf("Cloud create must contain only the messaging workspace name, got %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"workspaceId":"rw_relayfile","relayfileUrl":"` + cloud.URL + `","createdAt":"2026-07-13T00:00:00Z"}`))
@@ -3045,7 +3131,8 @@ func TestLoginCanProvisionSeparateWorkspaceForMessagingOnlyRelaycastWorkspace(t 
 	}))
 	defer cloud.Close()
 
-	installFakeAgentRelay(t, `
+	resolverFailure := agentRelayResolver404Error(workspaceKey, relayfileCLITestFixture(t, "cloud-workspace-not-found.json"))
+	installFakeAgentRelay(t, fmt.Sprintf(`
 if [ "$*" = "cloud login --no-open" ]; then
   echo "agent-relay login ok"
   exit 0
@@ -3055,12 +3142,12 @@ if [ "$*" = "cloud session --json" ]; then
   exit 0
 fi
 if [ "$*" = "workspace active --json" ]; then
-  echo 'Workspace resolve failed at /api/v1/workspaces/active?key=`+workspaceKey+`: 404 Workspace not found' >&2
+  printf '%%s\n' %s >&2
   exit 1
 fi
 echo "unexpected args: $*" >&2
 exit 2
-`)
+`, strconv.Quote(resolverFailure.Error())))
 
 	var stdout bytes.Buffer
 	if err := run([]string{"login", "--no-open", "--provision-messaging-only"}, strings.NewReader(""), &stdout, &stdout); err != nil {
@@ -3070,12 +3157,12 @@ exit 2
 		t.Fatalf("Cloud calls create=%d mint=%d, want 1 each", createCalls, mintCalls)
 	}
 	gotOutput := stdout.String()
-	for _, want := range []string{"separate Relayfile-backed workspace chat-only", "id: rw_relayfile", "messaging-only Agent Relay workspace and its key were left unchanged"} {
+	for _, want := range []string{"separate Relayfile-backed workspace chat-only (Relayfile)", "id: rw_relayfile", "messaging-only Agent Relay workspace and its key were left unchanged"} {
 		if !strings.Contains(gotOutput, want) {
 			t.Fatalf("provisioning output missing %q: %q", want, gotOutput)
 		}
 	}
-	record, ok := workspaceRecordByName("chat-only")
+	record, ok := workspaceRecordByName("chat-only (Relayfile)")
 	if !ok || record.ID != "rw_relayfile" {
 		t.Fatalf("separate Relayfile workspace was not persisted: ok=%v record=%+v", ok, record)
 	}
@@ -3085,6 +3172,14 @@ exit 2
 	}
 	if delegated.Workspace() != "rw_relayfile" || delegated.BearerToken() != "rf_access" {
 		t.Fatalf("unexpected provisioned delegated credentials: %+v", delegated)
+	}
+
+	stdout.Reset()
+	if err := run([]string{"login", "--no-open", "--provision-messaging-only"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("repeat local provisioning failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if createCalls != 1 || mintCalls != 2 {
+		t.Fatalf("repeat local provisioning calls create=%d mint=%d, want create=1 mint=2", createCalls, mintCalls)
 	}
 }
 

--- a/cmd/relayfile-cli/main_test.go
+++ b/cmd/relayfile-cli/main_test.go
@@ -2846,6 +2846,8 @@ func clearRelayfileEnv(t *testing.T) {
 	t.Setenv("RELAYFILE_CLOUD_TOKEN", "")
 	t.Setenv("RELAYFILE_MOUNT_CREDS_FILE", "")
 	t.Setenv("RELAYFILE_DELEGATED_CREDENTIALS_FILE", "")
+	t.Setenv("RELAYCAST_BASE_URL", "")
+	t.Setenv("RELAY_BASE_URL", "")
 	t.Setenv("AGENT_RELAY_BIN", "")
 }
 
@@ -2895,6 +2897,195 @@ echo "unexpected args: $*" >&2
 exit 2
 `, apiURL, accessToken, name, cloudWorkspaceID, relayfileWorkspaceID)
 	installFakeAgentRelay(t, body)
+}
+
+func TestActiveWorkspaceFromAgentRelayReportsMessagingOnlyWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceKey = "rk_live_messaging_only_test"
+	var validationCalls int
+	relaycast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		validationCalls++
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/workspace" {
+			t.Fatalf("unexpected Relaycast request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+workspaceKey {
+			t.Fatalf("unexpected Relaycast Authorization: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"rc_123","name":"chat-only"}}`))
+	}))
+	defer relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
+	installFakeAgentRelay(t, `
+if [ "$*" = "workspace active --json" ]; then
+  echo 'Workspace resolve failed at /api/v1/workspaces/active?key=`+workspaceKey+`: 404 Workspace not found' >&2
+  exit 1
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	_, err := activeWorkspaceFromAgentRelay()
+	if err == nil {
+		t.Fatal("expected messaging-only workspace error")
+	}
+	var messagingOnly *agentRelayMessagingOnlyWorkspaceError
+	if !errors.As(err, &messagingOnly) {
+		t.Fatalf("expected agentRelayMessagingOnlyWorkspaceError, got %T: %v", err, err)
+	}
+	if messagingOnly.Name != "chat-only" {
+		t.Fatalf("messaging-only workspace name = %q, want chat-only", messagingOnly.Name)
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"messaging-only (Relaycast-only)",
+		"not Relayfile-backed",
+		`relayfile setup --workspace "chat-only"`,
+		"relayfile login --provision-messaging-only",
+		"messaging workspace and its key will remain unchanged",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("messaging-only error missing %q: %q", want, got)
+		}
+	}
+	for _, unwanted := range []string{"404", "Workspace resolve failed", workspaceKey} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("messaging-only error leaked opaque resolver detail %q: %q", unwanted, got)
+		}
+	}
+	if validationCalls != 1 {
+		t.Fatalf("Relaycast validation calls = %d, want 1", validationCalls)
+	}
+}
+
+func TestActiveWorkspaceFromAgentRelayDoesNotMisclassifyInvalidKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceKey = "rk_live_invalid_test"
+	relaycast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer "+workspaceKey {
+			t.Fatalf("unexpected Relaycast Authorization: %q", got)
+		}
+		http.Error(w, "invalid key", http.StatusUnauthorized)
+	}))
+	defer relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
+	installFakeAgentRelay(t, `
+if [ "$*" = "workspace active --json" ]; then
+  echo 'Workspace resolve failed at /api/v1/workspaces/`+workspaceKey+`/resolve: 404 Workspace not found' >&2
+  exit 1
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	_, err := activeWorkspaceFromAgentRelay()
+	if err == nil {
+		t.Fatal("expected invalid workspace key error")
+	}
+	var messagingOnly *agentRelayMessagingOnlyWorkspaceError
+	if errors.As(err, &messagingOnly) {
+		t.Fatalf("invalid key was misclassified as messaging-only: %v", err)
+	}
+	var invalidKey *agentRelayInvalidWorkspaceKeyError
+	if !errors.As(err, &invalidKey) {
+		t.Fatalf("expected agentRelayInvalidWorkspaceKeyError, got %T: %v", err, err)
+	}
+	got := err.Error()
+	if !strings.Contains(got, "invalid or unknown") || !strings.Contains(got, "agent-relay workspace switch <name>") {
+		t.Fatalf("invalid-key error was not actionable: %q", got)
+	}
+	if strings.Contains(got, "404") || strings.Contains(got, workspaceKey) {
+		t.Fatalf("invalid-key error leaked opaque resolver detail: %q", got)
+	}
+}
+
+func TestLoginCanProvisionSeparateWorkspaceForMessagingOnlyRelaycastWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearRelayfileEnv(t)
+
+	const workspaceKey = "rk_live_messaging_only_provision_test"
+	relaycast := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspace" || r.Header.Get("Authorization") != "Bearer "+workspaceKey {
+			t.Fatalf("unexpected Relaycast validation request: %s auth=%q", r.URL.Path, r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"data":{"id":"rc_messaging","name":"chat-only"}}`))
+	}))
+	defer relaycast.Close()
+	t.Setenv("RELAYCAST_BASE_URL", relaycast.URL)
+
+	var createCalls, mintCalls int
+	var cloud *httptest.Server
+	cloud = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces":
+			createCalls++
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode Cloud create body: %v", err)
+			}
+			if len(body) != 1 || body["name"] != "chat-only" {
+				t.Fatalf("Cloud create must contain only the messaging workspace name, got %#v", body)
+			}
+			_, _ = w.Write([]byte(`{"workspaceId":"rw_relayfile","relayfileUrl":"` + cloud.URL + `","createdAt":"2026-07-13T00:00:00Z"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces/rw_relayfile/relayfile/delegated-token":
+			mintCalls++
+			if got := r.Header.Get("Authorization"); got != "Bearer cld_access" {
+				t.Fatalf("unexpected delegated-token Authorization: %q", got)
+			}
+			writeDelegatedBundleResponse(t, w, cloud.URL, "rw_relayfile", "rf_access", "rf_refresh")
+		default:
+			t.Fatalf("unexpected Cloud request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer cloud.Close()
+
+	installFakeAgentRelay(t, `
+if [ "$*" = "cloud login --no-open" ]; then
+  echo "agent-relay login ok"
+  exit 0
+fi
+if [ "$*" = "cloud session --json" ]; then
+  echo '{"apiUrl":"`+cloud.URL+`","accessToken":"cld_access"}'
+  exit 0
+fi
+if [ "$*" = "workspace active --json" ]; then
+  echo 'Workspace resolve failed at /api/v1/workspaces/active?key=`+workspaceKey+`: 404 Workspace not found' >&2
+  exit 1
+fi
+echo "unexpected args: $*" >&2
+exit 2
+`)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"login", "--no-open", "--provision-messaging-only"}, strings.NewReader(""), &stdout, &stdout); err != nil {
+		t.Fatalf("run login with messaging-only provisioning failed: %v\noutput:\n%s", err, stdout.String())
+	}
+	if createCalls != 1 || mintCalls != 1 {
+		t.Fatalf("Cloud calls create=%d mint=%d, want 1 each", createCalls, mintCalls)
+	}
+	gotOutput := stdout.String()
+	for _, want := range []string{"separate Relayfile-backed workspace chat-only", "id: rw_relayfile", "messaging-only Agent Relay workspace and its key were left unchanged"} {
+		if !strings.Contains(gotOutput, want) {
+			t.Fatalf("provisioning output missing %q: %q", want, gotOutput)
+		}
+	}
+	record, ok := workspaceRecordByName("chat-only")
+	if !ok || record.ID != "rw_relayfile" {
+		t.Fatalf("separate Relayfile workspace was not persisted: ok=%v record=%+v", ok, record)
+	}
+	delegated, err := delegatedauth.Load(delegatedCredentialsPathForRequest("rw_relayfile", defaultJoinScopes))
+	if err != nil {
+		t.Fatalf("load provisioned delegated credentials: %v", err)
+	}
+	if delegated.Workspace() != "rw_relayfile" || delegated.BearerToken() != "rf_access" {
+		t.Fatalf("unexpected provisioned delegated credentials: %+v", delegated)
+	}
 }
 
 func testJWTWithWorkspace(workspaceID string) string {

--- a/cmd/relayfile-cli/testdata/cloud-workspace-not-found.json
+++ b/cmd/relayfile-cli/testdata/cloud-workspace-not-found.json
@@ -1,0 +1,1 @@
+{"error":"Workspace not found"}

--- a/docs/cli-design.md
+++ b/docs/cli-design.md
@@ -125,7 +125,7 @@ This path is intentionally a wrapper over the lower-level commands and Cloud API
 Authenticate through the canonical relay session.
 
 ```
-relayfile login [--no-open]
+relayfile login [--no-open] [--provision-messaging-only]
 ```
 
 | Flag | Default | Description |
@@ -133,12 +133,18 @@ relayfile login [--no-open]
 | `--no-open` | `false` | Forwarded to `agent-relay login --no-open` |
 | `--api-key` | `false` | Preserve the self-hosted/API-key credential path |
 | `--server` | `https://api.relayfile.dev` | Server base URL for `--api-key` |
+| `--provision-messaging-only` | `false` | When the active Agent Relay workspace exists only in Relaycast, create a separate Relayfile-backed workspace with a ` (Relayfile)` display-name suffix. |
 
 **Behavior:**
 
 1. Default path delegates to `agent-relay login`.
 2. Relayfile does not write `~/.relayfile/cloud-credentials.json`.
 3. `--api-key` keeps the self-hosted compatibility path and writes `~/.relayfile/credentials.json` with `0600` permissions.
+
+Messaging-only provisioning deduplicates against
+`~/.relayfile/workspaces.json`, so the guarantee is local to the current
+machine. Running the flag from a second machine without that catalog entry can
+create another Relayfile-backed workspace with the same display name.
 
 **Errors:**
 - Server unreachable: `Error: cannot reach <server> — check the URL and your network.`


### PR DESCRIPTION
## Summary

- Detect the messaging-only case precisely: only an Agent Relay Cloud workspace-resolver 404 followed by a successful authenticated Relaycast `GET /v1/workspace` is classified as Relaycast-only.
- Replace the opaque resolver 404 with an actionable error that explains the workspace is not Relayfile-backed and points to `relayfile setup --workspace <name>`.
- Distinguish invalid or unknown keys when Relaycast rejects the key, with separate remediation and no key leakage.
- Add opt-in `relayfile login --provision-messaging-only`, which uses Relayfile's existing Cloud `POST /api/v1/workspaces` create path, mints and persists delegated credentials, and continues with the new Relayfile workspace.

## Two-plane rationale

Agent Relay messaging workspaces and Cloud/Relayfile workspaces intentionally live on separate planes. This change does not modify Relay or Cloud, does not adopt a Relaycast key into Cloud, and does not rewrite the active Agent Relay workspace. The provisioning request contains only the workspace name; Cloud creates an independent Relayfile-backed workspace with its own `rw_...` identity.

## Validation

- `go build ./...`
- `go test ./cmd/relayfile-cli -count=1`
- `go test ./...`

New tests cover the actionable messaging-only error (including absence of the opaque 404 and key), invalid-key non-misclassification, and the separate Cloud-create/delegated-credential path.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

