### PR TITLE
feat(contract): fixture cases for colon paths and empty scope-path segment

### DIFF
--- a/contract/fixtures/auth-matching.json
+++ b/contract/fixtures/auth-matching.json
@@ -256,6 +256,30 @@
       "expect": { "auth_matches": true }
     },
     {
+      "name": "colon-in-scope-path-is-preserved",
+      "description": "Scope splitting is SplitN(scope, \":\", 4): the path segment keeps any further colons (§4). Pins the truncating-split divergence found in hosted TS (String.split with a limit drops the remainder).",
+      "scopes": ["relayfile:fs:read:/a:b/**"],
+      "required": "fs:read",
+      "file": "/a:b/x.json",
+      "expect": { "auth_matches": true }
+    },
+    {
+      "name": "colon-in-scope-path-does-not-truncate-to-prefix",
+      "description": "A truncating split turns /a:b/** into the exact path /a; this case fails such an implementation.",
+      "scopes": ["relayfile:fs:read:/a:b/**"],
+      "required": "fs:read",
+      "file": "/a",
+      "expect": { "auth_matches": false }
+    },
+    {
+      "name": "empty-fourth-segment-is-a-narrow-grant-matching-nothing",
+      "description": "relayfile:fs:read: (trailing colon, empty scope path) is an invalid narrow grant: it matches no file and, being narrow, still suppresses nothing-else semantics — it must NOT be read as the 3-segment full-namespace form. Pins the hosted-TS empty-path-becomes-* divergence.",
+      "scopes": ["relayfile:fs:read:"],
+      "required": "fs:read",
+      "file": "/src/app.ts",
+      "expect": { "auth_matches": false }
+    },
+    {
       "name": "two-segment-scope-is-opaque-literal-not-grant",
       "description": "Scopes with <3 segments never act as path grants; they only match as exact literals of the requirement string.",
       "scopes": ["fs:write"],

--- a/contract/fixtures/scope-paths.json
+++ b/contract/fixtures/scope-paths.json
@@ -19,6 +19,12 @@
     { "name": "prefix-glob-valid", "scope_path": "/github/repos/acme-*", "expect": { "valid": true, "mounts_at": "/github/repos" } },
     { "name": "top-level-prefix-glob-mounts-at-root", "scope_path": "/github*", "expect": { "valid": true, "mounts_at": "/" } },
     {
+      "name": "colon-in-segment-valid",
+      "scope_path": "/a:b/**",
+      "description": "Colons are ordinary path bytes; only the first three colons of the scope string delimit segments (§4).",
+      "expect": { "valid": true, "mounts_at": "/a:b" }
+    },
+    {
       "name": "mid-path-segment-globs-invalid",
       "scope_path": "/github/repos/*/*/issues/**",
       "description": "THE production divergence (parent spec §2.1): cloud emits this scope; hosted TS matches it, OSS Go does not. Invalid under the contract — a token carrying only this scope authorizes nothing.",


### PR DESCRIPTION
## Summary

Adds the three fixture gaps identified by the Phase 2 divergence map (cloud#2738, §"Fixture-suite gaps"):

- **Colon-containing scope paths** (`/a:b/**`): pins §4's SplitN semantics. Hosted TS uses `String.split(":", 4)` which *drops* the remainder — the grant silently becomes the exact path `/a`. Two auth cases (must match `/a:b/x.json`, must not match `/a`) plus a scope-paths validity/mounts_at case fail any truncating implementation.
- **Empty fourth segment** (`relayfile:fs:read:`): pins that a trailing-colon scope is a narrow grant matching nothing. Hosted TS currently maps it to `*` — a full-namespace privilege hole. The fixture makes that a suite failure.

Additive v1 cases, no version bump. All pass against unmodified Go enforcement (`make contract-test` green) — behavior pinned, not changed.

The matching hosted-side fixes land separately in relayfile-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

