### PR TITLE
docs: add release runbook covering the next dist-tag two-step

### DIFF
--- a/docs/ci-cd-design.md
+++ b/docs/ci-cd-design.md
@@ -1,5 +1,10 @@
 # RelayFile CI/CD Pipeline Design
 
+> **Design intent, not current state.** Some of this has drifted from what ships
+> — publishing lives in `publish.yml` (not `publish-npm.yml`) and authenticates
+> with OIDC trusted publishing rather than the npm token described below. For
+> the steps to actually cut a release, see [`releasing.md`](./releasing.md).
+
 ## Overview
 
 Four GitHub Actions workflows covering continuous integration, SDK publishing, binary releases, and Cloudflare Workers deployment. Designed to match the proven patterns from the relaycast project.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,90 @@
+# Releasing relayfile
+
+Operational runbook for cutting a release. For the pipeline's design intent, see
+[`ci-cd-design.md`](./ci-cd-design.md).
+
+## Cutting a release
+
+`publish.yml` (`workflow_dispatch`) is the only supported way to publish. One run
+version-bumps every package, publishes them, commits `chore(release): vX.Y.Z`,
+and creates the GitHub release.
+
+```bash
+gh workflow run publish.yml --ref main \
+  -f package=all -f version=patch -f tag=latest -f dry_run=false
+```
+
+| Input | Notes |
+| --- | --- |
+| `package` | Must be `all` for a real publish. The workflow hard-fails otherwise: it rewrites every manifest, and lockfile regeneration needs every `@relayfile/mount-*` package already published at the new version so npm can resolve tarball integrity metadata. |
+| `version` | `patch` / `minor` / `major`, or `prerelease` with `preid=rc` for a release candidate. |
+| `tag` | `latest` for stable, `next` for prereleases. |
+
+The bump is computed from the root `package.json` **on the ref you dispatch
+from**, so check it before dispatching. Note `patch` on a prerelease drops the
+prerelease rather than bumping the patch digit: `0.10.27-rc.0` → `0.10.27`.
+
+## Promoting an RC, and the `next` tag
+
+**Promoting an RC to stable strands the `next` tag.** `next` keeps pointing at
+the RC you just superseded, so `@next` resolves *older* than `@latest`:
+
+```
+latest: 0.10.27
+next:   0.10.27-rc.0   # older than latest — anyone on @next is behind
+```
+
+`npm dist-tag add relayfile@0.10.27 next` would fix this in one command, but it
+**cannot run in this repo's CI**. `publish.yml` authenticates with npm OIDC
+trusted publishing, and npm's OIDC covers only `npm publish` / `npm stage
+publish` — every other command, `dist-tag` included, still needs a traditional
+token ([npm/cli#8547](https://github.com/npm/cli/issues/8547)). This repo holds
+no npm token secret by design, so there is nothing for `dist-tag` to
+authenticate with.
+
+The fix is a second dispatch that publishes a new version *forward* onto `next`
+— `npm publish` is the one command OIDC does cover:
+
+```bash
+gh workflow run publish.yml --ref main \
+  -f package=all -f version=patch -f tag=next -f dry_run=false
+```
+
+```
+latest: 0.10.27   # stable, unchanged
+next:   0.10.28   # newer than latest
+```
+
+Run this after **every** RC → stable promotion, or `next` stays stranded until
+the next RC.
+
+The trade-off: this publishes a version whose content is identical to the stable
+release, so version numbers advance faster than shipped changes. That is the
+cost of not holding a long-lived npm token. The alternative is a granular npm
+token scoped to `relayfile` + `@relayfile/*`, which would allow a single
+`dist-tag` step instead — a deliberate security trade, not an oversight.
+
+## After the release
+
+Verify against the registry rather than the workflow log — a green run does not
+prove the tags are right:
+
+```bash
+npm view relayfile dist-tags
+npm view @relayfile/client dist-tags
+```
+
+The `next` dispatch creates its own GitHub release and GitHub marks the newest
+tag "Latest", even though npm's `latest` is the stable version. Realign so the
+releases page matches the registry:
+
+```bash
+gh release edit v0.10.27 --latest   # the stable version, not the next-tag one
+```
+
+## Consumers
+
+Downstream `^x.y.z` ranges resolve by semver across **all** published versions —
+dist-tags do not gate them. A version published only to `next` will still
+satisfy a caret range in a consumer's manifest on any lockfile refresh. Committed
+lockfiles pin exact versions, so `npm ci` is unaffected.


### PR DESCRIPTION
## Why

Promoting an RC to stable strands the `next` dist-tag on the superseded RC, so `@next` resolves **older** than `@latest`. That happened on today's v0.10.27 release and took a while to diagnose — worth writing down rather than rediscovering.

```
latest: 0.10.27
next:   0.10.27-rc.0   # older than latest
```

`npm dist-tag add` fixes this in one command, but it **cannot run in this repo's CI**: `publish.yml` uses OIDC trusted publishing, and [npm's OIDC covers only `npm publish` / `npm stage publish`](https://docs.npmjs.com/trusted-publishers/) — every other command, `dist-tag` included, needs a traditional token. There's an open upstream issue for exactly this: [npm/cli#8547](https://github.com/npm/cli/issues/8547). This repo holds no npm token by design, so the gap is structural, not an oversight.

## What

Adds `docs/releasing.md` — an operational runbook:

- Dispatching `publish.yml` (and why `package` must be `all`)
- The version math gotcha: `patch` on a prerelease **drops** the prerelease (`0.10.27-rc.0` → `0.10.27`), it doesn't bump the patch digit
- The RC→stable `next` two-step, why `dist-tag` isn't available, and the workaround's cost (publishes a version identical in content to the stable release)
- Verifying tags against the registry rather than the workflow log
- Realigning GitHub's "Latest" release flag, which the `next` dispatch hijacks
- That `^x.y.z` consumer ranges resolve across all versions regardless of dist-tag

Also adds a drift note to `ci-cd-design.md`, which describes `publish-npm.yml` and an "NPM Token Setup" — neither matches what ships today. It's design intent; the runbook is current state.

## Verification

Every claim was checked against `publish.yml` rather than written from memory:

- `package=all` enforcement → `publish.yml:86-89`
- OIDC-only → `grep -c "NPM_TOKEN\|NODE_AUTH_TOKEN"` = **0**
- release commit → `publish.yml:604`
- semver math → `semver.inc('0.10.27-rc.0','patch')` = `0.10.27`

Docs only — no code, no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

