### PR TITLE
fix(mountsync): prune nested runtime trees before traversal

### DIFF
--- a/internal/mountsync/http_client_test.go
+++ b/internal/mountsync/http_client_test.go
@@ -14,6 +14,41 @@ import (
 	"testing"
 )
 
+func TestHTTPClientListTreeRequestsPrePaginationMountRuntimeExclusion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/workspaces/ws_mount/fs/tree" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if got := query.Get("path"); got != "/slack/channels" {
+			t.Fatalf("expected normalized mount path, got %q", got)
+		}
+		if got := query.Get("depth"); got != "3" {
+			t.Fatalf("expected depth 3, got %q", got)
+		}
+		if got := query.Get("cursor"); got != "/slack/channels/C123" {
+			t.Fatalf("expected cursor to be forwarded, got %q", got)
+		}
+		if got := query.Get("excludeMountRuntime"); got != "true" {
+			t.Fatalf("expected server-side mount runtime exclusion, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"path":"/slack/channels","entries":[],"nextCursor":null}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient(server.URL, "token", server.Client())
+	if _, err := client.ListTree(
+		context.Background(),
+		"ws_mount",
+		"/slack/channels/",
+		3,
+		"/slack/channels/C123",
+	); err != nil {
+		t.Fatalf("list tree failed: %v", err)
+	}
+}
+
 func TestHTTPClientRetriesTransientFailure(t *testing.T) {
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1127,11 +1127,12 @@ type mountState struct {
 	// are additive/omitempty: legacy state files load with zero values
 	// (BootstrapComplete=false), which self-heals by forcing a full
 	// reconcile on the next cycle.
-	BootstrapComplete    bool   `json:"bootstrapComplete,omitempty"`
-	BootstrapCursor      string `json:"bootstrapCursor,omitempty"`
-	BootstrapFilesSynced int    `json:"bootstrapFilesSynced,omitempty"`
-	BootstrapFilesTotal  int    `json:"bootstrapFilesTotal,omitempty"`
-	BootstrapStartedAt   string `json:"bootstrapStartedAt,omitempty"`
+	BootstrapComplete    bool     `json:"bootstrapComplete,omitempty"`
+	BootstrapDirectories []string `json:"bootstrapDirectories,omitempty"`
+	BootstrapCursor      string   `json:"bootstrapCursor,omitempty"`
+	BootstrapFilesSynced int      `json:"bootstrapFilesSynced,omitempty"`
+	BootstrapFilesTotal  int      `json:"bootstrapFilesTotal,omitempty"`
+	BootstrapStartedAt   string   `json:"bootstrapStartedAt,omitempty"`
 	// QuarantinedPaths holds remote paths that cannot be materialized locally
 	// due to file/directory name collisions. Persisted across cycle restarts
 	// so the daemon does not re-fetch these paths from the cloud until the
@@ -4031,7 +4032,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 	metrics := fullTreeTraversalMetrics{startedAt: time.Now()}
 	defer func() {
 		s.logf(
-			"mount full-tree traversal summary remote_root=%q list_calls=%d entries_seen=%d files_seen=%d directories_seen=%d bytes_seen=%d runtime_entries_seen=%d traversal_complete=%t duration_ms=%d",
+			"mount full-tree traversal summary remote_root=%q list_calls=%d entries_seen=%d files_seen=%d directories_seen=%d bytes_seen=%d runtime_entries_seen=%d runtime_subtrees_pruned=%d traversal_complete=%t traversal_failed=%t duration_ms=%d",
 			s.remoteRoot,
 			metrics.listCalls,
 			metrics.entriesSeen,
@@ -4039,35 +4040,71 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			metrics.directoriesSeen,
 			metrics.bytesSeen,
 			metrics.runtimeEntriesSeen,
+			metrics.runtimeSubtreesPruned,
 			metrics.traversalComplete,
+			returnErr != nil,
 			time.Since(metrics.startedAt).Milliseconds(),
 		)
 	}()
 	remotePaths := map[string]struct{}{}
-	// Resumable bootstrap: if a prior bootstrap was interrupted mid-tree,
-	// pick traversal back up from the persisted cursor rather than
-	// re-reading everything. startedFromEmpty tracks whether this process
-	// traversed the WHOLE tree (empty start -> NextCursor==nil): only then
-	// is the snapshot delete pass authoritative. Resuming from a persisted
-	// cursor means we did not observe the full remote set this cycle, so
-	// the delete pass is skipped (next full cycle does the authoritative
-	// delete) — preserving the #164/#165 mount-root-clobber invariants.
+	// Traverse one directory level at a time. A deep ListTree request makes the
+	// server enumerate every descendant before the client can reject reserved
+	// runtime paths. The shallow queue sees a nested .relay directory first and
+	// can prune it without ever requesting its state/outbox descendants.
+	directories := []string{s.remoteRoot}
 	cursor := ""
-	if !s.state.BootstrapComplete && strings.TrimSpace(s.state.BootstrapCursor) != "" {
-		cursor = s.state.BootstrapCursor
-		s.logf("resuming bootstrap full-tree pull from persisted cursor (%d files already synced)", s.state.BootstrapFilesSynced)
+	startedFromEmpty := true
+	if !s.state.BootstrapComplete && len(s.state.BootstrapDirectories) > 0 {
+		resumedDirectories := make([]string, 0, len(s.state.BootstrapDirectories))
+		for _, directory := range s.state.BootstrapDirectories {
+			directory = normalizeRemotePath(directory)
+			if !isUnderRemoteRoot(s.remoteRoot, directory) || isMountRuntimeRemotePath(directory) {
+				continue
+			}
+			resumedDirectories = append(resumedDirectories, directory)
+		}
+		if len(resumedDirectories) > 0 {
+			directories = resumedDirectories
+			cursor = strings.TrimSpace(s.state.BootstrapCursor)
+			startedFromEmpty = false
+			s.logf("resuming bootstrap shallow-tree pull at %s from persisted cursor (%d directories pending, %d files already synced)", directories[0], len(directories), s.state.BootstrapFilesSynced)
+		}
+	} else if !s.state.BootstrapComplete && strings.TrimSpace(s.state.BootstrapCursor) != "" {
+		// v0.10.28 and older persisted a cursor into one depth=200 listing.
+		// That cursor is invalid for a depth=1 directory page, so restart from
+		// the root. The local-hash fast path avoids re-reading unchanged files.
+		s.logf("discarding legacy deep-tree bootstrap cursor and restarting shallow traversal from %s", s.remoteRoot)
+		s.state.BootstrapCursor = ""
 	}
-	startedFromEmpty := cursor == ""
+	queuedDirectories := make(map[string]struct{}, len(directories))
+	for _, directory := range directories {
+		queuedDirectories[directory] = struct{}{}
+	}
 	if s.state.BootstrapStartedAt == "" {
 		s.state.BootstrapStartedAt = time.Now().UTC().Format(time.RFC3339Nano)
 	}
+	persistTraversal := func(filesThisPage int) error {
+		if s.state.BootstrapComplete {
+			return nil
+		}
+		s.state.BootstrapDirectories = append([]string(nil), directories...)
+		s.state.BootstrapCursor = cursor
+		s.state.BootstrapFilesSynced += filesThisPage
+		prog.touch()
+		if err := s.saveState(); err != nil {
+			return err
+		}
+		prog.touch()
+		return nil
+	}
 	maxObservedRevision := ""
 	var transientBootstrapAbort bool
-	for {
+	for len(directories) > 0 {
+		currentDirectory := directories[0]
 		var page TreeResponse
 		var err error
 		s.runFullPullIO(func() {
-			page, err = s.client.ListTree(ctx, s.workspace, s.remoteRoot, 200, cursor)
+			page, err = s.client.ListTree(ctx, s.workspace, currentDirectory, 1, cursor)
 		})
 		metrics.listCalls++
 		if err != nil {
@@ -4079,6 +4116,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		filesThisPage := 0
 		readJobs := make([]bootstrapReadJob, 0, len(page.Entries))
 		for _, entry := range page.Entries {
+			remotePath := normalizeRemotePath(entry.Path)
 			metrics.entriesSeen++
 			switch entry.Type {
 			case "file":
@@ -4089,25 +4127,34 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			case "dir":
 				metrics.directoriesSeen++
 			}
-			if isMountRuntimeRemotePath(entry.Path) {
+			if isMountRuntimeRemotePath(remotePath) {
 				metrics.runtimeEntriesSeen++
+			}
+			if !isUnderRemoteRoot(s.remoteRoot, remotePath) {
+				continue
+			}
+			if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
+				if entry.Type == "dir" {
+					metrics.runtimeSubtreesPruned++
+				}
+				continue
+			}
+			// Contract: lazy GitHub repos do not eagerly hydrate per-repo content at startup.
+			if s.lazyRepos && isUnderLazyGithubRepoSubtree(s.remoteRoot, remotePath) {
+				continue
+			}
+			if entry.Type == "dir" {
+				if _, exists := queuedDirectories[remotePath]; !exists {
+					queuedDirectories[remotePath] = struct{}{}
+					directories = append(directories, remotePath)
+				}
+				continue
 			}
 			if entry.Type != "file" {
 				continue
 			}
 			if revisionAdvances(maxObservedRevision, entry.Revision) {
 				maxObservedRevision = entry.Revision
-			}
-			remotePath := normalizeRemotePath(entry.Path)
-			if !isUnderRemoteRoot(s.remoteRoot, remotePath) {
-				continue
-			}
-			if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
-				continue
-			}
-			// Contract: lazy GitHub repos do not eagerly hydrate per-repo content at startup.
-			if s.lazyRepos && isUnderLazyGithubRepoSubtree(s.remoteRoot, remotePath) {
-				continue
 			}
 			if tracked, ok := s.state.Files[remotePath]; ok && tracked.Denied {
 				continue
@@ -4203,31 +4250,30 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		// cursor so the same page (including the failing path) is retried next
 		// cycle. Save state up to the last successfully-committed cursor.
 		if transientBootstrapAbort {
-			if !s.state.BootstrapComplete {
-				s.state.BootstrapFilesSynced += filesThisPage
-				if err := s.saveState(); err != nil {
-					return err
-				}
-			}
-			break
-		}
-		if page.NextCursor == nil || *page.NextCursor == "" {
-			metrics.traversalComplete = true
-			break
-		}
-		cursor = *page.NextCursor
-		// Persist the resume point + progress so an interrupted bootstrap
-		// (timeout, crash, watchdog cancel) picks up here next cycle
-		// instead of restarting the whole tree.
-		if !s.state.BootstrapComplete {
-			s.state.BootstrapCursor = cursor
-			s.state.BootstrapFilesSynced += filesThisPage
-			prog.touch()
-			if err := s.saveState(); err != nil {
+			if err := persistTraversal(filesThisPage); err != nil {
 				return err
 			}
-			prog.touch()
+			break
 		}
+		if page.NextCursor != nil && *page.NextCursor != "" {
+			cursor = *page.NextCursor
+			if err := persistTraversal(filesThisPage); err != nil {
+				return err
+			}
+			continue
+		}
+		// This directory is exhausted. Persist the remaining queue before
+		// requesting its next member so cancellation resumes at a directory
+		// boundary instead of restarting the root.
+		directories = directories[1:]
+		cursor = ""
+		if len(directories) > 0 {
+			if err := persistTraversal(filesThisPage); err != nil {
+				return err
+			}
+			continue
+		}
+		metrics.traversalComplete = true
 	}
 
 	// A transient read error stopped the page scan early. Bootstrap is not
@@ -4240,8 +4286,8 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 
 	// Resumed/partial traversal safety: only run the authoritative
 	// snapshot delete pass when this process traversed the ENTIRE tree
-	// (started from an empty cursor and reached NextCursor==nil). If the
-	// traversal began from a persisted resume cursor, remotePaths only
+	// (started from the root with an empty directory queue). If the
+	// traversal began from a persisted directory/cursor boundary, remotePaths only
 	// covers the tail of the tree, so deleting "everything not in
 	// remotePaths" would wipe the already-mirrored prefix — exactly the
 	// #164/#165 clobber failure mode. Skip the delete pass this cycle;
@@ -4275,14 +4321,15 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 }
 
 type fullTreeTraversalMetrics struct {
-	startedAt          time.Time
-	listCalls          int
-	entriesSeen        int
-	filesSeen          int
-	directoriesSeen    int
-	bytesSeen          int64
-	runtimeEntriesSeen int
-	traversalComplete  bool
+	startedAt             time.Time
+	listCalls             int
+	entriesSeen           int
+	filesSeen             int
+	directoriesSeen       int
+	bytesSeen             int64
+	runtimeEntriesSeen    int
+	runtimeSubtreesPruned int
+	traversalComplete     bool
 }
 
 type bootstrapReadJob struct {
@@ -4409,6 +4456,7 @@ func bootstrapReadWorkers() int {
 // gate (Step 5) cannot be satisfied by a partial pull.
 func (s *Syncer) markBootstrapComplete() {
 	s.state.BootstrapComplete = true
+	s.state.BootstrapDirectories = nil
 	s.state.BootstrapCursor = ""
 	s.state.BootstrapStartedAt = ""
 	s.state.BootstrapFilesSynced = 0
@@ -5496,17 +5544,50 @@ func (s *Syncer) skipMountRuntimeRemotePath(remotePath string, conflicted map[st
 		return false
 	}
 	s.logf("skipping mount runtime path surfaced as workspace content: %s", remotePath)
-	if err := s.applyRemoteDelete(remotePath, conflicted); err != nil {
-		s.logf("failed to clean local mount runtime path %s: %v", remotePath, err)
-	}
-	if localPath, err := s.remoteToLocalPath(remotePath); err == nil {
-		if removeErr := os.Remove(localPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			s.logf("failed to remove local mount runtime file %s (%s): %v", remotePath, localPath, removeErr)
+	prefix := strings.TrimSuffix(remotePath, "/") + "/"
+	for trackedPath := range s.state.Files {
+		if trackedPath != remotePath && !strings.HasPrefix(trackedPath, prefix) {
+			continue
+		}
+		delete(s.state.Files, trackedPath)
+		s.clearIncrementalReadNotReady(trackedPath)
+		if conflicted != nil {
+			delete(conflicted, trackedPath)
 		}
 	}
-	delete(s.state.Files, remotePath)
+	for notReadyPath := range s.state.IncrementalReadNotReadySince {
+		if notReadyPath == remotePath || strings.HasPrefix(notReadyPath, prefix) {
+			s.clearIncrementalReadNotReady(notReadyPath)
+		}
+	}
+	if localPath, err := s.remoteToLocalPath(remotePath); err == nil {
+		if s.isActiveMountRuntimeLocalPath(localPath) {
+			// A leaked remote /.relay entry maps onto this daemon's own public
+			// runtime directory. Reject the remote entry, but never delete the
+			// live local state/outbox while doing so.
+		} else if err := s.assertNotMountRoot(localPath); err != nil {
+			s.logf("failed to clean local mount runtime path %s: %v", remotePath, err)
+		} else if removeErr := os.RemoveAll(localPath); removeErr != nil {
+			s.logf("failed to remove local mount runtime subtree %s (%s): %v", remotePath, localPath, removeErr)
+		}
+	}
 	s.clearIncrementalReadNotReady(remotePath)
 	return true
+}
+
+func (s *Syncer) isActiveMountRuntimeLocalPath(localPath string) bool {
+	localPath = filepath.Clean(localPath)
+	publicRuntimeRoot := filepath.Join(filepath.Clean(s.localRoot), ".relay")
+	if relative, err := filepath.Rel(publicRuntimeRoot, localPath); err == nil &&
+		(relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))) {
+		return true
+	}
+	stateFile := filepath.Clean(s.stateFile)
+	if localPath == stateFile {
+		return true
+	}
+	return filepath.Dir(localPath) == filepath.Dir(stateFile) &&
+		strings.HasPrefix(filepath.Base(localPath), "."+filepath.Base(stateFile)+".tmp-")
 }
 
 func (s *Syncer) applyLocalPermissions(localPath string, canWrite bool) error {
@@ -6202,6 +6283,7 @@ func (s *Syncer) loadState() error {
 	if s.state.BootstrapComplete && s.state.SyncMode == "write-only" && !s.writeOnly {
 		s.logf("syncMode transition write-only->mirror detected; resetting BootstrapComplete to force a full bootstrap pull (backfills records missed while write-only)")
 		s.state.BootstrapComplete = false
+		s.state.BootstrapDirectories = nil
 		s.state.BootstrapCursor = ""
 		s.state.BootstrapStartedAt = ""
 		s.state.BootstrapFilesSynced = 0

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -423,6 +423,10 @@ func (c *HTTPClient) logHTTPStatus(method, requestPath string, statusCode int, r
 func (c *HTTPClient) ListTree(ctx context.Context, workspaceID, path string, depth int, cursor string) (TreeResponse, error) {
 	q := url.Values{}
 	q.Set("path", normalizeRemotePath(path))
+	// Relayfile mount owns .relay and its atomic state files as private runtime
+	// data. Ask the server to remove those rows before raw SQL pagination so a
+	// large acked outbox cannot consume every page before real content appears.
+	q.Set("excludeMountRuntime", "true")
 	if depth > 0 {
 		q.Set("depth", fmt.Sprintf("%d", depth))
 	}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -113,12 +113,18 @@ const (
 	defaultCursorResolutionAttempts   = 3
 	defaultCursorRetryBaseDelay       = 250 * time.Millisecond
 	defaultBootstrapReadWorkers       = 16
-	defaultIncrementalEventPageLimit  = 50
-	defaultRetryAfterMaxDelay         = 60 * time.Second
-	defaultWebSocketReconnectBase     = 1 * time.Second
-	defaultWebSocketReconnectMax      = 60 * time.Second
-	defaultWebSocketReconnectJitter   = 200 * time.Millisecond
-	DefaultWebSocketMaintenanceEvery  = 1 * time.Second
+	// fullTreeTraversalDepth bounds each tree request so the client can see and
+	// prune a reserved .relay directory before the server reaches deep
+	// outbox/acked/mountcmd_* leaves. Depth 3 also covers the common Slack
+	// channels/<id>/messages frontier in one request, avoiding one network
+	// round trip per message directory.
+	fullTreeTraversalDepth           = 3
+	defaultIncrementalEventPageLimit = 50
+	defaultRetryAfterMaxDelay        = 60 * time.Second
+	defaultWebSocketReconnectBase    = 1 * time.Second
+	defaultWebSocketReconnectMax     = 60 * time.Second
+	defaultWebSocketReconnectJitter  = 200 * time.Millisecond
+	DefaultWebSocketMaintenanceEvery = 1 * time.Second
 )
 
 // resolveDurationEnv returns the option value if non-zero, else parses the
@@ -4047,10 +4053,11 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		)
 	}()
 	remotePaths := map[string]struct{}{}
-	// Traverse one directory level at a time. A deep ListTree request makes the
+	// Traverse in bounded-depth chunks. A depth=200 ListTree request makes the
 	// server enumerate every descendant before the client can reject reserved
-	// runtime paths. The shallow queue sees a nested .relay directory first and
-	// can prune it without ever requesting its state/outbox descendants.
+	// runtime paths. A small fixed depth sees a nested .relay directory before
+	// it reaches deep outbox/acked/mountcmd_* leaves, while advancing through a
+	// representative Slack tree in a few requests rather than one per directory.
 	directories := []string{s.remoteRoot}
 	cursor := ""
 	startedFromEmpty := true
@@ -4067,13 +4074,13 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			directories = resumedDirectories
 			cursor = strings.TrimSpace(s.state.BootstrapCursor)
 			startedFromEmpty = false
-			s.logf("resuming bootstrap shallow-tree pull at %s from persisted cursor (%d directories pending, %d files already synced)", directories[0], len(directories), s.state.BootstrapFilesSynced)
+			s.logf("resuming bootstrap bounded-tree pull at %s from persisted cursor (%d directories pending, %d files already synced)", directories[0], len(directories), s.state.BootstrapFilesSynced)
 		}
 	} else if !s.state.BootstrapComplete && strings.TrimSpace(s.state.BootstrapCursor) != "" {
 		// v0.10.28 and older persisted a cursor into one depth=200 listing.
-		// That cursor is invalid for a depth=1 directory page, so restart from
+		// That cursor is invalid for a bounded-depth directory page, so restart from
 		// the root. The local-hash fast path avoids re-reading unchanged files.
-		s.logf("discarding legacy deep-tree bootstrap cursor and restarting shallow traversal from %s", s.remoteRoot)
+		s.logf("discarding legacy deep-tree bootstrap cursor and restarting bounded traversal from %s", s.remoteRoot)
 		s.state.BootstrapCursor = ""
 	}
 	queuedDirectories := make(map[string]struct{}, len(directories))
@@ -4099,12 +4106,13 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 	}
 	maxObservedRevision := ""
 	var transientBootstrapAbort bool
+	prunedRuntimeRoots := map[string]struct{}{}
 	for len(directories) > 0 {
 		currentDirectory := directories[0]
 		var page TreeResponse
 		var err error
 		s.runFullPullIO(func() {
-			page, err = s.client.ListTree(ctx, s.workspace, currentDirectory, 1, cursor)
+			page, err = s.client.ListTree(ctx, s.workspace, currentDirectory, fullTreeTraversalDepth, cursor)
 		})
 		metrics.listCalls++
 		if err != nil {
@@ -4127,15 +4135,18 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			case "dir":
 				metrics.directoriesSeen++
 			}
-			if isMountRuntimeRemotePath(remotePath) {
+			runtimeRoot := mountRuntimeRemoteRoot(remotePath)
+			if runtimeRoot != "" {
 				metrics.runtimeEntriesSeen++
 			}
 			if !isUnderRemoteRoot(s.remoteRoot, remotePath) {
 				continue
 			}
-			if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
-				if entry.Type == "dir" {
+			if runtimeRoot != "" {
+				if _, pruned := prunedRuntimeRoots[runtimeRoot]; !pruned {
+					prunedRuntimeRoots[runtimeRoot] = struct{}{}
 					metrics.runtimeSubtreesPruned++
+					s.skipMountRuntimeRemotePath(runtimeRoot, conflicted)
 				}
 				continue
 			}
@@ -4144,7 +4155,10 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 				continue
 			}
 			if entry.Type == "dir" {
-				if _, exists := queuedDirectories[remotePath]; !exists {
+				if remoteDescendantDepth(currentDirectory, remotePath) >= fullTreeTraversalDepth {
+					if _, exists := queuedDirectories[remotePath]; exists {
+						continue
+					}
 					queuedDirectories[remotePath] = struct{}{}
 					directories = append(directories, remotePath)
 				}
@@ -5539,8 +5553,8 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 }
 
 func (s *Syncer) skipMountRuntimeRemotePath(remotePath string, conflicted map[string]struct{}) bool {
-	remotePath = normalizeRemotePath(remotePath)
-	if !isMountRuntimeRemotePath(remotePath) {
+	remotePath = mountRuntimeRemoteRoot(remotePath)
+	if remotePath == "" {
 		return false
 	}
 	s.logf("skipping mount runtime path surfaced as workspace content: %s", remotePath)
@@ -5586,8 +5600,9 @@ func (s *Syncer) isActiveMountRuntimeLocalPath(localPath string) bool {
 	if localPath == stateFile {
 		return true
 	}
+	stateTempPrefix := strings.TrimSuffix(atomicTempPattern(stateFile), "*")
 	return filepath.Dir(localPath) == filepath.Dir(stateFile) &&
-		strings.HasPrefix(filepath.Base(localPath), "."+filepath.Base(stateFile)+".tmp-")
+		strings.HasPrefix(filepath.Base(localPath), stateTempPrefix)
 }
 
 func (s *Syncer) applyLocalPermissions(localPath string, canWrite bool) error {
@@ -6223,25 +6238,34 @@ func normalizeScopes(scopes []string) []string {
 }
 
 func isMountRuntimeRemotePath(path string) bool {
-	return isMountRuntimeRelativePath(strings.TrimPrefix(normalizeRemotePath(path), "/"))
+	return mountRuntimeRemoteRoot(path) != ""
 }
 
 func isMountRuntimeRelativePath(path string) bool {
-	normalized := filepath.ToSlash(strings.TrimSpace(path))
+	return mountRuntimeRemoteRoot("/"+strings.TrimPrefix(filepath.ToSlash(strings.TrimSpace(path)), "/")) != ""
+}
+
+// mountRuntimeRemoteRoot returns the reserved runtime subtree containing path.
+// Canonicalizing descendants to their first reserved segment lets a bounded
+// tree page clean/log one .relay root without treating its state/outbox
+// children as separate subtrees.
+func mountRuntimeRemoteRoot(path string) string {
+	normalized := strings.TrimPrefix(filepath.ToSlash(normalizeRemotePath(path)), "/")
 	if normalized == "" || normalized == "." {
-		return false
+		return ""
 	}
-	for _, segment := range strings.Split(normalized, "/") {
+	segments := strings.Split(normalized, "/")
+	for index, segment := range segments {
 		if segment == "" || segment == "." {
 			continue
 		}
 		if segment == ".relay" ||
 			segment == ".relayfile-mount-state.json" ||
 			strings.HasPrefix(segment, ".relayfile-mount-state.json.tmp-") {
-			return true
+			return normalizeRemotePath("/" + strings.Join(segments[:index+1], "/"))
 		}
 	}
-	return false
+	return ""
 }
 
 func (s *Syncer) logMountControlPathSkipped(relativePath string) {
@@ -6849,6 +6873,20 @@ func isUnderRemoteRoot(remoteRoot, remotePath string) bool {
 		return true
 	}
 	return remotePath == remoteRoot || strings.HasPrefix(remotePath, remoteRoot+"/")
+}
+
+func remoteDescendantDepth(remoteRoot, remotePath string) int {
+	remoteRoot = normalizeRemotePath(remoteRoot)
+	remotePath = normalizeRemotePath(remotePath)
+	if remotePath == remoteRoot || !isUnderRemoteRoot(remoteRoot, remotePath) {
+		return 0
+	}
+	relative := strings.TrimPrefix(remotePath, remoteRoot)
+	relative = strings.TrimPrefix(relative, "/")
+	if relative == "" {
+		return 0
+	}
+	return len(strings.Split(relative, "/"))
 }
 
 func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error) {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -4027,7 +4027,22 @@ func isLazyGithubRepoSubtreePath(path string) bool {
 	return false
 }
 
-func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]struct{}, prog bootstrapProgress) error {
+func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]struct{}, prog bootstrapProgress) (returnErr error) {
+	metrics := fullTreeTraversalMetrics{startedAt: time.Now()}
+	defer func() {
+		s.logf(
+			"mount full-tree traversal summary remote_root=%q list_calls=%d entries_seen=%d files_seen=%d directories_seen=%d bytes_seen=%d runtime_entries_seen=%d traversal_complete=%t duration_ms=%d",
+			s.remoteRoot,
+			metrics.listCalls,
+			metrics.entriesSeen,
+			metrics.filesSeen,
+			metrics.directoriesSeen,
+			metrics.bytesSeen,
+			metrics.runtimeEntriesSeen,
+			metrics.traversalComplete,
+			time.Since(metrics.startedAt).Milliseconds(),
+		)
+	}()
 	remotePaths := map[string]struct{}{}
 	// Resumable bootstrap: if a prior bootstrap was interrupted mid-tree,
 	// pick traversal back up from the persisted cursor rather than
@@ -4054,6 +4069,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		s.runFullPullIO(func() {
 			page, err = s.client.ListTree(ctx, s.workspace, s.remoteRoot, 200, cursor)
 		})
+		metrics.listCalls++
 		if err != nil {
 			s.recordCloudFailure(err)
 			return err
@@ -4063,6 +4079,19 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 		filesThisPage := 0
 		readJobs := make([]bootstrapReadJob, 0, len(page.Entries))
 		for _, entry := range page.Entries {
+			metrics.entriesSeen++
+			switch entry.Type {
+			case "file":
+				metrics.filesSeen++
+				if entry.Size > 0 {
+					metrics.bytesSeen += entry.Size
+				}
+			case "dir":
+				metrics.directoriesSeen++
+			}
+			if isMountRuntimeRemotePath(entry.Path) {
+				metrics.runtimeEntriesSeen++
+			}
 			if entry.Type != "file" {
 				continue
 			}
@@ -4183,6 +4212,7 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 			break
 		}
 		if page.NextCursor == nil || *page.NextCursor == "" {
+			metrics.traversalComplete = true
 			break
 		}
 		cursor = *page.NextCursor
@@ -4242,6 +4272,17 @@ func (s *Syncer) pullRemoteFullTree(ctx context.Context, conflicted map[string]s
 	}
 	s.markBootstrapComplete()
 	return nil
+}
+
+type fullTreeTraversalMetrics struct {
+	startedAt          time.Time
+	listCalls          int
+	entriesSeen        int
+	filesSeen          int
+	directoriesSeen    int
+	bytesSeen          int64
+	runtimeEntriesSeen int
+	traversalComplete  bool
 }
 
 type bootstrapReadJob struct {

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7477,6 +7477,7 @@ func (c *fakeClient) ListTree(ctx context.Context, workspaceID, path string, dep
 			Type:        "file",
 			Revision:    file.Revision,
 			ContentHash: file.ContentHash,
+			Size:        int64(len(file.Content)),
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
@@ -9880,10 +9881,12 @@ func TestPullRemoteFullTreeSkipsNestedMountRuntimeState(t *testing.T) {
 		},
 	}
 	localDir := t.TempDir()
+	logger := &captureLogger{}
 	syncer, err := NewSyncer(client, SyncerOptions{
 		WorkspaceID: "ws_pull_nested_relay",
 		RemoteRoot:  "/slack",
 		LocalRoot:   localDir,
+		Logger:      logger,
 	})
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
@@ -9916,6 +9919,27 @@ func TestPullRemoteFullTreeSkipsNestedMountRuntimeState(t *testing.T) {
 	}
 	if got := client.readFileCallsByPath["/slack/channels/C123/messages/.relay/state.json"]; got != 0 {
 		t.Fatalf("nested mount runtime path should not be read from remote, got %d reads", got)
+	}
+	var summary string
+	for _, line := range logger.lines {
+		if strings.Contains(line, "mount full-tree traversal summary") {
+			summary = line
+		}
+	}
+	if summary == "" {
+		t.Fatalf("expected a full-tree traversal summary, logs: %#v", logger.lines)
+	}
+	for _, field := range []string{
+		"list_calls=1",
+		"entries_seen=2",
+		"files_seen=2",
+		"directories_seen=0",
+		"runtime_entries_seen=1",
+		"traversal_complete=true",
+	} {
+		if !strings.Contains(summary, field) {
+			t.Fatalf("traversal summary %q missing %q", summary, field)
+		}
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7502,14 +7502,23 @@ type hierarchicalTreeClient struct {
 	*fakeClient
 	calls           []hierarchicalTreeCall
 	entriesReturned int
+	returnedPaths   []string
+	listDelay       time.Duration
 	failAtCall      int
 	failErr         error
 }
 
-func (c *hierarchicalTreeClient) ListTree(_ context.Context, _ string, path string, depth int, cursor string) (TreeResponse, error) {
+func (c *hierarchicalTreeClient) ListTree(ctx context.Context, _ string, path string, depth int, cursor string) (TreeResponse, error) {
 	base := normalizeRemotePath(path)
 	if depth <= 0 {
 		depth = 1
+	}
+	if c.listDelay > 0 {
+		select {
+		case <-time.After(c.listDelay):
+		case <-ctx.Done():
+			return TreeResponse{}, ctx.Err()
+		}
 	}
 	callNumber := len(c.calls) + 1
 	if c.failAtCall == callNumber {
@@ -7566,6 +7575,9 @@ func (c *hierarchicalTreeClient) ListTree(_ context.Context, _ string, path stri
 	}
 	c.calls = append(c.calls, hierarchicalTreeCall{path: base, depth: depth, entries: len(entries)})
 	c.entriesReturned += len(entries)
+	for _, entry := range entries {
+		c.returnedPaths = append(c.returnedPaths, entry.Path)
+	}
 	return TreeResponse{Path: base, Entries: entries}, nil
 }
 
@@ -10055,6 +10067,8 @@ func TestSkipMountRuntimeRemotePathPreservesActiveRootRuntime(t *testing.T) {
 	localDir := t.TempDir()
 	activeState := filepath.Join(localDir, ".relay", "state.json")
 	activeOutbox := filepath.Join(localDir, ".relay", "outbox", "pending", "mountcmd_live.json")
+	activeLegacyState := filepath.Join(localDir, LegacyMountStateFileName)
+	activeLegacyTemp := filepath.Join(localDir, ".relayfile-mount-state.json.tmp-live")
 	if err := os.MkdirAll(filepath.Dir(activeOutbox), 0o755); err != nil {
 		t.Fatalf("mkdir active runtime tree: %v", err)
 	}
@@ -10064,6 +10078,12 @@ func TestSkipMountRuntimeRemotePathPreservesActiveRootRuntime(t *testing.T) {
 	if err := os.WriteFile(activeOutbox, []byte(`{"pending":true}`), 0o644); err != nil {
 		t.Fatalf("write active outbox: %v", err)
 	}
+	if err := os.WriteFile(activeLegacyState, []byte(`{"ready":true}`), 0o644); err != nil {
+		t.Fatalf("write active legacy state: %v", err)
+	}
+	if err := os.WriteFile(activeLegacyTemp, []byte(`{"pending":true}`), 0o644); err != nil {
+		t.Fatalf("write active legacy state temp: %v", err)
+	}
 	syncer, err := NewSyncer(&fakeClient{files: map[string]RemoteFile{}}, SyncerOptions{
 		WorkspaceID: "ws_active_runtime",
 		RemoteRoot:  "/",
@@ -10072,10 +10092,16 @@ func TestSkipMountRuntimeRemotePathPreservesActiveRootRuntime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
 	}
-	if !syncer.skipMountRuntimeRemotePath("/.relay", nil) {
-		t.Fatalf("expected remote /.relay to be classified as runtime")
+	for _, remoteRuntimePath := range []string{
+		"/.relay",
+		"/.relayfile-mount-state.json",
+		"/.relayfile-mount-state.json.tmp-live",
+	} {
+		if !syncer.skipMountRuntimeRemotePath(remoteRuntimePath, nil) {
+			t.Fatalf("expected remote %s to be classified as runtime", remoteRuntimePath)
+		}
 	}
-	for _, activePath := range []string{activeState, activeOutbox} {
+	for _, activePath := range []string{activeState, activeOutbox, activeLegacyState, activeLegacyTemp} {
 		if _, err := os.Stat(activePath); err != nil {
 			t.Fatalf("active mount runtime %s was removed: %v", activePath, err)
 		}
@@ -10093,16 +10119,21 @@ func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t
 		"/slack/channels/C123/messages/1780145510_376649/outbox/acked/mountcmd_real.json": {
 			Path: "/slack/channels/C123/messages/1780145510_376649/outbox/acked/mountcmd_real.json", Revision: "rev_real_cmd", Content: `{"real":true}`,
 		},
-		"/slack/channels/C123/messages/1780145510_376649/.relay/state.json": {
-			Path: "/slack/channels/C123/messages/1780145510_376649/.relay/state.json", Revision: "rev_runtime_state", Content: `{"pendingWriteback":400}`,
+		"/slack/channels/C123/messages/1780145510_376649/.relayfile-mount-state.json.backup": {
+			Path: "/slack/channels/C123/messages/1780145510_376649/.relayfile-mount-state.json.backup", Revision: "rev_real_backup", Content: `{"backup":true}`,
 		},
 	}
-	for index := 0; index < 400; index++ {
-		path := fmt.Sprintf("/slack/channels/C123/messages/1780145510_376649/.relay/outbox/acked/mountcmd_%03d.json", index)
-		files[path] = RemoteFile{Path: path, Revision: fmt.Sprintf("rev_runtime_%03d", index), Content: `{"runtime":true}`}
+	for message := 0; message < 200; message++ {
+		messageID := fmt.Sprintf("1780145510_%06d", message)
+		statePath := fmt.Sprintf("/slack/channels/C123/messages/%s/.relay/state.json", messageID)
+		files[statePath] = RemoteFile{Path: statePath, Revision: fmt.Sprintf("rev_runtime_state_%03d", message), Content: `{"pendingWriteback":2}`}
+		for artifact := 0; artifact < 2; artifact++ {
+			path := fmt.Sprintf("/slack/channels/C123/messages/%s/.relay/outbox/acked/mountcmd_%03d.json", messageID, artifact)
+			files[path] = RemoteFile{Path: path, Revision: fmt.Sprintf("rev_runtime_%03d_%d", message, artifact), Content: `{"runtime":true}`}
+		}
 	}
 	baseClient := &fakeClient{files: files}
-	client := &hierarchicalTreeClient{fakeClient: baseClient}
+	client := &hierarchicalTreeClient{fakeClient: baseClient, listDelay: 5 * time.Millisecond}
 	logger := &captureLogger{}
 	localDir := t.TempDir()
 	syncer, err := NewSyncer(client, SyncerOptions{
@@ -10114,7 +10145,7 @@ func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
 	}
-	runtimeDir := filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relay")
+	runtimeDir := filepath.Join(localDir, "channels", "C123", "messages", "1780145510_000000", ".relay")
 	staleRuntimePath := filepath.Join(runtimeDir, "outbox", "acked", "mountcmd_stale.json")
 	if err := os.MkdirAll(filepath.Dir(staleRuntimePath), 0o755); err != nil {
 		t.Fatalf("mkdir stale runtime tree: %v", err)
@@ -10122,33 +10153,48 @@ func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t
 	if err := os.WriteFile(staleRuntimePath, []byte(`{"stale":true}`), 0o644); err != nil {
 		t.Fatalf("write stale runtime artifact: %v", err)
 	}
-	staleRemotePath := "/slack/channels/C123/messages/1780145510_376649/.relay/outbox/acked/mountcmd_stale.json"
+	staleRemotePath := "/slack/channels/C123/messages/1780145510_000000/.relay/outbox/acked/mountcmd_stale.json"
 	syncer.state.Files[staleRemotePath] = trackedFile{Revision: "rev_stale", Hash: hashString(`{"stale":true}`)}
 
+	startedAt := time.Now()
 	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
 		t.Fatalf("pullRemoteFullTree failed: %v", err)
 	}
+	elapsed := time.Since(startedAt)
 
-	if client.entriesReturned >= 40 {
-		t.Fatalf("runtime subtree was enumerated before filtering: returned %d entries across calls %#v", client.entriesReturned, client.calls)
+	if len(client.calls) != 3 {
+		t.Fatalf("representative Slack traversal used %d ListTree calls, want exactly 3: %#v", len(client.calls), client.calls)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Fatalf("representative Slack traversal exceeded bounded latency: %s across %d delayed calls", elapsed, len(client.calls))
+	}
+	if client.entriesReturned >= 1000 {
+		t.Fatalf("runtime subtree traversal was not bounded: returned %d entries across calls %#v", client.entriesReturned, client.calls)
 	}
 	for _, call := range client.calls {
 		if isMountRuntimeRemotePath(call.path) {
 			t.Fatalf("ListTree descended into reserved runtime subtree: %#v", call)
 		}
-		if call.depth != 1 {
-			t.Fatalf("ListTree depth = %d for %s, want 1 so runtime directories can be pruned before descent", call.depth, call.path)
+		if call.depth != fullTreeTraversalDepth {
+			t.Fatalf("ListTree depth = %d for %s, want bounded depth %d", call.depth, call.path, fullTreeTraversalDepth)
+		}
+	}
+	for _, returnedPath := range client.returnedPaths {
+		if strings.Contains(filepath.Base(returnedPath), "mountcmd_") && isMountRuntimeRemotePath(returnedPath) {
+			t.Fatalf("deep runtime artifact was enumerated before pruning: %s", returnedPath)
 		}
 	}
 	for _, realPath := range []string{
 		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649.json"),
 		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relay-notes", "keep.md"),
 		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", "outbox", "acked", "mountcmd_real.json"),
+		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relayfile-mount-state.json.backup"),
 	} {
 		if _, err := os.Stat(realPath); err != nil {
 			t.Fatalf("expected real workspace content %s to remain mirrored: %v", realPath, err)
 		}
 	}
+	assertLocalFileContent(t, filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relayfile-mount-state.json.backup"), `{"backup":true}`)
 	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("nested runtime subtree should be absent after pruning, stat err=%v", err)
 	}
@@ -10166,16 +10212,19 @@ func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t
 			summary = line
 		}
 	}
-	if !strings.Contains(summary, "runtime_subtrees_pruned=1") {
-		t.Fatalf("expected traversal summary to report one pruned runtime subtree, got %q", summary)
+	if !strings.Contains(summary, "runtime_subtrees_pruned=200") {
+		t.Fatalf("expected traversal summary to report 200 pruned runtime subtrees, got %q", summary)
+	}
+	if !strings.Contains(summary, "list_calls=3") {
+		t.Fatalf("expected traversal summary to report the measured three-call frontier, got %q", summary)
 	}
 }
 
 func TestPullRemoteFullTreeResumesPersistedShallowDirectoryQueue(t *testing.T) {
 	files := map[string]RemoteFile{
-		"/a/one.md":        {Path: "/a/one.md", Revision: "rev_a", Content: "one"},
-		"/b/two.md":        {Path: "/b/two.md", Revision: "rev_b", Content: "two"},
-		"/c/deep/three.md": {Path: "/c/deep/three.md", Revision: "rev_c", Content: "three"},
+		"/a/level1/level2/one.md":   {Path: "/a/level1/level2/one.md", Revision: "rev_a", Content: "one"},
+		"/b/level1/level2/two.md":   {Path: "/b/level1/level2/two.md", Revision: "rev_b", Content: "two"},
+		"/c/level1/level2/three.md": {Path: "/c/level1/level2/three.md", Revision: "rev_c", Content: "three"},
 	}
 	client := &hierarchicalTreeClient{
 		fakeClient: &fakeClient{files: files},
@@ -10191,17 +10240,25 @@ func TestPullRemoteFullTreeResumesPersistedShallowDirectoryQueue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new syncer failed: %v", err)
 	}
+	preservedPrefixPath := filepath.Join(localDir, "preserved-prefix.md")
+	if err := os.WriteFile(preservedPrefixPath, []byte("prefix mirrored before interruption"), 0o644); err != nil {
+		t.Fatalf("seed tracked prefix: %v", err)
+	}
+	syncer.state.Files["/preserved-prefix.md"] = trackedFile{
+		Revision: "rev_prefix",
+		Hash:     hashString("prefix mirrored before interruption"),
+	}
 	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err == nil {
 		t.Fatalf("expected first traversal to fail")
 	}
-	if got := syncer.state.BootstrapDirectories; len(got) == 0 || got[0] != "/b" {
-		t.Fatalf("persisted directory queue = %#v, want /b at the resume boundary", got)
+	if got := syncer.state.BootstrapDirectories; len(got) == 0 || got[0] != "/b/level1/level2" {
+		t.Fatalf("persisted directory queue = %#v, want /b/level1/level2 at the resume boundary", got)
 	}
 	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
 		t.Fatalf("resumed traversal failed: %v", err)
 	}
-	if len(client.calls) < 4 || client.calls[3].path != "/b" {
-		t.Fatalf("resumed traversal did not restart at /b: %#v", client.calls)
+	if len(client.calls) < 4 || client.calls[3].path != "/b/level1/level2" {
+		t.Fatalf("resumed traversal did not restart at /b/level1/level2: %#v", client.calls)
 	}
 	if !syncer.state.BootstrapComplete {
 		t.Fatalf("resumed traversal did not mark bootstrap complete")
@@ -10209,10 +10266,14 @@ func TestPullRemoteFullTreeResumesPersistedShallowDirectoryQueue(t *testing.T) {
 	if len(syncer.state.BootstrapDirectories) != 0 {
 		t.Fatalf("completed traversal retained directory queue: %#v", syncer.state.BootstrapDirectories)
 	}
+	if _, tracked := syncer.state.Files["/preserved-prefix.md"]; !tracked {
+		t.Fatalf("resumed partial traversal applied an authoritative delete to the tracked prefix")
+	}
+	assertLocalFileContent(t, preservedPrefixPath, "prefix mirrored before interruption")
 	for _, localPath := range []string{
-		filepath.Join(localDir, "a", "one.md"),
-		filepath.Join(localDir, "b", "two.md"),
-		filepath.Join(localDir, "c", "deep", "three.md"),
+		filepath.Join(localDir, "a", "level1", "level2", "one.md"),
+		filepath.Join(localDir, "b", "level1", "level2", "two.md"),
+		filepath.Join(localDir, "c", "level1", "level2", "three.md"),
 	} {
 		if _, err := os.Stat(localPath); err != nil {
 			t.Fatalf("expected resumed traversal to mirror %s: %v", localPath, err)

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7502,12 +7502,23 @@ type hierarchicalTreeClient struct {
 	*fakeClient
 	calls           []hierarchicalTreeCall
 	entriesReturned int
+	failAtCall      int
+	failErr         error
 }
 
 func (c *hierarchicalTreeClient) ListTree(_ context.Context, _ string, path string, depth int, cursor string) (TreeResponse, error) {
 	base := normalizeRemotePath(path)
 	if depth <= 0 {
 		depth = 1
+	}
+	callNumber := len(c.calls) + 1
+	if c.failAtCall == callNumber {
+		c.calls = append(c.calls, hierarchicalTreeCall{path: base, depth: depth})
+		c.failAtCall = 0
+		if c.failErr != nil {
+			return TreeResponse{}, c.failErr
+		}
+		return TreeResponse{}, errors.New("synthetic ListTree failure")
 	}
 	entriesByPath := map[string]TreeEntry{}
 	for remotePath, file := range c.files {
@@ -9820,6 +9831,9 @@ func TestLoadStateResetsBootstrapCompleteOnlyOnWriteOnlyToMirrorSyncMode(t *test
 				t.Fatalf("BootstrapComplete = %v, want %v", got, tc.wantBootstrapComplete)
 			}
 			if tc.wantCleared {
+				if len(syncer.state.BootstrapDirectories) != 0 {
+					t.Fatalf("BootstrapDirectories = %#v, want empty", syncer.state.BootstrapDirectories)
+				}
 				if syncer.state.BootstrapCursor != "" {
 					t.Fatalf("BootstrapCursor = %q, want empty", syncer.state.BootstrapCursor)
 				}
@@ -10037,6 +10051,37 @@ func TestIsMountRuntimeRelativePathExcludesOnlyReservedRuntimeArtifacts(t *testi
 	}
 }
 
+func TestSkipMountRuntimeRemotePathPreservesActiveRootRuntime(t *testing.T) {
+	localDir := t.TempDir()
+	activeState := filepath.Join(localDir, ".relay", "state.json")
+	activeOutbox := filepath.Join(localDir, ".relay", "outbox", "pending", "mountcmd_live.json")
+	if err := os.MkdirAll(filepath.Dir(activeOutbox), 0o755); err != nil {
+		t.Fatalf("mkdir active runtime tree: %v", err)
+	}
+	if err := os.WriteFile(activeState, []byte(`{"ready":true}`), 0o644); err != nil {
+		t.Fatalf("write active state: %v", err)
+	}
+	if err := os.WriteFile(activeOutbox, []byte(`{"pending":true}`), 0o644); err != nil {
+		t.Fatalf("write active outbox: %v", err)
+	}
+	syncer, err := NewSyncer(&fakeClient{files: map[string]RemoteFile{}}, SyncerOptions{
+		WorkspaceID: "ws_active_runtime",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if !syncer.skipMountRuntimeRemotePath("/.relay", nil) {
+		t.Fatalf("expected remote /.relay to be classified as runtime")
+	}
+	for _, activePath := range []string{activeState, activeOutbox} {
+		if _, err := os.Stat(activePath); err != nil {
+			t.Fatalf("active mount runtime %s was removed: %v", activePath, err)
+		}
+	}
+}
+
 func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t *testing.T) {
 	files := map[string]RemoteFile{
 		"/slack/channels/C123/messages/1780145510_376649.json": {
@@ -10123,6 +10168,55 @@ func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t
 	}
 	if !strings.Contains(summary, "runtime_subtrees_pruned=1") {
 		t.Fatalf("expected traversal summary to report one pruned runtime subtree, got %q", summary)
+	}
+}
+
+func TestPullRemoteFullTreeResumesPersistedShallowDirectoryQueue(t *testing.T) {
+	files := map[string]RemoteFile{
+		"/a/one.md":        {Path: "/a/one.md", Revision: "rev_a", Content: "one"},
+		"/b/two.md":        {Path: "/b/two.md", Revision: "rev_b", Content: "two"},
+		"/c/deep/three.md": {Path: "/c/deep/three.md", Revision: "rev_c", Content: "three"},
+	}
+	client := &hierarchicalTreeClient{
+		fakeClient: &fakeClient{files: files},
+		failAtCall: 3,
+		failErr:    &HTTPError{StatusCode: http.StatusBadGateway, Code: "bad_gateway", Message: "synthetic interruption"},
+	}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_shallow_resume",
+		RemoteRoot:  "/",
+		LocalRoot:   localDir,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err == nil {
+		t.Fatalf("expected first traversal to fail")
+	}
+	if got := syncer.state.BootstrapDirectories; len(got) == 0 || got[0] != "/b" {
+		t.Fatalf("persisted directory queue = %#v, want /b at the resume boundary", got)
+	}
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("resumed traversal failed: %v", err)
+	}
+	if len(client.calls) < 4 || client.calls[3].path != "/b" {
+		t.Fatalf("resumed traversal did not restart at /b: %#v", client.calls)
+	}
+	if !syncer.state.BootstrapComplete {
+		t.Fatalf("resumed traversal did not mark bootstrap complete")
+	}
+	if len(syncer.state.BootstrapDirectories) != 0 {
+		t.Fatalf("completed traversal retained directory queue: %#v", syncer.state.BootstrapDirectories)
+	}
+	for _, localPath := range []string{
+		filepath.Join(localDir, "a", "one.md"),
+		filepath.Join(localDir, "b", "two.md"),
+		filepath.Join(localDir, "c", "deep", "three.md"),
+	} {
+		if _, err := os.Stat(localPath); err != nil {
+			t.Fatalf("expected resumed traversal to mirror %s: %v", localPath, err)
+		}
 	}
 }
 

--- a/internal/mountsync/syncer_test.go
+++ b/internal/mountsync/syncer_test.go
@@ -7488,6 +7488,76 @@ func (c *fakeClient) ListTree(ctx context.Context, workspaceID, path string, dep
 	}, nil
 }
 
+type hierarchicalTreeCall struct {
+	path    string
+	depth   int
+	entries int
+}
+
+// hierarchicalTreeClient mirrors the production tree contract: a request
+// returns files and synthesized directories only through the requested depth.
+// It lets traversal tests distinguish pruning before descent from filtering a
+// flat depth=200 response after the server has already enumerated every leaf.
+type hierarchicalTreeClient struct {
+	*fakeClient
+	calls           []hierarchicalTreeCall
+	entriesReturned int
+}
+
+func (c *hierarchicalTreeClient) ListTree(_ context.Context, _ string, path string, depth int, cursor string) (TreeResponse, error) {
+	base := normalizeRemotePath(path)
+	if depth <= 0 {
+		depth = 1
+	}
+	entriesByPath := map[string]TreeEntry{}
+	for remotePath, file := range c.files {
+		remotePath = normalizeRemotePath(remotePath)
+		if !isUnderRemoteRoot(base, remotePath) || remotePath == base {
+			continue
+		}
+		relative := strings.TrimPrefix(strings.TrimPrefix(remotePath, base), "/")
+		parts := strings.Split(relative, "/")
+		levels := depth
+		if len(parts) < levels {
+			levels = len(parts)
+		}
+		for level := 1; level <= levels; level++ {
+			entryPath := normalizeRemotePath(strings.TrimSuffix(base, "/") + "/" + strings.Join(parts[:level], "/"))
+			if level == len(parts) {
+				entriesByPath[entryPath] = TreeEntry{
+					Path:        entryPath,
+					Type:        "file",
+					Revision:    file.Revision,
+					ContentHash: file.ContentHash,
+					Size:        int64(len(file.Content)),
+				}
+				continue
+			}
+			if _, exists := entriesByPath[entryPath]; !exists {
+				entriesByPath[entryPath] = TreeEntry{Path: entryPath, Type: "dir", Revision: "dir"}
+			}
+		}
+	}
+	entries := make([]TreeEntry, 0, len(entriesByPath))
+	for _, entry := range entriesByPath {
+		entries = append(entries, entry)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	if cursor != "" {
+		start := len(entries)
+		for index, entry := range entries {
+			if entry.Path == cursor {
+				start = index + 1
+				break
+			}
+		}
+		entries = entries[start:]
+	}
+	c.calls = append(c.calls, hierarchicalTreeCall{path: base, depth: depth, entries: len(entries)})
+	c.entriesReturned += len(entries)
+	return TreeResponse{Path: base, Entries: entries}, nil
+}
+
 func (c *fakeClient) LatestEventID(ctx context.Context, workspaceID, provider string) (string, error) {
 	_ = ctx
 	_ = workspaceID
@@ -9940,6 +10010,119 @@ func TestPullRemoteFullTreeSkipsNestedMountRuntimeState(t *testing.T) {
 		if !strings.Contains(summary, field) {
 			t.Fatalf("traversal summary %q missing %q", summary, field)
 		}
+	}
+}
+
+func TestIsMountRuntimeRelativePathExcludesOnlyReservedRuntimeArtifacts(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: ".relay", want: true},
+		{path: "slack/channels/C123/messages/1/.relay/state.json", want: true},
+		{path: "slack/channels/C123/messages/1/.relay/outbox/acked/mountcmd_1.json", want: true},
+		{path: "slack/channels/C123/messages/1/.relayfile-mount-state.json", want: true},
+		{path: "slack/channels/C123/messages/1/relay/state.json", want: false},
+		{path: "slack/channels/C123/messages/1/.relay-notes/state.json", want: false},
+		{path: "slack/channels/C123/messages/1/outbox/acked/mountcmd_1.json", want: false},
+		{path: "slack/channels/C123/messages/1/notes/mountcmd_1.json", want: false},
+		{path: "slack/channels/C123/messages/1/.relayfile-mount-state.json.backup", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := isMountRuntimeRelativePath(tt.path); got != tt.want {
+				t.Fatalf("isMountRuntimeRelativePath(%q) = %t, want %t", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPullRemoteFullTreePrunesNestedMountRuntimeBeforeDescendantEnumeration(t *testing.T) {
+	files := map[string]RemoteFile{
+		"/slack/channels/C123/messages/1780145510_376649.json": {
+			Path: "/slack/channels/C123/messages/1780145510_376649.json", Revision: "rev_msg", Content: `{"text":"hello"}`,
+		},
+		"/slack/channels/C123/messages/1780145510_376649/.relay-notes/keep.md": {
+			Path: "/slack/channels/C123/messages/1780145510_376649/.relay-notes/keep.md", Revision: "rev_notes", Content: "real notes",
+		},
+		"/slack/channels/C123/messages/1780145510_376649/outbox/acked/mountcmd_real.json": {
+			Path: "/slack/channels/C123/messages/1780145510_376649/outbox/acked/mountcmd_real.json", Revision: "rev_real_cmd", Content: `{"real":true}`,
+		},
+		"/slack/channels/C123/messages/1780145510_376649/.relay/state.json": {
+			Path: "/slack/channels/C123/messages/1780145510_376649/.relay/state.json", Revision: "rev_runtime_state", Content: `{"pendingWriteback":400}`,
+		},
+	}
+	for index := 0; index < 400; index++ {
+		path := fmt.Sprintf("/slack/channels/C123/messages/1780145510_376649/.relay/outbox/acked/mountcmd_%03d.json", index)
+		files[path] = RemoteFile{Path: path, Revision: fmt.Sprintf("rev_runtime_%03d", index), Content: `{"runtime":true}`}
+	}
+	baseClient := &fakeClient{files: files}
+	client := &hierarchicalTreeClient{fakeClient: baseClient}
+	logger := &captureLogger{}
+	localDir := t.TempDir()
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_prune_nested_relay",
+		RemoteRoot:  "/slack",
+		LocalRoot:   localDir,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("new syncer failed: %v", err)
+	}
+	runtimeDir := filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relay")
+	staleRuntimePath := filepath.Join(runtimeDir, "outbox", "acked", "mountcmd_stale.json")
+	if err := os.MkdirAll(filepath.Dir(staleRuntimePath), 0o755); err != nil {
+		t.Fatalf("mkdir stale runtime tree: %v", err)
+	}
+	if err := os.WriteFile(staleRuntimePath, []byte(`{"stale":true}`), 0o644); err != nil {
+		t.Fatalf("write stale runtime artifact: %v", err)
+	}
+	staleRemotePath := "/slack/channels/C123/messages/1780145510_376649/.relay/outbox/acked/mountcmd_stale.json"
+	syncer.state.Files[staleRemotePath] = trackedFile{Revision: "rev_stale", Hash: hashString(`{"stale":true}`)}
+
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("pullRemoteFullTree failed: %v", err)
+	}
+
+	if client.entriesReturned >= 40 {
+		t.Fatalf("runtime subtree was enumerated before filtering: returned %d entries across calls %#v", client.entriesReturned, client.calls)
+	}
+	for _, call := range client.calls {
+		if isMountRuntimeRemotePath(call.path) {
+			t.Fatalf("ListTree descended into reserved runtime subtree: %#v", call)
+		}
+		if call.depth != 1 {
+			t.Fatalf("ListTree depth = %d for %s, want 1 so runtime directories can be pruned before descent", call.depth, call.path)
+		}
+	}
+	for _, realPath := range []string{
+		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649.json"),
+		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", ".relay-notes", "keep.md"),
+		filepath.Join(localDir, "channels", "C123", "messages", "1780145510_376649", "outbox", "acked", "mountcmd_real.json"),
+	} {
+		if _, err := os.Stat(realPath); err != nil {
+			t.Fatalf("expected real workspace content %s to remain mirrored: %v", realPath, err)
+		}
+	}
+	if _, err := os.Stat(runtimeDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("nested runtime subtree should be absent after pruning, stat err=%v", err)
+	}
+	if _, exists := syncer.state.Files[staleRemotePath]; exists {
+		t.Fatalf("stale nested runtime artifact remained tracked")
+	}
+	for path, calls := range baseClient.readFileCallsByPath {
+		if isMountRuntimeRemotePath(path) && calls > 0 {
+			t.Fatalf("runtime artifact %s was read %d time(s)", path, calls)
+		}
+	}
+	var summary string
+	for _, line := range logger.lines {
+		if strings.Contains(line, "mount full-tree traversal summary") {
+			summary = line
+		}
+	}
+	if !strings.Contains(summary, "runtime_subtrees_pruned=1") {
+		t.Fatalf("expected traversal summary to report one pruned runtime subtree, got %q", summary)
 	}
 }
 


### PR DESCRIPTION
## Problem

Cold Relayfile mounts still paid for one depth=200 ListTree enumeration before the client filtered nested mount runtime artifacts. Production Slack message trees can contain hundreds of .relay/outbox/acked/mountcmd_* leaves, so the traversal hit the runtime cap even though those files were never user content.

## Change

- Add one structured full-tree traversal summary with list calls, entries/files/directories/bytes seen, runtime entries, pruned roots, completion/failure, and duration.
- Replace the single depth=200 request with a resumable depth-3 frontier. A nested .relay root is visible and pruned before descendant mountcmd_* leaves can be enumerated.
- Canonicalize and remove only reserved .relay and exact mount state artifacts. Preserve real similarly named content such as .relay-notes, outbox/acked/mountcmd_real.json, and mount state backup files.
- Protect the active mount root runtime directory while removing stale nested runtime trees and tracked state.
- Persist directory plus cursor resume state. Resumed traversals skip authoritative deletion, and legacy deep-list cursors restart safely at root.

## Measured regression

The RED fixture against the old depth=200 path returned 414 entries before filtering.

The representative bounded fixture contains 200 Slack message directories and 400 nested runtime mountcmd artifacts. It now completes in exactly 3 ListTree calls, returns zero runtime mountcmd leaves, prunes 200 canonical .relay roots, and remains under the simulated request-latency budget. Real similarly named content is still mirrored.

## Validation

- Focused runtime predicate, active-root protection, prune, resume, bootstrap-cursor, and delete-safety regressions pass uncached.
- go test -p 1 ./... passes at head; internal/mountsync completed in 112.804s.
- git diff --check passes and the worktree is clean.

## Release and Cloud adoption

This PR must publish a new relayfile-mount release tag after merge. Cloud adoption is a separate PR that bumps RELAYFILE_MOUNT_VERSION in rebuild-snapshot.yml to that released tag and rebuilds the Daytona snapshot. No SDK package bump is involved.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

