### PR TITLE
fix(mountsync): survive overlong mirror names

### DIFF
--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -413,6 +413,71 @@ func TestLegacyLongValidBasenameOutboxMigratesWithoutState(t *testing.T) {
 	}
 }
 
+func TestExistingExactSiblingDoesNotStealShortenedTrackedIdentity(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("remote-title-", 18) + "tracked.json"
+	if got := len(longBase); got <= maxLocalMirrorBasenameBytes || got > 255 {
+		t.Fatalf("test basename is %d bytes, want %d < length <= 255", got, maxLocalMirrorBasenameBytes)
+	}
+	remotePath := normalizeRemotePath("/reddit/posts/" + longBase)
+	shortenedPath, err := remoteToLocalPath(localRoot, "/", remotePath)
+	if err != nil {
+		t.Fatalf("map shortened mirror path: %v", err)
+	}
+	exactPath, err := remoteToLocalPathWithShortening(localRoot, "/", remotePath, false)
+	if err != nil {
+		t.Fatalf("map exact sibling path: %v", err)
+	}
+	for _, path := range []string{shortenedPath, exactPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create parent for %s: %v", path, err)
+		}
+	}
+	shortenedContent := []byte(`{"source":"remote"}`)
+	if err := os.WriteFile(shortenedPath, shortenedContent, 0o644); err != nil {
+		t.Fatalf("create shortened tracked mirror: %v", err)
+	}
+	if err := os.WriteFile(exactPath, []byte(`{"source":"local-sibling"}`), 0o644); err != nil {
+		t.Fatalf("create exact sibling: %v", err)
+	}
+
+	syncer, err := NewSyncer(&fakeClient{}, SyncerOptions{
+		WorkspaceID: "ws_long_exact_sibling",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	if err := syncer.loadState(); err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	syncer.state.Files[remotePath] = trackedFile{
+		Revision:    "rev_shortened_mirror",
+		ContentType: "application/json",
+		Hash:        hashBytes(shortenedContent),
+	}
+	if got, err := syncer.remoteToLocalPath(remotePath); err != nil {
+		t.Fatalf("map tracked remote path: %v", err)
+	} else if got != shortenedPath {
+		t.Fatalf("exact sibling stole shortened tracked identity: mapped=%q want=%q", got, shortenedPath)
+	}
+	localFiles, err := syncer.scanLocalFiles()
+	if err != nil {
+		t.Fatalf("scan local files: %v", err)
+	}
+	shortRel, err := filepath.Rel(localRoot, shortenedPath)
+	if err != nil {
+		t.Fatalf("shortened relative path: %v", err)
+	}
+	shortenedLiteralRemote := normalizeRemotePath("/" + filepath.ToSlash(shortRel))
+	if _, exists := localFiles[shortenedLiteralRemote]; exists && shortenedLiteralRemote != remotePath {
+		t.Fatalf("shortened mirror leaked as new cloud path %q", shortenedLiteralRemote)
+	}
+}
+
 func TestBootstrapSkipsOneUnmaterializablePathAndContinues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -2,6 +2,7 @@ package mountsync
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,6 +119,92 @@ func TestRemoteLongBasenameHashSuffixAvoidsPrefixCollisions(t *testing.T) {
 		if got := len([]byte(filepath.Base(localPath))); got > 255 {
 			t.Fatalf("local basename %s is %d bytes, want <= NAME_MAX (255)", label, got)
 		}
+	}
+}
+
+func TestLocallyCreatedLongValidBasenameKeepsIdentityAcrossReconcile(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("local-title-", 19) + "draft.json"
+	if got := len(longBase); got <= maxLocalMirrorBasenameBytes || got > 255 {
+		t.Fatalf("test basename is %d bytes, want %d < length <= 255", got, maxLocalMirrorBasenameBytes)
+	}
+	remotePath := normalizeRemotePath("/reddit/posts/" + longBase)
+	localPath := filepath.Join(localRoot, "reddit", "posts", longBase)
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("create local parent: %v", err)
+	}
+
+	client := &fakeClient{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_valid_name",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(`{"version":1}`), 0o644); err != nil {
+		t.Fatalf("create long valid local file: %v", err)
+	}
+	// The scan path derives the correct remote name from the local path, but
+	// must keep reading the original local identity instead of remapping the
+	// remote path through the mirror-shortening function.
+	if _, err := syncer.pushLocal(context.Background()); err != nil {
+		t.Fatalf("initial scan writeback remapped the user-created name: %v", err)
+	}
+	if got, ok := client.files[remotePath]; !ok {
+		t.Fatalf("initial writeback did not create exact remote path %q", remotePath)
+	} else if got.Content != `{"version":1}` {
+		t.Fatalf("initial scan writeback content = %q, want version 1", got.Content)
+	}
+
+	// Subsequent remote reconciliation must update the same user-created path
+	// rather than materializing a second hash-shortened sibling.
+	remoteUpdate := RemoteFile{
+		Path:        remotePath,
+		Revision:    "rev_remote_update",
+		ContentType: "application/json",
+		Content:     `{"version":3}`,
+	}
+	if err := syncer.applyRemoteFile(remotePath, remoteUpdate, nil); err != nil {
+		t.Fatalf("apply remote update to preserved local identity: %v", err)
+	}
+	if got, err := os.ReadFile(localPath); err != nil {
+		t.Fatalf("read preserved local path: %v", err)
+	} else if string(got) != remoteUpdate.Content {
+		t.Fatalf("preserved local content = %q, want %q", got, remoteUpdate.Content)
+	}
+	shortenedPath, err := remoteToLocalPath(localRoot, "/", remotePath)
+	if err != nil {
+		t.Fatalf("compute default shortened path: %v", err)
+	}
+	if shortenedPath == localPath {
+		t.Fatalf("test did not exercise a shortened default path")
+	}
+	if _, err := os.Stat(shortenedPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("reconcile created shortened sibling %q: %v", shortenedPath, err)
+	}
+
+	if err := syncer.saveState(); err != nil {
+		t.Fatalf("persist local identity mapping: %v", err)
+	}
+	restarted, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_valid_name",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("restart syncer: %v", err)
+	}
+	if err := restarted.loadState(); err != nil {
+		t.Fatalf("load persisted local identity mapping: %v", err)
+	}
+	if got, err := restarted.remoteToLocalPath(remotePath); err != nil {
+		t.Fatalf("map remote path after restart: %v", err)
+	} else if got != localPath {
+		t.Fatalf("remote path mapped to %q after restart, want preserved %q", got, localPath)
 	}
 }
 

--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -343,13 +343,28 @@ func TestExistingLongValidBasenameMigratesFromPrefixState(t *testing.T) {
 	if err := restarted.loadState(); err != nil {
 		t.Fatalf("load pre-fix state: %v", err)
 	}
+	remoteUpdate := RemoteFile{
+		Path:        remotePath,
+		Revision:    "rev_after_long_name_fix",
+		ContentType: "application/json",
+		Content:     `{"version":"upgraded"}`,
+	}
+	if err := restarted.applyRemoteFile(remotePath, remoteUpdate, nil); err != nil {
+		t.Fatalf("apply remote update while migrating pre-fix state: %v", err)
+	}
+	wantRel := filepath.ToSlash(filepath.Join("reddit", "posts", longBase))
+	if got := restarted.state.Files[remotePath].LocalRelativePath; got != wantRel {
+		t.Fatalf("remote apply overwrote migrated local identity = %q, want %q", got, wantRel)
+	}
 	if got, err := restarted.remoteToLocalPath(remotePath); err != nil {
 		t.Fatalf("map pre-fix tracked path: %v", err)
 	} else if got != localPath {
 		t.Fatalf("upgrade remapped existing local identity: mapped=%q want=%q", got, localPath)
 	}
-	if got := restarted.state.Files[remotePath].LocalRelativePath; got != filepath.ToSlash(filepath.Join("reddit", "posts", longBase)) {
-		t.Fatalf("migrated local identity = %q, want exact legacy relative path", got)
+	if got, err := os.ReadFile(localPath); err != nil {
+		t.Fatalf("read migrated local path after remote apply: %v", err)
+	} else if string(got) != remoteUpdate.Content {
+		t.Fatalf("migrated local content = %q, want %q", got, remoteUpdate.Content)
 	}
 }
 

--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -220,6 +220,199 @@ func TestLocallyCreatedLongValidBasenameKeepsIdentityAcrossReconcile(t *testing.
 	}
 }
 
