### PR TITLE
ci: pin publish workflow to npm 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,8 +411,10 @@ jobs:
           cp "/tmp/relayfile-mount-binary/${{ matrix.mount_binary }}" "${{ matrix.path }}/bin/relayfile-mount"
           chmod 755 "${{ matrix.path }}/bin/relayfile-mount"
 
+      # Pinned to the npm 11 line (OIDC needs >= 11.5.1): @latest broke
+      # 2026-07-13 when npm 12 dropped support for the runner's node 22.14.
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'
@@ -494,8 +496,10 @@ jobs:
           cp "/tmp/relayfile-mount-binary/${{ steps.resolve-package.outputs.mount_binary }}" "${{ steps.resolve-package.outputs.path }}/bin/relayfile-mount"
           chmod 755 "${{ steps.resolve-package.outputs.path }}/bin/relayfile-mount"
 
+      # Pinned to the npm 11 line (OIDC needs >= 11.5.1): @latest broke
+      # 2026-07-13 when npm 12 dropped support for the runner's node 22.14.
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Dry run check
         if: github.event.inputs.dry_run == 'true'


### PR DESCRIPTION
## What this is

Both "Update npm for OIDC support" steps in `publish.yml` installed `npm@latest`, which resolved to npm 12.0.1 as of 2026-07-13 — and npm 12 requires node `^22.22.2` while setup-node's toolcache serves node 22.14.0, so the next publish dispatch will die with `EBADENGINE`. Same failure already hit the workforce repo's release run (fix: AgentWorkforce/workforce#259).

`npm@11` satisfies the OIDC trusted-publisher requirement (≥ 11.5.1), supports node ≥ 22.9, and a pinned major can't be broken by future npm releases dropping node ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

