### PR TITLE
feat(contract): Relayfile Path Contract v1 — grammar, fixtures, Go conformance runners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MOUNT_BIN := relayfile-mount
 TARGETS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64
 RELEASE_BINS := $(CLI_BIN) $(SERVER_BIN) $(MOUNT_BIN)
 
-.PHONY: build build-all install test release clean
+.PHONY: build build-all install test contract-test release clean
 
 build:
 	mkdir -p $(BIN_DIR)
@@ -49,6 +49,12 @@ install: build
 
 test:
 	$(GO) test ./...
+
+# Path-contract conformance suite (contract/README.md + contract/fixtures/).
+# Also runs as part of plain `go test ./...`; this target is the named entry
+# point other repos' docs reference.
+contract-test:
+	$(GO) test ./internal/httpapi ./internal/relayfile -run 'TestContractFixtures'
 
 release: clean build-all
 	set -eu; \

--- a/contract/README.md
+++ b/contract/README.md
@@ -144,6 +144,15 @@ of three glob forms:
 | `<name>*` | `/github/acme-*` | `f` starts with the raw byte prefix `/github/acme-` |
 | `*` | `*` | any `f`, including the empty required-path |
 
+**The `/` vs `*` asymmetry.** Both `/` and `*` are valid scope paths with
+`mounts_at: /`, but their authorization behavior is opposite: `*` matches
+every file path (including the empty required-path), while `/` is an exact
+path like any other — it matches **only the root node itself**, nothing
+beneath it. An author who writes `/` intending "the whole tree" gets a
+valid-looking scope that authorizes almost nothing. Whole-namespace access
+is spelled `*` (or `/**`). The fixtures pin both sides
+(`root-scope-path-*` cases in `auth-matching.json`).
+
 Points that pin known cross-implementation disagreements:
 
 - **`/*` is not single-segment.** `/github/*` matches
@@ -269,6 +278,18 @@ failure.
   and `cloud` consume these files (vendored copy or package) and report.
   Phase 2 is report-only; expected red: `relayfile-cloud` (segment-glob
   matcher is too permissive), `cloud` (emits invalid scopes).
+
+### Stricter subsets
+
+An implementation (typically a path **producer** or canonicalizer, e.g. a
+mount-path layer that accepts terminal `/**` only and not `/*` or `name*`)
+MAY accept a strict subset of this grammar — a scope path it rejects can
+never be one it wrongly honors. But a subset must be a **declared choice**:
+documented in that implementation, with a rationale, and its rejections must
+be explicit errors or reported degradations per §5.2. An undocumented subset
+is exactly the two-vocabularies drift that produced cloud#2297. Consumers
+and enforcers (anything answering `auth_matches`) get no such latitude: they
+must implement the full grammar and pass every fixture.
 
 ### Changing the contract
 

