### PR TITLE
fix(mountsync): prioritize writeback during full pulls

### DIFF
--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -11632,39 +11632,85 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	const degradedNoticeInterval = time.Minute
 	degradedAttempts := 0
 	var nextDegradedAttempt time.Time
+	var statusMu sync.Mutex
 	const degradedStallReason = "delegated relayfile credentials expired or revoked — re-bootstrap relayfile credentials with agent-relay cloud login"
 
 	enterDegraded := func() {
+		statusMu.Lock()
+		changed := false
 		if !degraded {
 			degraded = true
 			stallReason = degradedStallReason
 			lastDegradedNotice = time.Time{}
 			nextDegradedAttempt = time.Time{}
+			changed = true
+		}
+		statusMu.Unlock()
+		if changed {
 			log.Printf("mount entering read-only degraded state: %s", degradedStallReason)
 		}
 	}
 	exitDegraded := func() {
+		statusMu.Lock()
+		changed := false
 		if degraded {
 			degraded = false
 			stallReason = ""
 			lastDegradedNotice = time.Time{}
 			degradedAttempts = 0
 			nextDegradedAttempt = time.Time{}
+			changed = true
+		}
+		statusMu.Unlock()
+		if changed {
 			log.Printf("mount exiting degraded state; delegated relayfile credentials restored")
 		}
 	}
 	maybePrintRecovery := func() {
+		statusMu.Lock()
 		if !degraded {
+			statusMu.Unlock()
 			return
 		}
 		if time.Since(lastDegradedNotice) < degradedNoticeInterval {
+			statusMu.Unlock()
 			return
 		}
-		log.Printf("mount degraded: %s", degradedStallReason)
 		lastDegradedNotice = time.Now()
+		statusMu.Unlock()
+		log.Printf("mount degraded: %s", degradedStallReason)
+	}
+	isDegraded := func() bool {
+		statusMu.Lock()
+		defer statusMu.Unlock()
+		return degraded
+	}
+	setStallReason := func(reason string) {
+		statusMu.Lock()
+		stallReason = reason
+		statusMu.Unlock()
+	}
+	markCycleSuccess := func() {
+		statusMu.Lock()
+		stallReason = ""
+		lastSuccess = time.Now()
+		statusMu.Unlock()
+	}
+	lastSuccessAt := func() time.Time {
+		statusMu.Lock()
+		defer statusMu.Unlock()
+		return lastSuccess
+	}
+	currentStallReason := func() string {
+		statusMu.Lock()
+		defer statusMu.Unlock()
+		return stallReason
 	}
 
+	var authMu sync.Mutex
 	refreshMountAuth := func(force bool) error {
+		authMu.Lock()
+		defer authMu.Unlock()
 		if httpClient == nil {
 			return nil
 		}
@@ -11735,6 +11781,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		snapshotMu.Lock()
 		needFetch := !hasCachedStatus || time.Since(lastSnapshotFetchAt) >= syncStatusMinPollInterval
 		cached := lastSnapshotStatus
+		hadCachedStatus := hasCachedStatus
 		snapshotMu.Unlock()
 
 		status := cached
@@ -11748,7 +11795,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 				// Fetch failed; fall back to cached snapshot if we have one,
 				// otherwise skip this write — we'd rather have a stale
 				// snapshot than spin retrying on every file event.
-				if !hasCachedStatus {
+				if !hadCachedStatus {
 					return
 				}
 			} else {
@@ -11760,14 +11807,18 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 				status = fetched
 			}
 		}
