### PR TITLE
feat: add feature catalog and proactive guardian

### DIFF
--- a/.agentworkforce/agents/relayfile-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/agent.test.ts
@@ -1,0 +1,524 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  CYCLE_STATE_PATH,
+  MAX_STATE_BYTES,
+  ProgressStateConflictError,
+  assertTransition,
+  classifyManifestDelta,
+  confirmedSlackReceipt,
+  createHttpProgressStore,
+  featureIdempotencyKey,
+  parseFeatures,
+  parseProgressContent,
+  parseProgressState,
+  pickNextFeature,
+  resolveManifestPath,
+  runGuardian,
+  type Feature,
+  type GuardianContext,
+  type ProgressSnapshot,
+  type ProgressState,
+  type ProgressStore,
+  type SlackTransport,
+} from './agent.ts';
+
+const manifestRaw = readFileSync(new URL('../../features/manifest.yaml', import.meta.url), 'utf8');
+const allFeatures = parseFeatures(manifestRaw);
+
+function features(): Feature[] {
+  return [
+    {
+      id: 'critical-one', name: 'Critical One', description: 'first critical feature', tier: 1,
+      criticality: 'critical', category: 'a', locations: ['src/critical-one.ts'], covers: ['cli:critical-one'],
+      procedure: 'critical-procedure', verificationDocument: '.agentworkforce/features/verify/procedures.md',
+    },
+    {
+      id: 'critical-two', name: 'Critical Two', description: 'second critical feature', tier: 2,
+      criticality: 'critical', category: 'a', locations: ['src/critical-two.ts'], covers: ['http:data:GET /critical-two'],
+      procedure: 'critical-procedure', verificationDocument: '.agentworkforce/features/verify/procedures.md',
+    },
+    {
+      id: 'standard-one', name: 'Standard One', description: 'standard feature', tier: 1,
+      criticality: 'standard', category: 'b', locations: ['src/standard-one.ts'], covers: ['implementation:standard-one'],
+      procedure: 'standard-procedure', verificationDocument: '.agentworkforce/features/verify/procedures.md',
+    },
+  ];
+}
+
+function state(
+  checkedIds: string[] = [],
+  options: Partial<ProgressState> = {},
+): ProgressState {
+  const totalFeatures = options.totalFeatures ?? features().length;
+  let knownIds = options.knownIds;
+  if (!knownIds && totalFeatures === allFeatures.length) {
+    knownIds = allFeatures.map((feature) => feature.id).sort();
+  } else if (!knownIds && totalFeatures === allFeatures.length - 1) {
+    knownIds = allFeatures.slice(0, -1).map((feature) => feature.id).sort();
+  } else if (!knownIds && totalFeatures === allFeatures.length + 1) {
+    knownIds = [...allFeatures.map((feature) => feature.id), 'retired-id'].sort();
+  } else if (!knownIds && totalFeatures === allFeatures.length + 2) {
+    knownIds = [...allFeatures.map((feature) => feature.id), 'retired-one', 'retired-two'].sort();
+  }
+  return {
+    kind: 'relayfile-feature-guardian:progress',
+    version: 3,
+    generation: 1,
+    knownIds: knownIds ?? features().map((feature) => feature.id).sort(),
+    checkedIds,
+    cycleStartedAt: '2026-07-21T00:00:00.000Z',
+    totalFeatures,
+    ...(checkedIds.length ? { lastPost: { featureId: checkedIds.at(-1)!, ts: '1710000000.000001' } } : {}),
+    ...options,
+  };
+}
+
+class MemoryStore implements ProgressStore {
+  snapshot: ProgressSnapshot | null;
+  revision = 0;
+  saves = 0;
+  loads = 0;
+  conflicts = 0;
+  failOnSave = 0;
+  loadError: Error | null = null;
+
+  constructor(initial: ProgressState | null = null) {
+    this.snapshot = initial ? { state: structuredClone(initial), revision: 'r0' } : null;
+  }
+
+  async load(): Promise<ProgressSnapshot | null> {
+    this.loads += 1;
+    if (this.loadError) throw this.loadError;
+    return this.snapshot ? structuredClone(this.snapshot) : null;
+  }
+
+  async save(next: ProgressState, expected: ProgressSnapshot | null, currentFeatures: Feature[]): Promise<ProgressSnapshot> {
+    this.saves += 1;
+    if (this.conflicts > 0) {
+      this.conflicts -= 1;
+      throw new ProgressStateConflictError();
+    }
+    if (this.failOnSave === this.saves) throw new Error('injected checkpoint failure');
+    if (this.snapshot?.revision !== expected?.revision) throw new ProgressStateConflictError();
+    assertTransition(expected, next, currentFeatures);
+    this.revision += 1;
+    this.snapshot = { state: structuredClone(next), revision: `r${this.revision}` };
+    return structuredClone(this.snapshot);
+  }
+}
+
+class IdempotentSlack implements SlackTransport {
+  calls = 0;
+  actualPosts = 0;
+  texts: string[] = [];
+  keys = new Map<string, string>();
+  error: Error | null = null;
+  receiptless = false;
+  tsOnly = false;
+  delayMs = 0;
+
+  async post(input: { text: string; idempotencyKey: string; signal: AbortSignal }): Promise<{ externalId?: string; ts?: string }> {
+    this.calls += 1;
+    this.texts.push(input.text);
+    if (this.error) throw this.error;
+    if (this.delayMs) await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(resolve, this.delayMs);
+      input.signal.addEventListener('abort', () => {
+        clearTimeout(timer);
+        reject(new Error('transport aborted'));
+      }, { once: true });
+    });
+    if (this.receiptless) return {};
+    let receipt = this.keys.get(input.idempotencyKey);
+    if (!receipt) {
+      this.actualPosts += 1;
+      receipt = `1710000000.${String(this.actualPosts).padStart(6, '0')}`;
+      this.keys.set(input.idempotencyKey, receipt);
+    }
+    return this.tsOnly ? { ts: ` ${receipt} ` } : { externalId: receipt };
+  }
+}
+
+function context(overrides: Partial<GuardianContext> = {}): GuardianContext {
+  return {
+    workspaceDir: '/workspace',
+    readFile: async (path) => {
+      assert.equal(path, resolveManifestPath('/workspace'));
+      return manifestRaw;
+    },
+    inputs: { SLACK_CHANNEL: 'C123' },
+    now: () => new Date('2026-07-21T01:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('manifest clone and selection', () => {
+  it('uses the target-specific repository clone path', () => {
+    assert.equal(
+      resolveManifestPath('/mnt/workspace/'),
+      '/mnt/workspace/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/manifest.yaml',
+    );
+    assert.equal(allFeatures.length, 122);
+    assert.ok(allFeatures.every((feature) => feature.locations.length > 0));
+    assert.ok(allFeatures.every((feature) => feature.covers.length > 0));
+    assert.ok(allFeatures.every((feature) => feature.procedure.length > 0));
+  });
+
+  it('uses the target validator and rejects malformed routes, locations, surfaces, and totals', () => {
+    assert.throws(() => parseFeatures('version: 1.0\ncategories: {}'), /target validator.*version must be 1.1/);
+    for (const mutate of [
+      (raw: string) => raw.replace("updated: '2026-07-21'", 'updated: no'),
+      (raw: string) => raw.replace('    cli: cli-discovery-and-lifecycle\n', ''),
+      (raw: string) => raw.replace('        locations: [cmd/relayfile-cli/main.go]', '        locations: [../outside]'),
+      (raw: string) => raw.replace("        covers: ['cli:relayfile help', 'cli-alias:-h=>help', 'cli-alias:--help=>help']", '        covers: []'),
+      (raw: string) => raw.replace('  features: 122', '  features: 123'),
+    ]) assert.throws(() => parseFeatures(mutate(manifestRaw)), /target validator/);
+  });
+
+  it('orders criticality, then tier, then stable id', () => {
+    assert.equal(pickNextFeature(features().reverse(), new Set())?.id, 'critical-one');
+    assert.equal(pickNextFeature(features(), new Set(['critical-one']))?.id, 'critical-two');
+    assert.equal(pickNextFeature(features(), new Set(features().map((feature) => feature.id))), null);
+  });
+});
+
+describe('bounded exact progress state', () => {
+  it('parses canonical exact state and rejects malformed, duplicate, and unknown IDs', () => {
+    assert.deepEqual(parseProgressState(state(['critical-one']), features()), state(['critical-one']));
+    assert.throws(() => parseProgressContent('{', features()), /malformed JSON/);
+    assert.throws(() => parseProgressState({ ...state(), extra: true }, features()), /unknown field/);
+    assert.throws(() => parseProgressState({
+      ...state(),
+      knownIds: ['critical-one', 'critical-one', 'standard-one'],
+    }, features()), /duplicate known/);
+    assert.throws(() => parseProgressState({
+      ...state(),
+      knownIds: ['critical-one', 'critical-two', 'retired'],
+    }, features()), /does not match/);
+    assert.throws(() => parseProgressState(state(['critical-one', 'critical-one']), features()), /duplicate/);
+    assert.throws(() => parseProgressState(state(['retired']), features()), /unknown feature/);
+  });
+
+  it('measures the UTF-8 byte limit, not JavaScript character count', () => {
+    const oversized = '😀'.repeat(Math.floor(MAX_STATE_BYTES / 2));
+    assert.throws(() => parseProgressContent(oversized, features()), /oversized/);
+  });
+
+  it('accepts one historical ID only during reconcile loading', () => {
+    const historical = state(['retired'], {
+      knownIds: ['critical-one', 'critical-two', 'retired'],
+    });
+    assert.equal(parseProgressState(historical, features(), { allowHistoricalIds: true }).checkedIds[0], 'retired');
+  });
+
+  it('preserves additions and one unchecked retirement', () => {
+    const prior = state(['critical-one']);
+    const addition = [...features(), {
+      ...features()[0], id: 'added', name: 'Added', description: 'new', criticality: 'hot' as const, category: 'c',
+    }];
+    assert.equal(classifyManifestDelta(prior, addition).kind, 'preserve');
+    const uncheckedRetirement = features().slice(0, 2);
+    assert.deepEqual(classifyManifestDelta(prior, uncheckedRetirement), {
+      kind: 'preserve', removedCount: 1, retiredIds: [],
+    });
+  });
+
+  it('resets one checked retirement and fails closed on unsafe shrink', () => {
+    const prior = state(['standard-one']);
+    assert.equal(classifyManifestDelta(prior, features().slice(0, 2)).kind, 'reset-checked-retirement');
+    assert.equal(classifyManifestDelta(prior, features().slice(0, 1)).kind, 'unsafe');
+    const twoRetired = state(['critical-two', 'standard-one']);
+    assert.equal(classifyManifestDelta(twoRetired, features().slice(0, 1)).kind, 'unsafe');
+  });
+
+  it('fails closed when multiple unchecked retirements are masked by additions', () => {
+    const prior = state([], {
+      totalFeatures: 4,
+      knownIds: ['critical-one', 'critical-two', 'retired-a', 'retired-b'],
+    });
+    const replacement = [
+      ...features().slice(0, 2),
+      { ...features()[0], id: 'added-a', name: 'Added A', description: 'new', criticality: 'hot' as const, category: 'c' },
+      { ...features()[0], id: 'added-b', name: 'Added B', description: 'new', criticality: 'hot' as const, category: 'c' },
+    ];
+    assert.equal(classifyManifestDelta(prior, replacement).kind, 'unsafe');
+  });
+
+  it('rejects progress regression, checkpoint skips, and ambiguous reset', () => {
+    const snapshot = { state: state(['critical-one']), revision: 'r1' };
+    assert.throws(() => assertTransition(snapshot, state(), features()), /regressed|reset/);
+    assert.throws(() => assertTransition(snapshot, state(['critical-one', 'critical-two', 'standard-one']), features()), /skipped/);
+    assert.throws(() => assertTransition(snapshot, state([], { generation: 2, cycleStartedAt: '2026-07-21T01:00:00.000Z' }), features()), /reset/);
+    assert.throws(() => parseProgressState({ ...state(), cycleStartedAt: '2026-07-21T00:00:00Z' }, features()), /canonical/);
+    assert.throws(() => parseProgressState({ ...state(), lastPost: { featureId: 'critical-one', ts: 'draft' } }, features()), /lastPost|disagree/);
+  });
+});
+
+describe('HTTP exact-revision store', () => {
+  const credentials = { url: 'https://relayfile.invalid', token: 'secret', workspaceId: 'rw_test' };
+
+  it('treats only HTTP 404 as absent and fails auth responses', async () => {
+    const absent = createHttpProgressStore(credentials, { fetchImpl: async () => new Response('', { status: 404 }) });
+    assert.equal(await absent.load(features()), null);
+    const auth = createHttpProgressStore(credentials, { fetchImpl: async () => new Response('no', { status: 401 }) });
+    await assert.rejects(() => auth.load(features()), /HTTP 401/);
+  });
+
+  it('maps 409 and 412 writes to CAS conflicts with If-Match zero on bootstrap', async () => {
+    for (const status of [409, 412]) {
+      let ifMatch = '';
+      const store = createHttpProgressStore(credentials, {
+        fetchImpl: async (_url, init) => {
+          ifMatch = new Headers(init?.headers).get('if-match') ?? '';
+          return new Response('', { status });
+        },
+      });
+      await assert.rejects(() => store.save(state(), null, features()), ProgressStateConflictError);
+      assert.equal(ifMatch, '0');
+    }
+  });
+
+  it('requires matching readback and a revision advance', async () => {
+    const expected = { state: state(), revision: 'r1' };
+    const content = `${JSON.stringify(state())}\n`;
+    let calls = 0;
+    const unchanged = createHttpProgressStore(credentials, {
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) return new Response('', { status: 200 });
+        return Response.json({ path: CYCLE_STATE_PATH, revision: 'r1', content });
+      },
+    });
+    await assert.rejects(() => unchanged.save(state(), expected, features()), /did not advance/);
+
+    calls = 0;
+    const mismatch = createHttpProgressStore(credentials, {
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls === 1) return new Response('', { status: 200 });
+        return Response.json({ path: CYCLE_STATE_PATH, revision: 'r2', content: `${JSON.stringify(state(['critical-one']))}\n` });
+      },
+    });
+    await assert.rejects(() => mismatch.save(state(), expected, features()), /does not match/);
+  });
+
+  it('bounds a delayed state request', async () => {
+    const store = createHttpProgressStore(credentials, {
+      timeoutMs: 5,
+      fetchImpl: async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      }),
+    });
+    await assert.rejects(() => store.load(features()), /timed out|aborted/);
+  });
+
+  it('bounds a delayed save/readback transaction and rejects ambiguous revisions', async () => {
+    const hung = createHttpProgressStore(credentials, {
+      timeoutMs: 5,
+      fetchImpl: async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      }),
+    });
+    await assert.rejects(() => hung.save(state(), null, features()), /timed out|aborted/);
+
+    const ambiguous = createHttpProgressStore(credentials, {
+      fetchImpl: async () => Response.json(
+        { path: CYCLE_STATE_PATH, revision: 'r1', content: `${JSON.stringify(state())}\n` },
+        { headers: { ETag: '"r2"' } },
+      ),
+    });
+    await assert.rejects(() => ambiguous.load(features()), /ambiguous/);
+  });
+});
+
+describe('post-then-checkpoint guardian cycle', () => {
+  it('validates the clone but skips Slack and state when input is absent', async () => {
+    const outcome = await runGuardian(context({ inputs: {} }), { type: 'cron.tick' }, { transactionTimeoutMs: 100 });
+    assert.equal(outcome.status, 'SKIP');
+    assert.match(outcome.reason, /no Slack mount/);
+  });
+
+  it('does not post when bootstrap persistence fails', async () => {
+    const store = new MemoryStore();
+    store.failOnSave = 1;
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context(), {}, { store, slack });
+    assert.equal(outcome.status, 'FAIL');
+    assert.equal(slack.calls, 0);
+  });
+
+  it('retries pre-post CAS conflicts and still emits one message', async () => {
+    const store = new MemoryStore();
+    store.conflicts = 1;
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context(), {}, { store, slack });
+    assert.equal(outcome.status, 'PASS');
+    assert.equal(slack.actualPosts, 1);
+  });
+
+  it('uses one idempotency key after a post/checkpoint failure', async () => {
+    const current = state([], { totalFeatures: allFeatures.length });
+    const store = new MemoryStore(current);
+    store.failOnSave = 1;
+    const slack = new IdempotentSlack();
+    const first = await runGuardian(context(), {}, { store, slack });
+    assert.equal(first.status, 'FAIL');
+    assert.equal(slack.actualPosts, 1);
+    assert.match(first.reason, /checkpoint failed/);
+    store.failOnSave = 0;
+    const second = await runGuardian(context(), {}, { store, slack });
+    assert.equal(second.status, 'PASS');
+    assert.equal(slack.calls, 2);
+    assert.equal(slack.actualPosts, 1);
+  });
+
+  it('resets a completed cycle before posting the next generation', async () => {
+    const ids = allFeatures.map((feature) => feature.id);
+    const complete = state(ids, {
+      totalFeatures: ids.length,
+      lastPost: { featureId: ids.at(-1)!, ts: '1710000000.000001' },
+    });
+    const store = new MemoryStore(complete);
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context(), {}, { store, slack });
+    assert.equal(outcome.status, 'PASS');
+    assert.equal(store.snapshot?.state.generation, 2);
+    assert.equal(store.snapshot?.state.checkedIds.length, 1);
+  });
+
+  it('preserves progress across an addition and resets a checked retirement', async () => {
+    const firstId = allFeatures[0].id;
+    const prior = state([firstId], { totalFeatures: allFeatures.length - 1, lastPost: { featureId: firstId, ts: '1710000000.000001' } });
+    const addedStore = new MemoryStore(prior);
+    const added = await runGuardian(context(), {}, { store: addedStore, slack: new IdempotentSlack() });
+    assert.equal(added.status, 'PASS');
+    assert.equal(addedStore.snapshot?.state.generation, 1);
+    assert.equal(addedStore.snapshot?.state.checkedIds[0], firstId);
+
+    const retiredState = state(['retired-id'], { totalFeatures: allFeatures.length + 1, lastPost: { featureId: 'retired-id', ts: '1710000000.000001' } });
+    const retiredStore = new MemoryStore(retiredState);
+    const retired = await runGuardian(context(), {}, { store: retiredStore, slack: new IdempotentSlack() });
+    assert.equal(retired.status, 'PASS');
+    assert.equal(retiredStore.snapshot?.state.generation, 2);
+  });
+
+  it('reconciles one unchecked retirement without losing checked IDs or the receipt', async () => {
+    const checkedId = allFeatures[0].id;
+    const prior = state([checkedId], {
+      totalFeatures: allFeatures.length + 1,
+      knownIds: [...allFeatures.map((feature) => feature.id), 'retired-id'].sort(),
+      lastPost: { featureId: checkedId, ts: '1710000000.000001' },
+    });
+    const store = new MemoryStore(prior);
+    const outcome = await runGuardian(context(), {}, { store, slack: new IdempotentSlack() });
+    assert.equal(outcome.status, 'PASS');
+    assert.equal(store.snapshot?.state.generation, 1);
+    assert.equal(store.snapshot?.state.checkedIds[0], checkedId);
+    assert.equal(store.snapshot?.state.checkedIds.length, 2);
+  });
+
+  it('fails closed on an unsafe manifest shrink before Slack', async () => {
+    const store = new MemoryStore(state([], { totalFeatures: allFeatures.length + 2 }));
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context(), {}, { store, slack });
+    assert.equal(outcome.status, 'FAIL');
+    assert.match(outcome.reason, /unsafe manifest reconcile/);
+    assert.equal(slack.calls, 0);
+  });
+
+  it('fails closed when two retirements are masked by same-total additions', async () => {
+    const replaced = manifestRaw
+      .replace('      - id: cli-help', '      - id: added-one')
+      .replace('      - id: cli-version', '      - id: added-two');
+    const store = new MemoryStore(state([], { totalFeatures: allFeatures.length }));
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context({ readFile: async () => replaced }), {}, { store, slack });
+    assert.equal(outcome.status, 'FAIL');
+    assert.match(outcome.reason, /unsafe manifest reconcile/);
+    assert.equal(slack.calls, 0);
+    assert.deepEqual(store.snapshot?.state.checkedIds, []);
+  });
+
+  it('fails closed on manifest or exact-state reads without mutating progress', async () => {
+    const initial = state([], { totalFeatures: allFeatures.length });
+    const manifestStore = new MemoryStore(initial);
+    const manifestSlack = new IdempotentSlack();
+    const manifestFailure = await runGuardian(context({
+      readFile: async () => { throw new Error('manifest clone unavailable'); },
+    }), {}, { store: manifestStore, slack: manifestSlack });
+    assert.equal(manifestFailure.status, 'FAIL');
+    assert.equal(manifestStore.loads, 0);
+    assert.equal(manifestSlack.calls, 0);
+    assert.deepEqual(manifestStore.snapshot?.state, initial);
+
+    const stateStore = new MemoryStore(initial);
+    stateStore.loadError = new Error('exact state read denied');
+    const stateSlack = new IdempotentSlack();
+    const stateFailure = await runGuardian(context(), {}, { store: stateStore, slack: stateSlack });
+    assert.equal(stateFailure.status, 'FAIL');
+    assert.match(stateFailure.reason, /read denied/);
+    assert.equal(stateSlack.calls, 0);
+    assert.deepEqual(stateStore.snapshot?.state, initial);
+  });
+
+  it('fails on Slack error, delay, and receiptless response without progress', async () => {
+    for (const mode of ['error', 'delay', 'receiptless'] as const) {
+      const store = new MemoryStore(state([], { totalFeatures: allFeatures.length }));
+      const slack = new IdempotentSlack();
+      if (mode === 'error') slack.error = new Error('provider rejected');
+      if (mode === 'delay') slack.delayMs = 30;
+      if (mode === 'receiptless') slack.receiptless = true;
+      const outcome = await runGuardian(context(), {}, { store, slack, slackTimeoutMs: 5 });
+      assert.equal(outcome.status, 'FAIL', mode);
+      assert.deepEqual(store.snapshot?.state.checkedIds, [], mode);
+    }
+  });
+
+  it('uses the fallback feature message when the LLM fails', async () => {
+    const store = new MemoryStore(state([], { totalFeatures: allFeatures.length }));
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context({
+      llm: { complete: async () => { throw new Error('model unavailable'); } },
+    }), {}, { store, slack });
+    assert.equal(outcome.status, 'PASS');
+    assert.match(slack.texts[0], /Relayfile feature check/);
+    assert.match(slack.texts[0], /React ✅/);
+    const selected = pickNextFeature(allFeatures, new Set());
+    assert.ok(selected);
+    for (const location of selected.locations) assert.match(slack.texts[0], new RegExp(location.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    for (const surface of selected.covers) assert.ok(slack.texts[0].includes(surface), surface);
+    assert.ok(slack.texts[0].includes(`${selected.verificationDocument}#${selected.procedure}`));
+  });
+
+  it('accepts a delayed, trimmed provider ts before checkpointing', async () => {
+    const store = new MemoryStore(state([], { totalFeatures: allFeatures.length }));
+    const slack = new IdempotentSlack();
+    slack.delayMs = 15;
+    slack.tsOnly = true;
+    const outcome = await runGuardian(context(), {}, { store, slack, slackTimeoutMs: 100 });
+    assert.equal(outcome.status, 'PASS');
+    assert.equal(outcome.receipt, '1710000000.000001');
+    assert.equal(store.snapshot?.state.lastPost?.ts, '1710000000.000001');
+  });
+
+  it('bounds the whole guardian transaction before any post', async () => {
+    const store: ProgressStore = {
+      load: async () => new Promise<ProgressSnapshot | null>(() => undefined),
+      save: async () => { throw new Error('unreachable'); },
+    };
+    const slack = new IdempotentSlack();
+    const outcome = await runGuardian(context(), {}, { store, slack, transactionTimeoutMs: 5 });
+    assert.equal(outcome.status, 'FAIL');
+    assert.match(outcome.reason, /guardian transaction timed out/);
+    assert.equal(slack.calls, 0);
+  });
+
+  it('derives stable keys and accepts only provider-shaped Slack timestamps', () => {
+    assert.equal(featureIdempotencyKey('2026-07-21T00:00:00.000Z', 'cli-help'), 'relayfile-feature-guardian:2026-07-21T00:00:00.000Z:cli-help');
+    assert.equal(confirmedSlackReceipt({ externalId: ' 1710000000.000001 ' }), '1710000000.000001');
+    assert.equal(confirmedSlackReceipt({ externalId: 'draft-id' }), '');
+  });
+});