--- a/contract/README.md
+++ b/contract/README.md
@@ -1,0 +1,323 @@
+# Relayfile Path Contract — v1
+
+**Status:** authoritative
+**Version:** 1
+**Owner:** this repository (`agentworkforce/relayfile`)
+**Parent spec:** `cloud/specs/relayfile-path-contract-stabilization.md`
+**Prior art:** cloud#989 (`specs/relayfile-contract-tests.md`, HTTP-level contract suite)
+
+> **Ruling (operator, 2026-07-18):** the OSS implementation drives the contract,
+> to protect self-hosters. Where hosted and OSS disagree, OSS is correct and
+> hosted conforms — even when that means hosted gets stricter and something
+> breaks.
+
+This document defines, in one place, what a relayfile path means: syntax,
+normalization, containment, scope-glob matching, and mount-root derivation.
+The fixtures under `contract/fixtures/` are the executable form of this
+document. Every implementation of the relayfile path vocabulary — the Go
+server in this repo, the hosted Cloudflare Worker
+(`relayfile-cloud/packages/relayfile`), the relayauth scope minter, and the
+path producers in `cloud` — must run the fixtures in CI and be green.
+
+The grammar below is **exactly what `internal/httpapi/auth.go` already
+enforces**. Phase 1 documents and fences existing behavior; it does not change
+any verdict the Go server returns today.
+
+---
+
+## 1. Definitions
+
+- **File path** — the absolute, `/`-rooted identifier of an object in a
+  relayfile workspace, e.g. `/github/repos/acme/cloud/issues/5.json`.
+- **Scope** — a colon-delimited grant carried in a token's `scopes` claim:
+  `plane:resource:action[:path]`, e.g. `relayfile:fs:read:/github/**`.
+- **Scope path** — the optional fourth segment of a scope: either the literal
+  `*` or a file path that may carry **one suffix glob**.
+- **Canonical file path** — a file path in the canonical form of §2. Matching
+  (§5) is defined **only** for canonical file paths; behavior on
+  non-canonical input is unspecified and MUST NOT be relied upon.
+
+## 2. Canonical file path grammar
+
+```
+canonical-path = "/" | "/" segment *( "/" segment )
+segment        = 1*<any byte except "/">   ; excluding "." and ".."
+```
+
+A canonical file path:
+
+1. begins with `/`;
+2. has no trailing slash (except the root path `/` itself);
+3. has no empty segments (no `//`);
+4. has no `.` or `..` segments;
+5. contains no `*` in any segment (globs belong to scope paths only);
+6. is compared **byte-exact and case-sensitive**. No Unicode normalization,
+   no percent-decoding at this layer (transport decoding happens before the
+   contract applies).
+
+## 3. Normalization
+
+The reference normalizer is `normalizePath` in `internal/relayfile/store.go`:
+
+1. empty string → `/`;
+2. prepend `/` if missing;
+3. trim **one** trailing `/` (unless the result would be empty).
+
+That is the complete algorithm. It is deliberately minimal and is pinned
+byte-for-byte by `fixtures/path-normalization.json`, including these
+**flagged quirks** (pinned as current behavior, candidates for a v2 change —
+which would be a versioned contract change, red across all repos on the same
+day):
+
+| input | output | note |
+|---|---|---|
+| `/a//` | `/a/` | only one trailing slash is trimmed |
+| `/a/../b` | `/a/../b` | dot segments are **not** collapsed; `.`/`..` are treated as literal segment names |
+| `/a/./b` | `/a/./b` | same |
+
+Because dot segments survive normalization, they can never alias another
+path: `/a/../b` and `/b` are two different keys in the virtual store. There
+is no filesystem underneath this namespace for `..` to escape into.
+
+### 3.1 Known in-repo divergences (flagged, not contract)
+
+These are inputs to the Phase 2 divergence map, recorded here so nobody
+mistakes them for the contract:
+
+- `internal/mountfuse/fs.go` `normalizeRemotePath` applies `path.Clean`
+  (collapses `//`, `.`, `..`) — stricter than the store normalizer.
+- `internal/httpapi/server.go`: the `read_file`/`write_file`/`delete_file`
+  routes auth-match the **raw trimmed** client path, while `tree`/`export`
+  normalize via `normalizeRoutePath` first. A request for `path=github/x`
+  (no leading slash) is therefore matched against scopes without the leading
+  slash on file routes.
+- `internal/httpapi/acl.go` `normalizeACLPath` collapses `.`/`..`
+  (ACL-marker resolution only).
+- `internal/httpapi/websocket.go` `webSocketPathMatches` implements a
+  **different, segment-wise glob grammar** (mid-path `*` allowed) for
+  WebSocket event *filters*. Event filters are a subscription convenience,
+  not an authorization surface, and are **out of scope** for this contract
+  (§9). They must never be conflated with scope paths.
+
+## 4. Scope grammar
+
+```
+scope       = plane ":" resource ":" action [ ":" scope-path ]
+plane       = "relayfile" | "workspace" | "*" | <other planes, non-matching>
+resource    = token | "*"          ; e.g. "fs"
+action      = "read" | "write" | "manage" | "*" | <others>
+scope-path  = "*" | glob-path
+```
+
+Splitting is `SplitN(scope, ":", 4)`: the scope path may itself contain
+colons (it never does in canonical form, but the split guarantees the path is
+not truncated). Scopes with fewer than three segments are **not** grants in
+this grammar; they participate only as opaque literals (§5.3).
+
+Plane semantics:
+
+- `relayfile` and `*` — segment 2 is the resource, segment 3 the action.
+- `workspace` — segment 2 is a **sponsor/workspace label, not a resource**;
+  the grant applies to the `fs` resource only. `workspace:<label>:read` and
+  `workspace:<label>:read:<scope-path>` are fs-grants.
+- Any other plane (e.g. `relaycast`) never matches relayfile requirements.
+
+Action semantics: `*` matches any action; `manage` implies `read` and
+`write` (but nothing implies `manage`).
+
+A 3-segment grant (`relayfile:fs:read`, `workspace:x:read`) is equivalent to
+a 4-segment grant with scope path `*`: full-namespace access.
+
+## 5. Scope-path glob grammar and matching
+
+### 5.1 Valid scope paths
+
+A scope path is either the literal `*`, or a path that satisfies the
+canonical-path rules of §2 **except** that its **final segment** may take one
+of three glob forms:
+
+| form | example | matches file `f` when |
+|---|---|---|
+| *(exact — no glob)* | `/a/b/c.json` | `f == "/a/b/c.json"` |
+| `<dir>/**` | `/github/**` | `f == "/github"` **or** `f` starts with `/github/` |
+| `<dir>/*` | `/github/*` | `f` starts with `/github/` — **any depth**, and **not** `/github` itself |
+| `<name>*` | `/github/acme-*` | `f` starts with the raw byte prefix `/github/acme-` |
+| `*` | `*` | any `f`, including the empty required-path |
+
+Points that pin known cross-implementation disagreements:
+
+- **`/*` is not single-segment.** `/github/*` matches
+  `/github/a/b/c.json`. Implementations that treat `*` as "one path
+  segment" are wrong under this contract.
+- **`/**` includes the directory node itself.** `/github/**` matches
+  `/github`; `/github/*` does not.
+- **`<name>*` is a raw byte prefix**, not a segment prefix: `/github*`
+  matches `/github`, `/github2`, and `/github/x`.
+- Matching order is: exact equality, then `/**`, then `/*`, then trailing
+  `*`. (For valid scope paths and canonical file paths the order is not
+  observable; it is recorded for implementors mirroring
+  `scopePathMatches`.)
+
+### 5.2 Invalid scope paths — mid-path globs
+
+**A `*` anywhere other than the final segment is invalid. `**` anywhere
+other than as the entire final segment is invalid.** Also invalid: missing
+leading `/`, empty segments, `.`/`..` segments, trailing slash, and a `*`
+that is not at the end of the final segment (`/git*hub`, `/a/re*po`,
+`/a/b**`).
+
+So `relayfile:fs:read:/github/repos/*/*/issues/**` — the exact scope hosted
+cloud emits today — is **invalid**. Under the reference matcher its `*`
+segments are literal bytes, so it matches no canonical file path: **a token
+carrying only that scope authorizes nothing**.
+
+Required behavior for every implementation:
+
+1. A validity check, where implemented, MUST report these scope paths
+   invalid (`valid: false` in the fixtures).
+2. The matcher MUST NOT match them against any canonical file path. The
+   fixtures probe this directly (`probe_files` with `auth_matches: false`) —
+   an implementation that *accepts* a mid-path glob **fails the suite**.
+3. **No silent drops.** A producer or client that encounters an invalid
+   scope path must surface an explicit error or an explicitly reported
+   degradation — never a vanished array element (cloud#2702).
+
+### 5.3 Grant-set matching (`scopeMatchesPath`)
+
+Given a granted scope set, a requirement `resource:action`, and a required
+file path `f` (empty means "no specific path — namespace-level access"):
+
+1. Collect every granted scope that is a path grant for the requirement per
+   §4 (plane, resource, action all match).
+2. If any such grant has scope path `*` (or is a 3-segment grant) → **allow**
+   (even when `f` is empty).
+3. If any narrow grant's scope path matches `f` per §5.1 → **allow**. An
+   empty `f` never matches a narrow grant.
+4. Otherwise, if the **literal** requirement string (e.g. `fs:read`) is in
+   the granted set: allow **only if no narrow path grant existed** in step 1.
+   **Narrow grants suppress the bare literal** — a token with
+   `fs:read` + `relayfile:fs:read:/github/**` is confined to `/github/**`.
+5. Otherwise → **deny**.
+
+Scope paths are whitespace-trimmed when extracted from the scope string; the
+required file path is whitespace-trimmed before matching.
+
+## 6. Containment
+
+`contains(base, candidate)` — reference: `withinBase` in
+`internal/relayfile/store.go`. Both inputs pass through the §3 normalizer,
+then:
+
+- base `/` contains everything;
+- otherwise `candidate == base`, or `candidate` starts with `base + "/"`.
+
+Byte-exact: `/github` does not contain `/github2`; `/gith` does not contain
+`/github` — segment boundaries are enforced by the appended `/`.
+
+## 7. Mount-root derivation (`mounts_at`)
+
+The deepest concrete directory implied by a **valid** scope path — where a
+mount client may anchor the grant locally:
+
+| scope path | mounts_at |
+|---|---|
+| `*` | `/` |
+| `/` | `/` |
+| exact `/a/b/c.json` | `/a/b/c.json` |
+| `/a/b/**` | `/a/b` |
+| `/a/b/*` | `/a/b` |
+| `/a/acme-*` | `/a` (parent of the prefixed segment) |
+| `/**`, `/*` | `/` |
+
+An invalid scope path has **no** mount root (`mounts_at: null`). Mount
+layers MUST NOT guess one (cloud#2297, cloud#2702: the silent guess is how
+paths vanished).
+
+Reference implementation: `scopePathMountRoot` in
+`internal/httpapi/path_contract.go`.
+
+## 8. Fixtures
+
+Language-neutral JSON under `contract/fixtures/`. Every file:
+
+```json
+{ "contract": "relayfile-path-contract", "version": 1, "area": "<area>", "cases": [ ... ] }
+```
+
+| file | area | case shape → expectations |
+|---|---|---|
+| `path-normalization.json` | `path-normalization` | `{path}` → `{normalized}` |
+| `containment.json` | `containment` | `{base, candidate}` → `{contains}` |
+| `scope-paths.json` | `scope-paths` | `{scope_path, probe_files?}` → `{valid, mounts_at}`; every `probe_files` entry must **not** match when `valid` is false |
+| `auth-matching.json` | `auth-matching` | `{scopes, required, file}` → `{auth_matches}` |
+
+Case fields: `name` (unique per file), optional `description`, optional
+`quirk: true` (behavior pinned as-is, flagged for a future versioned change).
+Implementations without a scope-path validity function may skip `valid`
+assertions but MUST still run the `probe_files` and `auth_matches`
+assertions — that is the fence that makes accepting a mid-path glob a CI
+failure.
+
+### Runners
+
+- **Go (this repo):** `make contract-test` — fixture-driven tests in
+  `internal/httpapi/contract_fixtures_test.go` (scope paths, auth matching)
+  and `internal/relayfile/contract_fixtures_test.go` (normalization,
+  containment). Also runs under plain `go test ./...`, so the existing
+  `ci.yml` / `contract.yml` workflows already gate it.
+- **TS (Phase 2):** `relayfile-cloud`, `relayauth`, `relayfile-adapters`,
+  and `cloud` consume these files (vendored copy or package) and report.
+  Phase 2 is report-only; expected red: `relayfile-cloud` (segment-glob
+  matcher is too permissive), `cloud` (emits invalid scopes).
+
+### Changing the contract
+
+A contract change is a **versioned event**: bump `version`, change the
+fixtures and the reference implementation in the same PR, and expect every
+downstream repo to go red the same day (that is the acceptance test from the
+parent spec, not an accident). Never change a fixture to make one
+implementation pass.
+
+## 9. Out of scope for v1
+
+- **WebSocket event filters** (`webSocketPathMatches`): a separate,
+  segment-wise glob grammar on a non-authorization surface.
+- **ACL paths** (`normalizeACLPath`): ACL-marker directory resolution.
+- **Local-mount ignore/readonly patterns**: gitignore semantics by design
+  (see Appendix A).
+- HTTP request/response shapes — that is cloud#989's suite; this contract is
+  the path-vocabulary layer underneath it.
+
+---
+
+## Appendix A — audit of `packages/local-mount/src/mount.ts` (the fifth theory)
+
+Audited 2026-07-18 for the parent spec. `mount.ts` operates on **local,
+relative, workstation paths** (project ↔ mount sync), never on remote
+relayfile paths or scope paths — so it does not implement *this* contract,
+but it does hold three private path theories of its own:
+
+1. **gitignore glob semantics** via the `ignore` npm package for
+   `ignoredPatterns`, `readonlyPatterns`, and the no-sync-back matcher
+   (`createPathMatcher`, `isPathMatched`). Full gitignore grammar: mid-path
+   `*`/`**`, negations, anchoring, trailing-slash directory forms. This is
+   intentional (the inputs are user-authored ignore rules) but it means the
+   same spelling — `dir/*` — has **different meanings** in a mount ignore
+   pattern (one segment, gitignore) and in a scope path (any-depth suffix,
+   §5.1). Documentation that surfaces both must never present them as one
+   vocabulary.
+2. **`ExcludeRules`** (`createExcludeRules`/`addExcludeEntries`): a third
+   mini-grammar for `excludeDirs` — a bare name matches at any depth, an
+   entry containing `/` is a root-anchored prefix (`legacy` mode). No globs
+   at all.
+3. **`normalizeRelativePosix`**: separator swap only (`\` → `/`); no
+   dot-segment handling, no case folding. Containment is enforced
+   separately by `resolveSyncBackSource` → `isPathWithinRoot` via
+   `path.resolve` — a fourth containment check distinct from §6.
+
+Risk assessment: none of these touch scope paths today, so they cannot cause
+an authorization divergence. The exposure is **vocabulary drift** — a future
+change that forwards a mount pattern into a scope path (or vice versa) would
+silently change meaning. Verdict: leave the grammars as they are (they serve
+different inputs), keep them out of the contract, and treat any future
+crossing of the boundary as a contract-change event requiring fixtures.

--- a/contract/fixtures/auth-matching.json
+++ b/contract/fixtures/auth-matching.json
@@ -11,6 +11,22 @@
       "expect": { "auth_matches": true }
     },
     {
+      "name": "root-scope-path-matches-only-root-node",
+      "description": "\"/\" is an exact path like any other: it matches the root node and nothing else. It is NOT a whole-tree grant — compare star-scope-path and /** cases.",
+      "scopes": ["relayfile:fs:read:/"],
+      "required": "fs:read",
+      "file": "/",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "root-scope-path-denies-everything-beneath-root",
+      "description": "Pins the / vs * asymmetry: both are valid with mounts_at \"/\", but / authorizes nothing beneath the root node. An author wanting the whole tree must write * or /**.",
+      "scopes": ["relayfile:fs:read:/"],
+      "required": "fs:read",
+      "file": "/a.json",
+      "expect": { "auth_matches": false }
+    },
+    {
       "name": "exact-path-grant-denies-other-file",
       "scopes": ["relayfile:fs:read:/src/app.ts"],
       "required": "fs:read",

--- a/contract/fixtures/auth-matching.json
+++ b/contract/fixtures/auth-matching.json
@@ -1,0 +1,258 @@
+{
+  "contract": "relayfile-path-contract",
+  "version": 1,
+  "area": "auth-matching",
+  "cases": [
+    {
+      "name": "exact-path-grant-matches-exact-file",
+      "scopes": ["relayfile:fs:read:/src/app.ts"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "exact-path-grant-denies-other-file",
+      "scopes": ["relayfile:fs:read:/src/app.ts"],
+      "required": "fs:read",
+      "file": "/.env",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "recursive-glob-matches-directory-node-itself",
+      "scopes": ["relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "/github",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "recursive-glob-matches-deep-descendant",
+      "scopes": ["relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "/github/repos/acme/cloud/issues/5.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "recursive-glob-denies-sibling-name-prefix",
+      "scopes": ["relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "/github2/x",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "descendant-glob-denies-directory-node-itself",
+      "description": "Unlike /**, /* excludes the directory node.",
+      "scopes": ["relayfile:fs:read:/github/*"],
+      "required": "fs:read",
+      "file": "/github",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "descendant-glob-matches-any-depth",
+      "description": "/* is an any-depth descendant match, NOT single-segment. Pins a known cross-impl disagreement candidate.",
+      "scopes": ["relayfile:fs:read:/github/*"],
+      "required": "fs:read",
+      "file": "/github/repos/acme/cloud/issues/5.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "prefix-glob-matches-raw-byte-prefix",
+      "scopes": ["relayfile:fs:read:/github/repos/acme-*"],
+      "required": "fs:read",
+      "file": "/github/repos/acme-cloud/issues/1.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "prefix-glob-denies-non-prefixed-sibling",
+      "scopes": ["relayfile:fs:read:/github/repos/acme-*"],
+      "required": "fs:read",
+      "file": "/github/repos/other/issues/1.json",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "prefix-glob-crosses-segment-boundary",
+      "description": "<name>* is a raw byte prefix: /github* matches /github itself and /github/x.",
+      "scopes": ["relayfile:fs:read:/github*"],
+      "required": "fs:read",
+      "file": "/github/x",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "mid-path-segment-globs-authorize-nothing",
+      "description": "THE production divergence (parent spec §2.1). Hosted TS currently allows this; the contract verdict is deny. An implementation returning true here fails the suite.",
+      "scopes": ["relayfile:fs:read:/github/repos/*/*/issues/**"],
+      "required": "fs:read",
+      "file": "/github/repos/acme/cloud/issues/5.json",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "mid-path-single-star-authorizes-nothing",
+      "scopes": ["relayfile:fs:read:/github/*/issues"],
+      "required": "fs:read",
+      "file": "/github/acme/issues",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "narrow-grant-suppresses-bare-literal-outside",
+      "description": "Bare fs:read + a narrow path grant = confined to the narrow grant.",
+      "scopes": ["fs:read", "relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "/slack/messages/thread-1.json",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "narrow-grant-with-bare-literal-allows-inside",
+      "scopes": ["fs:read", "relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "/github/repos/acme/cloud/issues/5.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "pure-bare-literal-is-full-access",
+      "scopes": ["fs:read"],
+      "required": "fs:read",
+      "file": "/anything/at/all.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "three-segment-grant-is-full-namespace",
+      "scopes": ["relayfile:fs:read"],
+      "required": "fs:read",
+      "file": "/slack/users/user-1.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "star-scope-path-allows-empty-required-path",
+      "scopes": ["relayfile:fs:read:*"],
+      "required": "fs:read",
+      "file": "",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "narrow-grant-denies-empty-required-path",
+      "scopes": ["relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "wildcard-action-matches-write",
+      "scopes": ["relayfile:fs:*:/src/**"],
+      "required": "fs:write",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "manage-implies-write",
+      "scopes": ["relayfile:fs:manage:/src/**"],
+      "required": "fs:write",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "manage-implies-read",
+      "scopes": ["relayfile:fs:manage:/src/**"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "read-does-not-imply-write",
+      "scopes": ["relayfile:fs:read:/src/**"],
+      "required": "fs:write",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "read-does-not-imply-manage",
+      "scopes": ["relayfile:fs:read:/src/**"],
+      "required": "fs:manage",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "wildcard-resource-matches",
+      "scopes": ["relayfile:*:read:/src/**"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "wildcard-plane-matches",
+      "scopes": ["*:fs:read:/src/**"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "foreign-plane-never-matches",
+      "scopes": ["relaycast:fs:read:/src/**"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "workspace-plane-second-segment-is-label-not-resource",
+      "scopes": ["workspace:pear-integrations-slack-channels-c123-messages:read:/slack/channels/c123/messages/**"],
+      "required": "fs:read",
+      "file": "/slack/channels/c123/messages/1710000000.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "workspace-plane-grant-denies-outside-subtree",
+      "scopes": ["workspace:mount-sponsor:read:/slack/messages/**"],
+      "required": "fs:read",
+      "file": "/slack/users/user-1.json",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "workspace-plane-three-segment-is-full-namespace",
+      "scopes": ["workspace:mount-sponsor:read"],
+      "required": "fs:read",
+      "file": "/github/repos/acme/cloud/issues/5.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "workspace-plane-applies-to-fs-only",
+      "scopes": ["workspace:mount-sponsor:read:/slack/**"],
+      "required": "search:read",
+      "file": "/slack/messages/thread-1.json",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "matching-is-case-sensitive",
+      "scopes": ["relayfile:fs:read:/GitHub/**"],
+      "required": "fs:read",
+      "file": "/github/x",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "required-file-path-is-whitespace-trimmed",
+      "scopes": ["relayfile:fs:read:/github/**"],
+      "required": "fs:read",
+      "file": "  /github/x  ",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "scope-path-is-whitespace-trimmed",
+      "scopes": ["relayfile:fs:read: /github/** "],
+      "required": "fs:read",
+      "file": "/github/x",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "two-segment-scope-is-opaque-literal-not-grant",
+      "description": "Scopes with <3 segments never act as path grants; they only match as exact literals of the requirement string.",
+      "scopes": ["fs:write"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "empty-scope-set-denies",
+      "scopes": [],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    }
+  ]
+}

--- a/contract/fixtures/containment.json
+++ b/contract/fixtures/containment.json
@@ -1,0 +1,19 @@
+{
+  "contract": "relayfile-path-contract",
+  "version": 1,
+  "area": "containment",
+  "cases": [
+    { "name": "root-contains-everything", "base": "/", "candidate": "/github/repos/acme/cloud/issues/5.json", "expect": { "contains": true } },
+    { "name": "root-contains-root", "base": "/", "candidate": "/", "expect": { "contains": true } },
+    { "name": "base-contains-itself", "base": "/github", "candidate": "/github", "expect": { "contains": true } },
+    { "name": "base-contains-deep-descendant", "base": "/github", "candidate": "/github/repos/acme/cloud", "expect": { "contains": true } },
+    { "name": "sibling-name-prefix-not-contained", "base": "/github", "candidate": "/github2", "expect": { "contains": false } },
+    { "name": "shorter-prefix-not-contained", "base": "/github", "candidate": "/gith", "expect": { "contains": false } },
+    { "name": "parent-not-contained-by-child", "base": "/a/b", "candidate": "/a", "expect": { "contains": false } },
+    { "name": "base-normalized-before-compare", "base": "github", "candidate": "/github/x", "expect": { "contains": true } },
+    { "name": "trailing-slash-base-normalized", "base": "/github/", "candidate": "/github/x", "expect": { "contains": true } },
+    { "name": "candidate-normalized-before-compare", "base": "/github", "candidate": "github/x/", "expect": { "contains": true } },
+    { "name": "case-sensitive", "base": "/github", "candidate": "/GitHub/x", "expect": { "contains": false } },
+    { "name": "unrelated-tree", "base": "/slack/messages", "candidate": "/github/repos/acme", "expect": { "contains": false } }
+  ]
+}

--- a/contract/fixtures/path-normalization.json
+++ b/contract/fixtures/path-normalization.json
@@ -1,0 +1,42 @@
+{
+  "contract": "relayfile-path-contract",
+  "version": 1,
+  "area": "path-normalization",
+  "cases": [
+    { "name": "empty-becomes-root", "path": "", "expect": { "normalized": "/" } },
+    { "name": "root-unchanged", "path": "/", "expect": { "normalized": "/" } },
+    { "name": "missing-leading-slash-added", "path": "github", "expect": { "normalized": "/github" } },
+    { "name": "relative-multi-segment", "path": "a/b", "expect": { "normalized": "/a/b" } },
+    { "name": "canonical-unchanged", "path": "/github/repos/acme/cloud/issues/5.json", "expect": { "normalized": "/github/repos/acme/cloud/issues/5.json" } },
+    { "name": "single-trailing-slash-trimmed", "path": "/github/", "expect": { "normalized": "/github" } },
+    { "name": "relative-with-trailing-slash", "path": "a/b/", "expect": { "normalized": "/a/b" } },
+    {
+      "name": "double-trailing-slash-trims-one",
+      "path": "/a//",
+      "quirk": true,
+      "description": "Only one trailing slash is trimmed. Pinned current behavior; candidate for a v2 tightening.",
+      "expect": { "normalized": "/a/" }
+    },
+    {
+      "name": "dot-dot-segment-preserved",
+      "path": "/a/../b",
+      "quirk": true,
+      "description": "Dot segments are literal segment names in the virtual namespace; they are not collapsed and cannot alias another path.",
+      "expect": { "normalized": "/a/../b" }
+    },
+    {
+      "name": "dot-segment-preserved",
+      "path": "/a/./b",
+      "quirk": true,
+      "expect": { "normalized": "/a/./b" }
+    },
+    {
+      "name": "interior-double-slash-preserved",
+      "path": "/a//b",
+      "quirk": true,
+      "description": "Interior empty segments survive normalization; such paths are non-canonical distinct keys.",
+      "expect": { "normalized": "/a//b" }
+    },
+    { "name": "case-preserved", "path": "/GitHub/Repos", "expect": { "normalized": "/GitHub/Repos" } }
+  ]
+}

--- a/contract/fixtures/scope-paths.json
+++ b/contract/fixtures/scope-paths.json
@@ -4,7 +4,12 @@
   "area": "scope-paths",
   "cases": [
     { "name": "star-is-valid", "scope_path": "*", "expect": { "valid": true, "mounts_at": "/" } },
-    { "name": "root-is-valid", "scope_path": "/", "expect": { "valid": true, "mounts_at": "/" } },
+    {
+      "name": "root-is-valid-but-exact-only",
+      "scope_path": "/",
+      "description": "\"/\" is a valid EXACT path: it authorizes only the root node itself, nothing beneath it. Whole-namespace access is \"*\" (or \"/**\"). See auth-matching root-scope-* cases and README §5.1.",
+      "expect": { "valid": true, "mounts_at": "/" }
+    },
     { "name": "exact-path-valid", "scope_path": "/github/repos/acme/cloud/issues/5.json", "expect": { "valid": true, "mounts_at": "/github/repos/acme/cloud/issues/5.json" } },
     { "name": "recursive-glob-valid", "scope_path": "/github/**", "expect": { "valid": true, "mounts_at": "/github" } },
     { "name": "root-recursive-glob-valid", "scope_path": "/**", "expect": { "valid": true, "mounts_at": "/" } },

--- a/contract/fixtures/scope-paths.json
+++ b/contract/fixtures/scope-paths.json
@@ -1,0 +1,100 @@
+{
+  "contract": "relayfile-path-contract",
+  "version": 1,
+  "area": "scope-paths",
+  "cases": [
+    { "name": "star-is-valid", "scope_path": "*", "expect": { "valid": true, "mounts_at": "/" } },
+    { "name": "root-is-valid", "scope_path": "/", "expect": { "valid": true, "mounts_at": "/" } },
+    { "name": "exact-path-valid", "scope_path": "/github/repos/acme/cloud/issues/5.json", "expect": { "valid": true, "mounts_at": "/github/repos/acme/cloud/issues/5.json" } },
+    { "name": "recursive-glob-valid", "scope_path": "/github/**", "expect": { "valid": true, "mounts_at": "/github" } },
+    { "name": "root-recursive-glob-valid", "scope_path": "/**", "expect": { "valid": true, "mounts_at": "/" } },
+    { "name": "descendant-glob-valid", "scope_path": "/github/*", "expect": { "valid": true, "mounts_at": "/github" } },
+    { "name": "root-descendant-glob-valid", "scope_path": "/*", "expect": { "valid": true, "mounts_at": "/" } },
+    { "name": "deep-recursive-glob-valid", "scope_path": "/slack/channels/c123/messages/**", "expect": { "valid": true, "mounts_at": "/slack/channels/c123/messages" } },
+    { "name": "prefix-glob-valid", "scope_path": "/github/repos/acme-*", "expect": { "valid": true, "mounts_at": "/github/repos" } },
+    { "name": "top-level-prefix-glob-mounts-at-root", "scope_path": "/github*", "expect": { "valid": true, "mounts_at": "/" } },
+    {
+      "name": "mid-path-segment-globs-invalid",
+      "scope_path": "/github/repos/*/*/issues/**",
+      "description": "THE production divergence (parent spec §2.1): cloud emits this scope; hosted TS matches it, OSS Go does not. Invalid under the contract — a token carrying only this scope authorizes nothing.",
+      "probe_files": [
+        "/github/repos/acme/cloud/issues/5.json",
+        "/github/repos/acme/cloud/issues",
+        "/github/repos"
+      ],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "mid-path-single-star-invalid",
+      "scope_path": "/github/*/issues",
+      "probe_files": ["/github/acme/issues", "/github/acme/issues/5.json"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "mid-path-double-star-invalid",
+      "scope_path": "/github/**/issues",
+      "probe_files": ["/github/acme/issues", "/github/a/b/issues"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "star-inside-segment-invalid",
+      "scope_path": "/git*hub/repos",
+      "probe_files": ["/github/repos", "/gitXhub/repos"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "star-mid-final-segment-invalid",
+      "scope_path": "/github/re*po",
+      "probe_files": ["/github/repo", "/github/reXpo"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "double-star-suffix-of-name-invalid",
+      "scope_path": "/github/x**",
+      "probe_files": ["/github/x", "/github/xy", "/github/x/y"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "missing-leading-slash-invalid",
+      "scope_path": "github/**",
+      "probe_files": ["/github/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "bare-double-star-invalid",
+      "scope_path": "**",
+      "probe_files": ["/github/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "empty-segment-invalid",
+      "scope_path": "/github//repos/**",
+      "probe_files": ["/github/repos/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "trailing-slash-invalid",
+      "scope_path": "/github/",
+      "probe_files": ["/github/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "dot-dot-segment-invalid",
+      "scope_path": "/github/../secrets/**",
+      "probe_files": ["/secrets/key.json"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "dot-segment-invalid",
+      "scope_path": "/github/./repos/**",
+      "probe_files": ["/github/repos/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    },
+    {
+      "name": "empty-scope-path-invalid",
+      "scope_path": "",
+      "probe_files": ["/github/x"],
+      "expect": { "valid": false, "mounts_at": null }
+    }
+  ]
+}

--- a/internal/httpapi/contract_fixtures_test.go
+++ b/internal/httpapi/contract_fixtures_test.go
@@ -1,0 +1,128 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Fixture-driven conformance tests for the Relayfile Path Contract v1
+// (contract/README.md). The fixtures under contract/fixtures/ are
+// language-neutral; this runner executes the scope-path and auth-matching
+// areas against the real enforcement functions in auth.go and the grammar
+// reference in path_contract.go.
+
+type contractFixtureFile[T any] struct {
+	Contract string `json:"contract"`
+	Version  int    `json:"version"`
+	Area     string `json:"area"`
+	Cases    []T    `json:"cases"`
+}
+
+func loadContractFixtures[T any](t *testing.T, name, wantArea string) []T {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "contract", "fixtures", name))
+	if err != nil {
+		t.Fatalf("read fixture file %s: %v", name, err)
+	}
+	var file contractFixtureFile[T]
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parse fixture file %s: %v", name, err)
+	}
+	if file.Contract != "relayfile-path-contract" || file.Version != 1 || file.Area != wantArea {
+		t.Fatalf(
+			"fixture file %s header = (%q, %d, %q), want (\"relayfile-path-contract\", 1, %q)",
+			name, file.Contract, file.Version, file.Area, wantArea,
+		)
+	}
+	if len(file.Cases) == 0 {
+		t.Fatalf("fixture file %s has no cases", name)
+	}
+	return file.Cases
+}
+
+func TestContractFixturesScopePaths(t *testing.T) {
+	t.Parallel()
+
+	type scopePathCase struct {
+		Name       string   `json:"name"`
+		ScopePath  string   `json:"scope_path"`
+		ProbeFiles []string `json:"probe_files"`
+		Expect     struct {
+			Valid    bool    `json:"valid"`
+			MountsAt *string `json:"mounts_at"`
+		} `json:"expect"`
+	}
+
+	for _, tt := range loadContractFixtures[scopePathCase](t, "scope-paths.json", "scope-paths") {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := scopePathValid(tt.ScopePath); got != tt.Expect.Valid {
+				t.Fatalf("scopePathValid(%q) = %v, want %v", tt.ScopePath, got, tt.Expect.Valid)
+			}
+
+			root, ok := scopePathMountRoot(tt.ScopePath)
+			if tt.Expect.MountsAt == nil {
+				if ok {
+					t.Fatalf("scopePathMountRoot(%q) = (%q, true), want no mount root", tt.ScopePath, root)
+				}
+			} else if !ok || root != *tt.Expect.MountsAt {
+				t.Fatalf(
+					"scopePathMountRoot(%q) = (%q, %v), want (%q, true)",
+					tt.ScopePath, root, ok, *tt.Expect.MountsAt,
+				)
+			}
+
+			// Invalid scope paths must never match a canonical file path.
+			// This is the fence that fails an implementation whose matcher
+			// accepts mid-path globs, even if it skips validity checks.
+			if !tt.Expect.Valid {
+				for _, probe := range tt.ProbeFiles {
+					if scopePathMatches(tt.ScopePath, probe) {
+						t.Fatalf(
+							"scopePathMatches(%q, %q) = true, want false for invalid scope path",
+							tt.ScopePath, probe,
+						)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestContractFixturesAuthMatching(t *testing.T) {
+	t.Parallel()
+
+	type authCase struct {
+		Name     string   `json:"name"`
+		Scopes   []string `json:"scopes"`
+		Required string   `json:"required"`
+		File     string   `json:"file"`
+		Expect   struct {
+			AuthMatches bool `json:"auth_matches"`
+		} `json:"expect"`
+	}
+
+	for _, tt := range loadContractFixtures[authCase](t, "auth-matching.json", "auth-matching") {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			granted := map[string]struct{}{}
+			for _, scope := range tt.Scopes {
+				granted[scope] = struct{}{}
+			}
+			got := scopeMatchesPath(granted, tt.Required, tt.File)
+			if got != tt.Expect.AuthMatches {
+				t.Fatalf(
+					"scopeMatchesPath(%v, %q, %q) = %v, want %v",
+					tt.Scopes, tt.Required, tt.File, got, tt.Expect.AuthMatches,
+				)
+			}
+		})
+	}
+}

--- a/internal/httpapi/path_contract.go
+++ b/internal/httpapi/path_contract.go
@@ -1,0 +1,77 @@
+package httpapi
+
+import "strings"
+
+// This file codifies the scope-path grammar defined in contract/README.md
+// (Relayfile Path Contract v1). The grammar is exactly what scopePathMatches
+// enforces at runtime: suffix globs only. These helpers are the reference
+// implementation for the `valid` and `mounts_at` fixture expectations; they
+// do not change any runtime verdict — an invalid scope path already matches
+// nothing, because its glob characters are treated as literal bytes.
+
+// scopePathValid reports whether a scope path conforms to the contract
+// grammar: the literal "*", or an absolute path whose segments are non-empty,
+// are not "." or "..", and where "*" appears only in the final segment as
+// exactly "*", exactly "**", or a single trailing "*" on a non-empty name.
+func scopePathValid(scopePath string) bool {
+	if scopePath == "*" {
+		return true
+	}
+	if !strings.HasPrefix(scopePath, "/") {
+		return false
+	}
+	if scopePath == "/" {
+		return true
+	}
+	segments := strings.Split(scopePath[1:], "/")
+	for i, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+		if i != len(segments)-1 {
+			if strings.Contains(segment, "*") {
+				return false
+			}
+			continue
+		}
+		switch {
+		case !strings.Contains(segment, "*"):
+		case segment == "*" || segment == "**":
+		case strings.Count(segment, "*") == 1 && strings.HasSuffix(segment, "*"):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// scopePathMountRoot returns the deepest concrete directory implied by a
+// valid scope path — where a mount client may anchor the grant locally.
+// Invalid scope paths have no mount root; callers must surface that as an
+// explicit error, never as a silently dropped path.
+func scopePathMountRoot(scopePath string) (string, bool) {
+	if !scopePathValid(scopePath) {
+		return "", false
+	}
+	if scopePath == "*" || scopePath == "/" {
+		return "/", true
+	}
+	switch {
+	case strings.HasSuffix(scopePath, "/**"):
+		return orRoot(strings.TrimSuffix(scopePath, "/**")), true
+	case strings.HasSuffix(scopePath, "/*"):
+		return orRoot(strings.TrimSuffix(scopePath, "/*")), true
+	case strings.HasSuffix(scopePath, "*"):
+		prefix := strings.TrimSuffix(scopePath, "*")
+		return orRoot(prefix[:strings.LastIndex(prefix, "/")]), true
+	default:
+		return scopePath, true
+	}
+}
+
+func orRoot(dir string) string {
+	if dir == "" {
+		return "/"
+	}
+	return dir
+}

--- a/internal/relayfile/contract_fixtures_test.go
+++ b/internal/relayfile/contract_fixtures_test.go
@@ -1,0 +1,90 @@
+package relayfile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Fixture-driven conformance tests for the Relayfile Path Contract v1
+// (contract/README.md): the path-normalization and containment areas run
+// against the store's normalizePath and withinBase, the contract's
+// reference implementations.
+
+type pathContractFixtureFile[T any] struct {
+	Contract string `json:"contract"`
+	Version  int    `json:"version"`
+	Area     string `json:"area"`
+	Cases    []T    `json:"cases"`
+}
+
+func loadPathContractFixtures[T any](t *testing.T, name, wantArea string) []T {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "contract", "fixtures", name))
+	if err != nil {
+		t.Fatalf("read fixture file %s: %v", name, err)
+	}
+	var file pathContractFixtureFile[T]
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("parse fixture file %s: %v", name, err)
+	}
+	if file.Contract != "relayfile-path-contract" || file.Version != 1 || file.Area != wantArea {
+		t.Fatalf(
+			"fixture file %s header = (%q, %d, %q), want (\"relayfile-path-contract\", 1, %q)",
+			name, file.Contract, file.Version, file.Area, wantArea,
+		)
+	}
+	if len(file.Cases) == 0 {
+		t.Fatalf("fixture file %s has no cases", name)
+	}
+	return file.Cases
+}
+
+func TestContractFixturesPathNormalization(t *testing.T) {
+	t.Parallel()
+
+	type normalizationCase struct {
+		Name   string `json:"name"`
+		Path   string `json:"path"`
+		Expect struct {
+			Normalized string `json:"normalized"`
+		} `json:"expect"`
+	}
+
+	for _, tt := range loadPathContractFixtures[normalizationCase](t, "path-normalization.json", "path-normalization") {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizePath(tt.Path); got != tt.Expect.Normalized {
+				t.Fatalf("normalizePath(%q) = %q, want %q", tt.Path, got, tt.Expect.Normalized)
+			}
+		})
+	}
+}
+
+func TestContractFixturesContainment(t *testing.T) {
+	t.Parallel()
+
+	type containmentCase struct {
+		Name      string `json:"name"`
+		Base      string `json:"base"`
+		Candidate string `json:"candidate"`
+		Expect    struct {
+			Contains bool `json:"contains"`
+		} `json:"expect"`
+	}
+
+	for _, tt := range loadPathContractFixtures[containmentCase](t, "containment.json", "containment") {
+		tt := tt
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := withinBase(tt.Base, tt.Candidate); got != tt.Expect.Contains {
+				t.Fatalf("withinBase(%q, %q) = %v, want %v", tt.Base, tt.Candidate, got, tt.Expect.Contains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 1 of the path-contract stabilization plan (`cloud/specs/relayfile-path-contract-stabilization.md`). Per the operator ruling (2026-07-18), **this repo owns the path contract**; this PR documents and fences the grammar exactly as `internal/httpapi/auth.go` already enforces it. **No runtime verdict changes** — the fixture suite passes against unmodified enforcement code.

- **`contract/README.md`** — the authoritative v1 grammar: canonical file paths, normalization (quirks pinned + flagged), scope grammar (`plane:resource:action[:path]`), suffix-glob matching semantics, grant-set matching incl. narrow-grant precedence, containment, and `mounts_at` derivation. Mid-path segment globs are **invalid**: `relayfile:fs:read:/github/repos/*/*/issues/**` (the scope hosted cloud emits today) authorizes nothing under the contract.
- **`contract/fixtures/*.json`** — language-neutral conformance fixtures (`path-normalization`, `containment`, `scope-paths`, `auth-matching`; 58 cases). Invalid scope paths assert `valid: false` **and** carry `probe_files` that must not match — so an implementation whose matcher *accepts* a mid-path glob fails the suite even if it skips validity checks. The live hosted/OSS divergence case is pinned verbatim.
- **`internal/httpapi/path_contract.go`** — reference `scopePathValid` / `scopePathMountRoot` (grammar codification only).
- **Fixture runners** in `internal/httpapi` and `internal/relayfile` execute the fixtures against the real `scopeMatchesPath` / `scopePathMatches` / `normalizePath` / `withinBase`.
- **`make contract-test`** — named entry point; the suite also runs under plain `go test ./...`, so `ci.yml` / `contract.yml` already gate it.

Also includes the Phase 1 audit of `packages/local-mount/src/mount.ts` (README Appendix A): it holds three local-path theories (gitignore globs, ExcludeRules, `normalizeRelativePosix`) but never touches scope paths — no authorization exposure; the risk is vocabulary drift, flagged.

Prior art: cloud#989 (HTTP-level contract-test spec) — that suite remains the layer above; this PR is the path-vocabulary layer it depends on.

## Phase 2 consumers

`relayfile-cloud`, `relayauth`, `relayfile-adapters`, `cloud` run these fixtures and report divergence (expected red: relayfile-cloud too permissive, cloud emits invalid scopes). No fixture may be edited to make an implementation pass.

## Test plan

- `make contract-test` — green (60 httpapi subtests, 26 relayfile subtests)
- `go test ./internal/httpapi ./internal/relayfile` — green
- `go vet ./internal/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