-		_ = writeMirrorStateFile(localDir, buildSyncStateSnapshot(status, workspaceID, defaultMountMode, interval, localDir, readDaemonPID(localDir), stallReason))
+		_ = writeMirrorStateFile(localDir, buildSyncStateSnapshot(status, workspaceID, defaultMountMode, interval, localDir, readDaemonPID(localDir), currentStallReason()))
 	}
 
 	runCycle := func(reconcile bool) error {
-		if degraded {
+		statusMu.Lock()
+		currentlyDegraded := degraded
+		degradedRetryAt := nextDegradedAttempt
+		statusMu.Unlock()
+		if currentlyDegraded {
 			// Exponential backoff: skip recovery attempts until nextDegradedAttempt.
 			// This prevents hammering the auth endpoint on consecutive cycles.
-			if !nextDegradedAttempt.IsZero() && time.Now().Before(nextDegradedAttempt) {
+			if !degradedRetryAt.IsZero() && time.Now().Before(degradedRetryAt) {
 				maybePrintRecovery()
 				writeSnapshot()
 				return errors.New(degradedStallReason)
@@ -11777,6 +11828,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 				// Compute backoff for next attempt: base * 2^attempts, capped.
 				// Cap the exponent at 14 to prevent int64 overflow on 30s<<uint(n)
 				// after ~28 consecutive failures (would shift to negative).
+				statusMu.Lock()
 				exp := degradedAttempts
 				if exp > 14 {
 					exp = 14
@@ -11787,6 +11839,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 				}
 				degradedAttempts++
 				nextDegradedAttempt = time.Now().Add(backoff)
+				statusMu.Unlock()
 				if isMountCredentialExpired(err) {
 					maybePrintRecovery()
 					writeSnapshot()
@@ -11818,19 +11871,18 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			// only for that expected timeout case.
 			if errors.Is(err, context.DeadlineExceeded) {
 				if bs := readBootstrapStatus(localDir); bs != nil {
-					stallReason = ""
+					setStallReason("")
 					log.Printf("mount bootstrapping: %d/%d files (in progress)", bs.FilesSynced, bs.FilesTotal)
 					writeSnapshot()
 					return err
 				}
 			}
-			stallReason = err.Error()
+			setStallReason(err.Error())
 			log.Printf("mount sync cycle failed: %v", err)
 			writeSnapshot()
 			return err
 		}
-		stallReason = ""
-		lastSuccess = time.Now()
+		markCycleSuccess()
 		log.Printf("mount sync cycle completed")
 		writeSnapshot()
 		return nil
@@ -11844,7 +11896,7 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 	// filtered by HandleLocalChange's tracked hash check.
 	if !once {
 		watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
-			if degraded {
+			if isDegraded() {
 				// Local edit observed while delegated credentials are unusable.
 				// Leave the dirty state in place so the next successful cycle
 				// after re-login picks it up; do not attempt to push now.
@@ -11906,16 +11958,16 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 			if reconcile {
 				_ = runCycle(true)
 			}
-			if !degraded && time.Since(lastSuccess) >= 10*time.Minute {
+			if !isDegraded() && time.Since(lastSuccessAt()) >= 10*time.Minute {
 				if bs := readBootstrapStatus(localDir); bs != nil {
 					// Long-running initial mirror is making progress
 					// across cycles — not a stall.
-					stallReason = ""
+					setStallReason("")
 					log.Printf("mount bootstrapping: %d/%d files (in progress)", bs.FilesSynced, bs.FilesTotal)
 					writeSnapshot()
 				} else {
-					stallReason = "no successful reconcile for 10m"
-					log.Printf("mount stalled: %s", stallReason)
+					setStallReason("no successful reconcile for 10m")
+					log.Printf("mount stalled: %s", currentStallReason())
 					writeSnapshot()
 				}
 			}

--- a/cmd/relayfile-cli/main.go
+++ b/cmd/relayfile-cli/main.go
@@ -11836,42 +11836,50 @@ func runMountLoop(rootCtx context.Context, syncer *mountsync.Syncer, localDir, w
 		return nil
 	}
 
+	// The watcher must be accepting local edits before the initial bootstrap
+	// starts. A large full-tree export can run for minutes; starting the
+	// watcher afterward creates a blind window where a writeback draft is on
+	// disk but never reaches /fs/bulk until teardown. Full-pull I/O yields the
+	// Syncer's state lock to this callback, and unchanged down-mirror echoes are
+	// filtered by HandleLocalChange's tracked hash check.
+	if !once {
+		watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
+			if degraded {
+				// Local edit observed while delegated credentials are unusable.
+				// Leave the dirty state in place so the next successful cycle
+				// after re-login picks it up; do not attempt to push now.
+				maybePrintRecovery()
+				return
+			}
+			if err := withAuthRefresh(func(ctx context.Context) error {
+				return syncer.HandleLocalChange(ctx, relativePath, op)
+			}); err != nil {
+				if isMountCredentialExpired(err) {
+					enterDegraded()
+					maybePrintRecovery()
+					writeSnapshot()
+					return
+				}
+				log.Printf("mount local change failed: %v", err)
+			}
+			writeSnapshot()
+		})
+		if err != nil {
+			return fmt.Errorf("create file watcher: %w", err)
+		}
+		if err := watcher.Start(rootCtx); err != nil {
+			_ = watcher.Close()
+			return fmt.Errorf("start file watcher: %w", err)
+		}
+		defer watcher.Close()
+	}
+
 	log.Print(mountStartBanner(localDir, interval, intervalJitter))
 	initialErr := runCycle(true)
 	logStuckEventSummary(syncer, initialErr)
 	if once {
 		return initialErr
 	}
-
-	watcher, err := mountsync.NewFileWatcher(localDir, func(relativePath string, op fsnotify.Op) {
-		if degraded {
-			// Local edit observed while delegated credentials are unusable.
-			// Leave the dirty state in place so the next successful cycle
-			// after re-login picks it up; do not attempt to push now.
-			maybePrintRecovery()
-			return
-		}
-		if err := withAuthRefresh(func(ctx context.Context) error {
-			return syncer.HandleLocalChange(ctx, relativePath, op)
-		}); err != nil {
-			if isMountCredentialExpired(err) {
-				enterDegraded()
-				maybePrintRecovery()
-				writeSnapshot()
-				return
-			}
-			log.Printf("mount local change failed: %v", err)
-		}
-		writeSnapshot()
-	})
-	if err != nil {
-		return fmt.Errorf("create file watcher: %w", err)
-	}
-	if err := watcher.Start(rootCtx); err != nil {
-		_ = watcher.Close()
-		return fmt.Errorf("start file watcher: %w", err)
-	}
-	defer watcher.Close()
 
 	timer := time.NewTimer(jitteredIntervalWithSample(interval, intervalJitter, mathrand.Float64()))
 	defer timer.Stop()

--- a/cmd/relayfile-cli/mount_up_path_priority_test.go
+++ b/cmd/relayfile-cli/mount_up_path_priority_test.go
@@ -29,6 +29,36 @@ type blockingBootstrapClient struct {
 	opOnce        sync.Once
 }
 
+type concurrentCredentialFailureClient struct {
+	mountsync.RemoteClient
+
+	exportStarted chan struct{}
+	bulkStarted   chan struct{}
+	release       <-chan struct{}
+	exportOnce    sync.Once
+	bulkOnce      sync.Once
+}
+
+func (c *concurrentCredentialFailureClient) ExportFiles(ctx context.Context, _, _ string) ([]mountsync.RemoteFile, error) {
+	c.exportOnce.Do(func() { close(c.exportStarted) })
+	select {
+	case <-c.release:
+		return nil, ErrDelegatedRelayfileCredentialsExpired
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *concurrentCredentialFailureClient) WriteFilesBulk(ctx context.Context, _ string, _ []mountsync.BulkWriteFile) (mountsync.BulkWriteResponse, error) {
+	c.bulkOnce.Do(func() { close(c.bulkStarted) })
+	select {
+	case <-c.release:
+		return mountsync.BulkWriteResponse{}, ErrDelegatedRelayfileCredentialsExpired
+	case <-ctx.Done():
+		return mountsync.BulkWriteResponse{}, ctx.Err()
+	}
+}
+
 func (c *blockingBootstrapClient) ExportFiles(ctx context.Context, _, _ string) ([]mountsync.RemoteFile, error) {
 	c.exportOnce.Do(func() { close(c.exportStarted) })
 	<-ctx.Done()
@@ -156,6 +186,95 @@ func TestMountLoopStartsWatcherBeforeBlockedInitialBootstrap(t *testing.T) {
 		t.Fatalf("acked receipts = %v (glob err=%v), want exactly one", acked, globErr)
 	}
 
+	cancel()
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("mount loop shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("mount loop did not stop after cancel")
+	}
+}
+
+func TestMountLoopSerializesStatusWhenWatcherAndInitialBootstrapFailTogether(t *testing.T) {
+	localDir := t.TempDir()
+	draftRel := filepath.FromSlash("slack/channels/C123/messages/messages 6ab77d67-1111-4111-8111-123456789abc.json")
+	draftPath := filepath.Join(localDir, draftRel)
+	if err := os.MkdirAll(filepath.Dir(draftPath), 0o755); err != nil {
+		t.Fatalf("mkdir draft parent: %v", err)
+	}
+
+	release := make(chan struct{})
+	client := &concurrentCredentialFailureClient{
+		exportStarted: make(chan struct{}),
+		bulkStarted:   make(chan struct{}),
+		release:       release,
+	}
+	rootCtx, cancel := context.WithCancel(context.Background())
+	syncer, err := mountsync.NewSyncer(client, mountsync.SyncerOptions{
+		WorkspaceID: "ws_mount_loop_status_race",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		RootCtx:     rootCtx,
+		WebSocket:   boolPtr(false),
+		Logger:      log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	previousLogWriter := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(previousLogWriter)
+
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- runMountLoop(
+			rootCtx,
+			syncer,
+			localDir,
+			"ws_mount_loop_status_race",
+			"http://unused.test",
+			"",
+			time.Second,
+			time.Hour,
+			0,
+			false,
+			false,
+			false,
+			mountPIDFile(localDir),
+			mountLogFile(localDir),
+		)
+	}()
+
+	select {
+	case <-client.exportStarted:
+	case <-time.After(time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("initial export did not start")
+	}
+	if err := os.WriteFile(draftPath, []byte(`{"channel":"C123","text":"race status"}`), 0o644); err != nil {
+		cancel()
+		<-loopDone
+		t.Fatalf("write draft: %v", err)
+	}
+	select {
+	case <-client.bulkStarted:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("watcher did not reach concurrent credential failure")
+	}
+
+	// Both the blocked initial runCycle and the watcher callback now return
+	// the same terminal credential error. They independently transition the
+	// mount-loop status to degraded; -race must prove those transitions and
+	// snapshot reads are serialized.
+	close(release)
+	time.Sleep(100 * time.Millisecond)
 	cancel()
 	select {
 	case err := <-loopDone:

--- a/cmd/relayfile-cli/mount_up_path_priority_test.go
+++ b/cmd/relayfile-cli/mount_up_path_priority_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentworkforce/relayfile/internal/mountsync"
+	"github.com/agentworkforce/relayfile/internal/relayfile"
+)
+
+// blockingBootstrapClient embeds the full RemoteClient contract and overrides
+// only the calls this regression reaches. The nil promoted methods are a
+// deliberate tripwire: if the bootstrap flow unexpectedly leaves the export
+// path, the test panics instead of silently accepting a different scenario.
+type blockingBootstrapClient struct {
+	mountsync.RemoteClient
+
+	exportStarted chan struct{}
+	bulkCalled    chan struct{}
+	opCalled      chan struct{}
+	exportOnce    sync.Once
+	bulkOnce      sync.Once
+	opOnce        sync.Once
+}
+
+func (c *blockingBootstrapClient) ExportFiles(ctx context.Context, _, _ string) ([]mountsync.RemoteFile, error) {
+	c.exportOnce.Do(func() { close(c.exportStarted) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (c *blockingBootstrapClient) WriteFilesBulk(_ context.Context, _ string, files []mountsync.BulkWriteFile) (mountsync.BulkWriteResponse, error) {
+	c.bulkOnce.Do(func() { close(c.bulkCalled) })
+	return mountsync.BulkWriteResponse{
+		Written: 1,
+		Results: []mountsync.BulkWriteResult{{
+			Path:        files[0].Path,
+			Revision:    "rev_local_1",
+			ContentType: files[0].ContentType,
+			OpID:        "op_watcher_before_bootstrap",
+			Writeback:   &relayfile.BulkWriteWritebackResult{Provider: "slack", State: "running"},
+		}},
+		CorrelationID: "corr_watcher_before_bootstrap",
+	}, nil
+}
+
+func (c *blockingBootstrapClient) GetOperation(_ context.Context, _ string, opID string) (mountsync.OperationStatus, error) {
+	c.opOnce.Do(func() { close(c.opCalled) })
+	return mountsync.OperationStatus{
+		OpID:     opID,
+		Path:     "/slack/channels/C123/messages/messages 5ab77d67-1111-4111-8111-123456789abc.json",
+		Revision: "rev_local_1",
+		Provider: "slack",
+		Status:   "succeeded",
+	}, nil
+}
+
+func TestMountLoopStartsWatcherBeforeBlockedInitialBootstrap(t *testing.T) {
+	localDir := t.TempDir()
+	draftRel := filepath.FromSlash("slack/channels/C123/messages/messages 5ab77d67-1111-4111-8111-123456789abc.json")
+	draftPath := filepath.Join(localDir, draftRel)
+	if err := os.MkdirAll(filepath.Dir(draftPath), 0o755); err != nil {
+		t.Fatalf("mkdir draft parent: %v", err)
+	}
+
+	client := &blockingBootstrapClient{
+		exportStarted: make(chan struct{}),
+		bulkCalled:    make(chan struct{}),
+		opCalled:      make(chan struct{}),
+	}
+	rootCtx, cancel := context.WithCancel(context.Background())
+	syncer, err := mountsync.NewSyncer(client, mountsync.SyncerOptions{
+		WorkspaceID: "ws_watcher_before_bootstrap",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+		RootCtx:     rootCtx,
+		WebSocket:   boolPtr(false),
+		Logger:      log.New(io.Discard, "", 0),
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	previousLogWriter := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(previousLogWriter)
+
+	loopDone := make(chan error, 1)
+	go func() {
+		loopDone <- runMountLoop(
+			rootCtx,
+			syncer,
+			localDir,
+			"ws_watcher_before_bootstrap",
+			"http://unused.test",
+			"",
+			time.Second,
+			time.Hour,
+			0,
+			false,
+			false,
+			false,
+			mountPIDFile(localDir),
+			mountLogFile(localDir),
+		)
+	}()
+
+	select {
+	case <-client.exportStarted:
+	case <-time.After(time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("initial export did not start")
+	}
+	if err := os.WriteFile(draftPath, []byte(`{"channel":"C123","text":"watcher ready"}`), 0o644); err != nil {
+		cancel()
+		<-loopDone
+		t.Fatalf("write draft: %v", err)
+	}
+
+	select {
+	case <-client.bulkCalled:
+	case <-time.After(2 * time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("watcher did not admit local draft while initial export was blocked")
+	}
+	select {
+	case <-client.opCalled:
+	case <-time.After(time.Second):
+		cancel()
+		<-loopDone
+		t.Fatal("watcher did not settle operation receipt while initial export was blocked")
+	}
+
+	var acked []string
+	var globErr error
+	ackDeadline := time.Now().Add(time.Second)
+	for time.Now().Before(ackDeadline) {
+		acked, globErr = filepath.Glob(filepath.Join(localDir, ".relay", "outbox", "acked", "*.json"))
+		if globErr != nil || len(acked) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if globErr != nil || len(acked) != 1 {
+		cancel()
+		<-loopDone
+		t.Fatalf("acked receipts = %v (glob err=%v), want exactly one", acked, globErr)
+	}
+
+	cancel()
+	select {
+	case err := <-loopDone:
+		if err != nil {
+			t.Fatalf("mount loop shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("mount loop did not stop after cancel")
+	}
+}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1088,6 +1088,13 @@ func (s *Syncer) fullPullPathTouchedByUpPath(remotePath string) bool {
 	return ok
 }
 
+func (s *Syncer) markFullPullUpPath(remotePath string) {
+	if !s.fullPullActive {
+		return
+	}
+	s.fullPullUpPaths[normalizeRemotePath(remotePath)] = struct{}{}
+}
+
 // now returns the current time using the injected clock when set (tests),
 // otherwise the wall clock. Used by the outbox writeback path so retry-backoff
 // and dead-letter timing are deterministic under test without real sleeps.
@@ -1844,13 +1851,6 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 	if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 		return nil
 	}
-	if s.fullPullActive {
-		// The point-in-time snapshot may have been captured before this local
-		// change. Preserve up-path ownership even after /fs/bulk succeeds and
-		// clears Dirty: the resumed snapshot must not replay its older bytes or
-		// infer a delete for a newly-created draft absent from that listing.
-		s.fullPullUpPaths[remotePath] = struct{}{}
-	}
 	localPath := filepath.Join(s.localDir, filepath.FromSlash(relativePath))
 
 	saveWithStatus := func(run func() error) error {
@@ -2157,6 +2157,11 @@ func (s *Syncer) flushOutboxRecordChunk(ctx context.Context, records []outboxRec
 			}
 			continue
 		}
+		// The cloud accepted this record. Only now claim up-path ownership:
+		// watcher noise and per-path bulk errors must leave the point-in-time
+		// snapshot authoritative, while an admitted write must not be replayed
+		// with older bytes (or inferred absent) when the full pull resumes.
+		s.markFullPullUpPath(record.RemotePath)
 		if result, ok := resultsByPath[pendingWrite.remotePath]; ok && strings.TrimSpace(result.ContentType) != "" {
 			pendingWrite.snapshot.ContentType = result.ContentType
 		}
@@ -2703,6 +2708,9 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 	if err != nil {
 		var httpErr *HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			// Idempotent delete success: the remote is already absent, so a
+			// snapshot captured before this observation must not restore it.
+			s.markFullPullUpPath(remotePath)
 			delete(s.state.Files, remotePath)
 			return nil
 		}
@@ -2721,6 +2729,7 @@ func (s *Syncer) pushSingleDelete(ctx context.Context, remotePath, localPath str
 		}
 		return err
 	}
+	s.markFullPullUpPath(remotePath)
 	delete(s.state.Files, remotePath)
 	return nil
 }

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1003,10 +1003,18 @@ type Syncer struct {
 	// immediately — not just provider-layout-alias paths — without waiting the
 	// read-not-ready TTL. skipStuckMax bounds the number of events dropped
 	// (0 = unbounded); skipStuckCount tracks how many were dropped.
-	skipStuckMode         bool
-	skipStuckMax          int
-	skipStuckCount        int
-	syncActive            bool
+	skipStuckMode  bool
+	skipStuckMax   int
+	skipStuckCount int
+	syncActive     bool
+	// fullPullActive is true only while a normal SyncOnce/Reconcile cycle is
+	// applying a point-in-time full snapshot. The cycle still owns mu for all
+	// state mutation, but releases it around remote/downstream I/O so watcher
+	// writeback and durable receipt settlement can take priority. Paths touched
+	// by that up-path are remembered for the lifetime of the snapshot so stale
+	// export/tree data cannot overwrite or tombstone a concurrent local write.
+	fullPullActive        bool
+	fullPullUpPaths       map[string]struct{}
 	oversizedLogged       map[string]struct{}
 	controlSkipLogged     map[string]struct{}
 	lazyUntrackedLogged   map[string]struct{}
@@ -1027,6 +1035,57 @@ type Syncer struct {
 	// public state as credExpiresInSecs so operators get advance warning.
 	credExpiresAt string
 	mu            sync.Mutex
+}
+
+// runFullPullIO temporarily releases the Syncer's state mutex around a remote
+// read that belongs to a full snapshot. Callers enter with mu held and must not
+// access mutable Syncer state from fn. Direct low-level tests that invoke full
+// pull helpers without a reserved sync cycle leave fullPullActive false, so
+// they retain their historical lock-free calling convention.
+func (s *Syncer) runFullPullIO(fn func()) {
+	if !s.fullPullActive {
+		fn()
+		return
+	}
+	s.mu.Unlock()
+	defer s.mu.Lock()
+	fn()
+}
+
+// runReservedSyncIO is the same lock split for bounded down-path I/O that
+// brackets a full pull (for example, resolving the event cursor immediately
+// before/after bootstrap). These calls are not inside pullRemoteFull itself,
+// but leaving the mutex held for their independent 60s deadline would recreate
+// the same up-path starvation at the edge of the heavy mirror operation.
+func (s *Syncer) runReservedSyncIO(fn func()) {
+	if !s.syncActive {
+		fn()
+		return
+	}
+	s.mu.Unlock()
+	defer s.mu.Lock()
+	fn()
+}
+
+// yieldFullPullStateLock gives an already-waiting watcher/outbox operation a
+// scheduling point between local snapshot applications. Remote export can
+// return thousands of files at once, so releasing only around the HTTP body
+// would still let the subsequent disk apply monopolize mu for a long time.
+func (s *Syncer) yieldFullPullStateLock() {
+	if !s.fullPullActive {
+		return
+	}
+	s.mu.Unlock()
+	runtime.Gosched()
+	s.mu.Lock()
+}
+
+func (s *Syncer) fullPullPathTouchedByUpPath(remotePath string) bool {
+	if !s.fullPullActive {
+		return false
+	}
+	_, ok := s.fullPullUpPaths[normalizeRemotePath(remotePath)]
+	return ok
 }
 
 // now returns the current time using the injected clock when set (tests),
@@ -1784,6 +1843,13 @@ func (s *Syncer) HandleLocalChange(ctx context.Context, relativePath string, op 
 	remotePath := s.localRelativeToRemotePath(relativePath)
 	if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 		return nil
+	}
+	if s.fullPullActive {
+		// The point-in-time snapshot may have been captured before this local
+		// change. Preserve up-path ownership even after /fs/bulk succeeds and
+		// clears Dirty: the resumed snapshot must not replay its older bytes or
+		// infer a delete for a newly-created draft absent from that listing.
+		s.fullPullUpPaths[remotePath] = struct{}{}
 	}
 	localPath := filepath.Join(s.localDir, filepath.FromSlash(relativePath))
 
@@ -3279,7 +3345,11 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 		}
 	}
 	if s.state.BootstrapComplete && !s.forceFullReconcile && len(s.state.Files) > 0 {
-		cursor, err := s.resolveLatestEventCursor(ctx)
+		var cursor string
+		var err error
+		s.runReservedSyncIO(func() {
+			cursor, err = s.resolveLatestEventCursor(ctx)
+		})
 		if err == nil && strings.TrimSpace(cursor) != "" {
 			// Only short-circuit when the events feed yielded a real
 			// tip. An empty cursor means the feed has no usable
@@ -3338,7 +3408,11 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 	if strings.TrimSpace(s.state.EventsCursor) != "" {
 		return nil
 	}
-	cursor, err := s.resolveLatestEventCursor(bctx)
+	var cursor string
+	var err error
+	s.runReservedSyncIO(func() {
+		cursor, err = s.resolveLatestEventCursor(bctx)
+	})
 	if err != nil {
 		var httpErr *HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
@@ -3351,6 +3425,19 @@ func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{})
 }
 
 func (s *Syncer) pullRemoteFull(ctx context.Context, conflicted map[string]struct{}, prog bootstrapProgress) error {
+	// syncActive means this full pull was entered through SyncOnce/Reconcile,
+	// where the caller holds mu. Low-level tests also call pullRemoteFull
+	// directly without that reservation; keep those calls on the historical
+	// non-yielding path so we never unlock a mutex they do not own.
+	prioritizeUpPath := s.syncActive
+	if prioritizeUpPath {
+		s.fullPullActive = true
+		s.fullPullUpPaths = make(map[string]struct{})
+		defer func() {
+			s.fullPullActive = false
+			s.fullPullUpPaths = nil
+		}()
+	}
 	if client, ok := s.client.(githubWorkingTreeTarClient); ok {
 		used, err := s.pullRemoteFullGithubTarSeed(ctx, client, conflicted, prog)
 		if used {
@@ -3378,7 +3465,11 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 	if s.githubWorkingTree == nil || s.lazyRepos {
 		return false, nil
 	}
-	manifest, err := s.readGithubCloneManifest(ctx)
+	var manifest githubCloneManifest
+	var err error
+	s.runFullPullIO(func() {
+		manifest, err = s.readGithubCloneManifest(ctx)
+	})
 	if err != nil {
 		if exportSnapshotUnsupported(err) {
 			return false, nil
@@ -3398,7 +3489,9 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 		cursor = strings.TrimSpace(manifest.EventID)
 	}
 	if cursor == "" {
-		cursor, err = s.resolveGithubCloneManifestCursor(ctx, manifest)
+		s.runFullPullIO(func() {
+			cursor, err = s.resolveGithubCloneManifestCursor(ctx, manifest)
+		})
 		if err != nil {
 			s.logf("github tar seed unavailable: resolve clone manifest cursor failed: %v", err)
 			return false, nil
@@ -3409,7 +3502,11 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 		return false, nil
 	}
 
-	tree, maxObservedRevision, err := s.githubWorkingTreeSnapshot(ctx, prog)
+	var tree map[string]githubTreeFile
+	var maxObservedRevision string
+	s.runFullPullIO(func() {
+		tree, maxObservedRevision, err = s.githubWorkingTreeSnapshot(ctx, prog)
+	})
 	if err != nil {
 		s.logf("github tar seed unavailable: tree verification snapshot failed: %v", err)
 		return false, nil
@@ -3418,12 +3515,15 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 		return false, nil
 	}
 
-	tarBody, err := client.ExportGithubWorkingTreeTar(ctx, s.workspace, GithubWorkingTreeSeedRequest{
-		Owner:      s.githubWorkingTree.Owner,
-		Repo:       s.githubWorkingTree.Repo,
-		PathPrefix: s.githubWorkingTree.ContentsRoot,
-		HeadSHA:    headSHA,
-		Gzip:       false,
+	var tarBody GithubWorkingTreeTar
+	s.runFullPullIO(func() {
+		tarBody, err = client.ExportGithubWorkingTreeTar(ctx, s.workspace, GithubWorkingTreeSeedRequest{
+			Owner:      s.githubWorkingTree.Owner,
+			Repo:       s.githubWorkingTree.Repo,
+			PathPrefix: s.githubWorkingTree.ContentsRoot,
+			HeadSHA:    headSHA,
+			Gzip:       false,
+		})
 	})
 	if err != nil {
 		if exportSnapshotUnsupported(err) {
@@ -3432,7 +3532,9 @@ func (s *Syncer) pullRemoteFullGithubTarSeed(ctx context.Context, client githubW
 		s.recordCloudFailure(err)
 		return true, err
 	}
-	defer tarBody.Body.Close()
+	defer func() {
+		s.runFullPullIO(func() { _ = tarBody.Body.Close() })
+	}()
 	s.recordCloudSuccess()
 
 	remotePaths, err := s.applyGithubWorkingTreeTarSeed(tarBody, tree, conflicted, prog)
@@ -3476,7 +3578,11 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 		exportCtx, cancel = context.WithTimeout(ctx, s.exportTimeout)
 		defer cancel()
 	}
-	files, err := client.ExportFiles(exportCtx, s.workspace, s.remoteRoot)
+	var files []RemoteFile
+	var err error
+	s.runFullPullIO(func() {
+		files, err = client.ExportFiles(exportCtx, s.workspace, s.remoteRoot)
+	})
 	if err != nil {
 		if exportSnapshotUnsupported(err) {
 			return false, nil
@@ -3520,6 +3626,7 @@ func (s *Syncer) pullRemoteFullExport(ctx context.Context, client exportSnapshot
 		if err := s.applyRemoteFile(remotePath, files[i], conflicted); err != nil {
 			return true, err
 		}
+		s.yieldFullPullStateLock()
 		prog.touch()
 		remotePaths[remotePath] = struct{}{}
 		files[i].Content = ""
@@ -3691,7 +3798,11 @@ func (s *Syncer) applyGithubWorkingTreeTarSeed(tarBody GithubWorkingTreeTar, tre
 	reader := io.Reader(tarBody.Body)
 	buffered := bufio.NewReader(reader)
 	if strings.Contains(strings.ToLower(tarBody.ContentType), "gzip") {
-		gz, err := gzip.NewReader(buffered)
+		var gz *gzip.Reader
+		var err error
+		s.runFullPullIO(func() {
+			gz, err = gzip.NewReader(buffered)
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -3704,7 +3815,11 @@ func (s *Syncer) applyGithubWorkingTreeTarSeed(tarBody GithubWorkingTreeTar, tre
 	remotePaths := map[string]struct{}{}
 	seen := map[string]struct{}{}
 	for {
-		header, err := tr.Next()
+		var header *tar.Header
+		var err error
+		s.runFullPullIO(func() {
+			header, err = tr.Next()
+		})
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -3736,13 +3851,25 @@ func (s *Syncer) applyGithubWorkingTreeTarSeed(tarBody GithubWorkingTreeTar, tre
 				continue
 			}
 		}
-		data, err := io.ReadAll(tr)
+		var data []byte
+		s.runFullPullIO(func() {
+			data, err = io.ReadAll(tr)
+		})
 		if err != nil {
 			return nil, err
 		}
 		hash := hashBytes(data)
 		if hash != meta.ContentHash {
 			return nil, fmt.Errorf("github tar seed contentHash mismatch for %s: tar=%s tree=%s", rel, hash, meta.ContentHash)
+		}
+		if s.fullPullPathTouchedByUpPath(meta.RemotePath) {
+			// The tar/tree pair is a point-in-time snapshot too. A watcher
+			// writeback that completed while this body streamed owns the newer
+			// bytes; count the remote path as present but never replay the stale
+			// archive entry over it.
+			remotePaths[meta.RemotePath] = struct{}{}
+			s.yieldFullPullStateLock()
+			continue
 		}
 		localPath, err := safeLocalPath(s.localRoot, rel)
 		if err != nil {
@@ -3788,6 +3915,7 @@ func (s *Syncer) applyGithubWorkingTreeTarSeed(tarBody GithubWorkingTreeTar, tre
 			ReadOnly:    !canWrite,
 		}
 		remotePaths[meta.RemotePath] = struct{}{}
+		s.yieldFullPullStateLock()
 		prog.touch()
 	}
 	for rel, meta := range tree {
@@ -3912,7 +4040,11 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 	maxObservedRevision := ""
 	var transientBootstrapAbort bool
 	for {
-		page, err := s.client.ListTree(ctx, s.workspace, s.remoteRoot, 200, cursor)
+		var page TreeResponse
+		var err error
+		s.runFullPullIO(func() {
+			page, err = s.client.ListTree(ctx, s.workspace, s.remoteRoot, 200, cursor)
+		})
 		if err != nil {
 			s.recordCloudFailure(err)
 			return err
@@ -3982,7 +4114,11 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 				RemotePath: remotePath,
 			})
 		}
-		for _, result := range s.readBootstrapFiles(ctx, readJobs, prog) {
+		var readResults []bootstrapReadResult
+		s.runFullPullIO(func() {
+			readResults = s.readBootstrapFiles(ctx, readJobs, prog)
+		})
+		for _, result := range readResults {
 			if result.Err != nil {
 				// Context canceled/deadline exceeded — propagate; the cycle is
 				// being torn down and the next one will resume from the cursor.
@@ -4020,6 +4156,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			if err := s.applyRemoteFile(result.RemotePath, result.File, conflicted); err != nil {
 				return err
 			}
+			s.yieldFullPullStateLock()
 			prog.touch()
 			remotePaths[result.RemotePath] = struct{}{}
 			filesThisPage++
@@ -4453,16 +4590,26 @@ func (s *Syncer) applyRemoteSnapshotDeletesRev(remotePaths map[string]struct{}, 
 	stillMissing := map[string]struct{}{}
 	for _, remotePath := range statePaths {
 		if _, ok := remotePaths[remotePath]; ok {
+			s.yieldFullPullStateLock()
+			continue
+		}
+		if s.fullPullPathTouchedByUpPath(remotePath) {
+			// The snapshot predates this local write. Treat the up-path as the
+			// authoritative observation for this cycle and do not even create a
+			// first-pass tombstone from the stale absence.
+			s.yieldFullPullStateLock()
 			continue
 		}
 		stillMissing[remotePath] = struct{}{}
 		allow, tErr := s.observePendingDelete(remotePath, observedRevision)
 		if tErr != nil {
 			s.logf("tombstone update failed for %s: %v", remotePath, tErr)
+			s.yieldFullPullStateLock()
 			continue
 		}
 		if !allow {
 			// First observation (or aged-out reset) — record and skip.
+			s.yieldFullPullStateLock()
 			continue
 		}
 		if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
@@ -4471,6 +4618,7 @@ func (s *Syncer) applyRemoteSnapshotDeletesRev(remotePaths map[string]struct{}, 
 		// Confirmed delete fired; clear the marker.
 		s.removeTombstone(remotePath)
 		delete(stillMissing, remotePath)
+		s.yieldFullPullStateLock()
 	}
 
 	// Drop markers whose paths have reappeared.
@@ -5207,6 +5355,9 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		if _, skip := conflicted[remotePath]; skip {
 			return nil
 		}
+	}
+	if s.fullPullPathTouchedByUpPath(remotePath) {
+		return nil
 	}
 	remoteBytes, err := decodeRemoteFileContent(file)
 	if err != nil {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3249,6 +3249,497 @@ func TestFullPullDoesNotStarveLocalDraftAdmissionOrReceiptSettlement(t *testing.
 	}
 }
 
+func TestGithubTarFullPullDoesNotStarveOrClobberConcurrentWriteback(t *testing.T) {
+	const (
+		workspaceID  = "ws_github_tar_up_path_priority"
+		contentsRoot = "/github/repos/acme/widgets/contents"
+		headSHA      = "head123"
+		localRel     = "README.md"
+		remotePath   = contentsRoot + "/README.md@" + headSHA + ".json"
+		sentinelPath = "/github/repos/acme/widgets/.relayfile/clone.json"
+		opID         = "op_github_tar_up_path_priority"
+	)
+	oldBody := []byte("# stale remote snapshot\n")
+	newBody := []byte("# local writeback wins\n")
+	tarStarted := make(chan struct{})
+	tarRelease := make(chan struct{})
+	base := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				sentinelPath: {
+					Path:        sentinelPath,
+					Revision:    "rev_1",
+					ContentType: "application/json",
+					Content:     `{"headSha":"` + headSHA + `","eventsCursor":"evt_seed"}`,
+				},
+				remotePath: {
+					Path:        remotePath,
+					Revision:    "rev_2",
+					ContentType: "text/markdown",
+					Content:     string(oldBody),
+					ContentHash: hashBytes(oldBody),
+				},
+			},
+			operations: map[string]OperationStatus{
+				opID: {
+					OpID:     opID,
+					Path:     remotePath,
+					Revision: "rev_3",
+					Provider: "github",
+					Status:   "succeeded",
+				},
+			},
+		},
+		tarFiles: map[string][]byte{localRel: oldBody},
+	}
+	base.bulkWriteResponseFunc = successfulReceiptBulkResponse(remotePath, opID, "rev_3")
+	client := &blockingGithubTarClient{
+		fakeExportClient: base,
+		tarStarted:       tarStarted,
+		tarRelease:       tarRelease,
+	}
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   workspaceID,
+		RemoteRoot:    contentsRoot,
+		LocalRoot:     localDir,
+		WebSocket:     boolPtr(false),
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-tarStarted:
+	case <-time.After(time.Second):
+		t.Fatal("github tar snapshot did not block")
+	}
+
+	localPath := filepath.Join(localDir, localRel)
+	if err := os.WriteFile(localPath, newBody, 0o644); err != nil {
+		close(tarRelease)
+		<-pullDone
+		t.Fatalf("write local github file: %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- syncer.HandleLocalChange(context.Background(), localRel, fsnotify.Create) }()
+	assertWritebackSettlesWhilePullBlocked(t, localDir, base.fakeClient, remotePath, opID, writeDone, tarRelease, pullDone)
+
+	close(tarRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("github tar full pull after release: %v", err)
+	}
+	if base.tarCalls != 1 || base.exportCalls != 0 {
+		t.Fatalf("full-pull dispatch tar=%d export=%d, want tar=1 export=0", base.tarCalls, base.exportCalls)
+	}
+	assertLocalFileContent(t, localPath, string(newBody))
+}
+
+func TestTreeFullPullDoesNotStarveOrClobberConcurrentWriteback(t *testing.T) {
+	const (
+		workspaceID = "ws_tree_up_path_priority"
+		localRel    = "Docs/A.md"
+		remotePath  = "/notion/Docs/A.md"
+		opID        = "op_tree_up_path_priority"
+	)
+	oldBody := "# stale tree snapshot\n"
+	newBody := "# local writeback wins\n"
+	readStarted := make(chan struct{})
+	readRelease := make(chan struct{})
+	base := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				remotePath: {
+					Path:        remotePath,
+					Revision:    "rev_1",
+					ContentType: "text/markdown",
+					Content:     oldBody,
+					ContentHash: hashString(oldBody),
+				},
+			},
+			operations: map[string]OperationStatus{
+				opID: {
+					OpID:     opID,
+					Path:     remotePath,
+					Revision: "rev_2",
+					Provider: "notion",
+					Status:   "succeeded",
+				},
+			},
+		},
+		exportErr: &HTTPError{StatusCode: http.StatusNotFound, Code: "not_found", Message: "export unsupported"},
+	}
+	base.bulkWriteResponseFunc = successfulReceiptBulkResponse(remotePath, opID, "rev_2")
+	client := &blockingTreeReadClient{
+		fakeExportClient: base,
+		blockedPath:      remotePath,
+		readStarted:      readStarted,
+		readRelease:      readRelease,
+	}
+
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID:   workspaceID,
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		WebSocket:     boolPtr(false),
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("tree bootstrap ReadFile did not block")
+	}
+
+	localPath := filepath.Join(localDir, filepath.FromSlash(localRel))
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		close(readRelease)
+		<-pullDone
+		t.Fatalf("mkdir local tree file parent: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(newBody), 0o644); err != nil {
+		close(readRelease)
+		<-pullDone
+		t.Fatalf("write local tree file: %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() { writeDone <- syncer.HandleLocalChange(context.Background(), localRel, fsnotify.Create) }()
+	assertWritebackSettlesWhilePullBlocked(t, localDir, base.fakeClient, remotePath, opID, writeDone, readRelease, pullDone)
+
+	close(readRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("tree full pull after release: %v", err)
+	}
+	if base.exportCalls != 1 || base.listTreeCalls == 0 || base.tarCalls != 0 {
+		t.Fatalf("full-pull dispatch export=%d tree=%d tar=%d, want unsupported export then tree", base.exportCalls, base.listTreeCalls, base.tarCalls)
+	}
+	assertLocalFileContent(t, localPath, newBody)
+}
+
+func TestNoopWatcherEventDuringFullPullDoesNotSuppressRemoteUpdate(t *testing.T) {
+	const (
+		workspaceID = "ws_full_pull_noop_event"
+		localRel    = "Docs/A.md"
+		remotePath  = "/notion/Docs/A.md"
+	)
+	oldBody := "# tracked local bytes\n"
+	newBody := "# authoritative remote update\n"
+	base := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				remotePath: {
+					Path:        remotePath,
+					Revision:    "rev_1",
+					ContentType: "text/markdown",
+					Content:     oldBody,
+					ContentHash: hashString(oldBody),
+				},
+			},
+			eventsUnsupported: true,
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(base, SyncerOptions{
+		WorkspaceID:   workspaceID,
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		WebSocket:     boolPtr(false),
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial full pull: %v", err)
+	}
+	localPath := filepath.Join(localDir, filepath.FromSlash(localRel))
+	assertLocalFileContent(t, localPath, oldBody)
+
+	base.files[remotePath] = RemoteFile{
+		Path:        remotePath,
+		Revision:    "rev_2",
+		ContentType: "text/markdown",
+		Content:     newBody,
+		ContentHash: hashString(newBody),
+	}
+	exportStarted := make(chan struct{})
+	exportRelease := make(chan struct{})
+	base.exportStarted = exportStarted
+	base.exportRelease = exportRelease
+	syncer.forceFullReconcile = true
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-exportStarted:
+	case <-time.After(time.Second):
+		t.Fatal("authoritative export did not block")
+	}
+
+	if err := syncer.HandleLocalChange(context.Background(), localRel, fsnotify.Chmod); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("no-op Chmod event: %v", err)
+	}
+	if got := base.bulkWriteCalls; got != 0 {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("no-op event admitted %d writes, want 0", got)
+	}
+	close(exportRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("authoritative export after release: %v", err)
+	}
+	assertLocalFileContent(t, localPath, newBody)
+}
+
+func TestNoopWatcherEventDuringFullPullDoesNotSuppressRemoteDelete(t *testing.T) {
+	const (
+		workspaceID = "ws_full_pull_noop_remote_delete"
+		localRel    = "Docs/A.md"
+		remotePath  = "/notion/Docs/A.md"
+		keepPath    = "/notion/Docs/B.md"
+	)
+	body := "# tracked local bytes\n"
+	keepBody := "# remains remote\n"
+	base := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				remotePath: {
+					Path:        remotePath,
+					Revision:    "rev_1",
+					ContentType: "text/markdown",
+					Content:     body,
+					ContentHash: hashString(body),
+				},
+				keepPath: {
+					Path:        keepPath,
+					Revision:    "rev_2",
+					ContentType: "text/markdown",
+					Content:     keepBody,
+					ContentHash: hashString(keepBody),
+				},
+			},
+			eventsUnsupported: true,
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(base, SyncerOptions{
+		WorkspaceID:   workspaceID,
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		WebSocket:     boolPtr(false),
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial full pull: %v", err)
+	}
+	localPath := filepath.Join(localDir, filepath.FromSlash(localRel))
+	assertLocalFileContent(t, localPath, body)
+
+	delete(base.files, remotePath)
+	keep := base.files[keepPath]
+	keep.Revision = "rev_3"
+	base.files[keepPath] = keep
+	syncer.forceFullReconcile = true
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("first remote-delete observation: %v", err)
+	}
+	if _, err := os.Stat(localPath); err != nil {
+		t.Fatalf("first delete observation should retain local file: %v", err)
+	}
+
+	exportStarted := make(chan struct{})
+	exportRelease := make(chan struct{})
+	keep = base.files[keepPath]
+	keep.Revision = "rev_4"
+	base.files[keepPath] = keep
+	base.exportStarted = exportStarted
+	base.exportRelease = exportRelease
+	syncer.forceFullReconcile = true
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-exportStarted:
+	case <-time.After(time.Second):
+		t.Fatal("authoritative empty export did not block")
+	}
+
+	if err := syncer.HandleLocalChange(context.Background(), localRel, fsnotify.Chmod); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("no-op Chmod event: %v", err)
+	}
+	if got := base.bulkWriteCalls; got != 0 {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("no-op event admitted %d writes, want 0", got)
+	}
+	close(exportRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("confirmed remote-delete pull after release: %v", err)
+	}
+	if _, err := os.Stat(localPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("no-op event suppressed authoritative remote delete: %v", err)
+	}
+}
+
+func TestSuccessfulLocalDeleteDuringFullPullOwnsPathAgainstStaleSnapshot(t *testing.T) {
+	const (
+		workspaceID = "ws_full_pull_local_delete"
+		localRel    = "Docs/A.md"
+		remotePath  = "/notion/Docs/A.md"
+	)
+	body := "# stale snapshot must not restore this\n"
+	base := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				remotePath: {
+					Path:        remotePath,
+					Revision:    "rev_1",
+					ContentType: "text/markdown",
+					Content:     body,
+					ContentHash: hashString(body),
+				},
+			},
+			eventsUnsupported: true,
+		},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(base, SyncerOptions{
+		WorkspaceID:   workspaceID,
+		RemoteRoot:    "/notion",
+		LocalRoot:     localDir,
+		WebSocket:     boolPtr(false),
+		FullPullEvery: -1,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+	if err := syncer.SyncOnce(context.Background()); err != nil {
+		t.Fatalf("initial full pull: %v", err)
+	}
+	localPath := filepath.Join(localDir, filepath.FromSlash(localRel))
+
+	exportStarted := make(chan struct{})
+	exportRelease := make(chan struct{})
+	base.exportStarted = exportStarted
+	base.exportRelease = exportRelease
+	syncer.forceFullReconcile = true
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-exportStarted:
+	case <-time.After(time.Second):
+		t.Fatal("stale export did not block")
+	}
+	if err := os.Remove(localPath); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("remove local file: %v", err)
+	}
+	if err := syncer.HandleLocalChange(context.Background(), localRel, fsnotify.Remove); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("local delete writeback: %v", err)
+	}
+	if len(base.deleteCalls) != 1 || base.deleteCalls[0].Path != remotePath {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("delete calls = %+v, want one %s", base.deleteCalls, remotePath)
+	}
+	close(exportRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("stale full pull after local delete: %v", err)
+	}
+	if _, err := os.Stat(localPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale snapshot restored successfully-deleted local file: %v", err)
+	}
+}
+
+func successfulReceiptBulkResponse(remotePath, opID, revision string) func(context.Context, string, []BulkWriteFile) (BulkWriteResponse, error) {
+	return func(_ context.Context, _ string, files []BulkWriteFile) (BulkWriteResponse, error) {
+		if len(files) != 1 || normalizeRemotePath(files[0].Path) != normalizeRemotePath(remotePath) {
+			return BulkWriteResponse{}, fmt.Errorf("bulk admission paths = %+v, want %s", files, remotePath)
+		}
+		return BulkWriteResponse{
+			Written: 1,
+			Results: []BulkWriteResult{{
+				Path:        remotePath,
+				Revision:    revision,
+				ContentType: files[0].ContentType,
+				OpID:        opID,
+				Writeback:   &relayfile.BulkWriteWritebackResult{State: "running"},
+			}},
+			CorrelationID: "corr_" + opID,
+		}, nil
+	}
+}
+
+func assertWritebackSettlesWhilePullBlocked(
+	t *testing.T,
+	localDir string,
+	client *fakeClient,
+	remotePath, opID string,
+	writeDone <-chan error,
+	pullRelease chan struct{},
+	pullDone <-chan error,
+) {
+	t.Helper()
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			close(pullRelease)
+			<-pullDone
+			t.Fatalf("local writeback while full pull blocked: %v", err)
+		}
+	case <-time.After(750 * time.Millisecond):
+		close(pullRelease)
+		pullErr := <-pullDone
+		writeErr := <-writeDone
+		t.Fatalf("local admission/receipt settlement starved while full pull blocked (pull=%v write=%v)", pullErr, writeErr)
+	}
+	select {
+	case err := <-pullDone:
+		close(pullRelease)
+		t.Fatalf("full pull completed before release (err=%v)", err)
+	default:
+	}
+	if got := client.bulkWriteCalls; got != 1 {
+		close(pullRelease)
+		<-pullDone
+		t.Fatalf("bulk admissions = %d, want 1 for %s", got, remotePath)
+	}
+	if got := client.getOperationCalls; got != 1 {
+		close(pullRelease)
+		<-pullDone
+		t.Fatalf("operation settlement polls = %d, want 1", got)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		close(pullRelease)
+		<-pullDone
+		t.Fatalf("receipt remained pending: %+v", pending)
+	}
+	acked := readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked"))
+	if len(acked) != 1 || acked[0].OpID != opID || acked[0].DispatchStatus != "succeeded" {
+		close(pullRelease)
+		<-pullDone
+		t.Fatalf("settled receipt = %+v, want one succeeded %s", acked, opID)
+	}
+}
+
 func TestOutboxRestartDuringInFlightOperationResumesPolling(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
@@ -6840,6 +7331,56 @@ type fakeExportClient struct {
 	// arrives.
 	exportStarted chan struct{}
 	exportRelease <-chan struct{}
+}
+
+type blockingGithubTarClient struct {
+	*fakeExportClient
+	tarStarted chan struct{}
+	tarRelease <-chan struct{}
+}
+
+func (c *blockingGithubTarClient) ExportGithubWorkingTreeTar(ctx context.Context, workspaceID string, seed GithubWorkingTreeSeedRequest) (GithubWorkingTreeTar, error) {
+	tarBody, err := c.fakeExportClient.ExportGithubWorkingTreeTar(ctx, workspaceID, seed)
+	if err != nil {
+		return GithubWorkingTreeTar{}, err
+	}
+	close(c.tarStarted)
+	select {
+	case <-c.tarRelease:
+		return tarBody, nil
+	case <-ctx.Done():
+		_ = tarBody.Body.Close()
+		return GithubWorkingTreeTar{}, ctx.Err()
+	}
+}
+
+type blockingTreeReadClient struct {
+	*fakeExportClient
+	blockedPath string
+	readStarted chan struct{}
+	readRelease <-chan struct{}
+	once        sync.Once
+}
+
+func (c *blockingTreeReadClient) ReadFile(ctx context.Context, workspaceID, path string) (RemoteFile, error) {
+	file, err := c.fakeExportClient.ReadFile(ctx, workspaceID, path)
+	if normalizeRemotePath(path) != normalizeRemotePath(c.blockedPath) {
+		return file, err
+	}
+	shouldBlock := false
+	c.once.Do(func() {
+		shouldBlock = true
+		close(c.readStarted)
+	})
+	if !shouldBlock {
+		return file, err
+	}
+	select {
+	case <-c.readRelease:
+		return file, err
+	case <-ctx.Done():
+		return RemoteFile{}, ctx.Err()
+	}
 }
 
 func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -3104,6 +3104,151 @@ func TestOutboxAcksOnlyAfterWritebackOperationSucceeded(t *testing.T) {
 	}
 }
 
+// A full down-mirror is allowed to take minutes on a large workspace, but it
+// must not own the state lock for that entire wall-clock interval. Local
+// writeback is the latency-sensitive path: the watcher must still be able to
+// admit a newly-created draft to /fs/bulk and settle its operation receipt
+// while the point-in-time export remains blocked. The stale export must also
+// leave that concurrent draft alone when it eventually applies.
+func TestFullPullDoesNotStarveLocalDraftAdmissionOrReceiptSettlement(t *testing.T) {
+	const (
+		workspaceID = "ws_full_pull_up_path_priority"
+		draftRel    = "slack/channels/C123/messages/messages 5ab77d67-1111-4111-8111-123456789abc.json"
+		draftRemote = "/" + draftRel
+		opID        = "op_full_pull_up_path_priority"
+	)
+
+	localDir := t.TempDir()
+	exportStarted := make(chan struct{})
+	exportRelease := make(chan struct{})
+	client := &fakeExportClient{
+		fakeClient: &fakeClient{
+			files: map[string]RemoteFile{
+				"/notion/reference.md": {
+					Path:        "/notion/reference.md",
+					Revision:    "rev_1",
+					ContentType: "text/markdown",
+					Content:     "# Reference\n",
+				},
+			},
+			revisionCounter: 1,
+			operations: map[string]OperationStatus{
+				opID: {
+					OpID:     opID,
+					Path:     draftRemote,
+					Revision: "rev_2",
+					Provider: "slack",
+					Status:   "succeeded",
+				},
+			},
+		},
+		exportStarted: exportStarted,
+		exportRelease: exportRelease,
+	}
+	client.bulkWriteResponseFunc = func(_ context.Context, _ string, files []BulkWriteFile) (BulkWriteResponse, error) {
+		if len(files) != 1 {
+			return BulkWriteResponse{}, fmt.Errorf("bulk admission got %d files, want 1", len(files))
+		}
+		return BulkWriteResponse{
+			Written: 1,
+			Results: []BulkWriteResult{{
+				Path:        draftRemote,
+				Revision:    "rev_2",
+				ContentType: files[0].ContentType,
+				OpID:        opID,
+				Writeback:   &relayfile.BulkWriteWritebackResult{Provider: "slack", State: "running"},
+			}},
+			CorrelationID: "corr_full_pull_up_path_priority",
+		}, nil
+	}
+
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: workspaceID,
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("NewSyncer: %v", err)
+	}
+
+	pullDone := make(chan error, 1)
+	go func() { pullDone <- syncer.SyncOnce(context.Background()) }()
+	select {
+	case <-exportStarted:
+	case <-time.After(time.Second):
+		t.Fatal("full export did not start")
+	}
+
+	draftPath := filepath.Join(localDir, filepath.FromSlash(draftRel))
+	if err := os.MkdirAll(filepath.Dir(draftPath), 0o755); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("mkdir draft parent: %v", err)
+	}
+	const draftBody = `{"channel":"C123","text":"ship it"}`
+	if err := os.WriteFile(draftPath, []byte(draftBody), 0o644); err != nil {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("write local draft: %v", err)
+	}
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- syncer.HandleLocalChange(context.Background(), draftRel, fsnotify.Create)
+	}()
+
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			close(exportRelease)
+			<-pullDone
+			t.Fatalf("local writeback while export blocked: %v", err)
+		}
+	case <-time.After(750 * time.Millisecond):
+		close(exportRelease)
+		pullErr := <-pullDone
+		writeErr := <-writeDone
+		t.Fatalf("local /fs/bulk admission and receipt settlement were starved by the blocked full pull (pull=%v write=%v)", pullErr, writeErr)
+	}
+
+	select {
+	case err := <-pullDone:
+		close(exportRelease)
+		t.Fatalf("full pull completed before release (err=%v); test did not hold down-mirror I/O", err)
+	default:
+	}
+	if got := client.bulkWriteCalls; got != 1 {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("bulk admissions = %d, want 1", got)
+	}
+	if got := client.getOperationCalls; got != 1 {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("operation settlement polls = %d, want 1", got)
+	}
+	if pending := readPendingOutboxRecordsForTest(t, localDir); len(pending) != 0 {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("receipt remained pending while full pull blocked: %+v", pending)
+	}
+	acked := readOutboxRecordsInDirForTest(t, filepath.Join(localDir, ".relay", "outbox", "acked"))
+	if len(acked) != 1 || acked[0].OpID != opID || acked[0].DispatchStatus != "succeeded" {
+		close(exportRelease)
+		<-pullDone
+		t.Fatalf("settled receipt = %+v, want one succeeded %s", acked, opID)
+	}
+
+	close(exportRelease)
+	if err := <-pullDone; err != nil {
+		t.Fatalf("full pull after release: %v", err)
+	}
+	assertLocalFileContent(t, draftPath, draftBody)
+	if _, err := os.Stat(syncer.tombstoneFile(draftRemote)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale full snapshot tombstoned concurrent local write: %v", err)
+	}
+}
+
 func TestOutboxRestartDuringInFlightOperationResumesPolling(t *testing.T) {
 	localDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(localDir, "command.json"), []byte(`{"text":"hello"}`), 0o644); err != nil {
@@ -6689,6 +6834,12 @@ type fakeExportClient struct {
 	// slice regardless of the populated tree, simulating the production
 	// empty-200 export for a workspace that DOES have records.
 	exportReturnsEmpty bool
+	// exportStarted/exportRelease let concurrency tests hold a full export
+	// after its point-in-time snapshot has been captured. This reproduces a
+	// large down-mirror body that is still in flight while a local writeback
+	// arrives.
+	exportStarted chan struct{}
+	exportRelease <-chan struct{}
 }
 
 func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path string) ([]RemoteFile, error) {
@@ -6713,6 +6864,20 @@ func (c *fakeExportClient) ExportFiles(ctx context.Context, workspaceID, path st
 		files = append(files, file)
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	if c.exportStarted != nil {
+		select {
+		case <-c.exportStarted:
+		default:
+			close(c.exportStarted)
+		}
+	}
+	if c.exportRelease != nil {
+		select {
+		case <-c.exportRelease:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return files, nil
 }
 


### PR DESCRIPTION
## Summary

- let latency-sensitive mount writeback acquire the Syncer state lock while a full export/tree/tar pull is blocked on remote I/O
- preserve serialization for every state mutation and remember paths only after a proven accepted write/delete so a resumed point-in-time snapshot cannot overwrite or tombstone a newer local draft
- start the daemon watcher before initial bootstrap, eliminating the draft blind window during a large first mirror
- serialize watcher and mount-loop status/auth transitions exposed by the earlier watcher startup

## Root cause

`syncReserved` held the single `Syncer.mu` across the complete full-pull wall clock. `HandleLocalChange`, `/fs/bulk` admission, and durable receipt polling all need that mutex, so a multi-minute down-mirror serialized local writeback behind it. The daemon also started its watcher only after initial bootstrap returned.

The lock split is deliberately narrow: full-pull transport/body reads release `mu`; export/tree/tar apply and all state changes remain under it. Large apply loops yield between files. Paths whose write was accepted by `/fs/bulk`, successfully deleted, or observed already absent are skipped by stale content and snapshot-delete application. No-op watcher events and per-path write errors leave the snapshot authoritative.

Starting the watcher earlier also made its callback concurrent with initial `runCycle`, exposing a status tuple race that already existed during periodic cycles. A mount-loop-local mutex now protects only tuple copies/transitions (`degraded`, stall/recovery timing, attempts, and `lastSuccess`) and is never held across auth, sync, watcher writeback, logging, network, or file I/O. Credential refresh is independently serialized.

Covered down-path variants:

- atomic `ExportFiles`
- paginated `ListTree` plus parallel `ReadFile`
- GitHub manifest/cursor/tree/tar request
- streaming tar body reads and close
- bounded cursor resolution immediately bracketing bootstrap

## Red-first evidence

`TestFullPullDoesNotStarveLocalDraftAdmissionOrReceiptSettlement` captures an export snapshot, blocks its return, writes a Slack draft, and requires `/fs/bulk`, `GetOperation`, and the acked receipt to complete before releasing the export.

On baseline it deterministically failed at the 750ms bound:

```text
local /fs/bulk admission and receipt settlement were starved by the blocked full pull (pull=<nil> write=<nil>)
```

Both calls completed only after the export was released.

The TAR and TREE variants fail at the same 750ms starvation bound with the baseline lock behavior. Their green versions explicitly prove GitHub tar dispatch and paginated tree/parallel-read dispatch, receipt settlement, and non-clobber.

Two no-op regressions fail on the first PR head: Chmod on unchanged content incorrectly claims the up-path and suppresses an authoritative remote update or confirmed remote delete. Paired green tests prove only genuine accepted upload/delete ownership defeats a stale snapshot.

`TestMountLoopSerializesStatusWhenWatcherAndInitialBootstrapFailTogether` releases simultaneous credential failures from a blocked initial export and watcher writeback. Before the status fix, `go test -race` deterministically reports races on `degraded` and `lastDegradedNotice`; it is green after serialization.

## Validation

- `go test ./... -count=1` — green across every package
- `go test -race ./internal/mountsync ./cmd/relayfile-cli -count=1` — green (`122.566s`, `92.257s`)
- focused TAR/TREE/export, no-op update/delete, genuine upload/delete, and watcher/status concurrency tests under `-race` — green
- `go vet ./...` — green
- `make build` — green for CLI, server, and mount binaries
- `git diff --check` — green

## Safety

- no API/schema behavior change
- no production, credential, or live-workspace actions
- no merge requested or performed