--- a/.agentworkforce/agents/relayfile-feature-guardian/agent.test.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/agent.test.ts
@@ -270,14 +270,24 @@ describe('HTTP exact-revision store', () => {
   it('maps 409 and 412 writes to CAS conflicts with If-Match zero on bootstrap', async () => {
     for (const status of [409, 412]) {
       let ifMatch = '';
+      let contentType = '';
+      let requestBody = '';
       const store = createHttpProgressStore(credentials, {
         fetchImpl: async (_url, init) => {
-          ifMatch = new Headers(init?.headers).get('if-match') ?? '';
+          const headers = new Headers(init?.headers);
+          ifMatch = headers.get('if-match') ?? '';
+          contentType = headers.get('content-type') ?? '';
+          requestBody = String(init?.body ?? '');
           return new Response('', { status });
         },
       });
       await assert.rejects(() => store.save(state(), null, features()), ProgressStateConflictError);
       assert.equal(ifMatch, '0');
+      assert.equal(contentType, 'application/json');
+      assert.deepEqual(JSON.parse(requestBody), {
+        contentType: 'application/json',
+        content: `${JSON.stringify(state())}\n`,
+      });
     }
   });
 

--- a/.agentworkforce/agents/relayfile-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/agent.ts
@@ -463,12 +463,10 @@ export function createHttpProgressStore(
           headers: {
             Authorization: `Bearer ${credentials.token}`,
             'X-Correlation-Id': correlationId,
-            'Content-Type': 'application/octet-stream',
-            'X-Relayfile-Encoding': 'utf-8',
-            'X-Relayfile-Content-Type': 'application/json',
+            'Content-Type': 'application/json',
             'If-Match': expected?.revision ?? '0',
           },
-          body: content,
+          body: JSON.stringify({ contentType: 'application/json', content }),
           signal,
         });
         if (response.status === 409 || response.status === 412) throw new ProgressStateConflictError();

--- a/.agentworkforce/agents/relayfile-feature-guardian/agent.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/agent.ts
@@ -1,0 +1,732 @@
+/**
+ * Relayfile feature guardian.
+ *
+ * The runtime reuses the repository's structural manifest validator so the
+ * scoped clone cannot be interpreted with a weaker schema than local CI.
+ * A deployment adapter supplies the clone reader, exact Relayfile credentials,
+ * optional write-only Slack transport, logger, and LLM.
+ */
+import { randomUUID } from 'node:crypto';
+
+import { input } from '@agentworkforce/delivery';
+import {
+  defineAgent,
+  type CredentialsContext,
+  type WorkforceCtx,
+  type WorkforceEvent,
+} from '@agentworkforce/runtime';
+import { slackClient } from '@relayfile/relay-helpers';
+import { parse } from 'yaml';
+
+import { validateManifestData } from '../../../scripts/validate-feature-catalog.mjs';
+
+export type Criticality = 'critical' | 'hot' | 'standard';
+
+export interface Feature {
+  id: string;
+  name: string;
+  description: string;
+  tier: number;
+  criticality: Criticality;
+  category: string;
+  locations: string[];
+  covers: string[];
+  procedure: string;
+  verificationDocument: string;
+}
+
+interface Manifest {
+  version: string;
+  summary?: { features?: number };
+  verification: {
+    document: string;
+    categories: Record<string, string>;
+  };
+  categories: Record<string, {
+    criticality: Criticality;
+    features: Array<{
+      id: string;
+      name: string;
+      description: string;
+      verify_tier: number;
+      location?: string;
+      locations?: string[];
+      covers: string[];
+    }>;
+  }>;
+}
+
+export const REPOSITORY_CLONE_RELPATH = 'github/repos/AgentWorkforce/relayfile';
+export const MANIFEST_RELPATH = '.agentworkforce/features/manifest.yaml';
+export const CYCLE_STATE_PATH = '/memory/workspace/relayfile-feature-guardian/cycle-state.json';
+export const STATE_VERSION = 3 as const;
+export const MAX_STATE_BYTES = 64 * 1024;
+export const MAX_FEATURES = 10_000;
+export const MAX_SAFE_MANIFEST_SHRINK = 1;
+export const STATE_IO_TIMEOUT_MS = 5_000;
+export const SLACK_TIMEOUT_MS = 15_000;
+export const SLACK_POLL_MS = 250;
+export const TRANSACTION_TIMEOUT_MS = 45_000;
+const UTF8 = new TextEncoder();
+
+export interface ProgressState {
+  kind: 'relayfile-feature-guardian:progress';
+  version: 3;
+  generation: number;
+  knownIds: string[];
+  checkedIds: string[];
+  cycleStartedAt: string;
+  totalFeatures: number;
+  lastPost?: { featureId: string; ts: string };
+}
+
+export interface ProgressSnapshot {
+  state: ProgressState;
+  revision: string;
+}
+
+export interface ProgressStore {
+  load(features: Feature[]): Promise<ProgressSnapshot | null>;
+  save(state: ProgressState, expected: ProgressSnapshot | null, features: Feature[]): Promise<ProgressSnapshot>;
+}
+
+export interface RelayfileCredentials {
+  url: string;
+  token: string;
+  workspaceId: string;
+}
+
+export interface SlackReceipt {
+  externalId?: string;
+  ts?: string;
+}
+
+export interface SlackTransport {
+  post(input: {
+    channelId: string;
+    text: string;
+    idempotencyKey: string;
+    signal: AbortSignal;
+  }): Promise<SlackReceipt>;
+}
+
+export interface GuardianContext {
+  workspaceDir?: string;
+  sandbox?: {
+    cwd: string;
+    readFile(path: string): Promise<string>;
+  };
+  readFile?(path: string): Promise<string>;
+  inputs?: Record<string, string | undefined>;
+  getInput?(name: string): string | undefined;
+  credentials?: { relayfile: RelayfileCredentials } | RelayfileCredentials | CredentialsContext;
+  slack?: SlackTransport;
+  llm?: { complete(prompt: string, options: { maxTokens: number }): Promise<string> };
+  log?(level: 'info' | 'warn' | 'error', event: string, detail?: Record<string, unknown>): void;
+  now?(): Date;
+}
+
+export interface GuardianDependencies {
+  store?: ProgressStore;
+  slack?: SlackTransport;
+  fetchImpl?: typeof fetch;
+  stateTimeoutMs?: number;
+  slackTimeoutMs?: number;
+  transactionTimeoutMs?: number;
+}
+
+export interface GuardianOutcome {
+  status: 'PASS' | 'FAIL' | 'SKIP';
+  reason: string;
+  featureId?: string;
+  receipt?: string;
+}
+
+export class ProgressStateConflictError extends Error {
+  constructor(message = 'cycle state compare-and-set conflict') {
+    super(message);
+    this.name = 'ProgressStateConflictError';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const date = new Date(value);
+  return Number.isFinite(date.valueOf()) && date.toISOString() === value;
+}
+
+function slackTimestamp(value: unknown): value is string {
+  return typeof value === 'string' && /^\d+\.\d+$/.test(value.trim());
+}
+
+function assertByteLimit(value: string): void {
+  if (UTF8.encode(value).byteLength > MAX_STATE_BYTES) throw new Error('cycle state is oversized');
+}
+
+function featureIds(features: Feature[]): string[] {
+  return features.map((feature) => feature.id).sort();
+}
+
+export function resolveManifestPath(workspaceDir: string): string {
+  return `${workspaceDir.replace(/\/+$/, '')}/${REPOSITORY_CLONE_RELPATH}/${MANIFEST_RELPATH}`;
+}
+
+export function parseFeatures(raw: string): Feature[] {
+  const value = parse(raw) as unknown;
+  const validationErrors = validateManifestData(value, { structuralOnly: true });
+  if (validationErrors.length > 0) {
+    throw new Error(`feature manifest rejected by target validator: ${validationErrors.join('; ')}`);
+  }
+  const manifest = value as unknown as Manifest;
+  const features: Feature[] = [];
+  const ids = new Set<string>();
+  for (const [category, entry] of Object.entries(manifest.categories)) {
+    if (!isRecord(entry) || !['critical', 'hot', 'standard'].includes(entry.criticality) || !Array.isArray(entry.features)) {
+      throw new Error(`feature category ${category} is invalid`);
+    }
+    for (const candidate of entry.features) {
+      if (
+        !isRecord(candidate) ||
+        typeof candidate.id !== 'string' ||
+        typeof candidate.name !== 'string' ||
+        typeof candidate.description !== 'string' ||
+        !Number.isInteger(candidate.verify_tier) ||
+        candidate.verify_tier < 1 ||
+        candidate.verify_tier > 6 ||
+        !Array.isArray(candidate.covers) ||
+        ids.has(candidate.id)
+      ) {
+        throw new Error(`feature in ${category} is invalid or duplicated`);
+      }
+      ids.add(candidate.id);
+      features.push({
+        id: candidate.id,
+        name: candidate.name,
+        description: candidate.description,
+        tier: candidate.verify_tier,
+        criticality: entry.criticality,
+        category,
+        locations: candidate.locations ?? (candidate.location ? [candidate.location] : []),
+        covers: [...candidate.covers],
+        procedure: manifest.verification.categories[category],
+        verificationDocument: manifest.verification.document,
+      });
+    }
+  }
+  if (features.length === 0 || features.length > MAX_FEATURES) throw new Error('feature manifest count is invalid');
+  if (manifest.summary?.features !== features.length) throw new Error('feature manifest summary is stale');
+  return features;
+}
+
+export function parseProgressState(
+  value: unknown,
+  features: Feature[],
+  options: { allowHistoricalIds?: boolean } = {},
+): ProgressState {
+  if (!isRecord(value)) throw new Error('cycle state must be an object');
+  const exactKeys = new Set(['kind', 'version', 'generation', 'knownIds', 'checkedIds', 'cycleStartedAt', 'totalFeatures', 'lastPost']);
+  for (const key of Object.keys(value)) if (!exactKeys.has(key)) throw new Error(`cycle state has unknown field ${key}`);
+  if (value.kind !== 'relayfile-feature-guardian:progress' || value.version !== STATE_VERSION) {
+    throw new Error('cycle state kind/version is invalid');
+  }
+  if (!Number.isSafeInteger(value.generation) || Number(value.generation) < 1) throw new Error('cycle state generation is invalid');
+  if (!canonicalTimestamp(value.cycleStartedAt)) throw new Error('cycle state timestamp is not canonical');
+  if (!Number.isSafeInteger(value.totalFeatures) || Number(value.totalFeatures) < 1 || Number(value.totalFeatures) > MAX_FEATURES) {
+    throw new Error('cycle state total is invalid');
+  }
+  if (!Array.isArray(value.knownIds) || value.knownIds.length !== Number(value.totalFeatures)) {
+    throw new Error('cycle state known feature set is invalid');
+  }
+  const currentIds = featureIds(features);
+  const current = new Set(currentIds);
+  const knownIds = value.knownIds.map((id) => {
+    if (typeof id !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
+      throw new Error('cycle state contains an invalid known feature id');
+    }
+    return id;
+  });
+  if (new Set(knownIds).size !== knownIds.length) throw new Error('cycle state contains duplicate known feature ids');
+  const sortedKnownIds = [...knownIds].sort();
+  if (knownIds.some((id, index) => id !== sortedKnownIds[index])) {
+    throw new Error('cycle state known feature IDs are not canonical');
+  }
+  if (!options.allowHistoricalIds && (
+    knownIds.length !== currentIds.length || knownIds.some((id, index) => id !== currentIds[index])
+  )) throw new Error('cycle state known feature set does not match the manifest');
+
+  if (!Array.isArray(value.checkedIds) || value.checkedIds.length > Number(value.totalFeatures)) {
+    throw new Error('cycle state progress is invalid');
+  }
+  const known = new Set(knownIds);
+  const checkedIds = value.checkedIds.map((id) => {
+    if (
+      typeof id !== 'string' ||
+      id.length < 1 ||
+      id.length > 256 ||
+      !known.has(id) ||
+      (!options.allowHistoricalIds && !current.has(id))
+    ) throw new Error('cycle state contains an unknown feature id');
+    return id;
+  });
+  if (new Set(checkedIds).size !== checkedIds.length) throw new Error('cycle state contains duplicate feature ids');
+
+  let lastPost: ProgressState['lastPost'];
+  if (value.lastPost !== undefined) {
+    if (
+      !isRecord(value.lastPost) ||
+      Object.keys(value.lastPost).some((key) => !['featureId', 'ts'].includes(key)) ||
+      typeof value.lastPost.featureId !== 'string' ||
+      value.lastPost.featureId !== checkedIds.at(-1) ||
+      !slackTimestamp(value.lastPost.ts)
+    ) throw new Error('cycle state lastPost is invalid');
+    lastPost = { featureId: value.lastPost.featureId, ts: value.lastPost.ts.trim() };
+  }
+  if ((checkedIds.length === 0) !== (lastPost === undefined)) throw new Error('cycle state progress and lastPost disagree');
+  return {
+    kind: 'relayfile-feature-guardian:progress',
+    version: STATE_VERSION,
+    generation: Number(value.generation),
+    knownIds,
+    checkedIds,
+    cycleStartedAt: value.cycleStartedAt,
+    totalFeatures: Number(value.totalFeatures),
+    ...(lastPost ? { lastPost } : {}),
+  };
+}
+
+export function parseProgressContent(
+  content: string,
+  features: Feature[],
+  options: { allowHistoricalIds?: boolean } = {},
+): ProgressState {
+  assertByteLimit(content);
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch {
+    throw new Error('cycle state contains malformed JSON');
+  }
+  return parseProgressState(value, features, options);
+}
+
+export type ManifestDelta = {
+  kind: 'preserve' | 'reset-checked-retirement' | 'unsafe';
+  removedCount: number;
+  retiredIds: string[];
+  reason?: string;
+};
+
+export function classifyManifestDelta(state: ProgressState, features: Feature[]): ManifestDelta {
+  const current = new Set(features.map((feature) => feature.id));
+  const retiredIds = state.checkedIds.filter((id) => !current.has(id));
+  const removedCount = state.knownIds.filter((id) => !current.has(id)).length;
+  if (removedCount > MAX_SAFE_MANIFEST_SHRINK) {
+    return { kind: 'unsafe', removedCount, retiredIds, reason: 'manifest shrank by more than one feature' };
+  }
+  if (retiredIds.length > 1) {
+    return { kind: 'unsafe', removedCount, retiredIds, reason: 'multiple checked feature IDs disappeared' };
+  }
+  return { kind: retiredIds.length === 1 ? 'reset-checked-retirement' : 'preserve', removedCount, retiredIds };
+}
+
+function laterTimestamp(previous: string, now: Date): string {
+  return new Date(Math.max(now.valueOf(), new Date(previous).valueOf() + 1)).toISOString();
+}
+
+export function assertTransition(
+  expected: ProgressSnapshot | null,
+  nextValue: ProgressState,
+  features: Feature[],
+): void {
+  const next = parseProgressState(nextValue, features);
+  if (next.totalFeatures !== features.length) throw new Error('cycle state total does not match manifest');
+  if (!expected) {
+    if (next.generation !== 1 || next.checkedIds.length !== 0 || next.lastPost) {
+      throw new Error('bootstrap state must be empty generation one');
+    }
+    return;
+  }
+  const previous = expected.state;
+  if (next.generation === previous.generation) {
+    if (next.cycleStartedAt !== previous.cycleStartedAt) throw new Error('cycle timestamp changed within generation');
+    const sameProgress = next.checkedIds.length === previous.checkedIds.length &&
+      previous.checkedIds.every((id, index) => next.checkedIds[index] === id);
+    const oneCheckpoint = next.checkedIds.length === previous.checkedIds.length + 1 &&
+      previous.checkedIds.every((id, index) => next.checkedIds[index] === id);
+    if (!sameProgress && !oneCheckpoint) throw new Error('cycle progress regressed or skipped a checkpoint');
+    if (sameProgress && JSON.stringify(next.lastPost) !== JSON.stringify(previous.lastPost)) {
+      throw new Error('reconcile overwrote the latest receipt');
+    }
+    if (sameProgress && classifyManifestDelta(previous, features).kind !== 'preserve') {
+      throw new Error('unsafe manifest reconcile did not reset the cycle');
+    }
+    if (oneCheckpoint && next.lastPost?.featureId !== next.checkedIds.at(-1)) {
+      throw new Error('checkpoint receipt does not describe the new feature');
+    }
+    return;
+  }
+  const delta = classifyManifestDelta(previous, features);
+  const complete = features.every((feature) => previous.checkedIds.includes(feature.id));
+  if (
+    next.generation !== previous.generation + 1 ||
+    (!complete && delta.kind !== 'reset-checked-retirement') ||
+    next.checkedIds.length !== 0 ||
+    next.lastPost ||
+    new Date(next.cycleStartedAt) <= new Date(previous.cycleStartedAt)
+  ) throw new Error('cycle reset transition is invalid');
+}
+
+async function withDeadline<T>(
+  label: string,
+  timeoutMs: number,
+  run: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([run(controller.signal), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function stateUrl(credentials: RelayfileCredentials): URL {
+  const url = new URL(
+    `/v1/workspaces/${encodeURIComponent(credentials.workspaceId)}/fs/file`,
+    `${credentials.url.replace(/\/+$/, '')}/`,
+  );
+  url.searchParams.set('path', CYCLE_STATE_PATH);
+  return url;
+}
+
+function revisionFrom(response: Response, body: Record<string, unknown>): string {
+  const bodyRevision = typeof body.revision === 'string' ? body.revision.trim() : '';
+  const etag = (response.headers.get('etag') ?? '').trim().replace(/^W\//, '').replace(/^"|"$/g, '');
+  if (!bodyRevision && !etag) throw new Error('cycle state read has no revision');
+  if (bodyRevision && etag && bodyRevision !== etag) throw new Error('cycle state revision is ambiguous');
+  return bodyRevision || etag;
+}
+
+async function httpRead(
+  credentials: RelayfileCredentials,
+  features: Feature[],
+  fetchImpl: typeof fetch,
+  signal: AbortSignal,
+  correlationId: string,
+  allowHistoricalIds: boolean,
+): Promise<ProgressSnapshot | null> {
+  const response = await fetchImpl(stateUrl(credentials), {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${credentials.token}`, 'X-Correlation-Id': correlationId },
+    signal,
+  });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`cycle state GET failed with HTTP ${response.status}`);
+  const body = await response.json() as unknown;
+  if (!isRecord(body) || body.path !== CYCLE_STATE_PATH || typeof body.content !== 'string') {
+    throw new Error('cycle state GET returned an invalid file record');
+  }
+  return {
+    state: parseProgressContent(body.content, features, { allowHistoricalIds }),
+    revision: revisionFrom(response, body),
+  };
+}
+
+export function createHttpProgressStore(
+  credentials: RelayfileCredentials,
+  options: { fetchImpl?: typeof fetch; timeoutMs?: number } = {},
+): ProgressStore {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? STATE_IO_TIMEOUT_MS;
+  return {
+    load: (features) => withDeadline('cycle state load', timeoutMs, (signal) =>
+      httpRead(credentials, features, fetchImpl, signal, `guardian-load-${randomUUID()}`, true)),
+    save: (state, expected, features) => {
+      const canonical = parseProgressState(state, features);
+      assertTransition(expected, canonical, features);
+      const content = `${JSON.stringify(canonical)}\n`;
+      assertByteLimit(content);
+      return withDeadline('cycle state compare-and-set', timeoutMs, async (signal) => {
+        const correlationId = `guardian-save-${randomUUID()}`;
+        const response = await fetchImpl(stateUrl(credentials), {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${credentials.token}`,
+            'X-Correlation-Id': correlationId,
+            'Content-Type': 'application/octet-stream',
+            'X-Relayfile-Encoding': 'utf-8',
+            'X-Relayfile-Content-Type': 'application/json',
+            'If-Match': expected?.revision ?? '0',
+          },
+          body: content,
+          signal,
+        });
+        if (response.status === 409 || response.status === 412) throw new ProgressStateConflictError();
+        if (!response.ok) throw new Error(`cycle state PUT failed with HTTP ${response.status}`);
+        const readback = await httpRead(credentials, features, fetchImpl, signal, correlationId, false);
+        if (!readback || JSON.stringify(readback.state) !== JSON.stringify(canonical)) {
+          throw new Error('cycle state readback does not match compare-and-set value');
+        }
+        if (expected && readback.revision === expected.revision) throw new Error('cycle state revision did not advance');
+        return readback;
+      });
+    },
+  };
+}
+
+export function pickNextFeature(features: Feature[], checked: Set<string>): Feature | null {
+  const criticality: Record<Criticality, number> = { critical: 0, hot: 1, standard: 2 };
+  return [...features]
+    .sort((a, b) => criticality[a.criticality] - criticality[b.criticality] || a.tier - b.tier || a.id.localeCompare(b.id))
+    .find((feature) => !checked.has(feature.id)) ?? null;
+}
+
+export function featureIdempotencyKey(cycleStartedAt: string, featureId: string): string {
+  return `relayfile-feature-guardian:${cycleStartedAt}:${featureId}`;
+}
+
+export function confirmedSlackReceipt(receipt: SlackReceipt | null | undefined): string {
+  const externalId = receipt?.externalId?.trim() ?? '';
+  if (slackTimestamp(externalId)) return externalId;
+  const ts = receipt?.ts?.trim() ?? '';
+  return slackTimestamp(ts) ? ts : '';
+}
+
+function contextInput(ctx: GuardianContext, name: string): string {
+  if (ctx.getInput) return (ctx.getInput(name) ?? '').trim();
+  if (ctx.inputs) return (ctx.inputs[name] ?? '').trim();
+  return (input(ctx as WorkforceCtx, name) ?? '').trim();
+}
+
+function contextNow(ctx: GuardianContext): Date {
+  return ctx.now?.() ?? new Date();
+}
+
+function log(ctx: GuardianContext, level: 'info' | 'warn' | 'error', event: string, detail?: Record<string, unknown>) {
+  ctx.log?.(level, event, detail);
+}
+
+async function loadFeatures(ctx: GuardianContext): Promise<Feature[]> {
+  const workspace = ctx.sandbox?.cwd ?? ctx.workspaceDir;
+  if (!workspace) throw new Error('guardian workspace clone root is absent');
+  const path = resolveManifestPath(workspace);
+  const raw = ctx.sandbox ? await ctx.sandbox.readFile(path) : await ctx.readFile?.(path);
+  if (typeof raw !== 'string') throw new Error('guardian repository clone reader is absent');
+  return parseFeatures(raw);
+}
+
+function credentials(ctx: GuardianContext): RelayfileCredentials | null {
+  const value = ctx.credentials;
+  if (!value) return null;
+  if ('tryRequire' in value && typeof value.tryRequire === 'function') {
+    return value.tryRequire()?.relayfile ?? null;
+  }
+  return 'relayfile' in value ? value.relayfile : value;
+}
+
+function runtimeSlackTransport(timeoutMs: number): SlackTransport {
+  const client = slackClient({ writebackTimeoutMs: timeoutMs, writebackPollMs: SLACK_POLL_MS });
+  return {
+    post: async ({ channelId, text, idempotencyKey, signal }) => {
+      signal.throwIfAborted();
+      const result = await client.messages.write({ channelId }, { text, idempotencyKey });
+      signal.throwIfAborted();
+      return {
+        externalId: typeof result.receipt?.externalId === 'string' ? result.receipt.externalId : undefined,
+        ts: typeof result.receipt?.ts === 'string' ? result.receipt.ts : undefined,
+      };
+    },
+  };
+}
+
+async function messageFor(ctx: GuardianContext, feature: Feature): Promise<string> {
+  const sourceLine = `Sources: ${feature.locations.join(', ')}`;
+  const surfaceLine = `Public/API/CLI surfaces: ${feature.covers.join(', ')}`;
+  const procedureLine = `Procedure: ${feature.verificationDocument}#${feature.procedure}`;
+  const fallback = [
+    `Relayfile feature check: ${feature.name}.`,
+    `Expected: ${feature.description}`,
+    sourceLine,
+    surfaceLine,
+    procedureLine,
+    `Verify tier ${feature.tier} (${feature.category}).`,
+    'React ✅ if working, 🔧 if drifted, or ❓ if untested.',
+  ].join('\n');
+  if (!ctx.llm) return fallback;
+  try {
+    const result = await ctx.llm.complete(
+      `Write a concise internal Slack check (3-5 sentences, no headers) for Relayfile feature ${feature.name}. ` +
+      `Expected behavior: ${feature.description}. Tier: ${feature.tier}. ` +
+      `${sourceLine}. ${surfaceLine}. ${procedureLine}. Include every supplied source, surface, and procedure ` +
+      'verbatim, then end by asking for ✅, 🔧, or ❓.',
+      { maxTokens: 300 },
+    );
+    return result.trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function initialState(features: Feature[], now: Date): ProgressState {
+  return {
+    kind: 'relayfile-feature-guardian:progress', version: STATE_VERSION, generation: 1,
+    knownIds: featureIds(features), checkedIds: [], cycleStartedAt: now.toISOString(), totalFeatures: features.length,
+  };
+}
+
+function resetState(snapshot: ProgressSnapshot, features: Feature[], now: Date): ProgressState {
+  return {
+    kind: 'relayfile-feature-guardian:progress', version: STATE_VERSION,
+    generation: snapshot.state.generation + 1, knownIds: featureIds(features), checkedIds: [],
+    cycleStartedAt: laterTimestamp(snapshot.state.cycleStartedAt, now), totalFeatures: features.length,
+  };
+}
+
+async function prepareSnapshot(
+  ctx: GuardianContext,
+  store: ProgressStore,
+  features: Feature[],
+): Promise<ProgressSnapshot> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let snapshot = await store.load(features);
+    try {
+      if (!snapshot) return await store.save(initialState(features, contextNow(ctx)), null, features);
+      snapshot = { state: parseProgressState(snapshot.state, features, { allowHistoricalIds: true }), revision: snapshot.revision };
+      if (!snapshot.revision) throw new Error('cycle state revision is absent');
+      const delta = classifyManifestDelta(snapshot.state, features);
+      if (delta.kind === 'unsafe') throw new Error(`unsafe manifest reconcile: ${delta.reason}`);
+      if (delta.kind === 'reset-checked-retirement') {
+        return await store.save(resetState(snapshot, features, contextNow(ctx)), snapshot, features);
+      }
+      const currentIds = featureIds(features);
+      if (
+        snapshot.state.totalFeatures !== features.length ||
+        snapshot.state.knownIds.length !== currentIds.length ||
+        snapshot.state.knownIds.some((id, index) => id !== currentIds[index])
+      ) {
+        return await store.save({
+          ...snapshot.state,
+          knownIds: currentIds,
+          totalFeatures: features.length,
+        }, snapshot, features);
+      }
+      const checked = new Set(snapshot.state.checkedIds);
+      if (!pickNextFeature(features, checked)) {
+        return await store.save(resetState(snapshot, features, contextNow(ctx)), snapshot, features);
+      }
+      return snapshot;
+    } catch (error) {
+      if (error instanceof ProgressStateConflictError && attempt < 2) continue;
+      throw error;
+    }
+  }
+  throw new Error('cycle state CAS retry budget exhausted');
+}
+
+async function executeGuardian(
+  ctx: GuardianContext,
+  dependencies: GuardianDependencies,
+): Promise<GuardianOutcome> {
+  let features: Feature[];
+  try {
+    features = await loadFeatures(ctx);
+  } catch (error) {
+    log(ctx, 'error', 'relayfile-feature-guardian.manifest-load-failed', { error: String(error) });
+    return { status: 'FAIL', reason: String(error) };
+  }
+  log(ctx, 'info', 'relayfile-feature-guardian.manifest-loaded', { features: features.length });
+
+  const channel = contextInput(ctx, 'SLACK_CHANNEL');
+  if (!channel) {
+    log(ctx, 'warn', 'relayfile-feature-guardian.slack-skipped', { reason: 'SLACK_CHANNEL is absent' });
+    return { status: 'SKIP', reason: 'SLACK_CHANNEL is absent; no Slack mount, post, or checkpoint occurred' };
+  }
+  const slackTimeoutMs = dependencies.slackTimeoutMs ?? SLACK_TIMEOUT_MS;
+  const slack = dependencies.slack ?? ctx.slack ?? runtimeSlackTransport(slackTimeoutMs);
+  const exactCredentials = credentials(ctx);
+  const store = dependencies.store ?? (exactCredentials
+    ? createHttpProgressStore(exactCredentials, { fetchImpl: dependencies.fetchImpl, timeoutMs: dependencies.stateTimeoutMs })
+    : null);
+  if (!store) return { status: 'FAIL', reason: 'exact Relayfile credentials or an exact progress store are required' };
+
+  let snapshot: ProgressSnapshot;
+  try {
+    snapshot = await prepareSnapshot(ctx, store, features);
+  } catch (error) {
+    log(ctx, 'error', 'relayfile-feature-guardian.state-prepare-failed', { error: String(error) });
+    return { status: 'FAIL', reason: String(error) };
+  }
+  const feature = pickNextFeature(features, new Set(snapshot.state.checkedIds));
+  if (!feature) return { status: 'FAIL', reason: 'cycle reset produced no feature' };
+  const text = await messageFor(ctx, feature);
+  const idempotencyKey = featureIdempotencyKey(snapshot.state.cycleStartedAt, feature.id);
+  let receipt: string;
+  try {
+    const result = await withDeadline('Slack provider receipt', slackTimeoutMs, (signal) =>
+      slack.post({ channelId: channel, text, idempotencyKey, signal }));
+    receipt = confirmedSlackReceipt(result);
+    if (!receipt) throw new Error('Slack response has no confirmed provider receipt');
+  } catch (error) {
+    log(ctx, 'error', 'relayfile-feature-guardian.slack-failed', { featureId: feature.id, error: String(error) });
+    return { status: 'FAIL', reason: String(error), featureId: feature.id };
+  }
+
+  const completed: ProgressState = {
+    ...snapshot.state,
+    totalFeatures: features.length,
+    checkedIds: [...snapshot.state.checkedIds, feature.id],
+    lastPost: { featureId: feature.id, ts: receipt },
+  };
+  try {
+    const saved = await store.save(completed, snapshot, features);
+    log(ctx, 'info', 'relayfile-feature-guardian.posted', {
+      featureId: feature.id, receipt, revision: saved.revision,
+    });
+  } catch (error) {
+    log(ctx, 'error', 'relayfile-feature-guardian.post-checkpoint-failed', {
+      featureId: feature.id, receipt, error: String(error), idempotencyKey,
+    });
+    return {
+      status: 'FAIL',
+      reason: `provider receipt ${receipt} confirmed but checkpoint failed; retry with idempotency key ${idempotencyKey}: ${String(error)}`,
+      featureId: feature.id,
+      receipt,
+    };
+  }
+  return { status: 'PASS', reason: 'one feature posted and exact state checkpointed', featureId: feature.id, receipt };
+}
+
+export async function runGuardian(
+  ctx: GuardianContext,
+  _event: unknown,
+  dependencies: GuardianDependencies = {},
+): Promise<GuardianOutcome> {
+  try {
+    return await withDeadline(
+      'guardian transaction',
+      dependencies.transactionTimeoutMs ?? TRANSACTION_TIMEOUT_MS,
+      () => executeGuardian(ctx, dependencies),
+    );
+  } catch (error) {
+    log(ctx, 'error', 'relayfile-feature-guardian.transaction-failed', { error: String(error) });
+    return { status: 'FAIL', reason: String(error) };
+  }
+}
+
+export default defineAgent({
+  schedules: [{ name: 'hourly-check', cron: '0 * * * *', tz: 'UTC' }],
+  handler: async (ctx: WorkforceCtx, event: WorkforceEvent) => {
+    const outcome = await runGuardian(ctx, event);
+    if (outcome.status === 'FAIL') throw new Error(outcome.reason);
+  },
+});

--- a/.agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { parse } from 'yaml';
 
@@ -12,7 +13,7 @@ import {
 } from '../../../scripts/validate-feature-catalog.mjs';
 import guardian from './agent.ts';
 
-const root = resolve(new URL('../../../', import.meta.url).pathname);
+const root = resolve(fileURLToPath(new URL('../../../', import.meta.url)));
 const manifest = parse(readFileSync(resolve(root, '.agentworkforce/features/manifest.yaml'), 'utf8'));
 const procedures = readFileSync(resolve(root, '.agentworkforce/features/verify/procedures.md'), 'utf8');
 

--- a/.agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts
+++ b/.agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { resolve } from 'node:path';
+
+import { parse } from 'yaml';
+
+import { catalogSurfaceInventory, collectPublicSurfaces } from '../../../scripts/feature-catalog-surfaces.mjs';
+import {
+  computeSummary,
+  validateManifestData,
+} from '../../../scripts/validate-feature-catalog.mjs';
+import guardian from './agent.ts';
+
+const root = resolve(new URL('../../../', import.meta.url).pathname);
+const manifest = parse(readFileSync(resolve(root, '.agentworkforce/features/manifest.yaml'), 'utf8'));
+const procedures = readFileSync(resolve(root, '.agentworkforce/features/verify/procedures.md'), 'utf8');
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function errors(value: unknown, proceduresText = procedures): string[] {
+  return validateManifestData(value, { root, proceduresText });
+}
+
+describe('Relayfile manifest v1.1 contract', () => {
+  it('is fully valid with exact computed target-native totals', () => {
+    assert.deepEqual(errors(manifest), []);
+    assert.deepEqual(computeSummary(manifest), {
+      categories: 18,
+      features: 122,
+      criticality: { critical: 82, hot: 35, standard: 5 },
+      verify_tiers: { '1': 55, '2': 27, '3': 1, '4': 9, '5': 19, '6': 11 },
+    });
+  });
+
+  it('maps every and only every category to a unique named procedure', () => {
+    const categories = Object.keys(manifest.categories).sort();
+    const routes = Object.keys(manifest.verification.categories).sort();
+    assert.deepEqual(routes, categories);
+    assert.equal(new Set(Object.values(manifest.verification.categories)).size, categories.length);
+    for (const procedure of Object.values<string>(manifest.verification.categories)) {
+      assert.match(procedures, new RegExp(`^## ${procedure}$`, 'm'));
+    }
+  });
+
+  it('rejects missing and unknown routes plus missing documents/headings', () => {
+    const missing = clone(manifest);
+    delete missing.verification.categories.cli;
+    assert.ok(errors(missing).some((error) => error.includes('route missing')));
+
+    const unknown = clone(manifest);
+    unknown.verification.categories.unknown = 'unknown-procedure';
+    assert.ok(errors(unknown).some((error) => error.includes('unknown category')));
+
+    const document = clone(manifest);
+    document.verification.document = '.agentworkforce/features/verify/not-present.md';
+    assert.ok(validateManifestData(document, { root }).some((error) => error.includes('does not exist')));
+
+    assert.ok(errors(manifest, procedures.replace('## cli-discovery-and-lifecycle', '## renamed')).some((error) => error.includes('heading missing')));
+  });
+
+  it('rejects duplicate IDs, stale totals, and bad tiers', () => {
+    const duplicate = clone(manifest);
+    duplicate.categories.cli.features[1].id = duplicate.categories.cli.features[0].id;
+    assert.ok(errors(duplicate).some((error) => error.includes('duplicate feature id')));
+
+    const stale = clone(manifest);
+    stale.summary.features += 1;
+    assert.ok(errors(stale).some((error) => error.includes('stale summary totals')));
+
+    const tier = clone(manifest);
+    tier.categories.cli.features[0].verify_tier = 0;
+    assert.ok(errors(tier).some((error) => error.includes('invalid verify_tier')));
+  });
+
+  it('rejects path escapes, absolute paths, and missing locations', () => {
+    for (const location of ['../outside', '/tmp/outside', 'not/a/real/source.ts']) {
+      const changed = clone(manifest);
+      changed.categories.cli.features[0].locations = [location];
+      assert.ok(errors(changed).some((error) => /escapes|does not exist/.test(error)), location);
+    }
+  });
+
+  it('rejects uncovered, overlapping, and stale public surface selectors', () => {
+    const omission = clone(manifest);
+    omission.categories.cli.features[0].covers = ['cli:relayfile help-does-not-exist'];
+    const omissionErrors = errors(omission);
+    assert.ok(omissionErrors.some((error) => error.includes('public surface omission: cli:relayfile help')));
+    assert.ok(omissionErrors.some((error) => error.includes('matches no public surface')));
+
+    const overlap = clone(manifest);
+    overlap.categories.cli.features[1].covers.push('cli:relayfile help');
+    assert.ok(errors(overlap).some((error) => error.includes('overlapping feature coverage')));
+  });
+
+  it('exposes the same strict structural validator to the scoped guardian runtime', () => {
+    assert.deepEqual(validateManifestData(manifest, { structuralOnly: true }), []);
+    const escaped = clone(manifest);
+    escaped.categories.cli.features[0].locations = ['../outside'];
+    assert.ok(validateManifestData(escaped, { structuralOnly: true }).some((error) => error.includes('escapes')));
+    const malformedExclusions = clone(manifest);
+    malformedExclusions.surface_exclusions = {};
+    assert.ok(validateManifestData(malformedExclusions, { structuralOnly: true }).some((error) => error.includes('must be a sequence')));
+  });
+});
+
+describe('target-specific public surface enumeration', () => {
+  const surfaces = collectPublicSurfaces(root);
+
+  it('enumerates every canonical CLI leaf and reviewed alias/default dispatch', () => {
+    assert.equal(catalogSurfaceInventory.cliLeaves.length, 51);
+    for (const leaf of catalogSurfaceInventory.cliLeaves) assert.ok(surfaces.includes(`cli:relayfile ${leaf}`));
+    for (const alias of catalogSurfaceInventory.cliAliases) assert.ok(surfaces.includes(`cli-alias:${alias}`));
+  });
+
+  it('enumerates local, control-plane, hosted, and schema fields', () => {
+    for (const expected of [
+      'http:data:GET /health',
+      'http:data:GET /dashboard',
+      'http:data:POST /v1/workspaces/{workspaceId}/subscriptions',
+      'http:data:POST /v1/workspaces/{workspaceId}/subscriptions/deliveries/{deliveryId}/accept',
+      'http:control:POST /v1/integrations/connect',
+      'http:hosted:GET /v1/workspaces/{workspaceId}/fs/changes',
+      'schema:data:TreeEntry.path',
+      'schema:control:HelloResponse.apiVersion',
+    ]) assert.ok(surfaces.includes(expected), expected);
+  });
+
+  it('enumerates config/environment fields and mount flags', () => {
+    for (const expected of [
+      'config:env:server:RELAYFILE_BACKEND_PROFILE',
+      'config:env:mount:RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO',
+      'config:field:mount-state:guards',
+      'config:field:provider-binding:webhookSubscriptionId',
+      'flag:relayfile-mount:--sync-mode',
+      'flag:relayfile-mount:--flush-outbox-once',
+    ]) assert.ok(surfaces.includes(expected), expected);
+  });
+
+  it('enumerates package maps and exact TS/Python registries', () => {
+    for (const expected of [
+      'package-export:@relayfile/sdk:./mount-harness',
+      'package-export:@relayfile/agents:./openai',
+      'package-export:@relayfile/core:.',
+      'package-bin:relayfile:relayfile',
+      'package-artifact:@relayfile/mount-linux-arm64:bin',
+      'export:ts-sdk:RelayFileClient',
+      'export:python-root:AsyncRelayFileClient',
+    ]) assert.ok(surfaces.includes(expected), expected);
+  });
+
+  it('enumerates release-sensitive and dormant-safety implementation areas', () => {
+    for (const expected of [
+      'release:path:.github/workflows/publish.yml',
+      'release:path:scripts/check-contract-surface.sh',
+      'implementation:server-delete-storm-library-only',
+      'implementation:server-stale-running-library-only',
+      'implementation:terminal-provider-state-retained',
+    ]) assert.ok(surfaces.includes(expected), expected);
+  });
+});
+
+describe('guardian persona operating model', () => {
+  const persona = JSON.parse(readFileSync(resolve(root, '.agentworkforce/agents/relayfile-feature-guardian/persona.json'), 'utf8'));
+
+  it('matches the supported reference persona shape with target-narrowed scopes', () => {
+    assert.deepEqual(persona, {
+      id: 'relayfile-feature-guardian',
+      intent: 'relay-orchestrator',
+      tags: ['relayfile', 'verification', 'proactive', 'catalog', 'health'],
+      description: "Reads Relayfile's authoritative feature catalog from a repository-scoped clone each hour, advances an exact revisioned bounded cycle, and optionally posts one idempotent receipt-confirmed check to an input-selected Slack channel.",
+      cloud: true,
+      harness: 'opencode',
+      model: 'deepseek-v4-flash-free',
+      harnessSettings: {
+        reasoning: 'low',
+        timeoutSeconds: 300,
+      },
+      integrations: {
+        github: {
+          scope: {
+            repo: 'AgentWorkforce/relayfile',
+          },
+          relayfileMount: {
+            requiredReadPaths: [
+              '/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/manifest.yaml',
+              '/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/critical-paths.md',
+              '/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/verify/procedures.md',
+            ],
+            writeOnlyPaths: [],
+          },
+        },
+        slack: {
+          optional: true,
+          enabledByInput: 'SLACK_CHANNEL',
+          scope: {
+            paths: '/slack/channels/${SLACK_CHANNEL}/**',
+          },
+          relayfileMount: {
+            requiredReadPaths: [],
+            writeOnlyPaths: ['/slack/channels/${SLACK_CHANNEL}/**'],
+          },
+        },
+      },
+      inputs: {
+        SLACK_CHANNEL: {
+          description: 'Optional disposable Slack channel ID. No Slack mount or post occurs when absent.',
+          env: 'SLACK_CHANNEL',
+          optional: true,
+          picker: {
+            provider: 'slack',
+            resource: 'channels',
+          },
+        },
+      },
+      memory: {
+        enabled: true,
+        scopes: ['workspace'],
+        ttlDays: 14,
+      },
+      onEvent: './agent.ts',
+    });
+  });
+
+  it('is hourly with a dedicated harness and target repository clone', () => {
+    assert.equal(guardian.__workforceAgent, true);
+    assert.deepEqual(guardian.schedules, [{ name: 'hourly-check', cron: '0 * * * *', tz: 'UTC' }]);
+    assert.equal(persona.harness, 'opencode');
+    assert.equal(persona.model, 'deepseek-v4-flash-free');
+    assert.equal(Object.hasOwn(persona, 'useSubscription'), false);
+    assert.deepEqual(persona.harnessSettings, { reasoning: 'low', timeoutSeconds: 300 });
+    assert.equal(persona.integrations.github.scope.repo, 'AgentWorkforce/relayfile');
+  });
+
+  it('has catalog-only clone reads and optional input-gated write-only Slack', () => {
+    const github = persona.integrations.github.relayfileMount;
+    assert.deepEqual(github.writeOnlyPaths, []);
+    assert.equal(github.requiredReadPaths.length, 3);
+    assert.ok(github.requiredReadPaths.every((path: string) => path.startsWith('/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/')));
+    const slack = persona.integrations.slack;
+    assert.equal(slack.optional, true);
+    assert.equal(slack.enabledByInput, 'SLACK_CHANNEL');
+    assert.equal(slack.scope.paths, '/slack/channels/${SLACK_CHANNEL}/**');
+    assert.deepEqual(slack.relayfileMount.requiredReadPaths, []);
+    assert.deepEqual(slack.relayfileMount.writeOnlyPaths, ['/slack/channels/${SLACK_CHANNEL}/**']);
+    assert.equal(persona.inputs.SLACK_CHANNEL.default, undefined);
+    assert.equal(persona.inputs.SLACK_CHANNEL.optional, true);
+    assert.deepEqual(persona.memory, { enabled: true, scopes: ['workspace'], ttlDays: 14 });
+  });
+});

--- a/.agentworkforce/agents/relayfile-feature-guardian/persona.json
+++ b/.agentworkforce/agents/relayfile-feature-guardian/persona.json
@@ -1,0 +1,56 @@
+{
+  "id": "relayfile-feature-guardian",
+  "intent": "relay-orchestrator",
+  "tags": ["relayfile", "verification", "proactive", "catalog", "health"],
+  "description": "Reads Relayfile's authoritative feature catalog from a repository-scoped clone each hour, advances an exact revisioned bounded cycle, and optionally posts one idempotent receipt-confirmed check to an input-selected Slack channel.",
+  "cloud": true,
+  "harness": "opencode",
+  "model": "deepseek-v4-flash-free",
+  "harnessSettings": {
+    "reasoning": "low",
+    "timeoutSeconds": 300
+  },
+  "integrations": {
+    "github": {
+      "scope": {
+        "repo": "AgentWorkforce/relayfile"
+      },
+      "relayfileMount": {
+        "requiredReadPaths": [
+          "/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/manifest.yaml",
+          "/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/critical-paths.md",
+          "/github/repos/AgentWorkforce/relayfile/.agentworkforce/features/verify/procedures.md"
+        ],
+        "writeOnlyPaths": []
+      }
+    },
+    "slack": {
+      "optional": true,
+      "enabledByInput": "SLACK_CHANNEL",
+      "scope": {
+        "paths": "/slack/channels/${SLACK_CHANNEL}/**"
+      },
+      "relayfileMount": {
+        "requiredReadPaths": [],
+        "writeOnlyPaths": ["/slack/channels/${SLACK_CHANNEL}/**"]
+      }
+    }
+  },
+  "inputs": {
+    "SLACK_CHANNEL": {
+      "description": "Optional disposable Slack channel ID. No Slack mount or post occurs when absent.",
+      "env": "SLACK_CHANNEL",
+      "optional": true,
+      "picker": {
+        "provider": "slack",
+        "resource": "channels"
+      }
+    }
+  },
+  "memory": {
+    "enabled": true,
+    "scopes": ["workspace"],
+    "ttlDays": 14
+  },
+  "onEvent": "./agent.ts"
+}

--- a/.agentworkforce/features/README.md
+++ b/.agentworkforce/features/README.md
@@ -1,0 +1,28 @@
+# Relayfile feature catalog
+
+`manifest.yaml` is the authoritative implementation-derived catalog. Its checked summary is **18 categories and 122 features**: 82 critical, 35 hot, and 5 standard; tier counts are 55/27/1/9/19/11 for tiers 1–6.
+
+Run:
+
+```bash
+npm run features:validate
+npm run features:test
+npm run features:verify -- --tier 1
+```
+
+The validator recomputes totals, checks unique stable IDs and real repository paths, enforces a one-to-one category/procedure route, verifies procedure completeness, and maps every machine-enumerated public surface to exactly one feature. The independent inventory includes canonical CLI leaves and aliases, both OpenAPI operation/schema sets, hosted SDK paths, SDK methods and parity exports, Python `__all__`, package export/bin maps, mount flags, environment/config fields, provider paths, lifecycle/safety areas, observability, and release automation.
+
+Tier meanings:
+
+| Tier | Environment | Automation rule |
+|---|---|---|
+| 1 | Static and isolated local | Required in deterministic CI |
+| 2 | Local server/mount or optional local backend | Required when the host supports the named local prerequisite; otherwise explicit SKIP |
+| 3 | Privileged FUSE host | Explicit opt-in; unsupported is SKIP |
+| 4 | Clean packed consumer | Deterministic release gate; never publishes |
+| 5 | Disposable hosted workspace/service | Explicit opt-in and credentials |
+| 6 | Interactive provider or destructive release action | MANUAL unless a bounded disposable harness exists |
+
+Use `critical-paths.md` to select product flows and `verify/procedures.md` for exact setup, commands, positive/negative assertions, cleanup, limits, and result semantics. Do not add a prose list of feature IDs; update the manifest and machine surface inventory together.
+
+The hourly guardian under `.agentworkforce/agents/relayfile-feature-guardian/` reads only the cloned catalog paths. Slack is optional, input-gated, and write-only. Its exact revisioned state fails closed on malformed data, ambiguous manifest shrink, HTTP/auth/CAS ambiguity, and receiptless delivery.

--- a/.agentworkforce/features/critical-paths.md
+++ b/.agentworkforce/features/critical-paths.md
@@ -1,0 +1,46 @@
+# Relayfile critical paths
+
+Resolve each category through `manifest.yaml` and execute the named procedure in `verify/procedures.md`. These paths name categories, not a second feature-ID inventory.
+
+## Fast health triage
+
+1. Run `node scripts/validate-feature-catalog.mjs`.
+2. Run the `cli` procedure.
+3. Run the focused contract and guardian tests from `proactive-automation`.
+4. If source changed, continue with every category whose `locations` contains the changed path.
+
+## Local authenticated CRUD, revision, and ACL
+
+Run `server-storage-auth` → `filesystem` → `acl-revisions-forks`. Prove health, create/read/query/export, stale `If-Match` conflict, path-scope denial, and cleanup deletion. Any skipped local assertion makes the path incomplete.
+
+## Two-mount bidirectional convergence
+
+Run `mount` with two isolated local roots and the local server. Prove API seed reaches both mounts, each mount writes back to the other, delete tombstones converge, events advance, and both daemon PIDs exit. The outbound webhook receiver remains separately `SKIP` if absent.
+
+## Provider ingest to event and digest
+
+Run `ingest-digests` → `events`. Ingest create/update/terminal/delete in that order. Prove the provider file event and both current digest artifacts change; terminal state remains data; only the explicit upstream delete removes the provider file.
+
+## File write to provider receipt and recovery
+
+Run `operations-writeback`. Prove queued operation → provider result/receipt → acknowledgment. Then inject a retryable failure, prove bounded retry and dead letter, replay it, and prove final receipt. Mock proof is local; a provider receipt is a distinct Tier 5 result.
+
+## Bootstrap resume and destructive fences
+
+Run `mount` with a checkpointed traversal, cancel it, resume, and prove progress does not restart from zero. Trigger (without applying) delete-ratio, clobber, rehome, root-integrity, path-collision, and PID-reuse guards. Every fence must be externally visible in status or an incident artifact.
+
+## Hosted setup, connect, mount, and agent event
+
+Run `workspace-auth` → `integrations` → `sdk-typescript` or `sdk-python` → `agents` with disposable hosted credentials. Prove scoped invitation, backend-specific connection, mount-session renewal, WebSocket recovery, and agent read/write fence. Missing credentials produce `SKIP`, never `PASS`.
+
+## Durable resource subscription and delivery claim
+
+Run `sdk-typescript` and prove create-or-renew, owner-scoped list, delivery claim, claim-token acceptance, and cancellation use the exact OpenAPI routes. Assert the client drops a forged `ownerId`, rejects empty identifiers and out-of-range TTLs before I/O, and surfaces a capability `404`. This deterministic client-contract proof does not confirm a hosted implementation; exercise the same lifecycle against a disposable hosted workspace before reporting live service support as `PASS`.
+
+## Package consumer and release boundary
+
+Run `release-e2e` after `sdk-typescript`, `sdk-python`, `core-client-local-mount`, and `agents`. Install packed artifacts into clean temp consumers, import declared entrypoints, resolve the platform binary, and exercise help/version plus a local flow. Publishing, tagging, and release creation remain `MANUAL`.
+
+## Diagnosis and cleanup order
+
+On failure, retain redacted logs, identify the first broken boundary, and rerun its named procedure after repair. Cleanup order is external provider artifact → hosted subscription/workspace → WebSocket/client → mount daemon → local server → marker-checked temp root. If cleanup cannot be confirmed, report `FAIL` and the exact retained resource.

--- a/.agentworkforce/features/manifest.yaml
+++ b/.agentworkforce/features/manifest.yaml
@@ -1,0 +1,885 @@
+version: '1.1'
+updated: '2026-07-21'
+
+# Relayfile-only catalog. `covers` selectors are checked against the independently
+# enumerated source inventory in scripts/feature-catalog-surfaces.mjs. A selector
+# must match at least one surface, and every surface must match exactly one feature.
+summary:
+  categories: 18
+  features: 122
+  criticality:
+    critical: 82
+    hot: 35
+    standard: 5
+  verify_tiers:
+    '1': 55
+    '2': 27
+    '3': 1
+    '4': 9
+    '5': 19
+    '6': 11
+
+verification:
+  document: .agentworkforce/features/verify/procedures.md
+  categories:
+    cli: cli-discovery-and-lifecycle
+    workspace-auth: workspace-auth-and-scoped-invites
+    integrations: integration-catalog-connect-and-bindings
+    filesystem: filesystem-crud-query-export
+    acl-revisions-forks: acl-revision-and-fork-safety
+    events: events-websocket-and-recovery
+    ingest-digests: provider-ingest-events-and-digests
+    operations-writeback: writeback-retry-dead-letter-and-receipts
+    mount: mirror-mount-bootstrap-outbox-and-fences
+    fuse: fuse-virtual-artifacts-and-invalidation
+    sdk-typescript: typescript-exports-and-client-flow
+    sdk-python: python-exports-parity-and-client-flow
+    core-client-local-mount: package-exports-control-plane-and-local-mount
+    agents: agent-framework-tools-events-and-forwarder
+    server-storage-auth: server-backends-auth-and-ingress
+    hosted-observability: cloud-observer-status-and-alerts
+    release-e2e: packed-artifacts-and-release-smoke
+    proactive-automation: personas-evals-and-guardian
+
+surface_exclusions: []
+
+categories:
+  cli:
+    name: Command-line discovery and local lifecycle
+    description: Public relayfile command leaves, aliases, local process control, and inspection commands.
+    criticality: critical
+    features:
+      - id: cli-help
+        name: Help discovery
+        description: Prints root or command help through the canonical help leaf and both flag aliases.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile help', 'cli-alias:-h=>help', 'cli-alias:--help=>help']
+      - id: cli-version
+        name: CLI version
+        description: Reports the injected CLI version; the raw Go fallback remains a separately audited release risk.
+        locations: [cmd/relayfile-cli/main.go, packages/cli/scripts/run.js]
+        verify_tier: 1
+        covers: ['cli:relayfile version', 'cli-alias:--version=>version']
+      - id: cli-setup
+        name: Interactive setup
+        description: Configures a local or hosted Relayfile workspace and is the no-argument default command.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile setup', 'cli-alias:<no-args>=>setup']
+      - id: cli-pull
+        name: Pull remote state
+        description: Performs a bounded one-shot pull into the configured local workspace.
+        locations: [cmd/relayfile-cli/main.go, internal/mountsync]
+        verify_tier: 2
+        covers: ['cli:relayfile pull']
+      - id: cli-mount
+        name: Start mount synchronization
+        description: Starts the mount daemon through mount, start, or on dispatch.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile mount', 'cli-alias:start=>mount', 'cli-alias:on=>mount']
+      - id: cli-restart
+        name: Restart mount daemon
+        description: Stops a verified Relayfile mount process and starts it again with persisted configuration.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile restart']
+      - id: cli-supervisor-install
+        name: Install supervisor
+        description: Installs the platform service definition used to supervise a mount daemon.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile supervisor install']
+      - id: cli-supervisor-uninstall
+        name: Uninstall supervisor
+        description: Removes the Relayfile supervisor through uninstall or remove after process identity checks.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile supervisor uninstall', 'cli-alias:supervisor remove=>supervisor uninstall']
+      - id: cli-supervisor-status
+        name: Supervisor status
+        description: Reports whether the platform supervisor and its recorded process are healthy.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile supervisor status']
+      - id: cli-tree
+        name: Tree listing
+        description: Lists remote paths through tree or ls without mounting the workspace.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile tree', 'cli-alias:ls=>tree']
+      - id: cli-read
+        name: File read
+        description: Reads one remote file through read or cat with normal scope enforcement.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile read', 'cli-alias:cat=>read']
+      - id: cli-seed
+        name: Seed directory
+        description: Uploads a bounded local directory tree into the selected workspace.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile seed']
+      - id: cli-export
+        name: Workspace export
+        description: Exports workspace content as JSON, tar, or patch without publishing it.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile export']
+      - id: cli-status
+        name: Mount and workspace status
+        description: Reports configured workspace, daemon, bootstrap, guard, and provider state.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile status']
+      - id: cli-stop
+        name: Stop mount daemon
+        description: Stops a verified daemon through stop or off while refusing unrelated reused PIDs.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile stop', 'cli-alias:off=>stop']
+      - id: cli-logs
+        name: Mount logs
+        description: Reads bounded daemon log output from the configured Relayfile state directory.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile logs']
+      - id: cli-observer
+        name: File observer launch
+        description: Opens or reports the configured hosted/file-observer view for a workspace.
+        locations: [cmd/relayfile-cli/main.go, packages/file-observer/src]
+        verify_tier: 5
+        covers: ['cli:relayfile observer']
+      - id: cli-listen
+        name: Event listener
+        description: Streams workspace events through listen or watch with reconnect behavior.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile listen', 'cli-alias:watch=>listen']
+      - id: cli-control-plane-serve
+        name: Local control plane
+        description: Serves the versioned local integration API over a Unix domain socket.
+        locations: [cmd/relayfile-cli/main.go, cmd/relayfile-cli/control_plane.go]
+        verify_tier: 2
+        covers: ['cli:relayfile control-plane serve']
+      - id: cli-dev
+        name: Developer orchestration
+        description: Starts the local developer server and supporting processes without representing a production deployment.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile dev']
+      - id: cli-runtime-environment
+        name: CLI and cloud environment contract
+        description: Resolves CLI, cloud, control-plane, observer, Relaycast, and delegated credential inputs.
+        locations: [cmd/relayfile-cli/main.go, packages/sdk/typescript/src]
+        verify_tier: 1
+        covers: ['config:env:cli:*']
+
+  workspace-auth:
+    name: Workspace setup and authentication
+    description: Login, workspace lifecycle, delegated credentials, scoped invitations, and local negative auth behavior.
+    criticality: critical
+    features:
+      - id: cli-login
+        name: Login
+        description: Obtains and persists cloud and workspace credentials, with explicit messaging-only handling.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile login']
+      - id: cli-logout
+        name: Logout
+        description: Removes Relayfile authentication state without deleting workspace content.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile logout']
+      - id: cli-workspace-create
+        name: Create workspace
+        description: Creates a hosted Relayfile-backed workspace and stores the resulting scoped credentials.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile workspace create']
+      - id: cli-workspace-join
+        name: Join workspace
+        description: Joins an existing workspace by invitation and persists the minted workspace token.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile workspace join']
+      - id: cli-workspace-use
+        name: Select workspace
+        description: Selects a previously configured workspace without mutating remote content.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile workspace use']
+      - id: cli-workspace-list
+        name: List workspaces
+        description: Lists locally known workspaces and the active selection.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile workspace list']
+      - id: cli-workspace-current
+        name: Current workspace
+        description: Prints the active workspace record used by subsequent commands.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile workspace current']
+      - id: cli-workspace-status
+        name: Workspace status
+        description: Reports local and hosted status for the selected or explicit workspace.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile workspace status']
+      - id: cli-workspace-delete
+        name: Delete workspace
+        description: Deletes a hosted workspace only after the explicit --yes destructive fence.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile workspace delete']
+      - id: workspace-config-schema
+        name: Credential and workspace configuration
+        description: Persists versioned credential and workspace catalog fields used by CLI and setup clients.
+        locations: [cmd/relayfile-cli/main.go, packages/sdk/typescript/src/cli/setup.ts]
+        verify_tier: 1
+        covers: ['config:field:credentials:*', 'config:field:workspace:*']
+      - id: hosted-workspace-control
+        name: Hosted workspace and invite control
+        description: Uses cloud-only create, join, delegated-token, mount-session, and scoped invite paths; these are not local Go routes.
+        locations: [packages/sdk/typescript/src/cli/setup.ts, packages/sdk/python/src/relayfile/setup.py]
+        verify_tier: 5
+        covers: ['implementation:hosted-setup-scoped-invites']
+
+  integrations:
+    name: Integration catalog, connection, and bindings
+    description: Provider discovery, backend selection, connection lifecycle, canonical paths, bindings, and writeback secrets.
+    criticality: hot
+    features:
+      - id: cli-integration-connect
+        name: Connect integration
+        description: Starts a Nango or Composio connection flow for a catalog provider.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile integration connect']
+      - id: cli-integration-available
+        name: Available integrations
+        description: Lists the cloud catalog or the truthful six-provider fallback through all documented aliases.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile integration available', 'cli-alias:integration catalog=>integration available', 'cli-alias:integration providers=>integration available']
+      - id: cli-integration-search
+        name: Search integrations
+        description: Searches integration catalog metadata without claiming connection support for every canonical helper.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile integration search']
+      - id: cli-integration-list
+        name: Connected integrations
+        description: Lists provider connection and synchronization status for the selected workspace.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile integration list']
+      - id: cli-integration-disconnect
+        name: Disconnect integration
+        description: Disconnects a provider only after the explicit --yes destructive fence.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile integration disconnect']
+      - id: cli-integration-adopt
+        name: Adopt integration
+        description: Adopts an existing provider connection only after explicit --yes confirmation.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile integration adopt']
+      - id: cli-integration-metadata
+        name: Integration metadata
+        description: Sets provider metadata, including site selection where required, behind --yes confirmation.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile integration set-metadata']
+      - id: cli-integration-bind
+        name: Bind integration resource
+        description: Creates or lists local provider-to-resource bindings used by the control plane.
+        locations: [cmd/relayfile-cli/main.go, cmd/relayfile-cli/control_plane.go]
+        verify_tier: 5
+        covers: ['cli:relayfile integration bind']
+      - id: cli-integration-resolve-path
+        name: Resolve provider path
+        description: Resolves provider resources to canonical virtual filesystem paths.
+        locations: [cmd/relayfile-cli/main.go, packages/sdk/typescript/src/provider.ts]
+        verify_tier: 1
+        covers: ['cli:relayfile integration resolve-path']
+      - id: cli-integration-unbind
+        name: Unbind integration resource
+        description: Removes one exact provider resource binding without disconnecting the provider.
+        locations: [cmd/relayfile-cli/main.go, cmd/relayfile-cli/control_plane.go]
+        verify_tier: 5
+        covers: ['cli:relayfile integration unbind']
+      - id: cli-integration-writeback-secret
+        name: Integration writeback secret
+        description: Obtains the scoped secret used for provider writeback delivery.
+        locations: [cmd/relayfile-cli/main.go, cmd/relayfile-cli/control_plane.go]
+        verify_tier: 5
+        covers: ['cli:relayfile integration writeback-secret']
+      - id: control-plane-integrations
+        name: Local integration control-plane API
+        description: Implements provider discovery/status, connect, path resolution, bindings, secrets, and webhook subscription operations over the local socket.
+        locations: [cmd/relayfile-cli/control_plane.go, openapi/relayfile-control-plane-v1.openapi.yaml]
+        verify_tier: 2
+        covers: ['http:control:* /v1/integrations/*', 'schema:control:*']
+      - id: provider-catalog-layers
+        name: Provider catalog and connection layers
+        description: Distinguishes cloud catalog, local fallback, six setup identities, and Nango/Composio backends from canonical path helpers.
+        locations: [cmd/relayfile-cli/main.go, packages/sdk/typescript/src/cli/setup.ts, packages/sdk/python/src/relayfile/setup.py]
+        verify_tier: 5
+        covers: ['provider:catalog-*', 'provider:connect-*', 'provider:setup:*']
+      - id: provider-canonical-paths
+        name: Canonical provider path helpers
+        description: Computes canonical prefixes for seventeen named providers plus generic fallback without claiming live integration support.
+        locations: [packages/sdk/typescript/src/provider.ts, packages/sdk/python/src/relayfile/provider.py]
+        verify_tier: 1
+        covers: ['provider:canonical:*']
+      - id: provider-binding-config
+        name: Provider binding persistence
+        description: Persists exact path, webhook, subscription, and timestamp fields for local bindings.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['config:field:provider-binding:*']
+
+  filesystem:
+    name: Filesystem data plane
+    description: Local authenticated tree, file, bulk, query, export, and bounded GitHub tarball import behavior.
+    criticality: critical
+    features:
+      - id: api-health
+        name: Health endpoint
+        description: Reports local data-plane liveness without workspace data mutation.
+        locations: [internal/httpapi/server.go, openapi/relayfile-v1.openapi.yaml]
+        verify_tier: 1
+        covers: ['http:data:GET /health']
+      - id: api-tree
+        name: Filesystem tree
+        description: Lists normalized workspace paths with pagination and bounded depth.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:GET /v1/workspaces/{workspaceId}/fs/tree']
+      - id: api-file-crud
+        name: File CRUD
+        description: Reads, creates, updates, and actually deletes files with revision and path bounds.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/fs/file']
+      - id: api-bulk-write
+        name: Bulk write
+        description: Applies bounded per-file writes with independent results, revisions, identities, and writeback state.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:POST /v1/workspaces/{workspaceId}/fs/bulk']
+      - id: api-query
+        name: Metadata query
+        description: Queries paths and semantic metadata with cursor pagination.
+        locations: [internal/httpapi/server.go, packages/core/src/query.ts]
+        verify_tier: 1
+        covers: ['http:data:GET /v1/workspaces/{workspaceId}/fs/query']
+      - id: api-export
+        name: Data-plane export
+        description: Exports selected workspace state in JSON, tar, or patch form.
+        locations: [internal/httpapi/server.go, packages/core/src/export.ts]
+        verify_tier: 1
+        covers: ['http:data:GET /v1/workspaces/{workspaceId}/fs/export']
+      - id: api-github-import
+        name: Bounded GitHub tarball import
+        description: Imports uploaded or fetched GitHub tarballs with job status, byte, path, and archive safety bounds.
+        locations: [internal/httpapi/github_tarball.go, internal/httpapi/github_tarball_test.go]
+        verify_tier: 1
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/fs/import/*']
+      - id: data-plane-wire-schemas
+        name: Data-plane wire schemas
+        description: Defines every authoritative OpenAPI request, response, status, operation, ingest, writeback, import, and conflict field.
+        locations: [openapi/relayfile-v1.openapi.yaml]
+        verify_tier: 1
+        covers: ['schema:data:*']
+      - id: filesystem-core-implementation
+        name: Filesystem core semantics
+        description: Implements normalized CRUD, bulk, query, tree, and export semantics shared by server and SDK packages.
+        locations: [internal/relayfile, packages/core/src]
+        verify_tier: 1
+        covers: ['implementation:filesystem-crud-bulk-query-export']
+
+  acl-revisions-forks:
+    name: ACL, revisions, and forks
+    description: Workspace/path authorization, optimistic concurrency, and isolated fork lifecycle safety.
+    criticality: critical
+    features:
+      - id: acl-path-scopes
+        name: Directory ACL and token scopes
+        description: Enforces directory permission markers and scoped RS256 workspace claims for reads and writes.
+        locations: [internal/httpapi/auth.go, packages/core/src/acl.ts]
+        verify_tier: 1
+        covers: ['implementation:acl-directory-markers']
+      - id: revision-if-match
+        name: Optimistic revision fences
+        description: Requires and validates If-Match revisions for create, update, and delete conflicts.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['implementation:revision-if-match']
+      - id: api-forks
+        name: Fork overlay lifecycle
+        description: Creates expiring overlays, commits them against the parent revision, or discards them.
+        locations: [internal/httpapi/server.go, packages/core/src/forks.ts]
+        verify_tier: 1
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/forks*', 'implementation:fork-overlay-commit-discard']
+
+  events:
+    name: Events and reactivity
+    description: Cursor event feeds, WebSocket catch-up/live delivery, filtering, reconnect, and polling recovery.
+    criticality: critical
+    features:
+      - id: api-event-feed
+        name: Event feed
+        description: Returns cursor-ordered filesystem events with workspace and path scope filtering.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:GET /v1/workspaces/{workspaceId}/fs/events']
+      - id: api-event-websocket
+        name: Event WebSocket
+        description: Delivers catch-up and live filesystem events with bounded reconnect behavior.
+        locations: [internal/httpapi/server.go, packages/sdk/typescript/src/client.ts]
+        verify_tier: 2
+        covers: ['http:data:GET /v1/workspaces/{workspaceId}/fs/ws']
+      - id: reactive-client-recovery
+        name: Reactive client recovery
+        description: Reconnects, polls when required, coalesces updates, and invalidates read caches without losing the cursor.
+        locations: [packages/sdk/typescript/src/sync.ts, packages/sdk/python/src/relayfile/on_write.py, packages/agents/src]
+        verify_tier: 2
+        covers: ['implementation:events-feed-websocket']
+
+  ingest-digests:
+    name: Provider ingest and digest artifacts
+    description: Generic provider envelope normalization, deduplication, event emission, virtual layouts, and non-recursive digest regeneration.
+    criticality: critical
+    features:
+      - id: api-webhook-ingest
+        name: Internal and workspace ingest
+        description: Accepts signed internal envelopes and scoped workspace ingest with replay, skew, body, and rate limits.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:POST /v1/internal/webhook-envelopes', 'http:data:POST /v1/workspaces/{workspaceId}/webhooks/ingest']
+      - id: generic-provider-ingest
+        name: Generic provider normalization
+        description: Normalizes provider-neutral objects, semantic metadata, content identity, and deduplication before durable writes.
+        locations: [internal/relayfile, packages/core/src/webhooks.ts, packages/sdk/typescript/src/integration-adapter.ts]
+        verify_tier: 1
+        covers: ['provider:generic-ingest', 'implementation:ingest-dedup-semantics']
+      - id: digest-regeneration
+        name: Digest regeneration and events
+        description: Regenerates today and yesterday digests for non-digest mutations, avoids recursion, and emits normal digest-file events.
+        locations: [internal/digest, internal/relayfile, .claude/rules/relayfile-integration-digests.md]
+        verify_tier: 1
+        covers: ['provider:digest:*', 'implementation:digest-regeneration-events']
+      - id: provider-virtual-artifacts
+        name: Provider virtual layout artifacts
+        description: Exposes layout, index, alias, activity summary, schema, and read-only dead-letter artifacts.
+        locations: [internal/schema, internal/mountsync, internal/mountfuse]
+        verify_tier: 2
+        covers: ['provider:virtual:*']
+      - id: github-issue-schema
+        name: Bundled GitHub issue schema
+        description: Ships the one provider content schema bundled by this repository without implying other bundled provider schemas.
+        locations: [schemas/github/issue.schema.json]
+        verify_tier: 1
+        covers: ['provider:schema:*']
+      - id: terminal-state-retention
+        name: Terminal provider state retention
+        description: Retains closed, merged, archived, completed, canceled, and resolved objects as data unless upstream actually deletes them.
+        locations: [internal/relayfile, .claude/rules/relayfile-integration-digests.md]
+        verify_tier: 5
+        covers: ['implementation:terminal-provider-state-retained']
+
+  operations-writeback:
+    name: Operations and writeback recovery
+    description: Durable operation queues, provider receipts, retries, replay, dead letters, stuck cursor recovery, and draft cleanup.
+    criticality: critical
+    features:
+      - id: cli-ops-list
+        name: List operations
+        description: Lists durable operation state with cursor pagination.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile ops list']
+      - id: cli-ops-replay
+        name: Replay operation
+        description: Requeues one recoverable operation through the normal writeback path.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile ops replay']
+      - id: cli-writeback-list
+        name: List pending writebacks
+        description: Lists pending external-consumer writeback records without acknowledging them.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile writeback list']
+      - id: cli-writeback-push
+        name: Push writeback
+        description: Queues a local file create for provider writeback with byte and path bounds.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile writeback push']
+      - id: cli-writeback-update
+        name: Update writeback
+        description: Queues an update for a canonical provider-backed file.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 5
+        covers: ['cli:relayfile writeback update']
+      - id: cli-writeback-delete
+        name: Delete writeback
+        description: Queues an upstream delete intent while retaining durable tombstone state until confirmed.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile writeback delete']
+      - id: cli-writeback-status
+        name: Writeback status
+        description: Reports operation attempts, provider result, receipt, and terminal state for one operation.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 1
+        covers: ['cli:relayfile writeback status']
+      - id: cli-writeback-retry
+        name: Retry writeback
+        description: Replays a recoverable failed or dead-lettered writeback operation.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile writeback retry']
+      - id: cli-writeback-skip-stuck
+        name: Skip stuck cursor
+        description: Explicitly advances past a stuck writeback cursor after operator review.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 6
+        covers: ['cli:relayfile writeback skip-stuck']
+      - id: cli-writeback-sweep-drafts
+        name: Sweep stale drafts
+        description: Reports stale drafts by default and mutates them only with --apply.
+        locations: [cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['cli:relayfile writeback sweep-drafts']
+      - id: cli-digest-rebuild
+        name: Rebuild digests
+        description: Rebuilds current digest artifacts through the normal event-emitting store path.
+        locations: [cmd/relayfile-cli/main.go, internal/digest]
+        verify_tier: 2
+        covers: ['cli:relayfile digest rebuild']
+      - id: api-operations
+        name: Operation status and replay API
+        description: Lists, reads, and replays durable operations in workspace and admin scopes.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 1
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/ops*']
+      - id: api-writeback
+        name: External writeback API
+        description: Lists pending records, acknowledges provider receipts, and sweeps drafts through bounded endpoints.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 2
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/writeback/*']
+      - id: durable-operation-recovery
+        name: Durable operation recovery
+        description: Persists retry/backoff, replay, acknowledgment, dead-letter, and stale-running quarantine behavior.
+        locations: [internal/relayfile]
+        verify_tier: 2
+        covers: ['implementation:operation-retry-replay-dead-letter']
+      - id: provider-writeback-receipts
+        name: Provider writeback receipts
+        description: Records provider results and confirmed receipts, with draft sweep and bounded attempts.
+        locations: [internal/relayfile, packages/sdk/typescript/src/writeback-consumer.ts]
+        verify_tier: 5
+        covers: ['implementation:writeback-receipts-draft-sweep']
+
+  mount:
+    name: Mirror mount durability and fences
+    description: Native mount flags, mirror/write-only synchronization, bootstrap recovery, outbox state, token renewal, and destructive safety fences.
+    criticality: critical
+    features:
+      - id: mount-executable
+        name: Native mount executable
+        description: Runs the independently distributed relayfile-mount binary with explicit workspace, layout, sync, state, timeout, and diagnostic flags.
+        locations: [cmd/relayfile-mount/main.go]
+        verify_tier: 2
+        covers: ['executable:relayfile-mount', 'flag:relayfile-mount:*']
+      - id: mirror-mount-sync
+        name: Mirror and write-only synchronization
+        description: Performs initial, full, and incremental pulls across exact or scoped roots using polling or WebSocket updates.
+        locations: [cmd/relayfile-mount/main.go, internal/mountsync]
+        verify_tier: 2
+        covers: ['implementation:mount-initial-full-incremental']
+      - id: mount-bootstrap-recovery
+        name: Resumable bootstrap
+        description: Persists traversal checkpoints, detects progress-sensitive stalls, resumes safely, and defers first-empty-revision deletion.
+        locations: [internal/mountsync]
+        verify_tier: 2
+        covers: ['implementation:bootstrap-checkpoint-resume']
+      - id: mount-durable-outbox
+        name: Durable outbox and tombstones
+        description: Persists pending, acknowledged, failed, retry, and two-phase delete state independently of pull timeouts.
+        locations: [internal/mountsync]
+        verify_tier: 2
+        covers: ['implementation:durable-outbox-tombstones']
+      - id: mount-destructive-fences
+        name: Mount destructive safety fences
+        description: Blocks delete-ratio storms, mount-root clobber, unsafe rehome, root corruption, PID reuse, and unresolved path collisions.
+        locations: [internal/mountsync, cmd/relayfile-cli/main.go]
+        verify_tier: 2
+        covers: ['implementation:mount-delete-ratio-clobber-rehome-pid-fences']
+      - id: mount-lazy-diagnostics
+        name: Lazy, low-memory, and diagnostics modes
+        description: Supports lazy GitHub hydration, untracked-push refusal, watcher caps, low-memory mode, pprof, memory, and HTTP status logging.
+        locations: [cmd/relayfile-mount/main.go, internal/mountsync]
+        verify_tier: 2
+        covers: ['implementation:lazy-low-memory-diagnostics']
+      - id: mount-runtime-environment
+        name: Mount environment contract
+        description: Resolves mount paths, sync modes, durability thresholds, safety fences, diagnostics, timeouts, and timezone inputs.
+        locations: [cmd/relayfile-mount/main.go, internal/mountsync]
+        verify_tier: 1
+        covers: ['config:env:mount:*', 'config:field:mount-state:*']
+
+  fuse:
+    name: Optional FUSE filesystem
+    description: Privileged optional FUSE mode, cache invalidation, and read-only virtual artifact behavior.
+    criticality: standard
+    features:
+      - id: fuse-live-filesystem
+        name: FUSE mount and invalidation
+        description: Mounts an optional FUSE filesystem with inode/content caches, live invalidation, virtual files, and read-only fences.
+        locations: [internal/mountfuse, cmd/relayfile-mount/main.go]
+        verify_tier: 3
+        covers: ['implementation:fuse-cache-invalidation-virtual-readonly']
+
+  sdk-typescript:
+    name: TypeScript SDK
+    description: Published TypeScript modules, exact parity registry exports, data-plane client, hosted setup, and local control-plane client.
+    criticality: hot
+    features:
+      - id: typescript-sdk-exports
+        name: TypeScript SDK export registry
+        description: Publishes every checked parity symbol, including planned types as exports without claiming unimplemented runtime behavior.
+        locations: [packages/sdk/typescript/src/index.ts, packages/sdk/parity.json]
+        verify_tier: 1
+        covers: ['export:ts-sdk:*']
+      - id: typescript-sdk-subpaths
+        name: TypeScript SDK package subpaths
+        description: Publishes root, CLI, cloud-login, mount, seeder, dist, and package metadata subpaths declared by the package export map.
+        locations: [packages/sdk/typescript/package.json]
+        verify_tier: 4
+        covers: ['package-export:@relayfile/sdk:*']
+      - id: typescript-data-plane-client
+        name: TypeScript data-plane client
+        description: Implements configured retry, change-log, default read-cache/invalidation, file, fork, event, operation, sync, ingest, admin, hosted webhook, and writeback behavior.
+        locations: [packages/sdk/typescript/src/client.ts]
+        verify_tier: 1
+        covers: ['sdk-ts:relayfile-client:*', 'config:ts:sdk:*', 'implementation:ts-client-read-cache']
+      - id: durable-resource-subscriptions
+        name: Durable resource subscription lifecycle
+        description: Defines and exercises owner-scoped create-or-renew, list, cancel, delivery claim, and claim-token acceptance contracts for stable provider resources, including identifier, TTL, capability, and owner-forgery negatives.
+        locations: [openapi/relayfile-v1.openapi.yaml, packages/sdk/typescript/src/client.ts, packages/sdk/typescript/src/types.ts, packages/sdk/typescript/src/client.test.ts, packages/sdk/parity.json]
+        verify_tier: 1
+        covers: ['http:data:POST /v1/workspaces/{workspaceId}/subscriptions', 'http:data:GET /v1/workspaces/{workspaceId}/subscriptions', 'http:data:DELETE /v1/workspaces/{workspaceId}/subscriptions/{subscriptionId}', 'http:data:POST /v1/workspaces/{workspaceId}/subscriptions/deliveries/claim', 'http:data:POST /v1/workspaces/{workspaceId}/subscriptions/deliveries/{deliveryId}/accept']
+      - id: typescript-setup-client
+        name: TypeScript hosted setup client
+        description: Implements login, workspace, mount-session, integration, token, invite, and mounted handle methods against hosted control paths.
+        locations: [packages/sdk/typescript/src/cli/setup.ts]
+        verify_tier: 5
+        covers: ['sdk-ts:setup:*']
+      - id: typescript-control-plane-client
+        name: TypeScript local control-plane client
+        description: Negotiates API versions, auto-starts the daemon when allowed, and calls every local integration control-plane operation.
+        locations: [packages/client/src/client.ts]
+        verify_tier: 2
+        covers: ['sdk-ts:control-plane:*']
+
+  sdk-python:
+    name: Python SDK
+    description: Python root exports, parity classifications, synchronous/asynchronous clients, setup, writeback, and managed on-write subscriptions.
+    criticality: hot
+    features:
+      - id: python-sdk-root-exports
+        name: Python root exports
+        description: Exposes the exact relayfile.__all__ public module surface.
+        locations: [packages/sdk/python/src/relayfile/__init__.py]
+        verify_tier: 1
+        covers: ['export:python-root:*']
+      - id: python-sdk-parity
+        name: Python parity registry
+        description: Tracks implemented, language-specific, and planned parity names without turning planned entries into shipped runtime claims.
+        locations: [packages/sdk/parity.json, packages/sdk/python/src/relayfile]
+        verify_tier: 1
+        covers: ['export:python-parity:*']
+
+  core-client-local-mount:
+    name: Core, control-plane client, and local agent mount packages
+    description: Published package entrypoints for pure core semantics, generated local control-plane types, and one-way local agent mounts.
+    criticality: hot
+    features:
+      - id: core-package-exports
+        name: Core package exports
+        description: Publishes pure file, ACL, semantics, query, tree, event, operation, writeback, webhook, export, deduplication, and fork contracts.
+        locations: [packages/core/package.json, packages/core/src/index.ts]
+        verify_tier: 4
+        covers: ['package-export:@relayfile/core:*', 'config:ts:core:*']
+      - id: control-plane-package-exports
+        name: Control-plane client exports
+        description: Publishes the local client and generated versioned control-plane component, path, and operation types.
+        locations: [packages/client/package.json, packages/client/src/index.ts]
+        verify_tier: 4
+        covers: ['package-export:@relayfile/client:*', 'http:control:* /v1/hello', 'config:ts:client:*']
+      - id: local-mount-package-exports
+        name: Local agent mount exports
+        description: Publishes ignore/readonly population, symlink/copy, warm reattach, final sync, and teardown-safe local mount helpers.
+        locations: [packages/local-mount/package.json, packages/local-mount/src/index.ts]
+        verify_tier: 4
+        covers: ['package-export:@relayfile/local-mount:*', 'implementation:local-agent-mount-final-sync', 'config:ts:local-mount:*']
+
+  agents:
+    name: Agent framework adapters
+    description: Provider-neutral agent connection, reactive event recovery, writeback, Relaycast forwarding, and framework-specific read tools.
+    criticality: hot
+    features:
+      - id: agents-package-exports
+        name: Agent package exports
+        description: Publishes root, Vercel, OpenAI, LangChain, and package metadata entrypoints with optional lexical read-path prefix filters.
+        locations: [packages/agents/package.json, packages/agents/src/index.ts, packages/agents/src/tools]
+        verify_tier: 4
+        covers: ['package-export:@relayfile/agents:*', 'implementation:agent-framework-path-fences']
+      - id: agents-runtime-environment
+        name: Agent and observer environment contract
+        description: Resolves cloud credentials, workspace identity, observer base paths, and browser-visible Relayfile configuration.
+        locations: [packages/agents/src, packages/file-observer/src]
+        verify_tier: 5
+        covers: ['config:env:agents:*', 'config:ts:agents:*']
+
+  server-storage-auth:
+    name: Server, storage, and ingress security
+    description: Production server executable, memory/file/PostgreSQL backends, RS256/HMAC auth, bounds, queues, and sync recovery APIs.
+    criticality: critical
+    features:
+      - id: server-executable
+        name: Relayfile data-plane server
+        description: Runs the environment-configured HTTP service with no application command-line flags.
+        locations: [cmd/relayfile/main.go]
+        verify_tier: 1
+        covers: ['executable:relayfile-server']
+      - id: server-storage-profiles
+        name: Durable storage profiles
+        description: Selects memory, file, or PostgreSQL state and queue backends through explicit custom, local, memory, or production profiles.
+        locations: [cmd/relayfile/main.go, internal/relayfile]
+        verify_tier: 2
+        covers: ['implementation:storage-memory-file-postgres']
+      - id: server-auth-ingress-fences
+        name: Authentication and ingress fences
+        description: Enforces RS256/JWKS workspace scopes plus HMAC signature, replay, timestamp, rate, and request-body bounds for internal ingest.
+        locations: [internal/httpapi/auth.go, internal/httpapi/server.go]
+        verify_tier: 1
+        covers: ['implementation:auth-rs256-hmac-replay-limits']
+      - id: api-sync-recovery
+        name: Sync status and recovery API
+        description: Reports sync, ingress, and dead-letter state and permits scoped refresh, replay, and acknowledgement.
+        locations: [internal/httpapi/server.go, internal/relayfile]
+        verify_tier: 2
+        covers: ['http:data:* /v1/workspaces/{workspaceId}/sync/*']
+      - id: server-runtime-environment
+        name: Server environment contract
+        description: Resolves storage, auth, ingress, queue, retry, concurrency, suppression, coalescing, and body/rate limit settings.
+        locations: [cmd/relayfile/main.go]
+        verify_tier: 1
+        covers: ['config:env:server:*']
+      - id: server-delete-storm-library-fence
+        name: Store delete-storm breaker
+        description: Implements and tests an opt-in StoreOptions delete-storm breaker; the production server entrypoint currently leaves zero disabled.
+        locations: [internal/relayfile/delete_storm.go, internal/relayfile/delete_storm_test.go, cmd/relayfile/main.go]
+        verify_tier: 1
+        covers: ['implementation:server-delete-storm-library-only']
+      - id: server-stale-running-library-fence
+        name: Store stale-running quarantine
+        description: Implements and tests an opt-in StoreOptions stale-running quarantine; the production server entrypoint currently leaves zero disabled.
+        locations: [internal/relayfile/stale_running_test.go, internal/relayfile/store.go, cmd/relayfile/main.go]
+        verify_tier: 1
+        covers: ['implementation:server-stale-running-library-only']
+
+  hosted-observability:
+    name: Hosted paths and observability
+    description: Hosted-only SDK routes, local dashboard/admin status, CLI/mount diagnostics, file observer, and evaluation reports.
+    criticality: hot
+    features:
+      - id: hosted-only-http
+        name: Hosted-only control and change paths
+        description: Exposes retained changes, outbound webhooks, workspace control, mount sessions, and integration control through hosted services, not the local Go server.
+        locations: [packages/sdk/typescript/src/client.ts, packages/sdk/typescript/src/cli/setup.ts]
+        verify_tier: 5
+        covers: ['http:hosted:*']
+      - id: local-dashboard-admin
+        name: Local dashboard and admin APIs
+        description: Serves the HTML dashboard and backend, ingress, sync, envelope replay, and operation replay observability/recovery surfaces.
+        locations: [internal/httpapi/server.go, internal/httpapi/dashboard.go]
+        verify_tier: 1
+        covers: ['http:data:GET /dashboard', 'http:data:* /v1/admin/*']
+      - id: observability-surfaces
+        name: Operator observability surfaces
+        description: Covers dashboard, status, logs, observer, mount state, pprof, memory/HTTP logs, file-observer UI, and evaluation reports.
+        locations: [internal/httpapi, cmd/relayfile-cli/main.go, cmd/relayfile-mount/main.go, packages/file-observer, scripts/evals]
+        verify_tier: 2
+        covers: ['observability:*']
+
+  release-e2e:
+    name: Packaging, end-to-end, and release gates
+    description: Native and package artifact construction, clean-consumer checks, local E2E/conformance, parity, contract, and manual publish boundaries.
+    criticality: hot
+    features:
+      - id: cli-npm-bin
+        name: npm CLI binary
+        description: Publishes the relayfile npm launcher that selects the correct native CLI package.
+        locations: [packages/cli/package.json, packages/cli/scripts/run.js]
+        verify_tier: 4
+        covers: ['package-bin:relayfile:*']
+      - id: native-mount-packages
+        name: Native mount packages
+        description: Publishes Darwin and Linux arm64/x64 relayfile-mount binaries as optional platform packages.
+        locations: [packages/cli/scripts/build-binaries.js, scripts/build-mount-npm-packages.mjs]
+        verify_tier: 4
+        covers: ['package-artifact:@relayfile/mount-*']
+      - id: release-sensitive-automation
+        name: Release-sensitive automation
+        description: Builds, tests, contracts, packs, evaluates, and publishes through the exact checked-in release-sensitive scripts and workflows.
+        locations: [.github/workflows/ci.yml, .github/workflows/publish.yml, scripts/e2e.ts, scripts/conformance.ts]
+        verify_tier: 4
+        covers: ['release:path:*']
+      - id: automation-runtime-environment
+        name: Test, evaluation, and release inputs
+        description: Treats CI, live receiver, PostgreSQL, SDK harness, eval provider, and GitHub release inputs as explicit automation prerequisites.
+        locations: [scripts, .github/workflows]
+        verify_tier: 4
+        covers: ['config:env:automation:*']
+
+  proactive-automation:
+    name: Personas, evaluations, feature workflow, and guardian
+    description: Checked-in verification persona, evaluations, authoritative catalog, tier workflow, and fail-closed hourly feature guardian.
+    criticality: standard
+    features:
+      - id: integration-verifier-persona
+        name: Live integration verifier persona
+        description: Runs an explicitly requested real-provider verification playbook and may mutate disposable provider fixtures; it is not the guardian.
+        locations: [.agentworkforce/workforce/personas/integration-verifier.json]
+        verify_tier: 6
+        covers: ['automation:integration-verifier-persona']
+      - id: relayfile-evaluations
+        name: Relayfile evaluation automation
+        description: Compiles offline cases and optionally uses a configured model provider without treating provider absence as a pass.
+        locations: [.github/workflows/relayfile-evals.yml, scripts/evals]
+        verify_tier: 5
+        covers: ['automation:relayfile-evals']
+      - id: feature-catalog-contract
+        name: Authoritative feature catalog
+        description: Validates manifest v1.1 totals, routes, procedures, paths, tiers, IDs, and complete target-specific public surface coverage.
+        locations: [.agentworkforce/features/manifest.yaml, scripts/validate-feature-catalog.mjs, .agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts]
+        verify_tier: 1
+        covers: ['automation:feature-catalog']
+      - id: relayfile-feature-guardian
+        name: Hourly feature guardian
+        description: Reads the scoped repository clone, advances exact revisioned cycle state, and optionally posts receipt-confirmed idempotent Slack checks.
+        locations: [.agentworkforce/agents/relayfile-feature-guardian/persona.json, .agentworkforce/agents/relayfile-feature-guardian/agent.ts]
+        verify_tier: 1
+        covers: ['automation:feature-guardian']

--- a/.agentworkforce/features/verify/procedures.md
+++ b/.agentworkforce/features/verify/procedures.md
@@ -1,0 +1,990 @@
+# Relayfile feature verification procedures
+
+This document is routed by `manifest.yaml`; it intentionally does not repeat a second list of feature IDs. Run from the repository root. Every shell procedure starts in an isolated fixture and records one terminal result with `vf_result`.
+
+Outcome rules are strict:
+
+- `PASS`: every listed positive and negative assertion ran and matched.
+- `FAIL`: a command ran but an assertion, cleanup, or safety fence failed.
+- `SKIP`: the requested environment or credential was absent. A skip is never included in the pass count.
+- `MANUAL`: the check is inherently interactive/destructive or only an operator can confirm the external effect. Manual is never included in the pass count.
+
+Never run a hosted/provider procedure against a non-disposable workspace. Preserve command output in `.workflow-artifacts/verify-features/`; redact tokens and HMAC secrets.
+
+## cli-discovery-and-lifecycle
+
+### Prerequisites
+
+Go 1.22+, Node 22+, `bash`, and no live credentials. Supervisor install/uninstall and default interactive setup are manual-only.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start cli
+trap vf_cleanup EXIT
+go build -o "$VF_CASE_ROOT/relayfile" ./cmd/relayfile-cli
+export RELAYFILE_STATE_FILE="$VF_CASE_ROOT/state/state.json"
+export RELAYFILE_SOCK="$VF_CASE_ROOT/state/control.sock"
+```
+
+### Commands
+
+```bash
+"$VF_CASE_ROOT/relayfile" help >"$VF_CASE_ROOT/help.txt"
+"$VF_CASE_ROOT/relayfile" --help >"$VF_CASE_ROOT/help-flag.txt"
+"$VF_CASE_ROOT/relayfile" version >"$VF_CASE_ROOT/version.txt"
+"$VF_CASE_ROOT/relayfile" writeback sweep-drafts --help >"$VF_CASE_ROOT/sweep-help.txt"
+"$VF_CASE_ROOT/relayfile" listen --help >"$VF_CASE_ROOT/listen-help.txt"
+```
+
+### Positive assertions
+
+```bash
+cmp "$VF_CASE_ROOT/help.txt" "$VF_CASE_ROOT/help-flag.txt"
+grep -Eq '[0-9]+\.[0-9]+\.[0-9]+' "$VF_CASE_ROOT/version.txt"
+grep -q 'sweep-drafts' "$VF_CASE_ROOT/sweep-help.txt"
+grep -q 'listen' "$VF_CASE_ROOT/listen-help.txt"
+```
+
+### Negative assertions
+
+```bash
+if "$VF_CASE_ROOT/relayfile" definitely-not-a-command >"$VF_CASE_ROOT/bad.out" 2>&1; then exit 1; fi
+grep -Eqi 'unknown|usage' "$VF_CASE_ROOT/bad.out"
+```
+
+### Cleanup
+
+The EXIT trap calls `vf_cleanup`, which requires the fixture marker and a `relayfile-feature-*` basename before recursive removal. No home directory or supervisor state is touched.
+
+### Automation limits
+
+Report setup, supervisor mutation, observer browser launch, and destructive stop/restart against a real daemon as `MANUAL` unless a disposable service fixture is supplied. The raw Go version fallback may differ from release-injected builds; report the observed value rather than rewriting it.
+
+### Reporting
+
+```bash
+vf_result PASS cli-discovery-and-lifecycle 'help, version, hidden leaves, and unknown-command negative matched'
+```
+
+## workspace-auth-and-scoped-invites
+
+### Prerequisites
+
+Tier 1 negatives require Go. Hosted preflight requires `RELAYFILE_LIVE=1`, a disposable `RELAYFILE_CLOUD_API_URL`, token, and workspace. The full create/join/invite/mount/delete sequence remains manual until it has a receipt-bearing disposable harness.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start workspace-auth
+trap vf_cleanup EXIT
+go build -o "$VF_CASE_ROOT/relayfile" ./cmd/relayfile-cli
+export RELAYFILE_STATE_FILE="$VF_CASE_ROOT/state/state.json"
+```
+
+### Commands
+
+```bash
+"$VF_CASE_ROOT/relayfile" help >"$VF_CASE_ROOT/help.txt"
+go test ./cmd/relayfile-cli -run 'TestWorkspace(RequiresSubcommandMentionsJoin|UseSetsDefaultWorkspace|JoinStoresDelegatedRelayfileCredentials|DeleteRemovesCatalogEntry|ListIncludes|Current)' -count=1 | tee "$VF_CASE_ROOT/workspace-tests.log"
+go test ./internal/httpapi -run 'Test(AuthRequired|ScopeAndWorkspaceClaimsEnforced)' -count=1 | tee "$VF_CASE_ROOT/auth-tests.log"
+if [[ "${RELAYFILE_LIVE:-0}" == 1 ]]; then
+  : "${RELAYFILE_CLOUD_API_URL:?}" "${RELAYFILE_CLOUD_TOKEN:?}"
+  "$VF_CASE_ROOT/relayfile" workspace status "${RELAYFILE_WORKSPACE_ID:?}" >"$VF_CASE_ROOT/live-status.json"
+fi
+```
+
+### Positive assertions
+
+```bash
+grep -q 'relayfile workspace' "$VF_CASE_ROOT/help.txt"
+grep -q '^ok' "$VF_CASE_ROOT/workspace-tests.log"
+grep -q '^ok' "$VF_CASE_ROOT/auth-tests.log"
+if [[ "${RELAYFILE_LIVE:-0}" == 1 ]]; then grep -q "${RELAYFILE_WORKSPACE_ID}" "$VF_CASE_ROOT/live-status.json"; fi
+```
+
+### Negative assertions
+
+```bash
+if "$VF_CASE_ROOT/relayfile" workspace join >"$VF_CASE_ROOT/join.out" 2>&1; then exit 1; fi
+if "$VF_CASE_ROOT/relayfile" workspace use >"$VF_CASE_ROOT/use.out" 2>&1; then exit 1; fi
+grep -Eqi 'usage.*workspace join' "$VF_CASE_ROOT/join.out"
+grep -Eqi 'usage.*workspace use' "$VF_CASE_ROOT/use.out"
+```
+
+### Cleanup
+
+The deterministic block creates no remote workspace. For the manual hosted sequence, remove only the disposable workspace created for that run, then let the marker-checked EXIT trap remove local state. If remote deletion was not confirmed, report `FAIL`, retain its ID in evidence, and do not call cleanup complete.
+
+### Automation limits
+
+Without live inputs, local negatives may pass but hosted create/join/invite/mount-session assertions are `SKIP`. Login needing a browser and workspace delete remain `MANUAL` unless the disposable fixture explicitly authorizes them.
+
+### Reporting
+
+```bash
+if [[ "${RELAYFILE_LIVE:-0}" == 1 ]]; then vf_result MANUAL workspace-auth-and-scoped-invites 'hosted status preflight passed; create, scoped invite, mount session, and confirmed workspace cleanup still require operator evidence'; else vf_result SKIP workspace-auth-and-scoped-invites 'hosted workspace credentials absent; local negatives only'; fi
+```
+
+## integration-catalog-connect-and-bindings
+
+### Prerequisites
+
+Go, Node, a Unix-socket-capable host, and optionally `RELAYFILE_LIVE=1` with a disposable provider connection. Provider mutation requires explicit live opt-in.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start integrations
+trap vf_cleanup EXIT
+go build -o "$VF_CASE_ROOT/relayfile" ./cmd/relayfile-cli
+export RELAYFILE_SOCK="$VF_CASE_ROOT/state/control.sock"
+```
+
+### Commands
+
+```bash
+"$VF_CASE_ROOT/relayfile" integration available --json >"$VF_CASE_ROOT/catalog.json"
+"$VF_CASE_ROOT/relayfile" integration search github --json >"$VF_CASE_ROOT/search.json"
+"$VF_CASE_ROOT/relayfile" integration resolve-path github owner/repo >"$VF_CASE_ROOT/path.out"
+npm run test --workspace=@relayfile/client 2>&1 | tee "$VF_CASE_ROOT/client-test.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q 'github' "$VF_CASE_ROOT/catalog.json"
+grep -q 'github' "$VF_CASE_ROOT/search.json"
+grep -q '/github/' "$VF_CASE_ROOT/path.out"
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/client-test.log"
+```
+
+### Negative assertions
+
+```bash
+if "$VF_CASE_ROOT/relayfile" integration connect unknown-provider >"$VF_CASE_ROOT/unknown.out" 2>&1; then exit 1; fi
+"$VF_CASE_ROOT/relayfile" integration disconnect github >"$VF_CASE_ROOT/fence.out" 2>&1
+grep -Eqi 'unknown|--yes|confirm' "$VF_CASE_ROOT/unknown.out" "$VF_CASE_ROOT/fence.out"
+grep -Eqi 'aborted|declined' "$VF_CASE_ROOT/fence.out"
+```
+
+### Cleanup
+
+Unbind only paths created in the disposable workspace, disconnect only a connection created by this run, confirm absence through `integration list`, then run marker-checked local cleanup.
+
+### Automation limits
+
+Fallback catalog and canonical path helpers are Tier 1. OAuth, browser consent, Nango/Composio receipt, and real unbind/disconnect are `SKIP` without live inputs and `MANUAL` when provider UI confirmation is required.
+
+### Reporting
+
+```bash
+vf_result PASS integration-catalog-connect-and-bindings 'fallback catalog, path mapping, client contract, and destructive negatives passed'
+```
+
+## filesystem-crud-query-export
+
+### Prerequisites
+
+Go, Node 22, and a free loopback port. The conformance harness creates a local RS256/JWKS fixture and an isolated workspace in memory.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start filesystem
+trap vf_cleanup EXIT
+VF_PORT="$(vf_free_port)"
+export VF_PORT
+```
+
+### Commands
+
+```bash
+env -u RELAYFILE_BASE_URL \
+  RELAYFILE_PORT="$VF_PORT" \
+  RELAYFILE_DEV_MODE=1 \
+  RELAYFILE_CONFORMANCE_BINARY="$VF_CASE_ROOT/server" \
+  npx tsx scripts/conformance.ts --ci | tee "$VF_CASE_ROOT/conformance.log"
+```
+
+### Positive assertions
+
+```bash
+grep -Fq 'Read file returns content and metadata' "$VF_CASE_ROOT/conformance.log"
+grep -Fq 'Tree lists files and directories' "$VF_CASE_ROOT/conformance.log"
+grep -Fq 'Query by property (author=agent-beta)' "$VF_CASE_ROOT/conformance.log"
+grep -Fq 'JSON export returns all files with metadata' "$VF_CASE_ROOT/conformance.log"
+```
+
+### Negative assertions
+
+```bash
+grep -Fq 'Stale revision returns 409 with conflict details' "$VF_CASE_ROOT/conformance.log"
+grep -Fq 'If-Match: 0 fails for existing file' "$VF_CASE_ROOT/conformance.log"
+grep -Fq 'ACL marker denies access to unauthorized agent' "$VF_CASE_ROOT/conformance.log"
+test ! -e "$VF_CASE_ROOT/server"
+```
+
+### Cleanup
+
+The conformance harness deletes its fixture file, stops its recorded child, closes the JWKS server, and unlinks the temp binary before returning. The EXIT trap then removes only the marker-checked fixture.
+
+### Automation limits
+
+GitHub fetch-import requires a disposable reachable tarball and is `SKIP` locally; uploaded archive traversal and size bounds remain deterministic.
+
+### Reporting
+
+```bash
+vf_result PASS filesystem-crud-query-export 'authenticated CRUD, tree, query, export, stale revision, create-only, and ACL negatives passed'
+```
+
+## acl-revision-and-fork-safety
+
+### Prerequisites
+
+Go tests; hosted scope positives require two separately scoped disposable tokens.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start acl-forks
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+go test ./internal/httpapi ./internal/relayfile -run 'Test.*(ACL|IfMatch|Fork|Revision|Conflict)' -count=1 | tee "$VF_CASE_ROOT/tests.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/tests.log"
+```
+
+### Negative assertions
+
+The selected tests must observe a stale `If-Match` conflict and deny a token outside its path scope; a test filter that reports “no tests to run” is a `FAIL`.
+
+```bash
+grep -Eqi 'fork|acl|revision|conflict' internal/httpapi/*_test.go internal/relayfile/*_test.go
+! grep -q 'no tests to run' "$VF_CASE_ROOT/tests.log"
+```
+
+### Cleanup
+
+Go tests use in-memory/temp stores. Remove the marker-checked fixture; for hosted follow-up, discard the fork and confirm both tokens can no longer read its overlay.
+
+### Automation limits
+
+Hosted JWKS and two-token scope proofs are `SKIP` without disposable credentials. Never weaken token scopes to make a fixture pass.
+
+### Reporting
+
+```bash
+vf_result PASS acl-revision-and-fork-safety 'ACL, stale revision, conflict, and fork lifecycle tests passed'
+```
+
+## events-websocket-and-recovery
+
+### Prerequisites
+
+Go and Node; no external receiver is required for local event feed and WebSocket tests.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start events
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+go test ./internal/httpapi ./internal/relayfile -run 'Test.*(Event|WebSocket|Cursor)' -count=1 | tee "$VF_CASE_ROOT/go.log"
+npm run test --workspace=packages/sdk/typescript -- --run src/sync.test.ts | tee "$VF_CASE_ROOT/sdk.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/go.log"
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/sdk.log"
+```
+
+### Negative assertions
+
+Verify the tests include stale/invalid cursor or reconnect coverage and fail if only a live WebSocket happy path ran.
+
+```bash
+rg -q 'reconnect|cursor|fallback' packages/sdk/typescript/src/sync.test.ts internal/httpapi/*_test.go
+```
+
+### Cleanup
+
+Close every WebSocket/subscription in the test finally block and remove the marker-checked fixture. A leaked listener or process is `FAIL`.
+
+### Automation limits
+
+Network partition timing on a hosted workspace is Tier 5 and `SKIP` without opt-in. Local polling fallback is deterministic.
+
+### Reporting
+
+```bash
+vf_result PASS events-websocket-and-recovery 'event cursor, websocket, reconnect, and fallback assertions passed'
+```
+
+## provider-ingest-events-and-digests
+
+### Prerequisites
+
+Go. Live provider sequences require a disposable object and credentials for each claimed backend.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start ingest-digests
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+go test ./internal/relayfile ./internal/digest -run 'Test.*(Ingest|Digest|Envelope|Terminal|Delete)' -count=1 | tee "$VF_CASE_ROOT/tests.log"
+```
+
+### Positive assertions
+
+The fixture must assert both the provider file event and changed `/digests/today.md` plus `/digests/yesterday.md` artifacts.
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/tests.log"
+rg -q 'digests/(today|yesterday)\.md' internal/relayfile internal/digest
+```
+
+### Negative assertions
+
+Assert digest writes do not recurse and a terminal status update remains a file update; deletion is accepted only for an actual upstream delete.
+
+```bash
+rg -q 'isDigest|digest.*path|/digests/' internal/relayfile internal/digest
+rg -q 'closed|merged|archived|completed|canceled|resolved' internal/relayfile .claude/rules/relayfile-integration-digests.md
+```
+
+### Cleanup
+
+Remove only provider objects labeled with the run marker; confirm the corresponding real delete event, then remove the local fixture. Leave terminal-state objects intact until the explicit delete phase.
+
+### Automation limits
+
+Generic ingest tests are deterministic. Nango and Composio create/update/terminal/delete sequences are separate Tier 5 checks and `SKIP` without credentials; a JSON-only Nango dry run is not a live pass.
+
+### Reporting
+
+```bash
+vf_result PASS provider-ingest-events-and-digests 'generic ingest event, digest artifact, non-recursion, and terminal-state rules passed'
+```
+
+## writeback-retry-dead-letter-and-receipts
+
+### Prerequisites
+
+Go and Node. A provider receipt assertion needs an explicitly disposable external record.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start writeback
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+go test ./internal/relayfile ./internal/httpapi -run 'Test.*(Writeback|Operation|Replay|DeadLetter|Draft|StaleRunning)' -count=1 | tee "$VF_CASE_ROOT/go.log"
+npm run test --workspace=packages/sdk/typescript -- --run src/writeback-consumer.test.ts | tee "$VF_CASE_ROOT/sdk.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/go.log"
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/sdk.log"
+```
+
+### Negative assertions
+
+The fixture must reject an invalid acknowledgement/receipt, bound retries, and retain a dead-lettered operation for replay.
+
+```bash
+rg -q 'invalid.*receipt|dead.?letter|attempt' internal/relayfile/*_test.go packages/sdk/typescript/src/*test.ts
+```
+
+### Cleanup
+
+Acknowledge or delete only fixture operations after recording evidence. Confirm no pending item with the run correlation ID remains; remove the marker-checked fixture.
+
+### Automation limits
+
+Mock receipts prove local state transitions. A real provider-specific receipt is Tier 5 and `SKIP` without live credentials. `writeback skip-stuck` and destructive provider delete are `MANUAL` unless the fixture explicitly creates the stuck cursor/object.
+
+### Reporting
+
+```bash
+vf_result PASS writeback-retry-dead-letter-and-receipts 'queue, retry, replay, dead-letter, invalid receipt, and draft assertions passed'
+```
+
+## mirror-mount-bootstrap-outbox-and-fences
+
+### Prerequisites
+
+Go, Node, loopback ports, and filesystem watchers. No FUSE permission is needed.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start mount
+trap vf_cleanup EXIT
+export RELAYFILE_LOCAL_DIR="$VF_CASE_ROOT/mount"
+export RELAYFILE_MOUNT_STATE_DIR="$VF_CASE_ROOT/state"
+mkdir -p "$RELAYFILE_LOCAL_DIR"
+```
+
+### Commands
+
+```bash
+go test ./internal/mountsync -count=1 | tee "$VF_CASE_ROOT/mountsync.log"
+VF_PORT="$(vf_free_port)"
+RELAYFILE_PORT="$VF_PORT" npx tsx scripts/e2e.ts --ci | tee "$VF_CASE_ROOT/e2e.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/mountsync.log"
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/e2e.log"
+```
+
+### Negative assertions
+
+Confirm tests cover snapshot delete-ratio blocking, clobber acknowledgement, unsafe rehome/PID reuse, bootstrap stall/resume, tombstones, and untracked lazy push refusal.
+
+```bash
+rg -q 'delete.*ratio|clobber|rehome|PID|tombstone|stall|untracked' internal/mountsync cmd/relayfile-cli/*_test.go
+```
+
+### Cleanup
+
+Stop only the PID recorded under `$VF_CASE_ROOT/state`, verify it belongs to the built mount binary, wait for exit, then remove the marker-checked fixture. Never signal a PID from an unverified state file.
+
+### Automation limits
+
+The local two-mount flow is deterministic. E2E's absent outbound receiver must be recorded `SKIP` rather than included in its pass count. OS supervisor and long-running token renewal remain `MANUAL` or bounded dedicated tests.
+
+### Reporting
+
+```bash
+vf_result PASS mirror-mount-bootstrap-outbox-and-fences 'mountsync, two-mount flow, bootstrap, outbox, and destructive fences passed'
+```
+
+## fuse-virtual-artifacts-and-invalidation
+
+### Prerequisites
+
+Linux/macOS with FUSE installed, explicit mount permission, `RELAYFILE_LIVE_FUSE=1`, an existing disposable Relayfile workspace, and `RELAYFILE_BASE_URL`, `RELAYFILE_TOKEN`, and `RELAYFILE_WORKSPACE` set for that fixture.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start fuse
+trap vf_cleanup EXIT
+mkdir -p "$VF_CASE_ROOT/mount"
+```
+
+### Commands
+
+```bash
+if [[ "${RELAYFILE_LIVE_FUSE:-0}" != 1 ]]; then vf_result SKIP fuse-virtual-artifacts-and-invalidation 'FUSE opt-in absent'; exit 0; fi
+go test ./internal/mountfuse -count=1 | tee "$VF_CASE_ROOT/unit.log"
+VF_MOUNT_BIN="${RELAYFILE_MOUNT_BIN:-relayfile-mount}"
+"$VF_MOUNT_BIN" --mode fuse --local-dir "$VF_CASE_ROOT/mount" --state-dir "$VF_CASE_ROOT/state" >"$VF_CASE_ROOT/fuse.log" 2>&1 &
+VF_FUSE_PID=$!
+printf '%s\n' "$VF_FUSE_PID" >"$VF_CASE_ROOT/state/fuse.pid"
+for _ in {1..100}; do
+  if mount | grep -Fq -- "$VF_CASE_ROOT/mount"; then break; fi
+  kill -0 "$VF_FUSE_PID" 2>/dev/null
+  sleep 0.1
+done
+mount | grep -Fq -- "$VF_CASE_ROOT/mount"
+```
+
+### Positive assertions
+
+Read a normal file and each generated layout/schema/digest artifact, mutate the remote fixture, and assert the cached read invalidates to the new revision.
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/unit.log"
+test -r "$VF_CASE_ROOT/mount/LAYOUT.md"
+```
+
+### Negative assertions
+
+```bash
+if printf x >"$VF_CASE_ROOT/mount/LAYOUT.md" 2>"$VF_CASE_ROOT/readonly.err"; then exit 1; fi
+grep -Eqi 'read.?only|operation not permitted' "$VF_CASE_ROOT/readonly.err"
+```
+
+### Cleanup
+
+Verify `$VF_CASE_ROOT/state/fuse.pid` still names the child started by the command block. On Linux run `fusermount3 -u "$VF_CASE_ROOT/mount"` (or `fusermount -u` when that is the installed implementation); on macOS run `umount "$VF_CASE_ROOT/mount"`. Wait for `$VF_FUSE_PID`, confirm the exact mountpoint is absent from the platform mount table, then remove the marker-checked fixture. Failure to unmount or reap the recorded child is `FAIL`, not `SKIP`; automation must never signal an unverified PID.
+
+### Automation limits
+
+Unsupported host, missing FUSE package, or missing opt-in is `SKIP`. Interactive privilege escalation is `MANUAL`; automation must not invoke sudo.
+
+### Reporting
+
+```bash
+vf_result PASS fuse-virtual-artifacts-and-invalidation 'FUSE read, invalidation, virtual artifact, readonly negative, and unmount passed'
+```
+
+## typescript-exports-and-client-flow
+
+### Prerequisites
+
+Node 22 and root dependencies installed with `npm ci`.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start ts-sdk
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+npm run build --workspace=packages/core
+npm run build --workspace=packages/sdk/typescript
+npm run test --workspace=packages/sdk/typescript | tee "$VF_CASE_ROOT/test.log"
+(cd packages/sdk/typescript && npx vitest run src/client.test.ts -t 'durable resource subscriptions' --reporter=verbose) | tee "$VF_CASE_ROOT/durable-subscriptions.log"
+node scripts/check-sdk-parity.mjs | tee "$VF_CASE_ROOT/parity.log"
+```
+
+### Positive assertions
+
+```bash
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/test.log"
+grep -q 'creates, lists, claims, accepts, and cancels through owner-scoped routes' "$VF_CASE_ROOT/durable-subscriptions.log"
+grep -Eqi 'pass|ok' "$VF_CASE_ROOT/parity.log"
+node -e "import('@relayfile/sdk').then(m=>{if(!m.RelayFileClient)process.exit(1)})"
+```
+
+### Negative assertions
+
+Call the local client with a stale revision and an unreachable loopback URL; assert typed conflict/network failure instead of a successful empty result.
+
+```bash
+rg -q 'RevisionConflictError|RelayFileApiError' packages/sdk/typescript/src/client.test.ts packages/sdk/typescript/src/errors.ts
+grep -q 'surfaces capability 404s and validates identifiers before a request' "$VF_CASE_ROOT/durable-subscriptions.log"
+```
+
+### Cleanup
+
+Close subscriptions and clients in test finally blocks; remove the marker-checked fixture. Build output is project-native and may remain for later gates.
+
+### Automation limits
+
+Retained changes, hosted webhooks, setup, mount-session methods, and a live durable-subscription service are `SKIP` without hosted inputs. The durable-subscription unit flow proves exact routes, owner stripping, claim-token handling, and validation but does not claim that a hosted deployment implements the OpenAPI capability. Export presence alone does not pass a hosted behavior check.
+
+### Reporting
+
+```bash
+vf_result PASS typescript-exports-and-client-flow 'build, parity, root import, durable subscription lifecycle, client positives, and typed negatives passed'
+```
+
+## python-exports-parity-and-client-flow
+
+### Prerequisites
+
+Python 3.11+, `uv`, and locked extras synchronized.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start py-sdk
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+( cd packages/sdk/python && uv sync --all-extras --locked )
+( cd packages/sdk/python && uv run --locked python -m pytest tests ) | tee "$VF_CASE_ROOT/pytest.log"
+node scripts/check-sdk-parity.mjs | tee "$VF_CASE_ROOT/parity.log"
+( cd packages/sdk/python && uv run --locked python -c 'import relayfile; assert len(relayfile.__all__) == len(set(relayfile.__all__))' )
+```
+
+### Positive assertions
+
+```bash
+grep -Eqi 'passed' "$VF_CASE_ROOT/pytest.log"
+grep -Eqi 'pass|ok' "$VF_CASE_ROOT/parity.log"
+```
+
+### Negative assertions
+
+The client tests must assert typed errors for invalid state, oversize payload, queue full, and revision conflict.
+
+```bash
+rg -q 'InvalidStateError|PayloadTooLargeError|QueueFullError|RevisionConflictError' packages/sdk/python/tests
+```
+
+### Cleanup
+
+Close async clients/subscriptions and remove the marker-checked fixture. `.venv` is ignored project state and is not recursively deleted by this procedure.
+
+### Automation limits
+
+Hosted setup and `on_write` network recovery are `SKIP` without a disposable workspace. Sync and async local mock flows remain deterministic.
+
+### Reporting
+
+```bash
+vf_result PASS python-exports-parity-and-client-flow 'locked pytest, parity, unique __all__, and typed error assertions passed'
+```
+
+## package-exports-control-plane-and-local-mount
+
+### Prerequisites
+
+Node 22, Go, and Unix sockets for local control-plane tests.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start packages
+trap vf_cleanup EXIT
+export RELAYFILE_SOCK="$VF_CASE_ROOT/state/control.sock"
+```
+
+### Commands
+
+```bash
+npm run build --workspace=packages/core
+npm run build --workspace=@relayfile/client
+npm run build --workspace=packages/local-mount
+npm run test --workspace=@relayfile/client | tee "$VF_CASE_ROOT/client.log"
+npm run test --workspace=packages/local-mount | tee "$VF_CASE_ROOT/local.log"
+```
+
+### Positive assertions
+
+```bash
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/client.log" "$VF_CASE_ROOT/local.log"
+node -e "Promise.all([import('@relayfile/core'),import('@relayfile/client'),import('@relayfile/local-mount')]).then(x=>{if(x.some(v=>!v))process.exit(1)})"
+```
+
+### Negative assertions
+
+Assert control-plane API version mismatch fails and local mount readonly/exclude rules reject writes or population outside configured roots.
+
+```bash
+rg -q 'apiVersion|version.*mismatch' packages/client/src/*test.ts
+rg -q 'readonly|exclude|outside|travers' packages/local-mount/src/*test.ts
+```
+
+### Cleanup
+
+Stop the exact temp control-plane socket owner, run local-mount final sync/teardown, verify no symlink escapes the fixture, then remove the marker-checked fixture.
+
+### Automation limits
+
+Platform copy/symlink differences must be reported separately. A skipped optional symlink test is `SKIP`, not package PASS, unless all required platform assertions ran.
+
+### Reporting
+
+```bash
+vf_result PASS package-exports-control-plane-and-local-mount 'package imports, control-plane tests, and local mount safety passed'
+```
+
+## agent-framework-tools-events-and-forwarder
+
+### Prerequisites
+
+Node 22. Hosted/Relaycast forwarding needs disposable tokens and `RELAYFILE_LIVE=1`.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start agents
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+npm run build --workspace=packages/agents
+npx vitest run --reporter=verbose packages/agents/src/forward.test.ts packages/agents/src/tools/read-roots.test.ts | tee "$VF_CASE_ROOT/test.log"
+node -e "Promise.all([import('@relayfile/agents'),import('@relayfile/agents/vercel'),import('@relayfile/agents/openai'),import('@relayfile/agents/langchain')]).then(x=>{if(x.length!==4)process.exit(1)})"
+```
+
+### Positive assertions
+
+```bash
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/test.log"
+```
+
+### Negative assertions
+
+Invoke each framework read tool with an obvious out-of-prefix path and assert rejection; the current implementation is a lexical prefix filter and must not be described as canonical path traversal protection. Simulate forwarding exclusions with the focused test fixture.
+
+```bash
+grep -Fq 'rejects an out-of-prefix read' "$VF_CASE_ROOT/test.log"
+grep -Fq 'skips delete operations and adapter skip views' "$VF_CASE_ROOT/test.log"
+```
+
+### Cleanup
+
+Close agent subscriptions and delete only messages/files bearing the fixture correlation ID. Remove the marker-checked local fixture.
+
+### Automation limits
+
+Framework mocks are deterministic. Hosted credential refresh and Relaycast forwarding are `SKIP` without opt-in; sending to a real channel is `MANUAL` unless a disposable destination is supplied.
+
+### Reporting
+
+```bash
+vf_result PASS agent-framework-tools-events-and-forwarder 'exports, framework tools, path fences, and event recovery passed'
+```
+
+## server-backends-auth-and-ingress
+
+### Prerequisites
+
+Go; PostgreSQL requires a disposable `RELAYFILE_TEST_POSTGRES_DSN`. Never point tests at production DSNs.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start server
+trap vf_cleanup EXIT
+export RELAYFILE_DATA_DIR="$VF_CASE_ROOT/data"
+export RELAYFILE_STATE_FILE="$VF_CASE_ROOT/state/state.json"
+```
+
+### Commands
+
+```bash
+go test ./cmd/relayfile ./internal/httpapi ./internal/relayfile -count=1 | tee "$VF_CASE_ROOT/local.log"
+if [[ -n "${RELAYFILE_TEST_POSTGRES_DSN:-}" ]]; then go test ./internal/relayfile -run Postgres -count=1 | tee "$VF_CASE_ROOT/postgres.log"; fi
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/local.log"
+if [[ -n "${RELAYFILE_TEST_POSTGRES_DSN:-}" ]]; then grep -q '^ok' "$VF_CASE_ROOT/postgres.log"; fi
+```
+
+### Negative assertions
+
+Assert invalid bearer signature/scope, bad HMAC, stale timestamp, replayed delivery, oversize body, and rate-limit rejection. Also assert zero `StoreOptions` leaves delete-storm and stale-running protections disabled so the catalog does not misstate production policy.
+
+```bash
+rg -q 'HMAC|replay|skew|rate|body.*limit|scope' internal/httpapi/*_test.go
+rg -q 'defaults.*disabled|Disabled unless|Threshold.*0' internal/relayfile/delete_storm_test.go internal/relayfile/stale_running_test.go
+```
+
+### Cleanup
+
+Drop only the disposable PostgreSQL schema/database named for the run if one was created, close queues/workers, and remove the marker-checked local fixture.
+
+### Automation limits
+
+Memory/file backends and auth negatives are deterministic. PostgreSQL is `SKIP` without the explicit test DSN. Dormant server safety options are truthful library-only PASS, not production-enabled PASS.
+
+### Reporting
+
+```bash
+if [[ -n "${RELAYFILE_TEST_POSTGRES_DSN:-}" ]]; then vf_result PASS server-backends-auth-and-ingress 'memory, file, PostgreSQL, auth, ingress, and truthful dormant fences passed'; else vf_result SKIP server-backends-auth-and-ingress 'PostgreSQL absent; deterministic memory/file/auth assertions passed'; fi
+```
+
+## cloud-observer-status-and-alerts
+
+### Prerequisites
+
+Local Go/Node for dashboard/admin tests; hosted observer/change/webhook checks need `RELAYFILE_LIVE=1` and disposable credentials.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start observability
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+go test ./internal/httpapi -run 'Test.*(Dashboard|Admin|Ingress|Sync|Backend)' -count=1 | tee "$VF_CASE_ROOT/go.log"
+npm run test --workspace=@relayfile/file-observer | tee "$VF_CASE_ROOT/ui.log"
+```
+
+### Positive assertions
+
+```bash
+grep -q '^ok' "$VF_CASE_ROOT/go.log"
+grep -Eqi 'pass|passed' "$VF_CASE_ROOT/ui.log"
+```
+
+### Negative assertions
+
+Assert admin endpoints deny missing admin scope and alert pagination/truncation stays bounded. A local 404 for hosted retained-change or outbound-webhook routes is an expected `SKIP`, never a positive assertion.
+
+```bash
+rg -q 'admin:read|alertsTruncated|nextCursor' internal/httpapi/*_test.go openapi/relayfile-v1.openapi.yaml
+```
+
+### Cleanup
+
+Stop the local observer/server fixture and delete only a hosted webhook subscription created by this run. Confirm deletion before removing local evidence.
+
+### Automation limits
+
+Local dashboard/admin/UI is deterministic. Hosted observer, retained changes, public receiver delivery, DLQ, and replay are `SKIP` without live inputs. Browser visual confirmation is `MANUAL`.
+
+### Reporting
+
+```bash
+vf_result PASS cloud-observer-status-and-alerts 'local dashboard, admin status, alerts, scope negative, and observer tests passed; hosted surfaces reported separately'
+```
+
+## packed-artifacts-and-release-smoke
+
+### Prerequisites
+
+Node 22, Go, Python/uv, build toolchains, and a temp directory with enough space. Publishing credentials are neither required nor permitted.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start packed
+trap vf_cleanup EXIT
+mkdir -p "$VF_CASE_ROOT/packs" "$VF_CASE_ROOT/node-consumer" "$VF_CASE_ROOT/python-consumer"
+```
+
+### Commands
+
+```bash
+node scripts/packed-feature-e2e.mjs | tee "$VF_CASE_ROOT/packed.log"
+scripts/check-contract-surface.sh | tee "$VF_CASE_ROOT/contract.log"
+```
+
+### Positive assertions
+
+The packed E2E installs tarballs and a wheel into clean temp consumers, imports every declared export subpath, resolves the platform binary, and verifies CLI version plus Python root imports.
+
+```bash
+grep -Fq 'PACKED_FEATURE_E2E_PASS npm_tarballs=7 python_wheel=1 declared_imports=15' "$VF_CASE_ROOT/packed.log"
+grep -Fq 'contract check passed' "$VF_CASE_ROOT/contract.log"
+git diff --exit-code -- packages/client/src/generated/control-plane.ts
+```
+
+### Negative assertions
+
+The packed E2E asserts an undeclared SDK subpath import fails and verifies that the built packages contain the expected declared entrypoints.
+
+```bash
+grep -Fq 'undeclared_negative=1' "$VF_CASE_ROOT/packed.log"
+! rg -q 'npm publish|git tag|gh release create|twine upload' "$VF_CASE_ROOT/packed.log"
+```
+
+### Cleanup
+
+The packed E2E removes its own prefix-checked temp consumer in a `finally` block. The procedure trap removes only its marker-checked evidence fixture. Do not run `npm publish`, create tags/releases, mutate package versions, or delete project build output.
+
+### Automation limits
+
+Pack/install/import is Tier 4 deterministic. Cross-OS native execution is matrix-dependent. Any publish, tag, GitHub Release, PyPI upload, or provenance confirmation is `MANUAL` and excluded from automated PASS.
+
+### Reporting
+
+```bash
+vf_result PASS packed-artifacts-and-release-smoke 'clean pack/install/import/version/local-flow and negative package assertions passed; publish remains MANUAL'
+```
+
+## personas-evals-and-guardian
+
+### Prerequisites
+
+Node 22. Live Slack is optional and only enabled by explicit `SLACK_CHANNEL`; provider evals require `OPENROUTER_API_KEY` and live opt-in.
+
+### Isolated setup
+
+```bash
+source scripts/feature-runbook-lib.sh
+vf_start automation
+trap vf_cleanup EXIT
+```
+
+### Commands
+
+```bash
+node scripts/validate-feature-catalog.mjs | tee "$VF_CASE_ROOT/catalog.log"
+npx tsx --test .agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts .agentworkforce/agents/relayfile-feature-guardian/agent.test.ts | tee "$VF_CASE_ROOT/tests.log"
+npm run evals:compile
+: >"$VF_CASE_ROOT/evals.log"
+for VF_EVAL_SUITE in concurrency permissions provider-readiness slack-events vfs-contracts writeback; do
+  RELAYFILE_EVAL_RUNS_DIR="$VF_CASE_ROOT/eval-runs" \
+    node scripts/evals/run-relayfile-evals.mjs --mode offline --suite "$VF_EVAL_SUITE" | tee -a "$VF_CASE_ROOT/evals.log"
+done
+```
+
+### Positive assertions
+
+```bash
+grep -q 'FEATURE_CATALOG_PASS' "$VF_CASE_ROOT/catalog.log"
+grep -Eqi 'pass' "$VF_CASE_ROOT/tests.log"
+test "$(grep -c 'failed=0 skipped=0' "$VF_CASE_ROOT/evals.log")" -eq 6
+```
+
+### Negative assertions
+
+Tests must reject malformed/oversized guardian state, wrong clone path/scope, non-404 bootstrap responses, unsafe manifest shrink, CAS ambiguity, and receiptless Slack responses. Validator mutation tests must reject all A3 drift classes.
+
+```bash
+rg -q 'oversized|404|CAS|receipt|shrink|scope|path escape|stale summary' .agentworkforce/agents/relayfile-feature-guardian/*.test.ts
+```
+
+### Cleanup
+
+The deterministic tests use temp/in-memory state and mock Slack; eval run artifacts are redirected under `$VF_CASE_ROOT/eval-runs` and removed by the marker-checked trap. For live opt-in, delete the fixture Slack message only if policy permits, record its external receipt, and never grant read access to the Slack mount.
+
+### Automation limits
+
+The six selected offline suites are deterministic. The `initial-integrations-e2e` suite is a live/manual provider workflow, and the broader `integrations` suite currently contains human-review coverage plus a pre-existing unsupported `jqFilter` case; neither is included in deterministic PASS. Provider evals are `SKIP` without credentials. Real Slack delivery is `SKIP` without input and must use idempotent post-then-checkpoint semantics when enabled.
+
+### Reporting
+
+```bash
+vf_result PASS personas-evals-and-guardian 'catalog, omission contract, guardian failure matrix, and six deterministic offline eval suites passed; live/human suites and optional delivery reported separately'
+```

--- a/.claude/skills/verify-features.md
+++ b/.claude/skills/verify-features.md
@@ -1,0 +1,25 @@
+# verify-features
+
+Use this skill to verify Relayfile behavior from a user-visible boundary after a source change, release preparation, incident, or catalog update.
+
+## Select the checks
+
+1. Run `npm run features:validate` before behavior tests.
+2. Read `.agentworkforce/features/manifest.yaml` structurally. Select by requested ID/category, or match changed files against each feature's `locations`.
+3. Resolve every selected category through `verification.categories`; run the exact heading in `.agentworkforce/features/verify/procedures.md`.
+4. Add the applicable sequence from `.agentworkforce/features/critical-paths.md`.
+5. Never infer provider support from a canonical-path helper or an exported planned type.
+
+## Run and report
+
+Use `npm run features:verify -- --tier 1` for deterministic checks. Add `--tier 4` for packed consumers. Tiers 3, 5, and 6 require explicit opt-in described by their procedures; use `--require-live` only in a secrets-enabled disposable environment.
+
+Every check ends as exactly one of `PASS`, `FAIL`, `SKIP`, or `MANUAL`. Only PASS counts as passing. Missing credentials, FUSE support, receiver URLs, PostgreSQL DSNs, or provider fixtures are SKIP. Publish/tag/release and unbounded interactive mutations are MANUAL. Preserve redacted evidence in `.workflow-artifacts/verify-features/`.
+
+## Diagnose
+
+Start with the first failing boundary, not the final symptom: catalog/route → build/export → server/auth → data plane → events/mount → provider/writeback → hosted observer. Compare hosted SDK routes with the local OpenAPI before treating a local 404 as a defect. For ingest, always inspect both the event and `/digests/today.md` plus `/digests/yesterday.md`. For terminal provider state, require a file update unless upstream actually deleted the object.
+
+## Clean up
+
+Follow the procedure's order and marker-checked fixture cleanup. Confirm external provider objects/subscriptions/workspaces first, then clients, mount daemons, and local servers. Never clean a broad workspace, use an unverified PID, or report PASS when cleanup is unconfirmed.

--- a/.claude/skills/verify-features/SKILL.md
+++ b/.claude/skills/verify-features/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: verify-features
+description: Select and execute Relayfile's authoritative feature-catalog procedures with strict tier prerequisites, critical paths, cleanup, diagnosis, and PASS/FAIL/SKIP/MANUAL accounting.
+---
+
+# Verify Relayfile features
+
+Start with `npm run features:validate`. Select features from `.agentworkforce/features/manifest.yaml` by requested ID/category or by matching changed files against `locations`. Resolve every selected category through `verification.categories` and execute that exact heading in `.agentworkforce/features/verify/procedures.md`; do not invent a shorter happy-path check.
+
+Run `npm run features:verify -- --tier 1` for static/isolated checks, `--tier 2` for the full local server/mount flow, and `--tier 4` for clean packed consumers. Tiers 3, 5, and 6 require the explicit opt-in and disposable prerequisites named by the procedure. `--require-live` makes missing live prerequisites a failing workflow gate.
+
+Only `PASS` counts as passing. Missing credentials, FUSE, receiver, PostgreSQL, or provider fixtures are `SKIP`; publish/tag/release and unbounded interactive operations are `MANUAL`. Diagnose the first broken boundary using `.agentworkforce/features/critical-paths.md`, preserve redacted evidence, and follow the procedure's external-to-local cleanup order. Never claim hosted support from a local 404, provider support from a path helper, or digest correctness without both normal events and current digest artifacts.

--- a/.github/workflows/verify-features.yml
+++ b/.github/workflows/verify-features.yml
@@ -1,0 +1,73 @@
+name: Verify feature catalog
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      live_tier:
+        description: Explicit optional live tier
+        type: choice
+        options: ['none', '3', '5', '6']
+        default: 'none'
+      require_live:
+        description: Fail when the selected live tier skips or remains manual
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - uses: astral-sh/setup-uv@v5
+      - run: npm ci
+      - run: npm run features:validate
+      - run: npm run features:test
+      - run: npm run build
+      - run: npm run features:verify -- --tier deterministic
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: feature-verification-evidence
+          path: .workflow-artifacts/verify-features/latest.json
+          if-no-files-found: error
+
+  live-opt-in:
+    if: github.event_name == 'workflow_dispatch' && inputs.live_tier != 'none'
+    needs: deterministic
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: relayfile-feature-live
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+      - run: npm ci
+      - name: Run explicitly selected live tier
+        env:
+          RELAYFILE_LIVE: ${{ secrets.RELAYFILE_LIVE }}
+          RELAYFILE_LIVE_FUSE: ${{ secrets.RELAYFILE_LIVE_FUSE }}
+          RELAYFILE_PROVIDER_LIVE: ${{ secrets.RELAYFILE_PROVIDER_LIVE }}
+          RELAYFILE_CLOUD_API_URL: ${{ secrets.RELAYFILE_CLOUD_API_URL }}
+          RELAYFILE_CLOUD_TOKEN: ${{ secrets.RELAYFILE_CLOUD_TOKEN }}
+          RELAYFILE_WORKSPACE_ID: ${{ secrets.RELAYFILE_WORKSPACE_ID }}
+        run: npm run features:verify -- --tier "${{ inputs.live_tier }}" ${{ inputs.require_live && '--require-live' || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,14 @@ site/dist/
 packages/file-observer/out/
 packages/agents/dist
 .scratch/
+.workflow-artifacts/
 .agentworkforce/
+!.agentworkforce/
+.agentworkforce/*
+!.agentworkforce/features/
+!.agentworkforce/features/**
+!.agentworkforce/agents/
+.agentworkforce/agents/*
+!.agentworkforce/agents/relayfile-feature-guardian/
+!.agentworkforce/agents/relayfile-feature-guardian/**
 packages/**/.claude/

--- a/README.md
+++ b/README.md
@@ -389,3 +389,4 @@ Pipedream:
 - [API reference](docs/api-reference.md)
 - [Docker quickstart](docker/README.md)
 - [OpenAPI spec](openapi/relayfile-v1.openapi.yaml)
+- [Authoritative feature catalog and verification runbook](.agentworkforce/features/README.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,14 @@
       "devDependencies": {
         "@agent-assistant/telemetry": "^0.4.31",
         "@agent-relay/sdk": "^4.0.28",
+        "@agentworkforce/delivery": "^4.1.34",
+        "@agentworkforce/runtime": "^4.1.34",
         "@agentworkforce/workload-router": "^0.3.0",
+        "@relayfile/relay-helpers": "^0.4.9",
         "agent-trajectories": "^0.5.8",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "typescript": "^5.7.3",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/@agent-assistant/connectivity": {
@@ -130,6 +135,54 @@
         "@agent-relay/memory": "^6.0.9",
         "supermemory": "^4.21.1"
       }
+    },
+    "node_modules/@agent-assistant/proactive": {
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/proactive/-/proactive-0.4.35.tgz",
+      "integrity": "sha512-9Hfmyk/b4oONfFqE4T7U1ifV+dJg1Xn2YrpxZ34XP8iYIZUv4hoN/vS+wESFeHGzJpPIw/0exjBMZBLb2NfaPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/coordination": "^0.4.25",
+        "@agent-assistant/surfaces": ">=0.2.19",
+        "nanoid": "^5.0.7"
+      }
+    },
+    "node_modules/@agent-assistant/proactive/node_modules/@agent-assistant/coordination": {
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/coordination/-/coordination-0.4.35.tgz",
+      "integrity": "sha512-7NXA30o9igBBAGKZz+gCuEWr5ukRYeHVbC5YhIy+IWSUrfK8ydn0+5eJNO8k7eMXy9el4u/ub9eL14Qp7+3iCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@agent-assistant/connectivity": "^0.2.6",
+        "nanoid": "^5.1.6"
+      }
+    },
+    "node_modules/@agent-assistant/proactive/node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@agent-assistant/surfaces": {
+      "version": "0.4.35",
+      "resolved": "https://registry.npmjs.org/@agent-assistant/surfaces/-/surfaces-0.4.35.tgz",
+      "integrity": "sha512-h6YkyIl0DZSIeVTqgPZGgN+E2I0COcF7XjljVKGzZGLUKzmBKhLROeyiy9efz/YIpApat3xjLZ4Ac20+EsydTA==",
+      "dev": true
     },
     "node_modules/@agent-assistant/telemetry": {
       "version": "0.4.31",
@@ -383,6 +436,27 @@
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw==",
       "dev": true
     },