+func TestLongValidBasenameOutboxIdentitySurvivesCrashBeforeStateSave(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("local-title-", 19) + "crash.json"
+	if got := len(longBase); got <= maxLocalMirrorBasenameBytes || got > 255 {
+		t.Fatalf("test basename is %d bytes, want %d < length <= 255", got, maxLocalMirrorBasenameBytes)
+	}
+	remotePath := normalizeRemotePath("/reddit/posts/" + longBase)
+	localPath := filepath.Join(localRoot, "reddit", "posts", longBase)
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("create local parent: %v", err)
+	}
+	content := []byte(`{"version":"crash"}`)
+	if err := os.WriteFile(localPath, content, 0o644); err != nil {
+		t.Fatalf("create long valid local file: %v", err)
+	}
+
+	client := &fakeClient{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_crash",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	if err := syncer.loadState(); err != nil {
+		t.Fatalf("load initial state: %v", err)
+	}
+	snapshot, err := readLocalSnapshot(localPath, true)
+	if err != nil {
+		t.Fatalf("read local snapshot: %v", err)
+	}
+	pending, err := syncer.preparePendingBulkWrite(context.Background(), remotePath, localPath, snapshot, trackedFile{}, false)
+	if err != nil || pending == nil {
+		t.Fatalf("prepare pending write: pending=%v err=%v", pending, err)
+	}
+	record, err := syncer.ensureOutboxRecord(*pending)
+	if err != nil {
+		t.Fatalf("persist durable outbox record: %v", err)
+	}
+	wantRel := filepath.ToSlash(filepath.Join("reddit", "posts", longBase))
+	if record.LocalRelativePath != wantRel {
+		t.Fatalf("durable outbox local identity = %q, want %q", record.LocalRelativePath, wantRel)
+	}
+	persisted, err := syncer.readOutboxRecord(syncer.pendingOutboxPath(record.CommandID))
+	if err != nil {
+		t.Fatalf("read durable outbox record: %v", err)
+	}
+	if persisted.LocalRelativePath != wantRel {
+		t.Fatalf("persisted outbox local identity = %q, want %q", persisted.LocalRelativePath, wantRel)
+	}
+	// Simulate a crash here: the outbox is durable, but the in-memory state
+	// containing LocalRelativePath has deliberately not been saved.
+	restarted, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_crash",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("restart syncer: %v", err)
+	}
+	if err := restarted.FlushOutboxOnce(context.Background()); err != nil {
+		t.Fatalf("flush durable outbox after crash: %v", err)
+	}
+	if got, err := restarted.remoteToLocalPath(remotePath); err != nil {
+		t.Fatalf("map remote path after durable retry: %v", err)
+	} else if got != localPath {
+		t.Fatalf("durable outbox retry lost local identity: mapped=%q want=%q", got, localPath)
+	}
+}
+
+func TestExistingLongValidBasenameMigratesFromPrefixState(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("legacy-title-", 18) + "upgrade.json"
+	if got := len(longBase); got <= maxLocalMirrorBasenameBytes || got > 255 {
+		t.Fatalf("test basename is %d bytes, want %d < length <= 255", got, maxLocalMirrorBasenameBytes)
+	}
+	remotePath := normalizeRemotePath("/reddit/posts/" + longBase)
+	localPath := filepath.Join(localRoot, "reddit", "posts", longBase)
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("create legacy local parent: %v", err)
+	}
+	content := []byte(`{"version":"legacy"}`)
+	if err := os.WriteFile(localPath, content, 0o644); err != nil {
+		t.Fatalf("create legacy long local file: %v", err)
+	}
+
+	client := &fakeClient{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_upgrade",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	if err := syncer.loadState(); err != nil {
+		t.Fatalf("load initial state: %v", err)
+	}
+	syncer.state.Files[remotePath] = trackedFile{
+		Revision:    "rev_before_long_name_fix",
+		ContentType: "application/json",
+		Hash:        hashBytes(content),
+	}
+	if err := syncer.saveState(); err != nil {
+		t.Fatalf("persist pre-fix state: %v", err)
+	}
+
+	restarted, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_upgrade",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("restart upgraded syncer: %v", err)
+	}
+	if err := restarted.loadState(); err != nil {
+		t.Fatalf("load pre-fix state: %v", err)
+	}
+	if got, err := restarted.remoteToLocalPath(remotePath); err != nil {
+		t.Fatalf("map pre-fix tracked path: %v", err)
+	} else if got != localPath {
+		t.Fatalf("upgrade remapped existing local identity: mapped=%q want=%q", got, localPath)
+	}
+	if got := restarted.state.Files[remotePath].LocalRelativePath; got != filepath.ToSlash(filepath.Join("reddit", "posts", longBase)) {
+		t.Fatalf("migrated local identity = %q, want exact legacy relative path", got)
+	}
+}
+
+func TestLegacyLongValidBasenameOutboxMigratesWithoutState(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("legacy-outbox-", 16) + "upgrade.json"
+	if got := len(longBase); got <= maxLocalMirrorBasenameBytes || got > 255 {
+		t.Fatalf("test basename is %d bytes, want %d < length <= 255", got, maxLocalMirrorBasenameBytes)
+	}
+	remotePath := normalizeRemotePath("/reddit/posts/" + longBase)
+	localPath := filepath.Join(localRoot, "reddit", "posts", longBase)
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		t.Fatalf("create legacy local parent: %v", err)
+	}
+	content := `{"version":"legacy-outbox"}`
+	if err := os.WriteFile(localPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("create legacy long local file: %v", err)
+	}
+
+	client := &fakeClient{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_legacy_outbox",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+	record := outboxRecord{
+		CommandID:     "mountcmd_legacy_long_name",
+		WorkspaceID:   "ws_local_long_legacy_outbox",
+		RemotePath:    remotePath,
+		ContentType:   "application/json",
+		Content:       content,
+		Hash:          hashBytes([]byte(content)),
+		Status:        outboxStatusPending,
+		FirstSeenAt:   "2026-06-11T12:00:00Z",
+		CorrelationID: "mountcmd_legacy_long_name",
+	}
+	if err := syncer.saveOutboxRecord(record); err != nil {
+		t.Fatalf("persist legacy outbox record: %v", err)
+	}
+
+	restarted, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_local_long_legacy_outbox",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("restart upgraded syncer: %v", err)
+	}
+	if err := restarted.FlushOutboxOnce(context.Background()); err != nil {
+		t.Fatalf("flush legacy outbox after upgrade: %v", err)
+	}
+	if got, err := restarted.remoteToLocalPath(remotePath); err != nil {
+		t.Fatalf("map legacy outbox path: %v", err)
+	} else if got != localPath {
+		t.Fatalf("legacy outbox remapped existing identity: mapped=%q want=%q", got, localPath)
+	}
+}
+
 func TestBootstrapSkipsOneUnmaterializablePathAndContinues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -159,6 +159,18 @@ func TestLocallyCreatedLongValidBasenameKeepsIdentityAcrossReconcile(t *testing.
 	} else if got.Content != `{"version":1}` {
 		t.Fatalf("initial scan writeback content = %q, want version 1", got.Content)
 	}
+	pendingRetry, err := syncer.outboxRecordAsPending(outboxRecord{
+		RemotePath:  remotePath,
+		ContentType: "application/json",
+		Content:     `{"version":1}`,
+		Hash:        hashBytes([]byte(`{"version":1}`)),
+	}, syncer.state.Files[remotePath], true)
+	if err != nil {
+		t.Fatalf("rebuild pending retry: %v", err)
+	}
+	if pendingRetry.localPath != localPath {
+		t.Fatalf("pending retry mapped to %q, want preserved %q", pendingRetry.localPath, localPath)
+	}
 
 	// Subsequent remote reconciliation must update the same user-created path
 	// rather than materializing a second hash-shortened sibling.