+    "node_modules/@agent-assistant/turn-context/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
+      }
+    },
     "node_modules/@agent-assistant/turn-context/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -490,6 +564,46 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@agent-relay/events": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@agent-relay/events/-/events-6.3.6.tgz",
+      "integrity": "sha512-3el7/iImhQ/L+TKetELF8SY6MEebmpxI8hbJ8qX1GWNyy46aXhuM/SwCMSSKch+Wmk6w9kitmx8csCGuF+4iNA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/context-async-hooks": "^2.2.0",
+        "@opentelemetry/core": "^2.2.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.207.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-trace-base": "^2.2.0",
+        "@opentelemetry/sdk-trace-node": "^2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.37.0"
+      },
+      "peerDependencies": {
+        "@relayfile/adapter-github": "^0.2.5",
+        "@relayfile/adapter-jira": "^0.2.8",
+        "@relayfile/adapter-linear": "^0.2.5",
+        "@relayfile/adapter-notion": "^0.2.7",
+        "@relayfile/adapter-slack": "^0.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@relayfile/adapter-github": {
+          "optional": true
+        },
+        "@relayfile/adapter-jira": {
+          "optional": true
+        },
+        "@relayfile/adapter-linear": {
+          "optional": true
+        },
+        "@relayfile/adapter-notion": {
+          "optional": true
+        },
+        "@relayfile/adapter-slack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@agent-relay/github-primitive": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/@agent-relay/github-primitive/-/github-primitive-6.0.11.tgz",
@@ -591,6 +705,27 @@
       "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.11.0.tgz",
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw==",
       "dev": true
+    },
+    "node_modules/@agent-relay/hooks/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
+      }
     },
     "node_modules/@agent-relay/hooks/node_modules/zod": {
       "version": "3.25.76",
@@ -707,6 +842,26 @@
       "integrity": "sha512-jh55ppdc4yokXhIYq2La1J9cX0PTHAnMtXBwVXHmjwSfsTWxSpuHikEsC2MFlfBX4IHSLkXCVRO0dkOVEWE2Bw==",
       "dev": true
     },
+    "node_modules/@agentworkforce/delivery": {
+      "version": "4.1.34",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/delivery/-/delivery-4.1.34.tgz",
+      "integrity": "sha512-CBaq4mkwVoq8gT6qg+vkRZrAjliZrH0HvvxCmTy7I3oVLNVJv046shHLslap9G6OPQuWC5yJadlqvnx7OfP4NA==",
+      "dev": true,
+      "dependencies": {
+        "@agentworkforce/runtime": "4.1.34",
+        "@relayfile/relay-helpers": "^0.4.7"
+      }
+    },
+    "node_modules/@agentworkforce/events": {
+      "version": "4.1.34",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/events/-/events-4.1.34.tgz",
+      "integrity": "sha512-JBrPhkAYEtTiwaZ8B91m4uUy2P+bbg83FhILWMuht0+qL1XrFoCS+wdLvz6vQmr96Da4SC4FA9U7ILATX9GX1g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1"
+      }
+    },
     "node_modules/@agentworkforce/harness-kit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@agentworkforce/harness-kit/-/harness-kit-0.11.0.tgz",
@@ -721,6 +876,197 @@
       "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.11.0.tgz",
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw==",
       "dev": true
+    },
+    "node_modules/@agentworkforce/persona-kit": {
+      "version": "4.1.34",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/persona-kit/-/persona-kit-4.1.34.tgz",
+      "integrity": "sha512-CXdDI3vIgS6GJn0wp8aB7+Hnl7Mh1dKMWvUK2qCmuwsRRC8qH3Pu6b/1CHMy6Esk+E7z5qgX20x8W3C55tRuqg==",
+      "dev": true,
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.5.1",
+        "@relayfile/local-mount": "^0.10.23"
+      }
+    },
+    "node_modules/@agentworkforce/persona-kit/node_modules/@relayfile/adapter-core": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.5.11.tgz",
+      "integrity": "sha512-aXgTNLTNNbdXqz1xrcBUu5C053q8GIHyRQF/jkpzzrJEu+MRODWRSIu2l1lUGs01z7/dyWWivAD1iXZ9jyVxKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scalar/postman-to-openapi": "^0.6.0",
+        "cheerio": "^1.2.0",
+        "minimatch": "^10.0.3",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "adapter-core": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": ">=0.6.0 <1"
+      }
+    },
+    "node_modules/@agentworkforce/persona-kit/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
+      }
+    },
+    "node_modules/@agentworkforce/persona-kit/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@agentworkforce/persona-kit/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@agentworkforce/persona-kit/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@agentworkforce/runtime": {
+      "version": "4.1.34",
+      "resolved": "https://registry.npmjs.org/@agentworkforce/runtime/-/runtime-4.1.34.tgz",
+      "integrity": "sha512-CZEDGkuRurvRXo3aLAw83DQZlUX2N71+Po99WJovL37oOQG6StBusRcChh0ukEknfRYCYekn/BpyQ3yUzTSHvg==",
+      "dev": true,
+      "dependencies": {
+        "@agent-assistant/proactive": "^0.4.32",
+        "@agent-relay/events": "^6.3.3",
+        "@agentworkforce/events": "4.1.34",
+        "@agentworkforce/persona-kit": "4.1.34",
+        "@relayfile/adapter-core": "^0.5.9",
+        "@relayfile/relay-helpers": "^0.4.7",
+        "agent-trajectories": "^0.5.3"
+      }
+    },
+    "node_modules/@agentworkforce/runtime/node_modules/@relayfile/adapter-core": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.5.11.tgz",
+      "integrity": "sha512-aXgTNLTNNbdXqz1xrcBUu5C053q8GIHyRQF/jkpzzrJEu+MRODWRSIu2l1lUGs01z7/dyWWivAD1iXZ9jyVxKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scalar/postman-to-openapi": "^0.6.0",
+        "cheerio": "^1.2.0",
+        "minimatch": "^10.0.3",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "adapter-core": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": ">=0.6.0 <1"
+      }
+    },
+    "node_modules/@agentworkforce/runtime/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
+      }
+    },
+    "node_modules/@agentworkforce/runtime/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@agentworkforce/runtime/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@agentworkforce/runtime/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@agentworkforce/workload-router": {
       "version": "0.3.0",
@@ -1514,6 +1860,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -1773,6 +2120,418 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.9.0.tgz",
+      "integrity": "sha512-OQ0vzvbZBiUhjqLnUaoNfYmP8553Crr3aggB4y0ZUi815mZ7idpdJXQmoKdeBKJelYttoBlLSSHubmyw3wvX4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.207.0.tgz",
+      "integrity": "sha512-HSRBzXHIC7C8UfPQdu15zEEoBGv0yWkhEwxqgPCHVUKUQ9NLHVGXkVrf65Uaj7UwmAkC1gQfkuVYvLlD//AnUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.207.0",
+        "@opentelemetry/otlp-transformer": "0.207.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.207.0.tgz",
+      "integrity": "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.207.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.207.0.tgz",
+      "integrity": "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.207.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.207.0.tgz",
+      "integrity": "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.9.0.tgz",
+      "integrity": "sha512-ec9a7ps37huy5itYk0MalaZdSLlM6AXWp/FhtEjgMpp5leEGojBDvAl/UWttQnkMZOvFHKzRESn8TD3yKTF5nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.9.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/sdk-trace-base": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -2070,6 +2829,72 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
@@ -2162,6 +2987,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2175,6 +3001,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2188,6 +3015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2201,15 +3029,139 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@relayfile/sdk": {
-      "resolved": "packages/sdk/typescript",
-      "link": true
+    "node_modules/@relayfile/relay-helpers": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@relayfile/relay-helpers/-/relay-helpers-0.4.9.tgz",
+      "integrity": "sha512-mQ3HEAP95T2l7sLiXgblIGrL89mBv6FuEz2pxKtsX0jSXKnWr914T6Fy9gCfzzkBEQtStS5S7pi50wqwNufwZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.5.10",
+        "@relayfile/adapter-linear": "^0.4.8",
+        "@relayfile/adapter-reddit": "^0.2.7"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/@relayfile/adapter-core": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-core/-/adapter-core-0.5.11.tgz",
+      "integrity": "sha512-aXgTNLTNNbdXqz1xrcBUu5C053q8GIHyRQF/jkpzzrJEu+MRODWRSIu2l1lUGs01z7/dyWWivAD1iXZ9jyVxKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scalar/postman-to-openapi": "^0.6.0",
+        "cheerio": "^1.2.0",
+        "minimatch": "^10.0.3",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "adapter-core": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": ">=0.6.0 <1"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/@relayfile/adapter-linear": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-linear/-/adapter-linear-0.4.8.tgz",
+      "integrity": "sha512-O64IZFa1UG2v7G+l1zu96SiZZANEOuvo45/EnlOLfWQemaVWu6JcHbSHTGC7uMdxUOngMZ1cuMTk84BE+8dARA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": ">=0.6.0 <1"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/@relayfile/adapter-reddit": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@relayfile/adapter-reddit/-/adapter-reddit-0.2.7.tgz",
+      "integrity": "sha512-HgdVE/vprYNdYgD12jLjvk7jD+4RHRtc/CIMs/BbAIBR8B/aqQqVDpCWbKhXtg6b92inr3z0UxMQQTSIdsqsmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/adapter-core": "^0.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@relayfile/sdk": ">=0.6.0 <1"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@relayfile/relay-helpers/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -2560,6 +3512,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.1.tgz",
+      "integrity": "sha512-9VvPfv8b+YZVIFwR3SWeq4Y8ij/kU3/kf2M6NKcbf2iVyh63d8s0ssap5m/nOhiz/Puidv/29MAJlJCA0LRssA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/openapi-types": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scalar/openapi-types/-/openapi-types-0.7.0.tgz",
+      "integrity": "sha512-kN0PwlJW0de4bwQ4ib+mBHzKJUvBCyR/gwU4zLEq6SCbj+GfgYUh+2a0/yl1WYVUiSkkwFsHjfmQ8KjhR3HK0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/postman-to-openapi": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@scalar/postman-to-openapi/-/postman-to-openapi-0.6.3.tgz",
+      "integrity": "sha512-Y/tMuRZG34wEfpTxDfXFp5o2X3ibb5ojGWupGJ9ZxkThCx7rOGydnszJPzEbgDK3eF6nJ6UuE7bCTpIEutYnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.5.1",
+        "@scalar/openapi-types": "0.7.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -3463,6 +4449,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -3620,10 +4613,91 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -3811,6 +4885,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -3823,6 +4914,19 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3936,6 +5040,78 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3974,6 +5150,33 @@
       "optional": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -4489,6 +5692,39 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4860,7 +6096,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4882,7 +6117,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4904,7 +6138,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4926,7 +6159,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4948,7 +6180,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4970,7 +6201,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4992,7 +6222,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5014,7 +6243,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5036,7 +6264,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5058,7 +6285,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5080,7 +6306,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5179,6 +6404,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -5345,6 +6577,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5354,6 +6587,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -5491,6 +6725,19 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5668,6 +6915,85 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5826,6 +7152,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -6052,8 +7402,7 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -6501,6 +7850,7 @@
       "version": "7.5.20",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
       "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -6997,6 +8347,33 @@
         "node": ">=20"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -7132,6 +8509,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -7491,6 +8869,27 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "packages/agents/node_modules/@relayfile/sdk": {
+      "version": "0.10.34",
+      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
+      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
       }
     },
     "packages/agents/node_modules/@types/node": {
@@ -8485,29 +9884,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/sdk/typescript": {
-      "name": "@relayfile/sdk",
-      "version": "0.10.34",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@relayfile/core": "0.10.34",
-        "ignore": "^7.0.5",
-        "tar": "^7.5.10"
-      },
-      "devDependencies": {
-        "typescript": "^5.7.3",
-        "vitest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.10.34",
-        "@relayfile/mount-darwin-x64": "0.10.34",
-        "@relayfile/mount-linux-arm64": "0.10.34",
-        "@relayfile/mount-linux-x64": "0.10.34"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@agentworkforce/runtime": "^4.1.34",
         "@agentworkforce/workload-router": "^0.3.0",
         "@relayfile/relay-helpers": "^0.4.9",
+        "@types/node": "^22.10.0",
         "agent-trajectories": "^0.5.8",
         "tsx": "^4.21.0",
         "typescript": "^5.7.3",
@@ -436,27 +437,6 @@
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw==",
       "dev": true
     },