--- a/internal/mountsync/long_basename_test.go
+++ b/internal/mountsync/long_basename_test.go
@@ -1,0 +1,279 @@
+package mountsync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRemoteLongBasenameIsShortenedAndRoundTripsForWriteback(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	longBase := strings.Repeat("reddit-title-", 22) + "1uvwn9q.json"
+	if len(longBase) <= 255 {
+		t.Fatalf("test basename is only %d bytes; want > 255", len(longBase))
+	}
+	remotePath := "/reddit/subreddits/localllama/posts/" + longBase
+	client := &fakeClient{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_long_reddit_name",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	localPath, err := syncer.remoteToLocalPath(remotePath)
+	if err != nil {
+		t.Fatalf("remoteToLocalPath: %v", err)
+	}
+	if got := len([]byte(filepath.Base(localPath))); got > 255 {
+		t.Fatalf("local basename is %d bytes, want <= NAME_MAX (255): %q", got, filepath.Base(localPath))
+	}
+	localPathAgain, err := syncer.remoteToLocalPath(remotePath)
+	if err != nil {
+		t.Fatalf("second remoteToLocalPath: %v", err)
+	}
+	if localPathAgain != localPath {
+		t.Fatalf("long-name mapping is not deterministic: %q != %q", localPathAgain, localPath)
+	}
+
+	file := RemoteFile{
+		Path:        remotePath,
+		Revision:    "rev_reddit_long_name",
+		ContentType: "application/json",
+		Content:     `{"id":"1uvwn9q"}`,
+	}
+	if err := syncer.applyRemoteFile(remotePath, file, nil); err != nil {
+		t.Fatalf("applyRemoteFile(long basename): %v", err)
+	}
+	if got, err := os.ReadFile(localPath); err != nil {
+		t.Fatalf("read shortened local mirror: %v", err)
+	} else if string(got) != file.Content {
+		t.Fatalf("shortened local mirror content = %q, want %q", got, file.Content)
+	}
+
+	gotRemote, err := syncer.localPathToRemotePath(localPath, nil)
+	if err != nil {
+		t.Fatalf("localPathToRemotePath(shortened path): %v", err)
+	}
+	if gotRemote != remotePath {
+		t.Fatalf("writeback remote path = %q, want exact original %q", gotRemote, remotePath)
+	}
+	rel, err := filepath.Rel(localRoot, localPath)
+	if err != nil {
+		t.Fatalf("relative shortened path: %v", err)
+	}
+	if got := syncer.localRelativeToRemotePath(rel); got != remotePath {
+		t.Fatalf("watcher writeback remote path = %q, want exact original %q", got, remotePath)
+	}
+
+	// Exercise the real watcher/outbox writeback boundary, not only the path
+	// helpers: editing the shortened local file must update the original remote
+	// provider name and must never create a hash-shortened cloud path.
+	if err := syncer.saveState(); err != nil {
+		t.Fatalf("persist tracked long-name state: %v", err)
+	}
+	updated := `{"id":"1uvwn9q","edited":true}`
+	if err := os.WriteFile(localPath, []byte(updated), 0o644); err != nil {
+		t.Fatalf("edit shortened local mirror: %v", err)
+	}
+	if err := syncer.HandleLocalChange(context.Background(), filepath.ToSlash(rel), 0); err != nil {
+		t.Fatalf("write back shortened local mirror: %v", err)
+	}
+	if got := client.files[remotePath].Content; got != updated {
+		t.Fatalf("original remote path content = %q, want %q", got, updated)
+	}
+	shortRemote := normalizeRemotePath("/" + filepath.ToSlash(rel))
+	if shortRemote != remotePath {
+		if _, exists := client.files[shortRemote]; exists {
+			t.Fatalf("writeback created shortened remote path %q", shortRemote)
+		}
+	}
+}
+
+func TestRemoteLongBasenameHashSuffixAvoidsPrefixCollisions(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	prefix := strings.Repeat("same-reddit-title-", 18)
+	remoteA := "/reddit/posts/" + prefix + "a.json"
+	remoteB := "/reddit/posts/" + prefix + "b.json"
+	localA, err := remoteToLocalPath(localRoot, "/", remoteA)
+	if err != nil {
+		t.Fatalf("map A: %v", err)
+	}
+	localB, err := remoteToLocalPath(localRoot, "/", remoteB)
+	if err != nil {
+		t.Fatalf("map B: %v", err)
+	}
+	if filepath.Base(localA) == filepath.Base(localB) {
+		t.Fatalf("distinct long remote basenames collided at %q", filepath.Base(localA))
+	}
+	for label, localPath := range map[string]string{"A": localA, "B": localB} {
+		if got := len([]byte(filepath.Base(localPath))); got > 255 {
+			t.Fatalf("local basename %s is %d bytes, want <= NAME_MAX (255)", label, got)
+		}
+	}
+}
+
+func TestBootstrapSkipsOneUnmaterializablePathAndContinues(t *testing.T) {
+	t.Parallel()
+
+	localRoot := t.TempDir()
+	// Keep every component legal while making the total remote path just under
+	// MaxRemotePathLen. Adding the absolute temp-root prefix pushes the local
+	// mirror path over PATH_MAX on POSIX filesystems, deterministically yielding
+	// ENAMETOOLONG without relying on chmod behavior (which differs as root).
+	badPath := "/reddit"
+	for len(badPath)+len("/segment0123456789")+len("/pathological.json") < MaxRemotePathLen-8 {
+		badPath += "/segment0123456789"
+	}
+	badPath += "/pathological.json"
+	healthyPath := "/slack/channels/C1/messages/healthy.json"
+	client := &fakeClient{files: map[string]RemoteFile{
+		badPath: {
+			Path:        badPath,
+			Revision:    "rev_bad",
+			ContentType: "application/json",
+			Content:     `{"bad":true}`,
+		},
+		healthyPath: {
+			Path:        healthyPath,
+			Revision:    "rev_healthy",
+			ContentType: "application/json",
+			Content:     `{"ok":true}`,
+		},
+	}}
+	logger := &captureLogger{}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_skip_bad_local_path",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("bootstrap should skip one path-local failure and continue: %v", err)
+	}
+	if !syncer.state.BootstrapComplete {
+		t.Fatal("bootstrap did not complete after skipping one unmaterializable path")
+	}
+	if _, ok := syncer.state.SkippedMaterializations[badPath]; !ok {
+		t.Fatalf("skipped path %s was not durably queued for retry", badPath)
+	}
+	if err := syncer.saveStateWithoutLocalScan(); err != nil {
+		t.Fatalf("persist skipped-materialization queue: %v", err)
+	}
+	restarted, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_skip_bad_local_path",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+		Logger:      logger,
+	})
+	if err != nil {
+		t.Fatalf("new restarted syncer: %v", err)
+	}
+	if err := restarted.loadState(); err != nil {
+		t.Fatalf("load persisted skipped-materialization queue: %v", err)
+	}
+	if _, ok := restarted.state.SkippedMaterializations[badPath]; !ok {
+		t.Fatalf("skipped path %s was lost across process restart", badPath)
+	}
+	healthyLocal, err := syncer.remoteToLocalPath(healthyPath)
+	if err != nil {
+		t.Fatalf("map healthy path: %v", err)
+	}
+	if got, err := os.ReadFile(healthyLocal); err != nil {
+		t.Fatalf("healthy sibling was not mirrored: %v", err)
+	} else if string(got) != `{"ok":true}` {
+		t.Fatalf("healthy sibling content = %q", got)
+	}
+	if got := strings.Join(logger.lines, "\n"); !strings.Contains(got, "warning") ||
+		!strings.Contains(got, badPath) || !strings.Contains(got, "skipping") {
+		t.Fatalf("missing skip-and-continue warning for %s; logs:\n%s", badPath, got)
+	}
+}
+
+func TestSkippedMaterializationIsPersistedRetriedAndCleared(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission failure is not enforceable as root")
+	}
+
+	localRoot := t.TempDir()
+	blockedDir := filepath.Join(localRoot, "reddit", "posts")
+	if err := os.MkdirAll(blockedDir, 0o755); err != nil {
+		t.Fatalf("create blocked directory: %v", err)
+	}
+	if err := os.Chmod(blockedDir, 0o555); err != nil {
+		t.Fatalf("make directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blockedDir, 0o755) })
+
+	badPath := "/reddit/posts/temporarily-blocked.json"
+	healthyPath := "/slack/healthy.json"
+	client := &fakeClient{files: map[string]RemoteFile{
+		badPath: {
+			Path:        badPath,
+			Revision:    "rev_bad",
+			ContentType: "application/json",
+			Content:     `{"retry":true}`,
+		},
+		healthyPath: {
+			Path:        healthyPath,
+			Revision:    "rev_healthy",
+			ContentType: "application/json",
+			Content:     `{"ok":true}`,
+		},
+	}}
+	syncer, err := NewSyncer(client, SyncerOptions{
+		WorkspaceID: "ws_retry_skipped_materialization",
+		RemoteRoot:  "/",
+		LocalRoot:   localRoot,
+	})
+	if err != nil {
+		t.Fatalf("new syncer: %v", err)
+	}
+
+	if err := syncer.pullRemoteFullTree(context.Background(), nil, bootstrapProgress{}); err != nil {
+		t.Fatalf("bootstrap with one blocked file: %v", err)
+	}
+	if _, ok := syncer.state.SkippedMaterializations[badPath]; !ok {
+		t.Fatalf("blocked path %s was not persisted for retry", badPath)
+	}
+	if got := client.readFileCallsByPath[badPath]; got != 1 {
+		t.Fatalf("initial read count for blocked path = %d, want 1", got)
+	}
+
+	if err := os.Chmod(blockedDir, 0o755); err != nil {
+		t.Fatalf("unblock directory: %v", err)
+	}
+	// Make the normal event path a quiet fast-path. The only reason the remote
+	// file is read again must be the durable skipped-materialization retry.
+	syncer.state.EventsCursor = "evt_tip"
+	if err := syncer.pullRemote(context.Background(), nil); err != nil {
+		t.Fatalf("retry skipped materialization on quiet cycle: %v", err)
+	}
+	if _, ok := syncer.state.SkippedMaterializations[badPath]; ok {
+		t.Fatalf("successfully materialized path %s remained queued", badPath)
+	}
+	if got := client.readFileCallsByPath[badPath]; got != 2 {
+		t.Fatalf("read count after targeted retry = %d, want 2", got)
+	}
+	localPath, err := syncer.remoteToLocalPath(badPath)
+	if err != nil {
+		t.Fatalf("map retried path: %v", err)
+	}
+	if got, err := os.ReadFile(localPath); err != nil {
+		t.Fatalf("retried file was not materialized: %v", err)
+	} else if string(got) != `{"retry":true}` {
+		t.Fatalf("retried file content = %q", got)
+	}
+}

--- a/internal/mountsync/outbox.go
+++ b/internal/mountsync/outbox.go
@@ -31,26 +31,27 @@ const (
 )
 
 type outboxRecord struct {
-	CommandID      string       `json:"commandId"`
-	WorkspaceID    string       `json:"workspaceId"`
-	RemotePath     string       `json:"remotePath"`
-	ContentType    string       `json:"contentType"`
-	Content        string       `json:"content"`
-	Encoding       string       `json:"encoding,omitempty"`
-	Hash           string       `json:"hash"`
-	Exists         bool         `json:"exists"`
-	Status         outboxStatus `json:"status"`
-	FirstSeenAt    string       `json:"firstSeenAt"`
-	LastAttemptAt  string       `json:"lastAttemptAt,omitempty"`
-	NextAttemptAt  string       `json:"nextAttemptAt,omitempty"`
-	AttemptCount   int          `json:"attemptCount"`
-	LastError      string       `json:"lastError,omitempty"`
-	NeedsAttention bool         `json:"needsAttention,omitempty"`
-	OpID           string       `json:"opId,omitempty"`
-	DispatchStatus string       `json:"dispatchStatus,omitempty"`
-	AckedAt        string       `json:"ackedAt,omitempty"`
-	Revision       string       `json:"revision,omitempty"`
-	CorrelationID  string       `json:"correlationId,omitempty"`
+	CommandID         string       `json:"commandId"`
+	WorkspaceID       string       `json:"workspaceId"`
+	RemotePath        string       `json:"remotePath"`
+	ContentType       string       `json:"contentType"`
+	Content           string       `json:"content"`
+	Encoding          string       `json:"encoding,omitempty"`
+	Hash              string       `json:"hash"`
+	Exists            bool         `json:"exists"`
+	Status            outboxStatus `json:"status"`
+	FirstSeenAt       string       `json:"firstSeenAt"`
+	LastAttemptAt     string       `json:"lastAttemptAt,omitempty"`
+	NextAttemptAt     string       `json:"nextAttemptAt,omitempty"`
+	AttemptCount      int          `json:"attemptCount"`
+	LastError         string       `json:"lastError,omitempty"`
+	NeedsAttention    bool         `json:"needsAttention,omitempty"`
+	OpID              string       `json:"opId,omitempty"`
+	DispatchStatus    string       `json:"dispatchStatus,omitempty"`
+	AckedAt           string       `json:"ackedAt,omitempty"`
+	Revision          string       `json:"revision,omitempty"`
+	CorrelationID     string       `json:"correlationId,omitempty"`
+	LocalRelativePath string       `json:"localRelativePath,omitempty"`
 }
 
 type outboxSummary struct {
@@ -228,17 +229,18 @@ func (s *Syncer) ensureOutboxRecord(pending pendingBulkWrite) (outboxRecord, err
 	}
 	now := s.now().UTC().Format(time.RFC3339Nano)
 	record := outboxRecord{
-		CommandID:     newOutboxCommandID(s.workspace, pending.remotePath, pending.snapshot.Hash, now),
-		WorkspaceID:   s.workspace,
-		RemotePath:    pending.remotePath,
-		ContentType:   pending.snapshot.ContentType,
-		Content:       pending.snapshot.WireContent,
-		Encoding:      normalizeEncoding(pending.snapshot.Encoding),
-		Hash:          pending.snapshot.Hash,
-		Exists:        pending.exists,
-		Status:        outboxStatusPending,
-		FirstSeenAt:   now,
-		CorrelationID: "",
+		CommandID:         newOutboxCommandID(s.workspace, pending.remotePath, pending.snapshot.Hash, now),
+		WorkspaceID:       s.workspace,
+		RemotePath:        pending.remotePath,
+		ContentType:       pending.snapshot.ContentType,
+		Content:           pending.snapshot.WireContent,
+		Encoding:          normalizeEncoding(pending.snapshot.Encoding),
+		Hash:              pending.snapshot.Hash,
+		Exists:            pending.exists,
+		Status:            outboxStatusPending,
+		FirstSeenAt:       now,
+		CorrelationID:     "",
+		LocalRelativePath: pending.tracked.LocalRelativePath,
 	}
 	record.CorrelationID = record.CommandID
 	if err := s.saveOutboxRecord(record); err != nil {
@@ -417,7 +419,30 @@ func (s *Syncer) maxOutboxAttemptsValue() int {
 }
 
 func (s *Syncer) outboxRecordAsPending(record outboxRecord, tracked trackedFile, exists bool) (pendingBulkWrite, error) {
-	localPath, err := s.remoteToLocalPath(record.RemotePath)
+	var localPath string
+	var err error
+	if strings.TrimSpace(record.LocalRelativePath) != "" {
+		localPath, err = safeLocalPath(s.localRoot, record.LocalRelativePath)
+		if err == nil {
+			var mappedRemote string
+			mappedRemote, err = localToRemotePath(s.localRoot, s.remoteRoot, localPath)
+			if err == nil && normalizeRemotePath(mappedRemote) != normalizeRemotePath(record.RemotePath) {
+				err = fmt.Errorf("outbox local path %s maps to %s, want %s", record.LocalRelativePath, mappedRemote, record.RemotePath)
+			}
+		}
+		if err == nil && strings.TrimSpace(tracked.LocalRelativePath) == "" {
+			tracked.LocalRelativePath = filepath.ToSlash(record.LocalRelativePath)
+		}
+	} else {
+		if migratedPath, rel, found := s.existingPreShorteningLocalPath(record.RemotePath); found {
+			localPath = migratedPath
+			if strings.TrimSpace(tracked.LocalRelativePath) == "" {
+				tracked.LocalRelativePath = rel
+			}
+		} else {
+			localPath, err = s.remoteToLocalPath(record.RemotePath)
+		}
+	}
 	if err != nil {
 		return pendingBulkWrite{}, err
 	}

--- a/internal/mountsync/outbox.go
+++ b/internal/mountsync/outbox.go
@@ -416,8 +416,8 @@ func (s *Syncer) maxOutboxAttemptsValue() int {
 	return defaultOutboxMaxAttempts
 }
 
-func outboxRecordAsPending(record outboxRecord, localRoot, remoteRoot string, tracked trackedFile, exists bool) (pendingBulkWrite, error) {
-	localPath, err := remoteToLocalPath(localRoot, remoteRoot, record.RemotePath)
+func (s *Syncer) outboxRecordAsPending(record outboxRecord, tracked trackedFile, exists bool) (pendingBulkWrite, error) {
+	localPath, err := s.remoteToLocalPath(record.RemotePath)
 	if err != nil {
 		return pendingBulkWrite{}, err
 	}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1367,6 +1367,10 @@ type trackedFile struct {
 	Encoding    string `json:"encoding,omitempty"`
 	Hash        string `json:"hash"`
 	Dirty       bool   `json:"dirty,omitempty"`
+	// LocalRelativePath preserves the identity of a valid user-created local
+	// name when the mirror's conservative atomic-write limit would otherwise
+	// shorten it. Remote-origin names still use deterministic shortening.
+	LocalRelativePath string `json:"localRelativePath,omitempty"`
 	// DeletePending is set only by an observed local delete. A missing file
 	// during a scan is not enough evidence to delete cloud state.
 	DeletePending bool `json:"deletePending,omitempty"`
@@ -1396,6 +1400,7 @@ type localSnapshot struct {
 	ContentType   string
 	Encoding      string
 	Hash          string
+	LocalPath     string
 	SkipWriteback bool
 }
 
@@ -2077,6 +2082,7 @@ func (s *Syncer) preparePendingBulkWrite(
 	tracked trackedFile,
 	exists bool,
 ) (*pendingBulkWrite, error) {
+	tracked = s.trackLocalPathIdentity(remotePath, localPath, tracked)
 	// Shared choke point for both push paths: pushLocal (via scanLocalFiles)
 	// and the filesystem-watcher path (HandleLocalChange ->
 	// handleLocalWriteOrCreate -> pushSingleFile). The watcher path never
@@ -2541,12 +2547,13 @@ func (s *Syncer) reconcileBulkWrite(ctx context.Context, pendingWrite pendingBul
 	}
 	tracked.ContentType = contentType
 	s.state.Files[pendingWrite.remotePath] = trackedFile{
-		Revision:    revision,
-		ContentType: tracked.ContentType,
-		Encoding:    normalizeEncoding(pendingWrite.snapshot.Encoding),
-		Hash:        pendingWrite.snapshot.Hash,
-		Dirty:       false,
-		ReadOnly:    false,
+		Revision:          revision,
+		ContentType:       tracked.ContentType,
+		Encoding:          normalizeEncoding(pendingWrite.snapshot.Encoding),
+		Hash:              pendingWrite.snapshot.Hash,
+		Dirty:             false,
+		LocalRelativePath: tracked.LocalRelativePath,
+		ReadOnly:          false,
 	}
 	s.resolveConflictArtifacts(pendingWrite.remotePath)
 	return nil
@@ -2591,10 +2598,11 @@ func (s *Syncer) handleWriteError(
 				"agent does not have write permission; local copy preserved",
 			)
 			s.state.Files[remotePath] = trackedFile{
-				ContentType: snapshot.ContentType,
-				Hash:        snapshot.Hash,
-				WriteDenied: true,
-				DeniedHash:  snapshot.Hash,
+				ContentType:       snapshot.ContentType,
+				Hash:              snapshot.Hash,
+				LocalRelativePath: tracked.LocalRelativePath,
+				WriteDenied:       true,
+				DeniedHash:        snapshot.Hash,
 			}
 			return nil
 		}
@@ -2643,11 +2651,12 @@ func (s *Syncer) materializeConflict(ctx context.Context, remotePath, localPath 
 		contentType = snapshot.ContentType
 	}
 	s.state.Files[remotePath] = trackedFile{
-		Revision:    remoteFile.Revision,
-		ContentType: contentType,
-		Encoding:    normalizeEncoding(remoteFile.Encoding),
-		Hash:        hashBytes(remoteBytes),
-		ReadOnly:    !s.canWritePath(remotePath),
+		Revision:          remoteFile.Revision,
+		ContentType:       contentType,
+		Encoding:          normalizeEncoding(remoteFile.Encoding),
+		Hash:              hashBytes(remoteBytes),
+		LocalRelativePath: tracked.LocalRelativePath,
+		ReadOnly:          !s.canWritePath(remotePath),
 	}
 	s.logf("conflict at %s; local saved at %s", remotePath, artifactPath)
 	return nil
@@ -2711,13 +2720,13 @@ func (s *Syncer) materializeSchemaInvalid(
 		contentType = snapshot.ContentType
 	}
 	s.state.Files[remotePath] = trackedFile{
-		Revision:    remoteFile.Revision,
-		ContentType: contentType,
-		Encoding:    normalizeEncoding(remoteFile.Encoding),
-		Hash:        hashBytes(remoteBytes),
-		ReadOnly:    !s.canWritePath(remotePath),
+		Revision:          remoteFile.Revision,
+		ContentType:       contentType,
+		Encoding:          normalizeEncoding(remoteFile.Encoding),
+		Hash:              hashBytes(remoteBytes),
+		LocalRelativePath: tracked.LocalRelativePath,
+		ReadOnly:          !s.canWritePath(remotePath),
 	}
-	_ = tracked
 	s.logf("schema validation failed at %s (%s); local saved at %s, remote restored",
 		remotePath, violationDescription, artifactPath)
 	return nil
@@ -4567,7 +4576,8 @@ func (s *Syncer) trySkipBootstrapRead(remotePath string, entry TreeEntry) (bool,
 	if strings.TrimSpace(entry.ContentHash) == "" {
 		return false, nil
 	}
-	if tracked, ok := s.state.Files[remotePath]; ok {
+	tracked, ok := s.state.Files[remotePath]
+	if ok {
 		if tracked.Dirty || tracked.Denied {
 			return false, nil
 		}
@@ -4599,12 +4609,13 @@ func (s *Syncer) trySkipBootstrapRead(remotePath string, entry TreeEntry) (bool,
 		return false, err
 	}
 	s.state.Files[remotePath] = trackedFile{
-		Revision:    entry.Revision,
-		ContentType: snapshot.ContentType,
-		Hash:        snapshot.Hash,
-		Dirty:       false,
-		Denied:      false,
-		ReadOnly:    !canWrite,
+		Revision:          entry.Revision,
+		ContentType:       snapshot.ContentType,
+		Hash:              snapshot.Hash,
+		Dirty:             false,
+		LocalRelativePath: tracked.LocalRelativePath,
+		Denied:            false,
+		ReadOnly:          !canWrite,
 	}
 	s.clearSkippedMaterialization(remotePath)
 	return true, nil
@@ -5575,12 +5586,13 @@ func (s *Syncer) trySkipIncrementalRead(remotePath string, event FilesystemEvent
 		revision = tracked.Revision
 	}
 	s.state.Files[remotePath] = trackedFile{
-		Revision:    revision,
-		ContentType: snapshot.ContentType,
-		Hash:        snapshot.Hash,
-		Dirty:       false,
-		Denied:      false,
-		ReadOnly:    !canWrite,
+		Revision:          revision,
+		ContentType:       snapshot.ContentType,
+		Hash:              snapshot.Hash,
+		Dirty:             false,
+		LocalRelativePath: tracked.LocalRelativePath,
+		Denied:            false,
+		ReadOnly:          !canWrite,
 	}
 	s.clearSkippedMaterialization(remotePath)
 	return true, nil
@@ -5838,13 +5850,14 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	}
 	tracked.ReadOnly = !canWrite
 	s.state.Files[remotePath] = trackedFile{
-		Revision:    file.Revision,
-		ContentType: contentType,
-		Encoding:    normalizeEncoding(file.Encoding),
-		Hash:        remoteHash,
-		Dirty:       false,
-		Denied:      false,
-		ReadOnly:    !canWrite,
+		Revision:          file.Revision,
+		ContentType:       contentType,
+		Encoding:          normalizeEncoding(file.Encoding),
+		Hash:              remoteHash,
+		Dirty:             false,
+		LocalRelativePath: tracked.LocalRelativePath,
+		Denied:            false,
+		ReadOnly:          !canWrite,
 	}
 	materialized = true
 	return nil
@@ -6043,9 +6056,12 @@ func (s *Syncer) pushLocal(ctx context.Context) (map[string]struct{}, error) {
 	for _, remotePath := range localRemotePaths {
 		snapshot := localFiles[remotePath]
 		tracked, exists := s.state.Files[remotePath]
-		localPath, err := s.remoteToLocalPath(remotePath)
-		if err != nil {
-			return nil, err
+		localPath := snapshot.LocalPath
+		if strings.TrimSpace(localPath) == "" {
+			localPath, err = s.remoteToLocalPath(remotePath)
+			if err != nil {
+				return nil, err
+			}
 		}
 		canWrite := s.canWritePath(remotePath)
 		tracked.ReadOnly = !canWrite
@@ -7009,6 +7025,7 @@ func newLocalSnapshot(path string, data []byte) localSnapshot {
 		ContentType: contentType,
 		Encoding:    encoding,
 		Hash:        hashBytes(data),
+		LocalPath:   path,
 	}
 }
 
@@ -7032,6 +7049,7 @@ func readLocalSnapshot(path string, includeContent bool) (localSnapshot, error) 
 	return localSnapshot{
 		ContentType: detectContentType(path),
 		Hash:        hex.EncodeToString(h.Sum(nil)),
+		LocalPath:   path,
 	}, nil
 }
 
@@ -7244,12 +7262,49 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 }
 
 func (s *Syncer) remoteToLocalPath(remotePath string) (string, error) {
+	remotePath = normalizeRemotePath(remotePath)
+	if tracked, ok := s.state.Files[remotePath]; ok && strings.TrimSpace(tracked.LocalRelativePath) != "" {
+		localPath, err := safeLocalPath(s.localRoot, tracked.LocalRelativePath)
+		if err != nil {
+			return "", fmt.Errorf("invalid preserved local path for %s: %w", remotePath, err)
+		}
+		return localPath, nil
+	}
+	return s.defaultRemoteToLocalPath(remotePath)
+}
+
+func (s *Syncer) defaultRemoteToLocalPath(remotePath string) (string, error) {
 	if s.githubWorkingTree != nil {
 		if rel, ok := s.githubWorkingTree.remotePathToWorkingTreeRel(remotePath); ok {
 			return safeLocalPath(s.localRoot, rel)
 		}
 	}
 	return remoteToLocalPath(s.localRoot, s.remoteRoot, remotePath)
+}
+
+func (s *Syncer) trackLocalPathIdentity(remotePath, localPath string, tracked trackedFile) trackedFile {
+	if strings.TrimSpace(tracked.LocalRelativePath) != "" || s.githubWorkingTree != nil {
+		return tracked
+	}
+	defaultPath, err := s.defaultRemoteToLocalPath(remotePath)
+	if err != nil || filepath.Clean(defaultPath) == filepath.Clean(localPath) {
+		return tracked
+	}
+	mappedRemote, err := localToRemotePath(s.localRoot, s.remoteRoot, localPath)
+	if err != nil || normalizeRemotePath(mappedRemote) != normalizeRemotePath(remotePath) {
+		return tracked
+	}
+	rel, err := filepath.Rel(s.localRoot, localPath)
+	if err != nil {
+		return tracked
+	}
+	rel = filepath.ToSlash(rel)
+	resolved, err := safeLocalPath(s.localRoot, rel)
+	if err != nil || filepath.Clean(resolved) != filepath.Clean(localPath) {
+		return tracked
+	}
+	tracked.LocalRelativePath = rel
+	return tracked
 }
 
 func (s *Syncer) localPathToRemotePath(localPath string, githubPathIndex map[string]string) (string, error) {
@@ -7734,7 +7789,11 @@ func waitWithContext(ctx context.Context, delay time.Duration) error {
 // "..relayfile-mount-state.json.tmp-*", which the file watcher's
 // shouldSkip didn't recognize as internal.
 func atomicTempPattern(path string) string {
-	base := filepath.Base(path)
+	// A user-created basename may be valid at 221-255 bytes even though
+	// prefixing it and appending the randomized temp suffix would exceed the
+	// filesystem's NAME_MAX. The temp name does not participate in the Path
+	// Contract, so shorten only the disposable temp basename.
+	base := shortenLocalBasename(filepath.Base(path))
 	if !strings.HasPrefix(base, ".") {
 		base = "." + base
 	}

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -7216,6 +7216,10 @@ func remoteDescendantDepth(remoteRoot, remotePath string) int {
 }
 
 func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error) {
+	return remoteToLocalPathWithShortening(localRoot, remoteRoot, remotePath, true)
+}
+
+func remoteToLocalPathWithShortening(localRoot, remoteRoot, remotePath string, shorten bool) (string, error) {
 	localRoot = filepath.Clean(localRoot)
 	remoteRoot = normalizeRemotePath(remoteRoot)
 	remotePath = normalizeRemotePath(remotePath)
@@ -7242,7 +7246,9 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 	// deterministically for the mirror. The Syncer resolves the inverse from
 	// its persisted remote-path state before writeback, preserving the exact
 	// provider name rather than sending the shortened local representation.
-	rel = shortenLocalRelativePath(rel)
+	if shorten {
+		rel = shortenLocalRelativePath(rel)
+	}
 	joined := filepath.Join(localRoot, filepath.FromSlash(rel))
 	cleanJoined := filepath.Clean(joined)
 	// Data-loss guard: a remote path whose only relative component is the
@@ -7263,14 +7269,51 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 
 func (s *Syncer) remoteToLocalPath(remotePath string) (string, error) {
 	remotePath = normalizeRemotePath(remotePath)
-	if tracked, ok := s.state.Files[remotePath]; ok && strings.TrimSpace(tracked.LocalRelativePath) != "" {
-		localPath, err := safeLocalPath(s.localRoot, tracked.LocalRelativePath)
-		if err != nil {
-			return "", fmt.Errorf("invalid preserved local path for %s: %w", remotePath, err)
+	if tracked, ok := s.state.Files[remotePath]; ok {
+		if strings.TrimSpace(tracked.LocalRelativePath) != "" {
+			localPath, err := safeLocalPath(s.localRoot, tracked.LocalRelativePath)
+			if err != nil {
+				return "", fmt.Errorf("invalid preserved local path for %s: %w", remotePath, err)
+			}
+			return localPath, nil
 		}
-		return localPath, nil
+		if localPath, rel, found := s.existingPreShorteningLocalPath(remotePath); found {
+			tracked.LocalRelativePath = rel
+			s.state.Files[remotePath] = tracked
+			return localPath, nil
+		}
 	}
 	return s.defaultRemoteToLocalPath(remotePath)
+}
+
+func (s *Syncer) existingPreShorteningLocalPath(remotePath string) (string, string, bool) {
+	if s.githubWorkingTree != nil ||
+		!pathHasComponentLongerThan(remotePath, maxLocalMirrorBasenameBytes) ||
+		pathHasComponentLongerThan(remotePath, maxLocalFilesystemBasenameBytes) {
+		return "", "", false
+	}
+	localPath, err := remoteToLocalPathWithShortening(s.localRoot, s.remoteRoot, remotePath, false)
+	if err != nil {
+		return "", "", false
+	}
+	info, err := os.Lstat(localPath)
+	if err != nil || info.IsDir() {
+		return "", "", false
+	}
+	mappedRemote, err := localToRemotePath(s.localRoot, s.remoteRoot, localPath)
+	if err != nil || normalizeRemotePath(mappedRemote) != normalizeRemotePath(remotePath) {
+		return "", "", false
+	}
+	rel, err := filepath.Rel(s.localRoot, localPath)
+	if err != nil {
+		return "", "", false
+	}
+	rel = filepath.ToSlash(rel)
+	resolved, err := safeLocalPath(s.localRoot, rel)
+	if err != nil || filepath.Clean(resolved) != filepath.Clean(localPath) {
+		return "", "", false
+	}
+	return localPath, rel, true
 }
 
 func (s *Syncer) defaultRemoteToLocalPath(remotePath string) (string, error) {
@@ -7378,9 +7421,10 @@ const (
 	// POSIX NAME_MAX is commonly 255 bytes. Atomic mirror writes prepend a dot
 	// and append a randomized ".tmp-*" suffix, so leave ample headroom for the
 	// temporary basename as well as the final target.
-	maxLocalMirrorBasenameBytes = 220
-	localNameHashBytes          = 16
-	maxPreservedExtensionBytes  = 32
+	maxLocalMirrorBasenameBytes     = 220
+	maxLocalFilesystemBasenameBytes = 255
+	localNameHashBytes              = 16
+	maxPreservedExtensionBytes      = 32
 )
 
 func shortenLocalRelativePath(rel string) string {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -5780,6 +5780,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		if err != nil {
 			return nil
 		}
+		tracked.LocalRelativePath = s.state.Files[remotePath].LocalRelativePath
 		if err := s.assertNotMountRoot(localPath); err != nil {
 			s.logf("skipping remote file %s: %v", remotePath, err)
 			return nil
@@ -5798,6 +5799,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 	if err != nil {
 		return nil
 	}
+	tracked.LocalRelativePath = s.state.Files[remotePath].LocalRelativePath
 	if err := s.assertNotMountRoot(localPath); err != nil {
 		s.logf("skipping remote file %s: %v", remotePath, err)
 		return nil

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -7296,9 +7296,14 @@ func (s *Syncer) trackedRemotePathForLocalPath(localPath string) (string, bool) 
 	if !localPathMayContainShortenedName(want) {
 		return "", false
 	}
-	remotePaths := make([]string, 0, len(s.state.Files))
+	var remotePaths []string
 	for remotePath := range s.state.Files {
-		remotePaths = append(remotePaths, remotePath)
+		// Only a remote path with an overlong component can map to a local
+		// path containing the shortening marker. Avoid hashing every ordinary
+		// tracked file when one shortened path is written back.
+		if pathHasComponentLongerThan(remotePath, maxLocalMirrorBasenameBytes) {
+			remotePaths = append(remotePaths, remotePath)
+		}
 	}
 	sort.Strings(remotePaths)
 	for _, remotePath := range remotePaths {
@@ -7311,12 +7316,7 @@ func (s *Syncer) trackedRemotePathForLocalPath(localPath string) (string, bool) 
 }
 
 func localPathMayContainShortenedName(localPath string) bool {
-	for _, component := range strings.Split(filepath.ToSlash(localPath), "/") {
-		if strings.Contains(component, "~rf-") {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(localPath, "~rf-")
 }
 
 const (
@@ -7329,26 +7329,45 @@ const (
 )
 
 func shortenLocalRelativePath(rel string) string {
-	parts := strings.Split(filepath.ToSlash(rel), "/")
+	rel = filepath.ToSlash(rel)
+	if !pathHasComponentLongerThan(rel, maxLocalMirrorBasenameBytes) {
+		return rel
+	}
+	parts := strings.Split(rel, "/")
 	for i, part := range parts {
 		parts[i] = shortenLocalBasename(part)
 	}
 	return strings.Join(parts, "/")
 }
 
+func pathHasComponentLongerThan(path string, maxBytes int) bool {
+	componentBytes := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] == '/' {
+			if componentBytes > maxBytes {
+				return true
+			}
+			componentBytes = 0
+			continue
+		}
+		componentBytes++
+	}
+	return componentBytes > maxBytes
+}
+
 func shortenLocalBasename(base string) string {
-	if len([]byte(base)) <= maxLocalMirrorBasenameBytes {
+	if len(base) <= maxLocalMirrorBasenameBytes {
 		return base
 	}
 	sum := sha256.Sum256([]byte(base))
 	hashSuffix := "~rf-" + hex.EncodeToString(sum[:localNameHashBytes])
 	ext := filepath.Ext(base)
 	stem := strings.TrimSuffix(base, ext)
-	if stem == "" || len([]byte(ext)) > maxPreservedExtensionBytes {
+	if stem == "" || len(ext) > maxPreservedExtensionBytes {
 		ext = ""
 		stem = base
 	}
-	prefixBytes := maxLocalMirrorBasenameBytes - len(hashSuffix) - len([]byte(ext))
+	prefixBytes := maxLocalMirrorBasenameBytes - len(hashSuffix) - len(ext)
 	if prefixBytes < 0 {
 		prefixBytes = 0
 	}
@@ -7360,7 +7379,7 @@ func truncateValidUTF8(value string, maxBytes int) string {
 	if maxBytes <= 0 {
 		return ""
 	}
-	if len([]byte(value)) <= maxBytes {
+	if len(value) <= maxBytes {
 		return value
 	}
 	value = value[:maxBytes]

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -2270,7 +2270,7 @@ func (s *Syncer) flushOutboxRecordChunk(ctx context.Context, records []outboxRec
 
 	for _, record := range uploadRecords {
 		tracked, exists := s.state.Files[record.RemotePath]
-		pendingWrite, pendingErr := outboxRecordAsPending(record, s.localRoot, s.remoteRoot, tracked, exists)
+		pendingWrite, pendingErr := s.outboxRecordAsPending(record, tracked, exists)
 		if pendingErr != nil {
 			if firstErr == nil {
 				firstErr = pendingErr

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -1204,9 +1204,13 @@ type mountState struct {
 	// so the daemon does not re-fetch these paths from the cloud until the
 	// adapter emitting the collision is fixed. Cleared on bootstrap completion
 	// so a fixed adapter gets a clean slate on the next full cycle.
-	QuarantinedPaths         map[string]string `json:"quarantinedPaths,omitempty"`
-	SyncMode                 string            `json:"syncMode,omitempty"`
-	GithubWorkingTreeHeadSHA string            `json:"githubWorkingTreeHeadSha,omitempty"`
+	QuarantinedPaths map[string]string `json:"quarantinedPaths,omitempty"`
+	// SkippedMaterializations durably retains per-path local apply failures
+	// after the traversal cursor advances. Later cycles retry these paths
+	// directly, so skip-and-continue cannot turn into silent mirror data loss.
+	SkippedMaterializations  map[string]skippedMaterialization `json:"skippedMaterializations,omitempty"`
+	SyncMode                 string                            `json:"syncMode,omitempty"`
+	GithubWorkingTreeHeadSHA string                            `json:"githubWorkingTreeHeadSha,omitempty"`
 	// IncrementalReadNotReadySince records first-seen timestamps for
 	// incremental create/update events whose remote content was not readable
 	// yet. The daemon retries these without advancing EventsCursor until the
@@ -1228,11 +1232,16 @@ type incrementalCheckpoint struct {
 type telemetryCounters struct {
 	SkippedOversizeWriteback uint64 `json:"skippedOversizeWriteback,omitempty"`
 	DeniedRootTarget         uint64 `json:"deniedRootTarget,omitempty"`
-	SnapshotDeleteBlocked    uint64 `json:"snapshotDeleteBlocked,omitempty"`
-	CircuitOpenEvents        uint64 `json:"circuitOpenEvents,omitempty"`
-	TombstonesPending        uint64 `json:"tombstonesPending,omitempty"`
-	TombstonesConfirmed      uint64 `json:"tombstonesConfirmed,omitempty"`
-	TombstonesAgedOut        uint64 `json:"tombstonesAgedOut,omitempty"`
+	// PathMaterializationSkipped counts remote files that could not be
+	// represented at one local path (for example ENAMETOOLONG/ELOOP). These
+	// failures are isolated to the file so one pathological provider record
+	// cannot prevent bootstrap checkpoint progress for the rest of the mount.
+	PathMaterializationSkipped uint64 `json:"pathMaterializationSkipped,omitempty"`
+	SnapshotDeleteBlocked      uint64 `json:"snapshotDeleteBlocked,omitempty"`
+	CircuitOpenEvents          uint64 `json:"circuitOpenEvents,omitempty"`
+	TombstonesPending          uint64 `json:"tombstonesPending,omitempty"`
+	TombstonesConfirmed        uint64 `json:"tombstonesConfirmed,omitempty"`
+	TombstonesAgedOut          uint64 `json:"tombstonesAgedOut,omitempty"`
 	// PathCollisionQuarantined counts apply attempts skipped because a remote
 	// path could not be represented on the local filesystem — an ancestor
 	// component exists as a regular file (or the target is a directory). The
@@ -1291,6 +1300,65 @@ func isRemotePathCollision(err error) bool {
 	return errors.Is(err, syscall.ENOTDIR) ||
 		errors.Is(err, syscall.EISDIR) ||
 		errors.Is(err, os.ErrExist)
+}
+
+// isPathLocalMaterializationError reports failures caused by one local path's
+// representation or permissions. They differ from process/system failures
+// such as EMFILE or ENOSPC: retrying the same provider path cannot make them
+// succeed, while aborting the whole page prevents unrelated files from being
+// mirrored and wedges the bootstrap checkpoint forever.
+func isPathLocalMaterializationError(err error) bool {
+	return errors.Is(err, syscall.ENAMETOOLONG) ||
+		errors.Is(err, syscall.ELOOP) ||
+		errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EPERM) ||
+		errors.Is(err, syscall.EROFS)
+}
+
+func (s *Syncer) skipPathLocalMaterializationError(remotePath, operation string, err error) bool {
+	if !isPathLocalMaterializationError(err) {
+		return false
+	}
+	s.recordSkippedMaterialization(remotePath, operation, err)
+	s.state.Counters.PathMaterializationSkipped++
+	s.logf("warning: skipping remote file %s after local %s failed: %v; continuing sync cycle", normalizeRemotePath(remotePath), operation, err)
+	return true
+}
+
+func (s *Syncer) recordSkippedMaterialization(remotePath, operation string, err error) {
+	remotePath = normalizeRemotePath(remotePath)
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	if s.state.SkippedMaterializations == nil {
+		s.state.SkippedMaterializations = map[string]skippedMaterialization{}
+	}
+	record := s.state.SkippedMaterializations[remotePath]
+	if record.FirstSeenAt == "" {
+		record.FirstSeenAt = now
+	}
+	record.LastAttemptAt = now
+	record.AttemptCount++
+	record.Operation = strings.TrimSpace(operation)
+	record.LastError = sanitizeOutboxError(err)
+	s.state.SkippedMaterializations[remotePath] = record
+}
+
+func (s *Syncer) clearSkippedMaterialization(remotePath string) {
+	if s.state.SkippedMaterializations == nil {
+		return
+	}
+	delete(s.state.SkippedMaterializations, normalizeRemotePath(remotePath))
+	if len(s.state.SkippedMaterializations) == 0 {
+		s.state.SkippedMaterializations = nil
+	}
+}
+
+type skippedMaterialization struct {
+	Operation     string `json:"operation,omitempty"`
+	FirstSeenAt   string `json:"firstSeenAt"`
+	LastAttemptAt string `json:"lastAttemptAt"`
+	AttemptCount  int    `json:"attemptCount"`
+	LastError     string `json:"lastError"`
 }
 
 type trackedFile struct {
@@ -3297,7 +3365,74 @@ func (s *Syncer) outboxContext(parent context.Context) (context.Context, context
 	return context.WithTimeout(root, timeout)
 }
 
+// retrySkippedMaterializations revisits remote paths that a prior traversal
+// deliberately skipped after a path-local filesystem failure. The retry runs
+// before the normal events fast-path, so a quiet workspace still repairs the
+// mirror once the local obstruction disappears. Records survive cursor/page
+// advancement and process restart until materialization succeeds or the
+// remote file is authoritatively gone.
+func (s *Syncer) retrySkippedMaterializations(ctx context.Context, conflicted map[string]struct{}) error {
+	if len(s.state.SkippedMaterializations) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(s.state.SkippedMaterializations))
+	for remotePath := range s.state.SkippedMaterializations {
+		remotePath = normalizeRemotePath(remotePath)
+		if remotePath == "/" || !isUnderRemoteRoot(s.remoteRoot, remotePath) {
+			s.clearSkippedMaterialization(remotePath)
+			continue
+		}
+		paths = append(paths, remotePath)
+	}
+	sort.Strings(paths)
+	for _, remotePath := range paths {
+		if conflicted != nil {
+			if _, skip := conflicted[remotePath]; skip {
+				continue
+			}
+		}
+		var file RemoteFile
+		var err error
+		s.runReservedSyncIO(func() {
+			file, err = s.client.ReadFile(ctx, s.workspace, remotePath)
+		})
+		if err != nil {
+			if ctx.Err() != nil {
+				return err
+			}
+			var httpErr *HTTPError
+			if errors.As(err, &httpErr) {
+				switch httpErr.StatusCode {
+				case http.StatusNotFound:
+					s.logf("clearing skipped local materialization for deleted remote file %s", remotePath)
+					s.clearSkippedMaterialization(remotePath)
+					continue
+				case http.StatusForbidden:
+					if markErr := s.markReadDenied(remotePath); markErr != nil {
+						return markErr
+					}
+					s.clearSkippedMaterialization(remotePath)
+					continue
+				}
+			}
+			s.recordSkippedMaterialization(remotePath, "retry read", err)
+			s.logf("warning: deferred retry read for skipped remote file %s failed: %v; keeping it queued", remotePath, err)
+			continue
+		}
+		if err := s.applyRemoteFile(remotePath, file, conflicted); err != nil {
+			return err
+		}
+		if _, pending := s.state.SkippedMaterializations[remotePath]; !pending {
+			s.logf("recovered skipped local materialization for remote file %s", remotePath)
+		}
+	}
+	return nil
+}
+
 func (s *Syncer) pullRemote(ctx context.Context, conflicted map[string]struct{}) error {
+	if err := s.retrySkippedMaterializations(ctx, conflicted); err != nil {
+		return err
+	}
 	if s.state.EventsCursor != "" && !s.forceFullReconcile {
 		// Skip-if-no-events short-circuit. Most reconcile cycles on a
 		// quiet workspace have nothing to pull; turning that into a
@@ -4458,6 +4593,9 @@ func (s *Syncer) trySkipBootstrapRead(remotePath string, entry TreeEntry) (bool,
 	}
 	canWrite := s.canWritePath(remotePath)
 	if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
+		if s.skipPathLocalMaterializationError(remotePath, "permission update", err) {
+			return true, nil
+		}
 		return false, err
 	}
 	s.state.Files[remotePath] = trackedFile{
@@ -4468,6 +4606,7 @@ func (s *Syncer) trySkipBootstrapRead(remotePath string, entry TreeEntry) (bool,
 		Denied:      false,
 		ReadOnly:    !canWrite,
 	}
+	s.clearSkippedMaterialization(remotePath)
 	return true, nil
 }
 
@@ -5443,6 +5582,7 @@ func (s *Syncer) trySkipIncrementalRead(remotePath string, event FilesystemEvent
 		Denied:      false,
 		ReadOnly:    !canWrite,
 	}
+	s.clearSkippedMaterialization(remotePath)
 	return true, nil
 }
 
@@ -5595,9 +5735,13 @@ func cursorResolutionRetryDelay(timeout time.Duration, attempt int) time.Duratio
 }
 
 func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted map[string]struct{}) (err error) {
+	materialized := false
 	defer func() {
 		if err == nil {
 			s.clearIncrementalReadNotReady(remotePath)
+			if materialized {
+				s.clearSkippedMaterialization(remotePath)
+			}
 		}
 	}()
 	if s.skipMountRuntimeRemotePath(remotePath, conflicted) {
@@ -5629,9 +5773,13 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 			return nil
 		}
 		if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
+			if s.skipPathLocalMaterializationError(remotePath, "permission update", err) {
+				return nil
+			}
 			return err
 		}
 		s.state.Files[remotePath] = tracked
+		materialized = true
 		return nil
 	}
 	localPath, err := s.remoteToLocalPath(remotePath)
@@ -5653,6 +5801,9 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 			s.quarantineRemotePath(remotePath, "cannot create parent directory", err)
 			return nil
 		}
+		if s.skipPathLocalMaterializationError(remotePath, "parent directory creation", err) {
+			return nil
+		}
 		return err
 	}
 	remoteHash := hashBytes(remoteBytes)
@@ -5669,10 +5820,16 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 				s.quarantineRemotePath(remotePath, "cannot write file (target is a directory)", err)
 				return nil
 			}
+			if s.skipPathLocalMaterializationError(remotePath, "atomic write", err) {
+				return nil
+			}
 			return err
 		}
 	}
 	if err := s.applyLocalPermissions(localPath, canWrite); err != nil {
+		if s.skipPathLocalMaterializationError(remotePath, "permission update", err) {
+			return nil
+		}
 		return err
 	}
 	contentType := strings.TrimSpace(file.ContentType)
@@ -5689,6 +5846,7 @@ func (s *Syncer) applyRemoteFile(remotePath string, file RemoteFile, conflicted 
 		Denied:      false,
 		ReadOnly:    !canWrite,
 	}
+	materialized = true
 	return nil
 }
 
@@ -5834,6 +5992,9 @@ func (s *Syncer) applyRemoteDelete(remotePath string, conflicted map[string]stru
 			return nil
 		}
 	}
+	// An authoritative remote delete resolves any earlier local
+	// materialization failure even when the file was never tracked locally.
+	s.clearSkippedMaterialization(remotePath)
 	tracked, ok := s.state.Files[remotePath]
 	if !ok || tracked.Dirty {
 		return nil
@@ -7058,6 +7219,12 @@ func remoteToLocalPath(localRoot, remoteRoot, remotePath string) (string, error)
 	if strings.HasPrefix(relSlash, "../") || relSlash == ".." || strings.Contains(relSlash, "/../") {
 		return "", fmt.Errorf("path %s escapes local root", remotePath)
 	}
+	// A provider basename can exceed the local filesystem's NAME_MAX even when
+	// the full remote path is valid. Shorten each overlong component
+	// deterministically for the mirror. The Syncer resolves the inverse from
+	// its persisted remote-path state before writeback, preserving the exact
+	// provider name rather than sending the shortened local representation.
+	rel = shortenLocalRelativePath(rel)
 	joined := filepath.Join(localRoot, filepath.FromSlash(rel))
 	cleanJoined := filepath.Clean(joined)
 	// Data-loss guard: a remote path whose only relative component is the
@@ -7086,6 +7253,9 @@ func (s *Syncer) remoteToLocalPath(remotePath string) (string, error) {
 }
 
 func (s *Syncer) localPathToRemotePath(localPath string, githubPathIndex map[string]string) (string, error) {
+	if remotePath, ok := s.trackedRemotePathForLocalPath(localPath); ok {
+		return remotePath, nil
+	}
 	if s.githubWorkingTree != nil {
 		rel, err := RelativeRemotePathFromLocal(s.localRoot, localPath)
 		if err != nil {
@@ -7101,6 +7271,11 @@ func (s *Syncer) localPathToRemotePath(localPath string, githubPathIndex map[str
 
 func (s *Syncer) localRelativeToRemotePath(relativePath string) string {
 	relativePath = filepath.ToSlash(strings.TrimSpace(relativePath))
+	if localPath, err := safeLocalPath(s.localRoot, relativePath); err == nil {
+		if remotePath, ok := s.trackedRemotePathForLocalPath(localPath); ok {
+			return remotePath
+		}
+	}
 	if s.githubWorkingTree != nil {
 		if remotePath := s.githubRemotePathForWorkingTreeRel(relativePath, nil); remotePath != "" {
 			return remotePath
@@ -7108,6 +7283,91 @@ func (s *Syncer) localRelativeToRemotePath(relativePath string) string {
 		return s.githubWorkingTree.workingTreeRelToRemotePath(relativePath)
 	}
 	return normalizeRemotePath(filepath.Join(s.remoteRoot, filepath.FromSlash(relativePath)))
+}
+
+// trackedRemotePathForLocalPath reverses deterministic local-name shortening
+// through the persisted remote-path keys in mount state. There is no lossless
+// stateless encoding from an arbitrary >NAME_MAX basename into <=NAME_MAX
+// bytes; state is therefore the Path Contract's authoritative inverse. Sorting
+// keeps the result deterministic even in the astronomically unlikely event of
+// a truncated SHA-256 collision.
+func (s *Syncer) trackedRemotePathForLocalPath(localPath string) (string, bool) {
+	want := filepath.Clean(localPath)
+	if !localPathMayContainShortenedName(want) {
+		return "", false
+	}
+	remotePaths := make([]string, 0, len(s.state.Files))
+	for remotePath := range s.state.Files {
+		remotePaths = append(remotePaths, remotePath)
+	}
+	sort.Strings(remotePaths)
+	for _, remotePath := range remotePaths {
+		mapped, err := s.remoteToLocalPath(remotePath)
+		if err == nil && filepath.Clean(mapped) == want {
+			return remotePath, true
+		}
+	}
+	return "", false
+}
+
+func localPathMayContainShortenedName(localPath string) bool {
+	for _, component := range strings.Split(filepath.ToSlash(localPath), "/") {
+		if strings.Contains(component, "~rf-") {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	// POSIX NAME_MAX is commonly 255 bytes. Atomic mirror writes prepend a dot
+	// and append a randomized ".tmp-*" suffix, so leave ample headroom for the
+	// temporary basename as well as the final target.
+	maxLocalMirrorBasenameBytes = 220
+	localNameHashBytes          = 16
+	maxPreservedExtensionBytes  = 32
+)
+
+func shortenLocalRelativePath(rel string) string {
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	for i, part := range parts {
+		parts[i] = shortenLocalBasename(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func shortenLocalBasename(base string) string {
+	if len([]byte(base)) <= maxLocalMirrorBasenameBytes {
+		return base
+	}
+	sum := sha256.Sum256([]byte(base))
+	hashSuffix := "~rf-" + hex.EncodeToString(sum[:localNameHashBytes])
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(base, ext)
+	if stem == "" || len([]byte(ext)) > maxPreservedExtensionBytes {
+		ext = ""
+		stem = base
+	}
+	prefixBytes := maxLocalMirrorBasenameBytes - len(hashSuffix) - len([]byte(ext))
+	if prefixBytes < 0 {
+		prefixBytes = 0
+	}
+	prefix := truncateValidUTF8(stem, prefixBytes)
+	return prefix + hashSuffix + ext
+}
+
+func truncateValidUTF8(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len([]byte(value)) <= maxBytes {
+		return value
+	}
+	value = value[:maxBytes]
+	for value != "" && !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
 }
 
 func (s *Syncer) githubRemotePathForWorkingTreeRel(rel string, githubPathIndex map[string]string) string {

--- a/internal/mountsync/syncer.go
+++ b/internal/mountsync/syncer.go
@@ -7292,6 +7292,16 @@ func (s *Syncer) existingPreShorteningLocalPath(remotePath string) (string, stri
 		pathHasComponentLongerThan(remotePath, maxLocalFilesystemBasenameBytes) {
 		return "", "", false
 	}
+	// Migration is only unambiguous when the deterministic post-fix path is
+	// absent. If both names exist, keep the shortened mirror authoritative so
+	// it cannot reappear in a scan as a new literal remote path.
+	defaultPath, err := s.defaultRemoteToLocalPath(remotePath)
+	if err != nil {
+		return "", "", false
+	}
+	if _, err := os.Lstat(defaultPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return "", "", false
+	}
 	localPath, err := remoteToLocalPathWithShortening(s.localRoot, s.remoteRoot, remotePath, false)
 	if err != nil {
 		return "", "", false


### PR DESCRIPTION
## What changed

- deterministically shortens mirror path components that exceed the local atomic-write-safe basename budget using a truncated prefix plus a 128-bit SHA-256 suffix while preserving ordinary extensions
- resolves shortened local paths back to the exact tracked remote path before watcher and scan writeback
- treats path-local materialization failures such as `ENAMETOOLONG`, `ELOOP`, and permission/path representation errors as per-file skip-and-continue warnings
- durably records skipped materializations and retries them before the quiet-events fast path so cursor advancement cannot silently lose an unwritten file
- clears the durable retry only after successful materialization, an authoritative delete, or a 403/404 resolution

## Root cause

A Reddit record produced a 277-byte basename. Atomic mirror writes derive their temporary basename from the target, so `os.CreateTemp` failed deterministically with `ENAMETOOLONG`. The error escaped `applyRemoteFile`, aborted every bootstrap cycle, prevented checkpoint completion, and eventually triggered the bootstrap stall guard.

Simply swallowing the error would let the traversal cursor advance past unwritten data. This change therefore combines deterministic local shortening with a persisted targeted-retry queue for any remaining path-local failure.

## Impact

A single pathological provider path no longer stalls a healthy mount. Long names remain exact remotely: edits to a shortened local mirror write back to the original provider path, never the hashed local representation.

## Validation

- red tests captured 298/330-byte local basenames and bootstrap abort on `file name too long`
- focused long-name, collision, watcher/outbox round-trip, skip-and-continue, restart persistence, and quiet-cycle retry tests pass
- `go vet ./internal/mountsync`
- `go test ./internal/mountsync -count=1`
  - `ok github.com/agentworkforce/relayfile/internal/mountsync 111.113s`
- `go test ./... -count=1`
  - all Go packages pass; final mountsync line: `ok github.com/agentworkforce/relayfile/internal/mountsync 113.538s`

No HTTP handler or provider mutation path changed, so the OpenAPI and digest runtime contracts are unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