-    "node_modules/@agent-assistant/turn-context/node_modules/@relayfile/sdk": {
-      "version": "0.10.34",
-      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
-      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@relayfile/core": "0.10.34",
-        "ignore": "^7.0.5",
-        "tar": "^7.5.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.10.34",
-        "@relayfile/mount-darwin-x64": "0.10.34",
-        "@relayfile/mount-linux-arm64": "0.10.34",
-        "@relayfile/mount-linux-x64": "0.10.34"
-      }
-    },
     "node_modules/@agent-assistant/turn-context/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -705,27 +685,6 @@
       "resolved": "https://registry.npmjs.org/@agentworkforce/workload-router/-/workload-router-0.11.0.tgz",
       "integrity": "sha512-6Fn4oDsYeNRPe+k7hVfS3Ae3yIocNjuvscVvRswn74CzxSC1X9+1wDhQ5eCvE+S1m1ixAjYGFC9/MNwuhFwjHw==",
       "dev": true
-    },
-    "node_modules/@agent-relay/hooks/node_modules/@relayfile/sdk": {
-      "version": "0.10.34",
-      "resolved": "https://registry.npmjs.org/@relayfile/sdk/-/sdk-0.10.34.tgz",
-      "integrity": "sha512-VU52piPz+12Ooogi5dxpf36rUPAdAkIYmpHMEuNwQcvq6S7fXxCmOw4B71k81C+KuwYxZQTIftpxIgZdvLzJQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@relayfile/core": "0.10.34",
-        "ignore": "^7.0.5",
-        "tar": "^7.5.10"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@relayfile/mount-darwin-arm64": "0.10.34",
-        "@relayfile/mount-darwin-x64": "0.10.34",
-        "@relayfile/mount-linux-arm64": "0.10.34",
-        "@relayfile/mount-linux-x64": "0.10.34"
-      }
     },
     "node_modules/@agent-relay/hooks/node_modules/zod": {
       "version": "3.25.76",
@@ -3035,6 +2994,10 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/@relayfile/sdk": {
+      "resolved": "packages/sdk/typescript",
+      "link": true
     },
     "node_modules/@relayfile/relay-helpers": {
       "version": "0.4.9",
@@ -6096,6 +6059,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6117,6 +6081,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6138,6 +6103,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6159,6 +6125,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6180,6 +6147,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6201,6 +6169,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6222,6 +6191,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6243,6 +6213,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6264,6 +6235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6285,6 +6257,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6306,6 +6279,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -9884,6 +9858,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/sdk/typescript": {
+      "name": "@relayfile/sdk",
+      "version": "0.10.34",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@relayfile/core": "0.10.34",
+        "ignore": "^7.0.5",
+        "tar": "^7.5.10"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.3",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@relayfile/mount-darwin-arm64": "0.10.34",
+        "@relayfile/mount-darwin-x64": "0.10.34",
+        "@relayfile/mount-linux-arm64": "0.10.34",
+        "@relayfile/mount-linux-x64": "0.10.34"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@agentworkforce/runtime": "^4.1.34",
     "@agentworkforce/workload-router": "^0.3.0",
     "@relayfile/relay-helpers": "^0.4.9",
+    "@types/node": "^22.10.0",
     "agent-trajectories": "^0.5.8",
     "tsx": "^4.21.0",
     "typescript": "^5.7.3",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,24 @@
     "evals:list": "npm run evals:compile && node scripts/evals/run-relayfile-evals.mjs --list",
     "evals:offline": "npm run evals:compile && node scripts/evals/run-relayfile-evals.mjs --mode offline",
     "evals:provider": "npm run evals:compile && node scripts/evals/run-relayfile-evals.mjs --provider",
+    "features:validate": "node scripts/validate-feature-catalog.mjs",
+    "features:typecheck": "tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --skipLibCheck .agentworkforce/agents/relayfile-feature-guardian/agent.ts workflows/verify-features.ts",
+    "features:test": "npm run features:typecheck && node --test scripts/verify-features.test.mjs && tsx --test .agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts .agentworkforce/agents/relayfile-feature-guardian/agent.test.ts && vitest run packages/agents/src/forward.test.ts packages/agents/src/tools/read-roots.test.ts",
+    "features:pack-e2e": "node scripts/packed-feature-e2e.mjs",
+    "features:verify": "node scripts/verify-features.mjs",
     "test:load:tier2-scoped-writeback": "node test/load/tier2-cfdo-scoped-writeback.mjs",
     "test:load:tier2-scoped-writeback:self-test": "node test/load/tier2-cfdo-scoped-writeback.mjs --self-test"
   },
   "devDependencies": {
     "@agent-assistant/telemetry": "^0.4.31",
     "@agent-relay/sdk": "^4.0.28",
+    "@agentworkforce/delivery": "^4.1.34",
+    "@agentworkforce/runtime": "^4.1.34",
     "@agentworkforce/workload-router": "^0.3.0",
+    "@relayfile/relay-helpers": "^0.4.9",
     "agent-trajectories": "^0.5.8",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "typescript": "^5.7.3",
+    "yaml": "^2.8.3"
   }
 }

--- a/packages/agents/src/tools/read-roots.test.ts
+++ b/packages/agents/src/tools/read-roots.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RelayfileAgents } from "../connect.js";
+import { langchainTools } from "./langchain.js";
+import { openaiTools } from "./openai.js";
+import { vercelTools } from "./vercel.js";
+
+function fakeRelayfile() {
+  const readFile = vi.fn(async () => ({ path: "/allowed/file.md", content: "ok" }));
+  const listTree = vi.fn(async () => ({ entries: [] }));
+  return {
+    readFile,
+    listTree,
+    rf: { workspaceId: "workspace", client: { readFile, listTree } } as unknown as RelayfileAgents,
+  };
+}
+
+describe("agent framework read-root filters", () => {
+  it("Vercel rejects an out-of-prefix read before calling Relayfile", async () => {
+    const { rf, readFile } = fakeRelayfile();
+    const tools = vercelTools(rf, { readPaths: ["/allowed"] });
+
+    await expect(tools.relayfile_read_file.execute?.({ path: "/denied/file.md" }, {} as never))
+      .rejects.toThrow("outside the allowed read roots");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("OpenAI rejects an out-of-prefix read before calling Relayfile", async () => {
+    const { rf, readFile } = fakeRelayfile();
+    const tool = openaiTools(rf, { readPaths: ["/allowed"] })[1];
+
+    const result = await tool.invoke(undefined as never, JSON.stringify({ path: "/denied/file.md" }));
+    expect(result).toContain("outside the allowed read roots");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("LangChain rejects an out-of-prefix read before calling Relayfile", async () => {
+    const { rf, readFile } = fakeRelayfile();
+    const tool = langchainTools(rf, { readPaths: ["/allowed"] })[1];
+
+    await expect(tool.invoke({ path: "/denied/file.md" })).rejects.toThrow("outside the allowed read roots");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/build-mount-npm-packages.mjs
+++ b/scripts/build-mount-npm-packages.mjs
@@ -5,15 +5,20 @@
 // which @relayfile/sdk resolves at runtime via require.resolve.
 //
 // Usage:
-//   make build-all            # produce dist/relayfile-mount-<os>-<arch>
+//   make build-all            # produce dist/<os>_<arch>/relayfile-mount
 //   node scripts/build-mount-npm-packages.mjs
 //
+// Packed-consumer verification may override RELAYFILE_MOUNT_DIST_DIR and
+// RELAYFILE_MOUNT_PACKAGES_DIR so release staging never mutates worktree
+// build output or checked-out package directories.
+//
 // For each target it:
-//   1. copies dist/relayfile-mount-<os>-<goarch> -> packages/mount-<os>-<arch>/bin/relayfile-mount
+//   1. copies dist/<os>_<goarch>/relayfile-mount (or the legacy flat release
+//      artifact dist/relayfile-mount-<os>-<goarch>) into the platform package
 //   2. rewrites that package's version to match @relayfile/sdk
 //
 // Note the arch naming: Go emits `amd64`, npm os/cpu uses Node's `x64`. The
-// dist files use the Go name; the package dirs use the Node name.
+// dist paths use the Go name; the package dirs use the Node name.
 import { chmod, copyFile, mkdir, readFile, writeFile } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { access } from 'node:fs/promises'
@@ -22,8 +27,8 @@ import { fileURLToPath } from 'node:url'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const repoRoot = resolve(scriptDir, '..')
-const distDir = join(repoRoot, 'dist')
-const packagesDir = join(repoRoot, 'packages')
+const distDir = resolve(process.env.RELAYFILE_MOUNT_DIST_DIR || join(repoRoot, 'dist'))
+const packagesDir = resolve(process.env.RELAYFILE_MOUNT_PACKAGES_DIR || join(repoRoot, 'packages'))
 
 // (npmArch used in package dir + os/cpu) -> (goArch used in dist file name)
 const TARGETS = [
@@ -53,7 +58,11 @@ async function main() {
   const missing = []
 
   for (const target of TARGETS) {
-    const distBinary = join(distDir, `relayfile-mount-${target.os}-${target.goArch}`)
+    // `make build-all` writes one target directory per GOOS/GOARCH. Keep the
+    // legacy flat filename as a fallback for older release artifact layouts.
+    const builtBinary = join(distDir, `${target.os}_${target.goArch}`, 'relayfile-mount')
+    const legacyBinary = join(distDir, `relayfile-mount-${target.os}-${target.goArch}`)
+    const distBinary = (await exists(builtBinary)) ? builtBinary : legacyBinary
     const pkgDir = join(packagesDir, `mount-${target.os}-${target.npmArch}`)
     const pkgJsonPath = join(pkgDir, 'package.json')
     const binTarget = join(pkgDir, 'bin', 'relayfile-mount')

--- a/scripts/conformance.ts
+++ b/scripts/conformance.ts
@@ -17,7 +17,10 @@
  *   npx tsx scripts/conformance.ts --ci
  */
 
-import { execSync, spawn, ChildProcess } from 'node:child_process';
+import { execFileSync, spawn, ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createLocalRs256Auth, type LocalRs256Auth } from './test-utils/rsa-signer';
 
 // ---------------------------------------------------------------------------
@@ -30,7 +33,13 @@ const REMOTE = flags.has('--remote');
 const HELP = flags.has('--help') || argv.includes('-h');
 
 const PORT = Number(process.env.RELAYFILE_PORT || 19090);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65_535) {
+  throw new Error(`RELAYFILE_PORT must be an integer from 1 to 65535, got ${process.env.RELAYFILE_PORT}`);
+}
 const BASE_URL = process.env.RELAYFILE_BASE_URL || `http://127.0.0.1:${PORT}`;
+const REQUESTED_LOCAL_SERVER_BINARY = process.env.RELAYFILE_CONFORMANCE_BINARY
+  ? resolve(process.env.RELAYFILE_CONFORMANCE_BINARY)
+  : undefined;
 const WORKSPACE = `conformance-${Date.now()}`;
 const DISABLE_SHARED_SECRET_JWT_ENV = `RELAYFILE_VERIFIER_ACCEPT_HS${256}`;
 
@@ -173,22 +182,77 @@ function errorCode(data: any): string | undefined {
   return typeof raw === 'string' ? raw : undefined;
 }
 
+class SkippedTest extends Error {}
+
 function skipCloudOnlyWebhookRoute(testName: string, response: { status: number }): boolean {
   if (response.status !== 404) return false;
-  log('⏭️ ', `${testName} skipped: webhook subscription routes are not implemented by this server`);
-  return true;
+  throw new SkippedTest(`${testName} skipped: webhook subscription routes are not implemented by this server`);
 }
 
 // ---------------------------------------------------------------------------
 // Process management
 // ---------------------------------------------------------------------------
 let serverProcess: ChildProcess | null = null;
+let localServerBinary: string | null = null;
+let localServerBinaryOwned = false;
+let localServerFixture: string | null = null;
+
+function prepareLocalServerBinary(): string {
+  if (REQUESTED_LOCAL_SERVER_BINARY) {
+    if (existsSync(REQUESTED_LOCAL_SERVER_BINARY)) {
+      throw new Error(`refusing to overwrite existing conformance binary: ${REQUESTED_LOCAL_SERVER_BINARY}`);
+    }
+    localServerBinaryOwned = true;
+    localServerBinary = REQUESTED_LOCAL_SERVER_BINARY;
+    return localServerBinary;
+  }
+
+  localServerFixture = mkdtempSync(join(tmpdir(), 'relayfile-conformance-'));
+  writeFileSync(join(localServerFixture, '.relayfile-conformance-fixture'), '');
+  localServerBinaryOwned = true;
+  localServerBinary = join(localServerFixture, process.platform === 'win32' ? 'relayfile.exe' : 'relayfile');
+  return localServerBinary;
+}
+
+function removeLocalServerFixture(): void {
+  if (!localServerFixture) return;
+  const marker = join(localServerFixture, '.relayfile-conformance-fixture');
+  const expectedParent = resolve(tmpdir());
+  if (
+    !existsSync(marker) ||
+    dirname(resolve(localServerFixture)) !== expectedParent ||
+    !basename(localServerFixture).startsWith('relayfile-conformance-')
+  ) {
+    throw new Error(`refusing unsafe conformance fixture cleanup: ${localServerFixture}`);
+  }
+  rmSync(localServerFixture, { recursive: true });
+  localServerFixture = null;
+}
+
+function waitForServerExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolveExit) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off('exit', onExit);
+      resolveExit(exited);
+    };
+    const onExit = () => finish(true);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    child.once('exit', onExit);
+    if (child.exitCode !== null || child.signalCode !== null) finish(true);
+  });
+}
 
 async function startServer(): Promise<void> {
   if (REMOTE) return;
   step('Building & starting local Go server');
-  execSync('go build -o relayfile-conformance ./cmd/relayfile', { stdio: 'inherit' });
-  serverProcess = spawn('./relayfile-conformance', [], {
+  const binary = prepareLocalServerBinary();
+  execFileSync('go', ['build', '-o', binary, './cmd/relayfile'], { stdio: 'inherit' });
+  serverProcess = spawn(binary, [], {
     env: {
       ...process.env,
       RELAYFILE_ADDR: `:${PORT}`,
@@ -220,14 +284,28 @@ async function startServer(): Promise<void> {
 
 async function stopServer() {
   if (serverProcess) {
-    serverProcess.kill('SIGTERM');
+    const child = serverProcess;
     serverProcess = null;
+    if (child.exitCode === null && child.signalCode === null) {
+      const termExit = waitForServerExit(child, 5_000);
+      child.kill('SIGTERM');
+      if (!(await termExit)) {
+        const killExit = waitForServerExit(child, 2_000);
+        child.kill('SIGKILL');
+        if (!(await killExit)) throw new Error(`conformance server process ${child.pid ?? 'unknown'} did not exit`);
+      }
+    }
   }
   if (rs256Auth) {
     await rs256Auth.close();
     rs256Auth = null;
   }
-  try { execSync('rm -f relayfile-conformance', { stdio: 'ignore' }); } catch {}
+  if (localServerBinaryOwned && localServerBinary && existsSync(localServerBinary)) {
+    unlinkSync(localServerBinary);
+  }
+  localServerBinary = null;
+  localServerBinaryOwned = false;
+  removeLocalServerFixture();
 }
 
 // ---------------------------------------------------------------------------
@@ -235,6 +313,7 @@ async function stopServer() {
 // ---------------------------------------------------------------------------
 const passed: string[] = [];
 const failed: string[] = [];
+const skipped: string[] = [];
 
 async function test(name: string, fn: () => Promise<void>) {
   try {
@@ -242,6 +321,11 @@ async function test(name: string, fn: () => Promise<void>) {
     ok(name);
     passed.push(name);
   } catch (err) {
+    if (err instanceof SkippedTest) {
+      log('⏭️ ', err.message);
+      skipped.push(name);
+      return;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     fail(`${name}: ${msg}`);
     failed.push(name);
@@ -747,6 +831,7 @@ Usage:
 Environment:
   RELAYFILE_BASE_URL  Base URL when using --remote
   RELAYFILE_PORT      Local server port when not using --remote
+  RELAYFILE_CONFORMANCE_BINARY  Optional non-existent local server binary path (never overwritten)
 `);
     return;
   }
@@ -784,6 +869,11 @@ ${B}${CYAN}╔══════════════════════
       console.log();
       log('❌', `${RED}${B}${failed.length} failed${R}`);
       for (const t of failed) log('  ', `${RED}• ${t}${R}`);
+    }
+    if (skipped.length > 0) {
+      console.log();
+      log('⏭️ ', `${YELLOW}${B}${skipped.length} skipped${R}`);
+      for (const t of skipped) log('  ', `${YELLOW}• ${t}${R}`);
     }
     console.log();
 

--- a/scripts/conformance.ts
+++ b/scripts/conformance.ts
@@ -283,6 +283,7 @@ async function startServer(): Promise<void> {
 }
 
 async function stopServer() {
+  const failures: string[] = [];
   if (serverProcess) {
     const child = serverProcess;
     serverProcess = null;
@@ -292,20 +293,33 @@ async function stopServer() {
       if (!(await termExit)) {
         const killExit = waitForServerExit(child, 2_000);
         child.kill('SIGKILL');
-        if (!(await killExit)) throw new Error(`conformance server process ${child.pid ?? 'unknown'} did not exit`);
+        if (!(await killExit)) failures.push(`conformance server process ${child.pid ?? 'unknown'} did not exit`);
       }
     }
   }
   if (rs256Auth) {
-    await rs256Auth.close();
+    try {
+      await rs256Auth.close();
+    } catch (error) {
+      failures.push(`RS256 fixture close failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
     rs256Auth = null;
   }
   if (localServerBinaryOwned && localServerBinary && existsSync(localServerBinary)) {
-    unlinkSync(localServerBinary);
+    try {
+      unlinkSync(localServerBinary);
+    } catch (error) {
+      failures.push(`local server binary cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
   localServerBinary = null;
   localServerBinaryOwned = false;
-  removeLocalServerFixture();
+  try {
+    removeLocalServerFixture();
+  } catch (error) {
+    failures.push(`local server fixture cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (failures.length > 0) throw new Error(failures.join('; '));
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -12,9 +12,9 @@
  *   npx tsx scripts/e2e.ts --webhook-receiver-url https://public-tunnel.example/hook
  */
 
-import { execSync, spawn, ChildProcess } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { execFileSync, spawn, ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { createLocalRs256Auth, type LocalRs256Auth } from './test-utils/rsa-signer';
 
@@ -27,7 +27,10 @@ const CI = flags.has('--ci') || !!process.env.CI;
 const CONTINUE_ON_FAILURE = flags.has('--continue-on-failure');
 const WEBHOOK_RECEIVER_URL = readArg('--webhook-receiver-url') || process.env.RELAYFILE_WEBHOOK_RECEIVER_URL || '';
 
-const PORT = 9090;
+const PORT = Number(process.env.RELAYFILE_PORT || 9090);
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65_535) {
+  throw new Error(`RELAYFILE_PORT must be an integer from 1 to 65535, got ${process.env.RELAYFILE_PORT}`);
+}
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const WORKSPACE = 'e2e-test';
 const DISABLE_SHARED_SECRET_JWT_ENV = `RELAYFILE_VERIFIER_ACCEPT_HS${256}`;
@@ -82,11 +85,33 @@ function sleep(ms: number) {
 const children: ChildProcess[] = [];
 let rs256Auth: LocalRs256Auth | null = null;
 
-function killAll() {
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+  return new Promise((resolveExit) => {
+    let settled = false;
+    const finish = (exited: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off('exit', onExit);
+      resolveExit(exited);
+    };
+    const onExit = () => finish(true);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    child.once('exit', onExit);
+    if (child.exitCode !== null || child.signalCode !== null) finish(true);
+  });
+}
+
+async function stopAll() {
   for (const child of children) {
-    try {
-      child.kill('SIGTERM');
-    } catch {}
+    if (child.exitCode !== null || child.signalCode !== null) continue;
+    const termExit = waitForExit(child, 5_000);
+    child.kill('SIGTERM');
+    if (await termExit) continue;
+    const killExit = waitForExit(child, 2_000);
+    child.kill('SIGKILL');
+    if (!(await killExit)) throw new Error(`child process ${child.pid ?? 'unknown'} did not exit`);
   }
 }
 
@@ -243,20 +268,29 @@ ${B}${CYAN}╔══════════════════════
 
   const passed: string[] = [];
   const failed: string[] = [];
+  const skipped: string[] = [];
 
   const SYNC_WAIT = CI ? 8_000 : 12_000;
   const MOUNT_WAIT = CI ? 10_000 : 15_000;
 
   // Temp dirs
-  const tmpBase = join(tmpdir(), `relayfile-e2e-${Date.now()}`);
+  const tmpBase = mkdtempSync(join(tmpdir(), 'relayfile-e2e-'));
+  const fixtureMarker = join(tmpBase, '.relayfile-e2e-fixture');
+  writeFileSync(fixtureMarker, '');
   const agentADir = join(tmpBase, 'agent-a');
   const agentBDir = join(tmpBase, 'agent-b');
+  const serverBinary = join(tmpBase, process.platform === 'win32' ? 'relayfile.exe' : 'relayfile');
+  const mountBinary = join(tmpBase, process.platform === 'win32' ? 'relayfile-mount.exe' : 'relayfile-mount');
   mkdirSync(agentADir, { recursive: true });
   mkdirSync(agentBDir, { recursive: true });
 
-  async function run(name: string, fn: () => Promise<void>) {
+  async function run(name: string, fn: () => Promise<void | 'SKIP'>) {
     try {
-      await fn();
+      const result = await fn();
+      if (result === 'SKIP') {
+        skipped.push(name);
+        return;
+      }
       ok(name);
       passed.push(name);
     } catch (err) {
@@ -274,17 +308,15 @@ ${B}${CYAN}╔══════════════════════
     // Build
     // ------------------------------------------------------------------
     step('Building relayfile and relayfile-mount');
-    execSync('go build -o relayfile ./cmd/relayfile && go build -o relayfile-mount ./cmd/relayfile-mount', {
-      cwd: process.cwd(),
-      stdio: 'inherit',
-    });
+    execFileSync('go', ['build', '-o', serverBinary, './cmd/relayfile'], { cwd: process.cwd(), stdio: 'inherit' });
+    execFileSync('go', ['build', '-o', mountBinary, './cmd/relayfile-mount'], { cwd: process.cwd(), stdio: 'inherit' });
     ok('Build succeeded');
 
     // ------------------------------------------------------------------
     // Start server
     // ------------------------------------------------------------------
     step('Starting relayfile server');
-    const server = spawnTracked('./relayfile', [], {
+    const server = spawnTracked(serverBinary, [], {
       RELAYFILE_ADDR: `:${PORT}`,
       RELAYFILE_BACKEND_PROFILE: 'memory',
       RELAYAUTH_JWKS_URL: rs256Auth.jwksUrl,
@@ -307,7 +339,7 @@ ${B}${CYAN}╔══════════════════════
     // Start mount daemons
     // ------------------------------------------------------------------
     step('Starting mount daemons');
-    const mountA = spawnTracked('./relayfile-mount', [
+    const mountA = spawnTracked(mountBinary, [
       '--base-url', BASE_URL,
       '--workspace', WORKSPACE,
       '--local-dir', agentADir,
@@ -319,7 +351,7 @@ ${B}${CYAN}╔══════════════════════
       if (line) log('🔄', `${DIM}[mount-a] ${line}${R}`);
     });
 
-    const mountB = spawnTracked('./relayfile-mount', [
+    const mountB = spawnTracked(mountBinary, [
       '--base-url', BASE_URL,
       '--workspace', WORKSPACE,
       '--local-dir', agentBDir,
@@ -615,7 +647,7 @@ ${B}${CYAN}╔══════════════════════
       // process owns delivery capture and HMAC verification for that URL.
       if (!WEBHOOK_RECEIVER_URL) {
         log('⏭️ ', 'webhook delivery smoke skipped: no public receiver URL');
-        return;
+        return 'SKIP';
       }
 
       let subscriptionId = '';
@@ -684,16 +716,15 @@ ${B}${CYAN}╔══════════════════════
     // Teardown
     // ------------------------------------------------------------------
     step('Teardown');
-    killAll();
+    await stopAll();
     await closeAuth();
-
-    // Wait briefly for processes to exit
-    await sleep(500);
-
-    try {
-      rmSync(tmpBase, { recursive: true, force: true });
-      log('🗑️ ', 'Cleaned up temp dirs');
-    } catch {}
+    if (
+      !existsSync(fixtureMarker) ||
+      dirname(resolve(tmpBase)) !== resolve(tmpdir()) ||
+      !basename(tmpBase).startsWith('relayfile-e2e-')
+    ) throw new Error(`refusing unsafe E2E fixture cleanup: ${tmpBase}`);
+    rmSync(tmpBase, { recursive: true });
+    log('🗑️ ', 'Cleaned up marker-checked temp dirs');
 
     // Summary
     console.log(`
@@ -714,6 +745,13 @@ ${B}${CYAN}╔══════════════════════
         log('  ', `${RED}• ${t}${R}`);
       }
     }
+    if (skipped.length > 0) {
+      console.log();
+      log('⏭️ ', `${YELLOW}${B}${skipped.length} skipped${R}`);
+      for (const t of skipped) {
+        log('  ', `${YELLOW}• ${t}${R}`);
+      }
+    }
     console.log();
 
     if (failed.length > 0) {
@@ -724,7 +762,7 @@ ${B}${CYAN}╔══════════════════════
 
 main().catch(async (err) => {
   fail(err instanceof Error ? err.message : String(err));
-  killAll();
+  await stopAll().catch((cleanupError) => fail(cleanupError instanceof Error ? cleanupError.message : String(cleanupError)));
   await closeAuth();
   process.exit(1);
 });

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -104,6 +104,7 @@ function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
 }
 
 async function stopAll() {
+  const failures: string[] = [];
   for (const child of children) {
     if (child.exitCode !== null || child.signalCode !== null) continue;
     const termExit = waitForExit(child, 5_000);
@@ -111,8 +112,9 @@ async function stopAll() {
     if (await termExit) continue;
     const killExit = waitForExit(child, 2_000);
     child.kill('SIGKILL');
-    if (!(await killExit)) throw new Error(`child process ${child.pid ?? 'unknown'} did not exit`);
+    if (!(await killExit)) failures.push(`child process ${child.pid ?? 'unknown'} did not exit`);
   }
+  if (failures.length > 0) throw new Error(failures.join('; '));
 }
 
 async function closeAuth() {

--- a/scripts/evals/run-relayfile-evals.mjs
+++ b/scripts/evals/run-relayfile-evals.mjs
@@ -25,7 +25,9 @@ import { createRelayfileExecutor } from "./relayfile-executor.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const SUITES_DIR = path.join(ROOT, "evals", "suites");
-const RUNS_DIR = path.join(ROOT, ".relayfile", "evals", "runs");
+const RUNS_DIR = process.env.RELAYFILE_EVAL_RUNS_DIR
+  ? path.resolve(ROOT, process.env.RELAYFILE_EVAL_RUNS_DIR)
+  : path.join(ROOT, ".relayfile", "evals", "runs");
 const DEFAULT_OPENROUTER_MODEL = "openai/gpt-oss-120b:free";
 const OPENROUTER_CHAT_COMPLETIONS_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
 

--- a/scripts/feature-catalog-surfaces.mjs
+++ b/scripts/feature-catalog-surfaces.mjs
@@ -1,0 +1,379 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parse } from 'yaml';
+import ts from 'typescript';
+
+const CLI_LEAVES = [
+  'help',
+  'version',
+  'setup',
+  'login',
+  'logout',
+  'workspace create',
+  'workspace join',
+  'workspace use',
+  'workspace list',
+  'workspace current',
+  'workspace status',
+  'workspace delete',
+  'integration connect',
+  'integration available',
+  'integration search',
+  'integration list',
+  'integration disconnect',
+  'integration adopt',
+  'integration set-metadata',
+  'integration bind',
+  'integration resolve-path',
+  'integration unbind',
+  'integration writeback-secret',
+  'ops list',
+  'ops replay',
+  'writeback list',
+  'writeback push',
+  'writeback update',
+  'writeback delete',
+  'writeback status',
+  'writeback retry',
+  'writeback skip-stuck',
+  'writeback sweep-drafts',
+  'digest rebuild',
+  'pull',
+  'mount',
+  'restart',
+  'supervisor install',
+  'supervisor uninstall',
+  'supervisor status',
+  'tree',
+  'read',
+  'seed',
+  'export',
+  'status',
+  'stop',
+  'logs',
+  'observer',
+  'listen',
+  'control-plane serve',
+  'dev',
+];
+
+const CLI_ALIASES = [
+  '-h=>help',
+  '--help=>help',
+  '--version=>version',
+  '<no-args>=>setup',
+  'integration catalog=>integration available',
+  'integration providers=>integration available',
+  'start=>mount',
+  'on=>mount',
+  'supervisor remove=>supervisor uninstall',
+  'ls=>tree',
+  'cat=>read',
+  'off=>stop',
+  'watch=>listen',
+];
+
+const HOSTED_HTTP = [
+  'GET /v1/workspaces/{workspaceId}/fs/changes',
+  'GET /v1/workspaces/{workspaceId}/fs/changes/resource',
+  'POST /v1/workspaces/{workspaceId}/webhooks',
+  'GET /v1/workspaces/{workspaceId}/webhooks',
+  'DELETE /v1/workspaces/{workspaceId}/webhooks/{subscriptionId}',
+  'GET /v1/workspaces/{workspaceId}/webhooks/dlq',
+  'POST /v1/workspaces/{workspaceId}/webhooks/dlq/{id}/replay',
+  'POST /api/v1/workspaces',
+  'POST /api/v1/workspaces/{workspaceId}/join',
+  'POST /api/v1/workspaces/{workspaceId}/delegated-token',
+  'POST /api/v1/workspaces/{workspaceId}/mount-sessions',
+  'GET /api/v1/integrations/catalog',
+  'POST /api/v1/integrations/connect-session',
+  'GET /api/v1/integrations/status',
+  'POST /api/v1/integrations/adopt',
+  'GET /api/v1/integrations/access-resources',
+  'POST /api/v1/integrations/metadata',
+];
+
+const SDK_METHODS = {
+  'relayfile-client': [
+    'getToken', 'getBaseUrl', 'listTree', 'readFile', 'queryFiles', 'writeFile', 'bulkWrite',
+    'deleteFile', 'createFork', 'discardFork', 'commitFork', 'getEvents', 'subscribe', 'open',
+    'getResourceAtEvent', 'listChangesSince', 'listLastNChanges', 'exportWorkspace',
+    'connectWebSocket', 'getOp', 'listOps', 'replayOp', 'replayAdminEnvelope', 'replayAdminOp',
+    'getBackendStatus', 'getAdminIngressStatus', 'getAdminSyncStatus', 'getSyncStatus',
+    'waitForData', 'getSyncIngressStatus', 'getSyncDeadLetters', 'getSyncDeadLetter',
+    'replaySyncDeadLetter', 'ackSyncDeadLetter', 'triggerSyncRefresh', 'ingestWebhook',
+    'registerWebhook', 'listWebhooks', 'deleteWebhook', 'getWebhookDeadLetters',
+    'replayWebhookDeadLetter', 'listPendingWritebacks', 'ackWriteback', 'sweepWritebackDrafts',
+  ],
+  setup: [
+    'login', 'fromCloudTokens', 'createWorkspace', 'joinWorkspace', 'mountWorkspace',
+    'ensureMountedWorkspace', 'getCloudApiUrl', 'client', 'connectIntegration', 'connectNotion',
+    'waitForConnection', 'waitForNotion', 'isConnected', 'disconnectIntegration',
+    'adoptIntegration', 'listAccessibleResources', 'setIntegrationMetadata', 'getToken',
+    'mountEnv', 'agentInvite', 'agentInviteScoped', 'refreshToken', 'getConnectionStatus',
+    'WorkspaceHandle.env', 'WorkspaceHandle.status', 'WorkspaceHandle.stop',
+  ],
+  'control-plane': [
+    'hello', 'resolvePath', 'bind', 'listBindings', 'unbind', 'providerStatus', 'connect',
+    'writebackSecret', 'listWebhookSubscriptions', 'createWebhookSubscription',
+    'deleteWebhookSubscription',
+  ],
+};
+
+const ENVIRONMENT = {
+  server: [
+    'RELAYFILE_ADDR', 'RELAYFILE_BACKEND_PROFILE', 'RELAYFILE_DATA_DIR', 'RELAYFILE_STATE_FILE',
+    'RELAYFILE_STATE_BACKEND_DSN', 'RELAYFILE_PRODUCTION_DSN', 'RELAYFILE_POSTGRES_DSN',
+    'RELAYAUTH_JWKS_URL', 'RELAYFILE_INTERNAL_HMAC_SECRET', 'RELAYFILE_INTERNAL_MAX_SKEW',
+    'RELAYFILE_RATE_LIMIT_MAX', 'RELAYFILE_RATE_LIMIT_WINDOW', 'RELAYFILE_MAX_BODY_BYTES',
+    'RELAYFILE_DEV_MODE', 'RELAYFILE_ENVELOPE_QUEUE_DSN', 'RELAYFILE_ENVELOPE_QUEUE_FILE',
+    'RELAYFILE_ENVELOPE_QUEUE_SIZE', 'RELAYFILE_ENVELOPE_RETRY_DELAY',
+    'RELAYFILE_ENVELOPE_WORKERS', 'RELAYFILE_MAX_ENVELOPE_ATTEMPTS',
+    'RELAYFILE_MAX_STORED_ENVELOPES', 'RELAYFILE_WRITEBACK_QUEUE_DSN',
+    'RELAYFILE_WRITEBACK_QUEUE_FILE', 'RELAYFILE_WRITEBACK_QUEUE_SIZE',
+    'RELAYFILE_WRITEBACK_RETRY_DELAY', 'RELAYFILE_WRITEBACK_WORKERS',
+    'RELAYFILE_MAX_WRITEBACK_ATTEMPTS', 'RELAYFILE_PROVIDER_MAX_CONCURRENCY',
+    'RELAYFILE_EXTERNAL_WRITEBACK', 'RELAYFILE_SUPPRESSION_WINDOW', 'RELAYFILE_COALESCE_WINDOW',
+  ],
+  cli: [
+    'RELAYFILE_SERVER', 'RELAYFILE_BASE_URL', 'RELAYFILE_URL', 'RELAYFILE_TOKEN',
+    'RELAYFILE_WORKSPACE', 'RELAYFILE_WORKSPACE_ID', 'RELAYFILE_CLOUD_API_URL',
+    'RELAYFILE_CLOUD_TOKEN', 'RELAYFILE_DELEGATED_CREDENTIALS_FILE', 'RELAYFILE_SOCK',
+    'RELAYFILE_BIN', 'RELAYFILE_REQUIRE_DAEMON', 'XDG_RUNTIME_DIR', 'AGENT_RELAY_BIN',
+    'RELAYCAST_API_KEY', 'RELAYCAST_BASE_URL', 'RELAY_API_KEY', 'RELAY_BASE_URL',
+    'RELAYFILE_OBSERVER_URL', 'RELAYFILE_SDK_DEBUG',
+  ],
+  mount: [
+    'RELAYFILE_LOCAL_DIR', 'RELAYFILE_REMOTE_PATH', 'RELAYFILE_MOUNT_CREDS_FILE',
+    'RELAYFILE_MOUNT_PATHS_FILE', 'RELAYFILE_MOUNT_PROVIDER', 'RELAYFILE_MOUNT_SCOPES',
+    'RELAYFILE_MOUNT_STATE_FILE', 'RELAYFILE_MOUNT_STATE_DIR', 'RELAYFILE_MOUNT_KIND',
+    'RELAYFILE_MOUNT_LOCAL_LAYOUT', 'RELAYFILE_MOUNT_SYNC_MODE', 'RELAYFILE_MOUNT_INTERVAL',
+    'RELAYFILE_MOUNT_INTERVAL_JITTER', 'RELAYFILE_MOUNT_TIMEOUT', 'RELAYFILE_BOOTSTRAP_TIMEOUT',
+    'RELAYFILE_BOOTSTRAP_IDLE_TIMEOUT', 'RELAYFILE_BOOTSTRAP_STALL_CYCLES',
+    'RELAYFILE_BOOTSTRAP_READ_CONCURRENCY', 'RELAYFILE_CURSOR_TIMEOUT', 'RELAYFILE_EXPORT_TIMEOUT',
+    'RELAYFILE_OUTBOX_TIMEOUT', 'RELAYFILE_INCREMENTAL_READ_NOT_READY_TTL',
+    'RELAYFILE_FORCE_FULL_RECONCILE', 'RELAYFILE_MOUNT_FULL_PULL_EVERY', 'RELAYFILE_LAZY_REPOS',
+    'RELAYFILE_MOUNT_LAZY_GITHUB_REPOS', 'RELAYFILE_LAZY_SKIP_UNTRACKED_PUSH',
+    'RELAYFILE_MOUNT_LOW_MEMORY', 'RELAYFILE_MOUNT_MAX_WATCH_DIRS',
+    'RELAYFILE_MOUNT_PPROF_ADDR', 'RELAYFILE_MOUNT_MEMLOG_INTERVAL',
+    'RELAYFILE_MOUNT_LOG_HTTP_STATUS', 'RELAYFILE_MOUNT_MODE', 'RELAYFILE_MOUNT_FUSE',
+    'RELAYFILE_MOUNT_FUSE_CONTENT_TTL', 'RELAYFILE_MOUNT_WEBSOCKET', 'RELAYFILE_MOUNT_BIN',
+    'RELAYFILE_ROOT', 'RELAYFILE_MAX_WRITEBACK_BYTES', 'RELAYFILE_MAX_WRITEBACK_BATCH_BYTES',
+    'RELAYFILE_SNAPSHOT_DELETE_MIN_RATIO', 'RELAYFILE_RESET_AFTER_CLOBBER',
+    'RELAYFILE_CB_THRESHOLD', 'RELAYFILE_CB_WINDOW', 'RELAYFILE_CB_COOLDOWN', 'RELAYFILE_TZ',
+  ],
+  agents: [
+    'CLOUD_API_ACCESS_TOKEN', 'CLOUD_API_REFRESH_TOKEN', 'CLOUD_API_ACCESS_TOKEN_EXPIRES_AT',
+    'CLOUD_API_URL', 'CLOUD_WORKSPACE_ID', 'FILE_OBSERVER_BASE_PATH',
+    'NEXT_PUBLIC_FILE_OBSERVER_BASE_PATH', 'NEXT_PUBLIC_RELAYFILE_BASE_URL',
+    'NEXT_PUBLIC_RELAYFILE_TOKEN', 'NEXT_PUBLIC_RELAYFILE_WORKSPACE_ID',
+    'NEXT_PUBLIC_RELAYFILE_WORKSPACE_IDS',
+  ],
+  automation: [
+    'CI', 'RELAYFILE_PORT', 'RELAYFILE_WEBHOOK_RECEIVER_URL', 'RELAYFILE_TEST_POSTGRES_DSN',
+    'SDK_E2E_*', 'POST_AUTH_*', 'HARNESS_*', 'LEAD_*', 'INVITE_FILE', 'OPENROUTER_API_KEY',
+    'RELAYFILE_EVAL_*', 'HUMAN_EVAL_*', 'GITHUB_REPOSITORY', 'GITHUB_SERVER_URL',
+    'GITHUB_TOKEN', 'GITHUB_STEP_SUMMARY', 'PR_NUMBER',
+  ],
+};
+
+const CONFIG_FIELDS = {
+  credentials: ['server', 'token', 'updatedAt', 'apiUrl', 'accessToken', 'accessTokenExpiresAt'],
+  workspace: [
+    'default', 'workspaces', 'name', 'id', 'relayWorkspaceId', 'createdAt', 'lastUsedAt',
+    'localDir', 'server', 'cloudApiUrl', 'agentName', 'scopes', 'timezone',
+  ],
+  'mount-state': [
+    'workspaceId', 'remoteRoot', 'mode', 'status', 'lastReconcileAt',
+    'lastSuccessfulReconcileAt', 'lastEventAt', 'intervalMs', 'providers',
+    'pendingWriteback', 'pendingConflicts', 'deniedPaths', 'failedWritebacks', 'stallReason',
+    'lastError', 'guards', 'bootstrap',
+  ],
+  'provider-binding': [
+    'provider', 'pathGlob', 'channel', 'webhookId', 'webhookToken', 'subscriptionId',
+    'webhookSubscriptionId', 'webhookSubscriptionWorkspaceId', 'createdAt', 'updatedAt',
+  ],
+};
+
+const PROVIDER_SURFACES = [
+  'generic-ingest', 'catalog-cloud', 'catalog-fallback', 'connect-nango', 'connect-composio',
+  'setup:github', 'setup:slack-sage', 'setup:slack-my-senior-dev', 'setup:slack-nightcto',
+  'setup:notion', 'setup:linear', 'canonical:zendesk', 'canonical:shopify', 'canonical:github',
+  'canonical:stripe', 'canonical:slack', 'canonical:linear', 'canonical:jira',
+  'canonical:hubspot', 'canonical:salesforce', 'canonical:gmail', 'canonical:notion',
+  'canonical:asana', 'canonical:trello', 'canonical:intercom', 'canonical:freshdesk',
+  'canonical:discord', 'canonical:twilio', 'canonical:generic', 'schema:github-issue',
+  'virtual:LAYOUT.md', 'virtual:.layout.md', 'virtual:_index.json', 'virtual:aliases',
+  'virtual:.skills/activity-summary.md', 'virtual:issues/.schema.json',
+  'virtual:.relay/dead-letter/*.error.json', 'digest:/digests/today.md',
+  'digest:/digests/yesterday.md', 'digest:/digests/this-week.md',
+  'digest:/digests/last-week.md', 'digest:date-stamped',
+];
+
+const IMPLEMENTATION_SURFACES = [
+  'filesystem-crud-bulk-query-export', 'acl-directory-markers', 'revision-if-match',
+  'fork-overlay-commit-discard', 'events-feed-websocket', 'ingest-dedup-semantics',
+  'digest-regeneration-events', 'operation-retry-replay-dead-letter',
+  'writeback-receipts-draft-sweep', 'storage-memory-file-postgres',
+  'mount-initial-full-incremental', 'bootstrap-checkpoint-resume', 'durable-outbox-tombstones',
+  'mount-delete-ratio-clobber-rehome-pid-fences', 'lazy-low-memory-diagnostics',
+  'fuse-cache-invalidation-virtual-readonly', 'local-agent-mount-final-sync',
+  'hosted-setup-scoped-invites', 'agent-framework-path-fences', 'ts-client-read-cache',
+  'auth-rs256-hmac-replay-limits',
+  'terminal-provider-state-retained', 'server-delete-storm-library-only',
+  'server-stale-running-library-only',
+];
+
+const OBSERVABILITY_SURFACES = [
+  'dashboard', 'admin-backends', 'admin-ingress', 'admin-sync', 'cli-status', 'cli-logs',
+  'cli-observer', 'mount-state', 'pprof', 'memory-log', 'http-status-log', 'file-observer-ui',
+  'eval-reports',
+];
+
+const RELEASE_PATHS = [
+  '.github/workflows/ci.yml', '.github/workflows/contract.yml', '.github/workflows/publish.yml',
+  '.github/workflows/publish-python.yml', '.github/workflows/relayfile-evals.yml',
+  'scripts/e2e.ts', 'scripts/conformance.ts', 'scripts/live-e2e.sh', 'scripts/nango-e2e.sh',
+  'scripts/check-contract-surface.sh', 'packages/cli/scripts/build-binaries.js',
+  'scripts/build-mount-npm-packages.mjs', 'packages/sdk/parity.json',
+  '.github/workflows/verify-features.yml', 'workflows/verify-features.ts',
+  'scripts/validate-feature-catalog.mjs', 'scripts/verify-features.mjs',
+  'scripts/packed-feature-e2e.mjs',
+];
+
+function add(set, prefix, values) {
+  for (const value of values) set.add(`${prefix}${value}`);
+}
+
+function openApiSurfaces(root, relPath, namespace, surfaces) {
+  const document = parse(readFileSync(join(root, relPath), 'utf8'));
+  for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
+    for (const method of ['get', 'put', 'post', 'delete', 'patch', 'head', 'options']) {
+      if (pathItem?.[method]) surfaces.add(`http:${namespace}:${method.toUpperCase()} ${path}`);
+    }
+  }
+  for (const [schemaName, schema] of Object.entries(document.components?.schemas ?? {})) {
+    for (const property of Object.keys(schema?.properties ?? {})) {
+      surfaces.add(`schema:${namespace}:${schemaName}.${property}`);
+    }
+  }
+}
+
+function packageSurfaces(root, surfaces) {
+  const packages = [
+    ['packages/sdk/typescript/package.json', '@relayfile/sdk'],
+    ['packages/core/package.json', '@relayfile/core'],
+    ['packages/client/package.json', '@relayfile/client'],
+    ['packages/local-mount/package.json', '@relayfile/local-mount'],
+    ['packages/agents/package.json', '@relayfile/agents'],
+    ['packages/cli/package.json', 'relayfile'],
+  ];
+  for (const [relPath, fallbackName] of packages) {
+    const pkg = JSON.parse(readFileSync(join(root, relPath), 'utf8'));
+    const name = pkg.name ?? fallbackName;
+    for (const key of Object.keys(pkg.exports ?? {})) surfaces.add(`package-export:${name}:${key}`);
+    if (!pkg.exports && (pkg.main || pkg.module || pkg.types)) surfaces.add(`package-export:${name}:.`);
+    for (const key of Object.keys(pkg.bin ?? {})) surfaces.add(`package-bin:${name}:${key}`);
+  }
+  for (const platform of ['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64']) {
+    const pkg = JSON.parse(readFileSync(join(root, `packages/mount-${platform}/package.json`), 'utf8'));
+    for (const key of Object.keys(pkg.bin ?? {})) surfaces.add(`package-bin:${pkg.name}:${key}`);
+    if ((pkg.files ?? []).includes('bin')) surfaces.add(`package-artifact:${pkg.name}:bin`);
+  }
+}
+
+function languageExportSurfaces(root, surfaces) {
+  const parity = JSON.parse(readFileSync(join(root, 'packages/sdk/parity.json'), 'utf8'));
+  const ts = new Set();
+  const py = new Set();
+  for (const capability of parity.capabilities ?? []) {
+    for (const value of capability.tsExports ?? []) ts.add(value);
+    for (const value of capability.pyExports ?? []) py.add(value);
+  }
+  add(surfaces, 'export:ts-sdk:', [...ts]);
+  add(surfaces, 'export:python-parity:', [...py]);
+
+  const python = readFileSync(join(root, 'packages/sdk/python/src/relayfile/__init__.py'), 'utf8');
+  const block = python.match(/__all__\s*=\s*\[([\s\S]*?)\]/)?.[1] ?? '';
+  const rootExports = [...block.matchAll(/["']([^"']+)["']/g)].map((match) => match[1]);
+  add(surfaces, 'export:python-root:', rootExports);
+}
+
+function mountFlagSurfaces(root, surfaces) {
+  const source = readFileSync(join(root, 'cmd/relayfile-mount/main.go'), 'utf8');
+  const flags = new Set();
+  for (const match of source.matchAll(/flag\.(?:String|Bool|Duration|Int|Float64)\(\s*"([^"]+)"/g)) {
+    flags.add(match[1]);
+  }
+  for (const match of source.matchAll(/flag\.(?:String|Bool|Duration|Int|Float64)?Var\([^,]*,\s*"([^"]+)"/g)) {
+    flags.add(match[1]);
+  }
+  add(surfaces, 'flag:relayfile-mount:--', [...flags]);
+}
+
+function typescriptConfigSurfaces(root, surfaces) {
+  const groups = {
+    sdk: 'packages/sdk/typescript/src',
+    core: 'packages/core/src',
+    client: 'packages/client/src',
+    agents: 'packages/agents/src',
+    'local-mount': 'packages/local-mount/src',
+  };
+  const walk = (directory) => readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? walk(path) : entry.isFile() && entry.name.endsWith('.ts') && !entry.name.includes('.test.') ? [path] : [];
+  });
+  for (const [group, relPath] of Object.entries(groups)) {
+    for (const path of walk(join(root, relPath))) {
+      const source = ts.createSourceFile(path, readFileSync(path, 'utf8'), ts.ScriptTarget.Latest, true);
+      for (const statement of source.statements) {
+        if (!ts.isInterfaceDeclaration(statement) || !/(Options|Config)$/.test(statement.name.text)) continue;
+        if (!statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) continue;
+        for (const member of statement.members) {
+          if (!ts.isPropertySignature(member) || !member.name) continue;
+          const name = ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) ? member.name.text : member.name.getText(source);
+          surfaces.add(`config:ts:${group}:${statement.name.text}.${name}`);
+        }
+      }
+    }
+  }
+}
+
+export function collectPublicSurfaces(root) {
+  const surfaces = new Set();
+  add(surfaces, 'cli:relayfile ', CLI_LEAVES);
+  add(surfaces, 'cli-alias:', CLI_ALIASES);
+  surfaces.add('executable:relayfile-server');
+  surfaces.add('executable:relayfile-mount');
+  openApiSurfaces(root, 'openapi/relayfile-v1.openapi.yaml', 'data', surfaces);
+  openApiSurfaces(root, 'openapi/relayfile-control-plane-v1.openapi.yaml', 'control', surfaces);
+  surfaces.add('http:data:GET /dashboard');
+  add(surfaces, 'http:hosted:', HOSTED_HTTP);
+  for (const [owner, methods] of Object.entries(SDK_METHODS)) {
+    add(surfaces, `sdk-ts:${owner}:`, methods);
+  }
+  packageSurfaces(root, surfaces);
+  languageExportSurfaces(root, surfaces);
+  mountFlagSurfaces(root, surfaces);
+  typescriptConfigSurfaces(root, surfaces);
+  for (const [group, names] of Object.entries(ENVIRONMENT)) add(surfaces, `config:env:${group}:`, names);
+  for (const [group, fields] of Object.entries(CONFIG_FIELDS)) add(surfaces, `config:field:${group}:`, fields);
+  add(surfaces, 'provider:', PROVIDER_SURFACES);
+  add(surfaces, 'implementation:', IMPLEMENTATION_SURFACES);
+  add(surfaces, 'observability:', OBSERVABILITY_SURFACES);
+  add(surfaces, 'release:path:', RELEASE_PATHS);
+  surfaces.add('automation:integration-verifier-persona');
+  surfaces.add('automation:relayfile-evals');
+  surfaces.add('automation:feature-catalog');
+  surfaces.add('automation:feature-guardian');
+  return [...surfaces].sort();
+}
+
+export const catalogSurfaceInventory = {
+  cliLeaves: CLI_LEAVES,
+  cliAliases: CLI_ALIASES,
+  environment: ENVIRONMENT,
+  configFields: CONFIG_FIELDS,
+  releasePaths: RELEASE_PATHS,
+};

--- a/scripts/feature-runbook-lib.sh
+++ b/scripts/feature-runbook-lib.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+vf_start() {
+  local name="${1:?procedure name required}"
+  local tmp_parent="${TMPDIR:-/tmp}"
+  VF_CASE_ROOT="$(mktemp -d "${tmp_parent%/}/relayfile-feature-${name}.XXXXXX")"
+  export VF_CASE_ROOT
+  : >"$VF_CASE_ROOT/.relayfile-feature-fixture"
+  export XDG_CONFIG_HOME="$VF_CASE_ROOT/xdg"
+  mkdir -p "$XDG_CONFIG_HOME" "$VF_CASE_ROOT/state" "$VF_CASE_ROOT/data"
+}
+
+vf_cleanup() {
+  local root="${VF_CASE_ROOT:-}"
+  if [[ -z "$root" || ! -f "$root/.relayfile-feature-fixture" ]]; then
+    printf '%s\n' 'FAIL cleanup refused: fixture marker is absent' >&2
+    return 1
+  fi
+  case "$(basename "$root")" in
+    relayfile-feature-*.??????) ;;
+    *) printf 'FAIL cleanup refused unexpected root: %s\n' "$root" >&2; return 1 ;;
+  esac
+  rm -rf -- "$root"
+  unset VF_CASE_ROOT
+}
+
+vf_result() {
+  local status="${1:?status required}"
+  local procedure="${2:?procedure required}"
+  local detail="${3:-}"
+  case "$status" in PASS|FAIL|SKIP|MANUAL) ;; *) return 2 ;; esac
+  printf '{"status":"%s","procedure":"%s","detail":"%s"}\n' \
+    "$status" "$procedure" "${detail//\"/\\\"}"
+}
+
+vf_wait_http() {
+  local url="${1:?url required}"
+  local attempts="${2:-50}"
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if curl --fail --silent --show-error --max-time 1 "$url" >/dev/null; then return 0; fi
+    sleep 0.1
+  done
+  return 1
+}
+
+vf_free_port() {
+  node -e 'const net=require("node:net");const s=net.createServer();s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close()})'
+}

--- a/scripts/feature-runbook-lib.sh
+++ b/scripts/feature-runbook-lib.sh
@@ -30,8 +30,10 @@ vf_result() {
   local procedure="${2:?procedure required}"
   local detail="${3:-}"
   case "$status" in PASS|FAIL|SKIP|MANUAL) ;; *) return 2 ;; esac
-  printf '{"status":"%s","procedure":"%s","detail":"%s"}\n' \
-    "$status" "$procedure" "${detail//\"/\\\"}"
+  node -e '
+    const [status, procedure, detail] = process.argv.slice(1);
+    process.stdout.write(`${JSON.stringify({ status, procedure, detail })}\n`);
+  ' "$status" "$procedure" "$detail"
 }
 
 vf_wait_http() {

--- a/scripts/packed-feature-e2e.mjs
+++ b/scripts/packed-feature-e2e.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
 const root = process.cwd();
+const cliVersion = JSON.parse(readFileSync(join(root, 'packages/cli/package.json'), 'utf8')).version;
+if (typeof cliVersion !== 'string' || !/^\d+\.\d+\.\d+$/u.test(cliVersion)) {
+  throw new Error(`invalid CLI package version: ${String(cliVersion)}`);
+}
 const fixture = mkdtempSync(join(tmpdir(), 'relayfile-packed-e2e.'));
 const packs = join(fixture, 'packs');
 const consumer = join(fixture, 'node-consumer');
@@ -81,7 +85,7 @@ try {
   if (undeclared.status === 0) throw new Error('undeclared SDK subpath unexpectedly imported');
 
   const cli = run('node', ['node_modules/relayfile/scripts/run.js', 'version'], { cwd: consumer });
-  if (!/0\.10\.33/.test(cli.stdout)) throw new Error(`packed CLI version drifted: ${cli.stdout}`);
+  if (!cli.stdout.includes(cliVersion)) throw new Error(`packed CLI version drifted: ${cli.stdout}`);
   const mountBinary = join(consumer, 'node_modules', '@relayfile', `mount-${platform}`, 'bin', 'relayfile-mount');
   if (!existsSync(mountBinary)) throw new Error(`packed mount binary is absent: ${mountBinary}`);
 
@@ -93,7 +97,7 @@ try {
   run('uv', ['pip', 'install', '--python', python, join(packs, wheel)]);
   run(python, ['-c', 'import relayfile; assert relayfile.RelayFileClient; assert len(relayfile.__all__) == len(set(relayfile.__all__))']);
 
-  console.log('PACKED_FEATURE_E2E_PASS npm_tarballs=7 python_wheel=1 declared_imports=15 cli_version=0.10.33 mount_binary=1 undeclared_negative=1');
+  console.log(`PACKED_FEATURE_E2E_PASS npm_tarballs=7 python_wheel=1 declared_imports=15 cli_version=${cliVersion} mount_binary=1 undeclared_negative=1`);
 } finally {
   if (
     !existsSync(fixtureMarker) ||

--- a/scripts/packed-feature-e2e.mjs
+++ b/scripts/packed-feature-e2e.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { cpSync, existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const root = process.cwd();
+const fixture = mkdtempSync(join(tmpdir(), 'relayfile-packed-e2e.'));
+const packs = join(fixture, 'packs');
+const consumer = join(fixture, 'node-consumer');
+const pythonConsumer = join(fixture, 'python-consumer');
+const crossBuildDist = join(fixture, 'cross-build-dist');
+const stagedMountPackages = join(fixture, 'mount-packages');
+const fixtureMarker = join(fixture, '.relayfile-packed-e2e-fixture');
+writeFileSync(fixtureMarker, '');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? root,
+    env: { ...process.env, ...options.env },
+    encoding: 'utf8',
+  });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} exited ${result.status}`);
+  return result;
+}
+
+try {
+  run('mkdir', ['-p', packs, consumer, pythonConsumer]);
+  run('npm', ['run', 'build']);
+  for (const name of readdirSync(join(root, 'packages')).filter((entry) => entry.startsWith('mount-'))) {
+    cpSync(join(root, 'packages', name), join(stagedMountPackages, name), { recursive: true });
+  }
+  run('make', ['build-all', `DIST_DIR=${crossBuildDist}`]);
+  run('node', ['scripts/build-mount-npm-packages.mjs'], {
+    env: {
+      RELAYFILE_MOUNT_DIST_DIR: crossBuildDist,
+      RELAYFILE_MOUNT_PACKAGES_DIR: stagedMountPackages,
+    },
+  });
+  for (const workspace of [
+    'packages/core',
+    'packages/sdk/typescript',
+    '@relayfile/client',
+    'packages/local-mount',
+    'packages/agents',
+    'packages/cli',
+  ]) run('npm', ['pack', `--workspace=${workspace}`, '--pack-destination', packs]);
+
+  const platform = `${process.platform}-${process.arch === 'x64' ? 'x64' : 'arm64'}`;
+  const mountPackage = join(stagedMountPackages, `mount-${platform}`);
+  if (!existsSync(mountPackage)) throw new Error(`unsupported packed mount platform ${platform}`);
+  run('npm', ['pack', mountPackage, '--pack-destination', packs]);
+
+  const tarballs = readdirSync(packs).filter((name) => name.endsWith('.tgz')).map((name) => join(packs, name));
+  if (tarballs.length !== 7) throw new Error(`expected 7 npm tarballs, found ${tarballs.length}`);
+  writeFileSync(join(consumer, 'package.json'), JSON.stringify({ name: 'relayfile-packed-consumer', private: true, type: 'module' }));
+  // npm installs optional peer frameworks so every declared agent subpath can
+  // be imported exactly as a real clean consumer would import it.
+  run('npm', [
+    'install', '--ignore-scripts',
+    'ai@^4.0.20', '@openai/agents@^0.0.13', '@langchain/core@^0.3.25',
+    ...tarballs,
+  ], { cwd: consumer });
+  run('node', ['--input-type=module', '-e', [
+    "const modules = await Promise.all([",
+    "  import('@relayfile/core'), import('@relayfile/sdk'), import('@relayfile/sdk/cli'),",
+    "  import('@relayfile/sdk/cloud-login'), import('@relayfile/sdk/mount-launcher'),",
+    "  import('@relayfile/sdk/mount-harness'), import('@relayfile/sdk/mount-path'),",
+    "  import('@relayfile/sdk/workspace-seeder'), import('@relayfile/sdk/workspace-mount'),",
+    "  import('@relayfile/client'), import('@relayfile/local-mount'), import('@relayfile/agents'),",
+    "  import('@relayfile/agents/vercel'), import('@relayfile/agents/openai'), import('@relayfile/agents/langchain'),",
+    "]);",
+    "if (modules.some((value) => !value)) process.exit(1);",
+    "if (!modules[1].RelayFileClient) throw new Error('RelayFileClient missing');",
+  ].join('\n')], { cwd: consumer });
+  const undeclared = spawnSync('node', ['--input-type=module', '-e', "await import('@relayfile/sdk/not-declared')"], {
+    cwd: consumer, encoding: 'utf8',
+  });
+  if (undeclared.status === 0) throw new Error('undeclared SDK subpath unexpectedly imported');
+
+  const cli = run('node', ['node_modules/relayfile/scripts/run.js', 'version'], { cwd: consumer });
+  if (!/0\.10\.33/.test(cli.stdout)) throw new Error(`packed CLI version drifted: ${cli.stdout}`);
+  const mountBinary = join(consumer, 'node_modules', '@relayfile', `mount-${platform}`, 'bin', 'relayfile-mount');
+  if (!existsSync(mountBinary)) throw new Error(`packed mount binary is absent: ${mountBinary}`);
+
+  run('uv', ['build', 'packages/sdk/python', '--out-dir', packs]);
+  const wheel = readdirSync(packs).find((name) => name.endsWith('.whl'));
+  if (!wheel) throw new Error('Python wheel was not built');
+  run('uv', ['venv', pythonConsumer]);
+  const python = join(pythonConsumer, process.platform === 'win32' ? 'Scripts/python.exe' : 'bin/python');
+  run('uv', ['pip', 'install', '--python', python, join(packs, wheel)]);
+  run(python, ['-c', 'import relayfile; assert relayfile.RelayFileClient; assert len(relayfile.__all__) == len(set(relayfile.__all__))']);
+
+  console.log('PACKED_FEATURE_E2E_PASS npm_tarballs=7 python_wheel=1 declared_imports=15 cli_version=0.10.33 mount_binary=1 undeclared_negative=1');
+} finally {
+  if (
+    !existsSync(fixtureMarker) ||
+    dirname(resolve(fixture)) !== resolve(tmpdir()) ||
+    !basename(fixture).startsWith('relayfile-packed-e2e.')
+  ) throw new Error(`refusing fixture cleanup: ${fixture}`);
+  rmSync(fixture, { recursive: true });
+}

--- a/scripts/validate-feature-catalog.mjs
+++ b/scripts/validate-feature-catalog.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parse } from 'yaml';
+
+import { collectPublicSurfaces } from './feature-catalog-surfaces.mjs';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+export const DEFAULT_ROOT = resolve(SCRIPT_DIR, '..');
+export const DEFAULT_MANIFEST = '.agentworkforce/features/manifest.yaml';
+const REQUIRED_PROCEDURE_PARTS = [
+  'Prerequisites',
+  'Isolated setup',
+  'Commands',
+  'Positive assertions',
+  'Negative assertions',
+  'Cleanup',
+  'Automation limits',
+  'Reporting',
+];
+
+function ownRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function secureRelativePath(root, value, label, errors, mustExist = true) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    errors.push(`${label} must be a non-empty relative path`);
+    return null;
+  }
+  if (isAbsolute(value) || value.split(/[\\/]/).includes('..')) {
+    errors.push(`${label} escapes the repository: ${value}`);
+    return null;
+  }
+  const absolute = resolve(root, value);
+  const rel = relative(root, absolute);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    errors.push(`${label} escapes the repository: ${value}`);
+    return null;
+  }
+  if (mustExist && !existsSync(absolute)) {
+    errors.push(`${label} does not exist: ${value}`);
+    return null;
+  }
+  if (mustExist) {
+    const canonicalRoot = realpathSync(root);
+    const canonical = realpathSync(absolute);
+    const canonicalRel = relative(canonicalRoot, canonical);
+    if (canonicalRel === '..' || canonicalRel.startsWith(`..${sep}`) || isAbsolute(canonicalRel)) {
+      errors.push(`${label} resolves outside the repository: ${value}`);
+      return null;
+    }
+  }
+  return absolute;
+}
+
+function globPattern(pattern) {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replaceAll('*', '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function sectionForProcedure(document, name) {
+  const lines = document.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `## ${name}`);
+  if (start < 0) return null;
+  const relativeEnd = lines.slice(start + 1).findIndex((line) => line.startsWith('## '));
+  const end = relativeEnd < 0 ? lines.length : start + 1 + relativeEnd;
+  return lines.slice(start + 1, end).join('\n');
+}
+
+export function computeSummary(manifest) {
+  const categories = Object.values(manifest.categories ?? {});
+  const features = categories.flatMap((category) => category.features ?? []);
+  const criticality = { critical: 0, hot: 0, standard: 0 };
+  const verify_tiers = { '1': 0, '2': 0, '3': 0, '4': 0, '5': 0, '6': 0 };
+  for (const category of categories) {
+    if (Object.hasOwn(criticality, category.criticality)) {
+      criticality[category.criticality] += (category.features ?? []).length;
+    }
+    for (const feature of category.features ?? []) {
+      if (Object.hasOwn(verify_tiers, String(feature.verify_tier))) {
+        verify_tiers[String(feature.verify_tier)] += 1;
+      }
+    }
+  }
+  return { categories: categories.length, features: features.length, criticality, verify_tiers };
+}
+
+export function validateManifestData(manifest, options = {}) {
+  const root = resolve(options.root ?? DEFAULT_ROOT);
+  const structuralOnly = options.structuralOnly === true;
+  const errors = [];
+  if (!ownRecord(manifest)) return ['manifest must be a mapping'];
+  if (String(manifest.version) !== '1.1') errors.push('manifest version must be 1.1');
+  if (typeof manifest.updated !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(manifest.updated)) {
+    errors.push('manifest updated must be an ISO calendar date');
+  }
+  if (!ownRecord(manifest.categories) || Object.keys(manifest.categories).length === 0) {
+    errors.push('manifest categories must be a non-empty mapping');
+  }
+  if (!ownRecord(manifest.verification) || !ownRecord(manifest.verification?.categories)) {
+    errors.push('verification.categories must be a mapping');
+  }
+
+  const categoryNames = Object.keys(manifest.categories ?? {}).sort();
+  const routeNames = Object.keys(manifest.verification?.categories ?? {}).sort();
+  for (const category of categoryNames) {
+    if (!routeNames.includes(category)) errors.push(`verification route missing for category ${category}`);
+  }
+  for (const route of routeNames) {
+    if (!categoryNames.includes(route)) errors.push(`verification route references unknown category ${route}`);
+  }
+
+  const documentPath = secureRelativePath(
+    root,
+    manifest.verification?.document,
+    'verification.document',
+    errors,
+    options.proceduresText === undefined && !structuralOnly
+  );
+  let procedures = options.proceduresText;
+  if (!structuralOnly && procedures === undefined && documentPath) procedures = readFileSync(documentPath, 'utf8');
+  const proceduresSeen = new Set();
+  for (const [category, procedure] of Object.entries(manifest.verification?.categories ?? {})) {
+    if (typeof procedure !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(procedure)) {
+      errors.push(`verification route for ${category} is not a named procedure`);
+      continue;
+    }
+    if (proceduresSeen.has(procedure)) errors.push(`procedure route is duplicated: ${procedure}`);
+    proceduresSeen.add(procedure);
+    if (typeof procedures === 'string') {
+      const section = sectionForProcedure(procedures, procedure);
+      if (section === null) {
+        errors.push(`procedure heading missing: ## ${procedure}`);
+      } else {
+        for (const part of REQUIRED_PROCEDURE_PARTS) {
+          if (!new RegExp(`^### ${part}\\s*$`, 'm').test(section)) {
+            errors.push(`procedure ${procedure} is missing ### ${part}`);
+          }
+        }
+        if (!/\b(PASS|FAIL|SKIP|MANUAL)\b/.test(section)) {
+          errors.push(`procedure ${procedure} lacks explicit outcome semantics`);
+        }
+      }
+    }
+  }
+
+  const ids = new Set();
+  const coverEntries = [];
+  for (const [categoryId, category] of Object.entries(manifest.categories ?? {})) {
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(categoryId)) errors.push(`invalid category id ${categoryId}`);
+    if (!ownRecord(category)) {
+      errors.push(`category ${categoryId} must be a mapping`);
+      continue;
+    }
+    if (typeof category.name !== 'string' || category.name.trim() === '') errors.push(`category ${categoryId} needs a name`);
+    if (typeof category.description !== 'string' || category.description.trim() === '') errors.push(`category ${categoryId} needs a description`);
+    if (!['critical', 'hot', 'standard'].includes(category.criticality)) errors.push(`category ${categoryId} has invalid criticality`);
+    if (!Array.isArray(category.features) || category.features.length === 0) {
+      errors.push(`category ${categoryId} must contain features`);
+      continue;
+    }
+    for (const feature of category.features) {
+      const label = `${categoryId}/${feature?.id ?? '<missing-id>'}`;
+      if (!ownRecord(feature)) {
+        errors.push(`${label} must be a mapping`);
+        continue;
+      }
+      if (typeof feature.id !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(feature.id)) {
+        errors.push(`${label} has an invalid stable id`);
+      } else if (ids.has(feature.id)) {
+        errors.push(`duplicate feature id ${feature.id}`);
+      } else {
+        ids.add(feature.id);
+      }
+      if (typeof feature.name !== 'string' || feature.name.trim() === '') errors.push(`${label} needs a name`);
+      if (typeof feature.description !== 'string' || feature.description.trim() === '') errors.push(`${label} needs a truthful description`);
+      if (!Number.isInteger(feature.verify_tier) || feature.verify_tier < 1 || feature.verify_tier > 6) {
+        errors.push(`${label} has invalid verify_tier`);
+      }
+      const locations = Array.isArray(feature.locations)
+        ? feature.locations
+        : typeof feature.location === 'string'
+          ? [feature.location]
+          : [];
+      if (locations.length === 0) errors.push(`${label} needs at least one implementation location`);
+      for (const location of locations) {
+        secureRelativePath(root, location, `${label} location`, errors, !structuralOnly);
+      }
+      if (!Array.isArray(feature.covers) || feature.covers.length === 0) {
+        errors.push(`${label} needs public surface coverage`);
+      } else {
+        for (const pattern of feature.covers) {
+          if (typeof pattern !== 'string' || pattern.trim() === '') errors.push(`${label} has an invalid coverage selector`);
+          else coverEntries.push({ categoryId, featureId: feature.id, pattern });
+        }
+      }
+    }
+  }
+
+  const expectedSummary = computeSummary(manifest);
+  if (JSON.stringify(manifest.summary) !== JSON.stringify(expectedSummary)) {
+    errors.push(`stale summary totals: expected ${JSON.stringify(expectedSummary)}`);
+  }
+
+  const exclusions = new Map();
+  const rawExclusions = manifest.surface_exclusions ?? [];
+  if (!Array.isArray(rawExclusions)) errors.push('surface_exclusions must be a sequence');
+  for (const exclusion of Array.isArray(rawExclusions) ? rawExclusions : []) {
+    if (!ownRecord(exclusion) || typeof exclusion.surface !== 'string' || typeof exclusion.reason !== 'string' || exclusion.reason.trim() === '') {
+      errors.push('surface exclusions require exact surface and non-empty reason');
+      continue;
+    }
+    if (exclusion.surface.includes('*')) errors.push(`surface exclusion must be exact: ${exclusion.surface}`);
+    if (exclusions.has(exclusion.surface)) errors.push(`duplicate surface exclusion: ${exclusion.surface}`);
+    exclusions.set(exclusion.surface, exclusion.reason);
+  }
+  if (structuralOnly) return errors;
+
+  const publicSurfaces = options.publicSurfaces ?? collectPublicSurfaces(root);
+  for (const excluded of exclusions.keys()) {
+    if (!publicSurfaces.includes(excluded)) errors.push(`surface exclusion is stale or unknown: ${excluded}`);
+  }
+
+  const usedPatterns = new Map(coverEntries.map((entry) => [`${entry.featureId}\0${entry.pattern}`, 0]));
+  for (const surface of publicSurfaces) {
+    const matches = coverEntries.filter((entry) => globPattern(entry.pattern).test(surface));
+    if (exclusions.has(surface)) {
+      if (matches.length > 0) errors.push(`excluded public surface is also covered: ${surface}`);
+      continue;
+    }
+    if (matches.length === 0) errors.push(`public surface omission: ${surface}`);
+    if (matches.length > 1) {
+      errors.push(`public surface has overlapping feature coverage: ${surface} (${matches.map((m) => m.featureId).join(', ')})`);
+    }
+    for (const match of matches) {
+      const key = `${match.featureId}\0${match.pattern}`;
+      usedPatterns.set(key, (usedPatterns.get(key) ?? 0) + 1);
+    }
+  }
+  for (const entry of coverEntries) {
+    if ((usedPatterns.get(`${entry.featureId}\0${entry.pattern}`) ?? 0) === 0) {
+      errors.push(`coverage selector matches no public surface: ${entry.featureId} -> ${entry.pattern}`);
+    }
+  }
+  return errors;
+}
+
+export function loadAndValidateManifest(options = {}) {
+  const root = resolve(options.root ?? DEFAULT_ROOT);
+  const manifestPath = secureRelativePath(root, options.manifestPath ?? DEFAULT_MANIFEST, 'manifest', [], true);
+  if (!manifestPath) throw new Error('manifest path is invalid or missing');
+  const manifest = parse(readFileSync(manifestPath, 'utf8'));
+  return { manifest, errors: validateManifestData(manifest, { ...options, root }) };
+}
+
+function main() {
+  const { manifest, errors } = loadAndValidateManifest();
+  if (errors.length > 0) {
+    console.error('FEATURE_CATALOG_FAIL');
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+  const summary = computeSummary(manifest);
+  console.log(`FEATURE_CATALOG_PASS categories=${summary.categories} features=${summary.features}`);
+  console.log(`criticality=${JSON.stringify(summary.criticality)} tiers=${JSON.stringify(summary.verify_tiers)}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/verify-features.mjs
+++ b/scripts/verify-features.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const valueAfter = (name) => {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+};
+const requested = valueAfter('--tier') ?? '1';
+const requireLive = args.includes('--require-live');
+const jsonOnly = args.includes('--json');
+const tierList = requested === 'deterministic' ? [1, 2, 4] : requested === 'all' ? [1, 2, 3, 4, 5, 6] : requested.split(',').map(Number);
+if (tierList.some((tier) => !Number.isInteger(tier) || tier < 1 || tier > 6)) {
+  console.error('usage: node scripts/verify-features.mjs --tier <1..6|comma-list|deterministic|all> [--require-live] [--json]');
+  process.exit(2);
+}
+
+const results = [];
+function record(status, tier, check, detail) {
+  const item = { status, tier, check, detail };
+  results.push(item);
+  if (!jsonOnly) console.log(`${status} tier=${tier} check=${check} detail=${detail}`);
+}
+
+function command(tier, check, executable, commandArgs, env = {}) {
+  const result = spawnSync(executable, commandArgs, {
+    cwd: process.cwd(), env: { ...process.env, ...env }, encoding: 'utf8',
+  });
+  if (!jsonOnly && result.stdout) process.stdout.write(result.stdout);
+  if (!jsonOnly && result.stderr) process.stderr.write(result.stderr);
+  if (result.status === 0) record('PASS', tier, check, `${executable} ${commandArgs.join(' ')}`);
+  else record('FAIL', tier, check, `exit=${result.status}: ${executable} ${commandArgs.join(' ')}`);
+}
+
+function freePort() {
+  const result = spawnSync(process.execPath, ['-e', [
+    'const net=require("node:net");',
+    'const server=net.createServer();',
+    'server.listen(0,"127.0.0.1",()=>{console.log(server.address().port);server.close();});',
+  ].join('')], { encoding: 'utf8' });
+  const port = Number(result.stdout.trim());
+  if (result.status !== 0 || !Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`failed to allocate loopback port: ${result.stderr || result.stdout}`);
+  }
+  return String(port);
+}
+
+for (const tier of tierList) {
+  if (tier === 1) {
+    command(1, 'catalog-validator', 'node', ['scripts/validate-feature-catalog.mjs']);
+    command(1, 'catalog-and-guardian-contracts', 'npx', ['tsx', '--test',
+      '.agentworkforce/agents/relayfile-feature-guardian/manifest-contract.test.ts',
+      '.agentworkforce/agents/relayfile-feature-guardian/agent.test.ts']);
+    command(1, 'sdk-parity', 'node', ['scripts/check-sdk-parity.mjs']);
+    command(1, 'openapi-contract-surface', 'bash', ['scripts/check-contract-surface.sh']);
+  } else if (tier === 2) {
+    const cleanEnv = { RELAYFILE_DEV_MODE: '1', RELAYFILE_BASE_URL: '', RELAYFILE_PORT: freePort() };
+    command(2, 'local-conformance', 'npx', ['tsx', 'scripts/conformance.ts', '--ci'], cleanEnv);
+    command(2, 'two-mount-e2e', 'npx', ['tsx', 'scripts/e2e.ts', '--ci'], { RELAYFILE_PORT: freePort() });
+    if (!process.env.RELAYFILE_TEST_POSTGRES_DSN) record('SKIP', 2, 'postgres-backend', 'RELAYFILE_TEST_POSTGRES_DSN is absent');
+  } else if (tier === 3) {
+    if (process.env.RELAYFILE_LIVE_FUSE !== '1') record('SKIP', 3, 'fuse-live', 'RELAYFILE_LIVE_FUSE=1 is required');
+    else {
+      command(3, 'fuse-unit-and-host-support', 'go', ['test', './internal/mountfuse', '-count=1']);
+      record('MANUAL', 3, 'fuse-mount-cycle', 'run the named FUSE procedure with an authorized disposable mountpoint');
+    }
+  } else if (tier === 4) {
+    command(4, 'packed-clean-consumer', 'node', ['scripts/packed-feature-e2e.mjs']);
+  } else if (tier === 5) {
+    if (process.env.RELAYFILE_LIVE !== '1') record('SKIP', 5, 'hosted-disposable-flow', 'RELAYFILE_LIVE=1 and disposable hosted credentials are required');
+    else record('MANUAL', 5, 'hosted-disposable-flow', 'live opt-in is present, but the checked-in SDK E2E is mocked; run the named hosted procedures and confirm cleanup before recording PASS');
+  } else if (tier === 6) {
+    if (process.env.RELAYFILE_PROVIDER_LIVE !== '1') record('SKIP', 6, 'provider-and-release', 'RELAYFILE_PROVIDER_LIVE=1 is absent');
+    else record('MANUAL', 6, 'provider-and-release', 'run the provider-specific named procedure; publish/tag/release remains manual');
+  }
+}
+
+const totals = { PASS: 0, FAIL: 0, SKIP: 0, MANUAL: 0 };
+for (const result of results) totals[result.status] += 1;
+const report = { generatedAt: new Date().toISOString(), requested, requireLive, totals, results };
+mkdirSync(join('.workflow-artifacts', 'verify-features'), { recursive: true });
+writeFileSync(join('.workflow-artifacts', 'verify-features', 'latest.json'), `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report));
+if (totals.FAIL > 0 || (requireLive && (totals.SKIP > 0 || totals.MANUAL > 0))) process.exitCode = 1;

--- a/scripts/verify-features.test.mjs
+++ b/scripts/verify-features.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+function runTier5({ live, requireLive = false }) {
+  const env = { ...process.env };
+  delete env.RELAYFILE_LIVE;
+  if (live) env.RELAYFILE_LIVE = '1';
+  const args = ['scripts/verify-features.mjs', '--tier', '5', '--json'];
+  if (requireLive) args.push('--require-live');
+  const result = spawnSync(process.execPath, args, { cwd: process.cwd(), env, encoding: 'utf8' });
+  const lines = result.stdout.trim().split('\n');
+  const report = JSON.parse(lines.at(-1));
+  return { result, report };
+}
+
+test('tier 5 without live opt-in is SKIP and fails a required-live gate', () => {
+  const optional = runTier5({ live: false });
+  assert.equal(optional.result.status, 0);
+  assert.deepEqual(optional.report.totals, { PASS: 0, FAIL: 0, SKIP: 1, MANUAL: 0 });
+
+  const required = runTier5({ live: false, requireLive: true });
+  assert.equal(required.result.status, 1);
+  assert.deepEqual(required.report.totals, { PASS: 0, FAIL: 0, SKIP: 1, MANUAL: 0 });
+});
+
+test('tier 5 live opt-in stays MANUAL instead of passing the mocked SDK E2E', () => {
+  const optional = runTier5({ live: true });
+  assert.equal(optional.result.status, 0);
+  assert.deepEqual(optional.report.totals, { PASS: 0, FAIL: 0, SKIP: 0, MANUAL: 1 });
+  assert.match(optional.report.results[0].detail, /checked-in SDK E2E is mocked/);
+
+  const required = runTier5({ live: true, requireLive: true });
+  assert.equal(required.result.status, 1);
+  assert.deepEqual(required.report.totals, { PASS: 0, FAIL: 0, SKIP: 0, MANUAL: 1 });
+});

--- a/scripts/verify-features.test.mjs
+++ b/scripts/verify-features.test.mjs
@@ -34,3 +34,20 @@ test('tier 5 live opt-in stays MANUAL instead of passing the mocked SDK E2E', ()
   assert.equal(required.result.status, 1);
   assert.deepEqual(required.report.totals, { PASS: 0, FAIL: 0, SKIP: 0, MANUAL: 1 });
 });
+
+test('runbook results remain valid one-line JSON for arbitrary details', () => {
+  const detail = 'windows\\path\n"quoted"\tcontrol';
+  const result = spawnSync('bash', [
+    '-c',
+    'source scripts/feature-runbook-lib.sh; vf_result PASS sample-procedure "$1"',
+    'vf-result-test',
+    detail,
+  ], { cwd: process.cwd(), encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim().split('\n').length, 1);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    status: 'PASS',
+    procedure: 'sample-procedure',
+    detail,
+  });
+});

--- a/workflows/verify-features.ts
+++ b/workflows/verify-features.ts
@@ -1,0 +1,58 @@
+/**
+ * Tier-aware Relayfile feature verification.
+ *
+ * Run: agent-relay run workflows/verify-features.ts
+ * Optional: RELAYFILE_FEATURE_LIVE_TIER=3|5|6 RELAYFILE_REQUIRE_LIVE=1
+ */
+import { workflow } from '@agent-relay/sdk/workflows';
+
+async function main() {
+  const result = await workflow('relayfile-verify-features')
+    .description('Validate the authoritative catalog, deterministic local/packed tiers, and an explicitly selected live tier with honest result accounting.')
+    .pattern('pipeline')
+    .channel('wf-relayfile-verify-features')
+    .maxConcurrency(1)
+    .timeout(3_600_000)
+    .step('catalog-contract', {
+      type: 'deterministic',
+      command: 'npm run features:validate && npm run features:test',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('deterministic-tiers', {
+      type: 'deterministic',
+      dependsOn: ['catalog-contract'],
+      command: 'npm run features:verify -- --tier deterministic',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('explicit-live-tier', {
+      type: 'deterministic',
+      dependsOn: ['deterministic-tiers'],
+      command: [
+        'if [ -z "${RELAYFILE_FEATURE_LIVE_TIER:-}" ]; then',
+        '  echo "SKIP live-tier: RELAYFILE_FEATURE_LIVE_TIER is absent"',
+        'else',
+        '  REQUIRE=""',
+        '  if [ "${RELAYFILE_REQUIRE_LIVE:-0}" = "1" ]; then REQUIRE="--require-live"; fi',
+        '  npm run features:verify -- --tier "$RELAYFILE_FEATURE_LIVE_TIER" $REQUIRE',
+        'fi',
+      ].join('\n'),
+      captureOutput: true,
+      failOnError: true,
+    })
+    .step('verify-evidence', {
+      type: 'deterministic',
+      dependsOn: ['explicit-live-tier'],
+      command: 'test -s .workflow-artifacts/verify-features/latest.json && node -e "const r=require(\'./.workflow-artifacts/verify-features/latest.json\'); if(r.totals.FAIL) process.exit(1)"',
+      captureOutput: true,
+      failOnError: true,
+    })
+    .run({ cwd: process.cwd() });
+  console.log(result.status);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add an implementation-derived catalog covering 18 categories and 122 features, with exact one-owner mapping for 1,632 public surfaces and current durable resource-subscription routes
- add agent-runnable procedures, critical paths, a verification skill, deterministic/live tier accounting, packed consumer checks, and CI
- add an hourly Relayfile feature guardian with exact CAS progress, bounded transactions, idempotent receipt-confirmed Slack delivery, and repository-scoped permissions
- harden existing test/build helpers so isolated and packed end-to-end verification is reproducible and cleanup remains marker-scoped

## Validation

- `npm run features:validate` — 18 categories / 122 features
- `npm run features:test` — 59 passing tests
- focused durable-resource-subscription lifecycle and negative test — 2 passing
- `npm run features:verify -- --tier deterministic` — 7 PASS / 1 explicit PostgreSQL SKIP
- `npm run features:pack-e2e`
- `bash scripts/check-contract-surface.sh`
- `npm run build`
- `npm run typecheck`
- `npm test` — 371 passing JS/TS tests / 3 platform skips
- `go test ./...`
- full reusable audit workflow — 13/13 steps passed, including fresh review and strict final gates

## Honest limits

Hosted/provider/FUSE/Slack/release operations remain SKIP or MANUAL without their named opt-ins and disposable credentials. The checked-in offline eval aggregate still exposes its pre-existing live-input and unsupported jq-filter cases; it is not counted as a passing deterministic gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayfile/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

